### PR TITLE
ESA: skip processing for short requests

### DIFF
--- a/unifiedcache/ucm_sparse/esa.py
+++ b/unifiedcache/ucm_sparse/esa.py
@@ -381,6 +381,7 @@ class ESA(UcmSparseBase):
         self.block_size = vllm_config.cache_config.block_size
         config = {"max_cache_size": 5368709120, "device": self.rank, "role": "worker"}
         self.connector = UcmConnectorFactory.create_connector("UcmDram", config)
+        # TODO: consider init self.is_mla here
 
     def attention_begin(
         self,
@@ -472,7 +473,10 @@ class ESA(UcmSparseBase):
         pass
 
     def estimate_num_slots_sparsed(self, request: Request) -> int:
-        if request.num_output_tokens == 0 or request.num_prompt_tokens < self.block_size :
+        if (
+            request.num_output_tokens == 0
+            or request.num_prompt_tokens < self.block_size
+        ):
             return INVALID_SLOT
         num_blocks = math.ceil(request.num_tokens / self.block_size)
         mid_window_sz = int(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Prupose

Ensure that short requests (with the number of tokens less than the block size) do not execute the Example Sparse Attention (ESA).
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

# Modifications 

Users will find that when processing long and short prompts, ESA will skip the short prompts.

<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

# Test

This PR has been tested via examples/offline_inference.py when implementing ESA with short prompts.


<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->