### PR TITLE
[bugfix]fix rank handing in  multi-node pp setup

### DIFF
--- a/unifiedcache/integration/vllm/uc_connector.py
+++ b/unifiedcache/integration/vllm/uc_connector.py
@@ -35,6 +35,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
     KVConnectorRole,
 )
+from vllm.distributed.parallel_state import get_world_group
 from vllm.v1.core.kv_cache_utils import hash_request_tokens
 from vllm.v1.core.sched.output import SchedulerOutput
 
@@ -121,7 +122,9 @@ class UnifiedCacheConnectorV1(KVConnectorBase_V1):
         self.use_layerwise = True
         self.kv_caches: dict[str, torch.Tensor] = {}
         self.total_tp_size = vllm_config.parallel_config.tensor_parallel_size
-        self.rank = vllm_config.parallel_config.rank
+        self.rank = (
+            -1 if role == KVConnectorRole.SCHEDULER else get_world_group().local_rank
+        )
         self.load_paras: dict[str, LoadPara] = {}
         self.save_paras: dict[str, SavePara] = {}
         # dump tasks record request -> block -> list[task]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Prupose
When PP == 2, vllm_config.parallel_config.rank is global rank, should change it to local rank
What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

# Modifications 
use get_world_group().local_rank instead
Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

# Test
It is tested on the customer's env. And I have tested it on Single-node environment.
<img width="1112" height="251" alt="image" src="https://github.com/user-attachments/assets/976971b3-d0cf-4f22-ae9a-8b79131f3288" />
How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->