### PR TITLE
[Perf]kv_block_size as well as transferIoSize are calculated rather than configured

### DIFF
--- a/ucm/integration/vllm/uc_connector.py
+++ b/ucm/integration/vllm/uc_connector.py
@@ -136,12 +136,13 @@ class UnifiedCacheConnectorV1(KVConnectorBase_V1):
                 "scheduler" if role == KVConnectorRole.SCHEDULER else "worker"
             )
             config_base = self.block_size * self.element_size * self.head_size
-            config["kv_block_size"]  = (
-                config_base * self.num_layers 
+            config["kv_block_size"] = (
+                config_base
+                * self.num_layers
                 * (1 if self.is_mla else self.num_head * self.total_tp_size * 2)
             )
-            config["transferIoSize"] = (
-                config_base * (1 if self.is_mla else self.num_head)
+            config["transferIoSize"] = config_base * (
+                1 if self.is_mla else self.num_head
             )
             logger.info(
                 "kv_block_size = %d, transferIoSize = %d,",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->


# Purpose


What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->kv_block_size as well as transferIoSize are calculated rather than configured

# Modifications 

Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
In the user's service launch command, only "storage_backends" needs to be configured in "kv_connector_extra_config"：
--kv-transfer-config \
'{
    "kv_connector": "UnifiedCacheConnectorV1",
    "kv_connector_module_path": "ucm.integration.vllm.uc_connector",
    "kv_role": "kv_both",
    "kv_connector_extra_config": {
        "ucm_connector_name": "UcmNfsStore",
        "ucm_connector_config": {
            "storage_backends": "/"
        }
    }
}'

# Test

How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Qwen32B
![11b89112-6c53-47e9-b016-533d41237588](https://github.com/user-attachments/assets/c95b9754-d975-41e5-ad9b-f88a3545b7ac)
DPV2 lite
![35f32bed-7341-4fa1-bfdf-60baaadbf34b](https://github.com/user-attachments/assets/9759d75b-9f58-4f20-8e08-a37409de5add)

