### PR TITLE
[fix] compile error on ascend

### DIFF
--- a/ucm/store/connector/nfsstore_connector.py
+++ b/ucm/store/connector/nfsstore_connector.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Tuple
 
 import torch
-import ucmnfsstore
+from connector import ucmnfsstore
 from connector.ucmstore import Task, UcmKVStoreBase
 
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->


# Purpose

Fix compile error on ascend.

<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

# Modifications 

No user-facing changed.

<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

# Test

```bash
[root@localhost store]# python3 test/e2e/nfsstore_embed.py 
[2025-09-26 10:42:59.485433][UC][I] NfsStore-(Debug). [2313,2313][nfsstore.cc:104,ShowConfig]
[2025-09-26 10:42:59.485499][UC][I] Set UC::StorageBackends to ["."]. [2313,2313][nfsstore.cc:105,ShowConfig]
[2025-09-26 10:42:59.485514][UC][I] Set UC::BlockSize to 8994816. [2313,2313][nfsstore.cc:106,ShowConfig]
[2025-09-26 10:42:59.485527][UC][I] Set UC::TransferEnable to true. [2313,2313][nfsstore.cc:107,ShowConfig]
[2025-09-26 10:42:59.485538][UC][I] Set UC::DeviceId to 1. [2313,2313][nfsstore.cc:108,ShowConfig]
[2025-09-26 10:42:59.485550][UC][I] Set UC::StreamNumber to 32. [2313,2313][nfsstore.cc:109,ShowConfig]
[2025-09-26 10:42:59.485560][UC][I] Set UC::IOSize to 147456. [2313,2313][nfsstore.cc:110,ShowConfig]
[2025-09-26 10:42:59.485571][UC][I] Set UC::BufferNumber to 512. [2313,2313][nfsstore.cc:111,ShowConfig]
[2025-09-26 10:42:59.485581][UC][I] Set UC::TimeoutMs to 30000. [2313,2313][nfsstore.cc:112,ShowConfig]
[2025-09-26 10:43:06.752704][UC][I] Task(1,NFS::D2S,15616,2302672896) finished, elapsed=0.235251s, bw=9.115934GB/s. [2313,2451][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:07.305849][UC][I] Task(2,NFS::D2S,15616,2302672896) finished, elapsed=0.469497s, bw=4.567724GB/s. [2313,2442][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:07.621606][UC][I] Task(3,NFS::D2S,15616,2302672896) finished, elapsed=0.227439s, bw=9.429049GB/s. [2313,2451][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:08.129343][UC][I] Task(4,NFS::D2S,15616,2302672896) finished, elapsed=0.424478s, bw=5.052166GB/s. [2313,2430][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:08.648494][UC][I] Task(5,NFS::D2S,15616,2302672896) finished, elapsed=0.434976s, bw=4.930230GB/s. [2313,2472][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:08.993405][UC][I] Task(6,NFS::D2S,15616,2302672896) finished, elapsed=0.260754s, bw=8.224342GB/s. [2313,2463][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:09.462830][UC][I] Task(7,NFS::D2S,15616,2302672896) finished, elapsed=0.385849s, bw=5.557950GB/s. [2313,2421][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:09.974866][UC][I] Task(8,NFS::D2S,15616,2302672896) finished, elapsed=0.427924s, bw=5.011472GB/s. [2313,2475][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:10.406019][UC][I] Task(9,NFS::D2S,15616,2302672896) finished, elapsed=0.347133s, bw=6.177845GB/s. [2313,2430][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:10.785193][UC][I] Task(10,NFS::D2S,15616,2302672896) finished, elapsed=0.295511s, bw=7.257037GB/s. [2313,2430][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:11.106866][UC][I] Task(11,NFS::D2S,15616,2302672896) finished, elapsed=0.237944s, bw=9.012749GB/s. [2313,2388][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:11.639354][UC][I] Task(12,NFS::D2S,15616,2302672896) finished, elapsed=0.445216s, bw=4.816833GB/s. [2313,2442][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:12.028620][UC][I] Task(13,NFS::D2S,15616,2302672896) finished, elapsed=0.304828s, bw=7.035222GB/s. [2313,2403][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:12.466876][UC][I] Task(14,NFS::D2S,15616,2302672896) finished, elapsed=0.354349s, bw=6.052034GB/s. [2313,2466][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:12.959652][UC][I] Task(15,NFS::D2S,15616,2302672896) finished, elapsed=0.408733s, bw=5.246780GB/s. [2313,2451][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:13.339809][UC][I] Task(16,NFS::D2S,15616,2302672896) finished, elapsed=0.295820s, bw=7.249457GB/s. [2313,2460][tsf_task_waiter.h:43,Done]
[root@localhost store]# python3 test/e2e/nfsstore_fetch.py 
[2025-09-26 10:43:28.608737][UC][I] NfsStore-(Debug). [2722,2722][nfsstore.cc:104,ShowConfig]
[2025-09-26 10:43:28.608805][UC][I] Set UC::StorageBackends to ["."]. [2722,2722][nfsstore.cc:105,ShowConfig]
[2025-09-26 10:43:28.608820][UC][I] Set UC::BlockSize to 8994816. [2722,2722][nfsstore.cc:106,ShowConfig]
[2025-09-26 10:43:28.608832][UC][I] Set UC::TransferEnable to true. [2722,2722][nfsstore.cc:107,ShowConfig]
[2025-09-26 10:43:28.608844][UC][I] Set UC::DeviceId to 1. [2722,2722][nfsstore.cc:108,ShowConfig]
[2025-09-26 10:43:28.608855][UC][I] Set UC::StreamNumber to 32. [2722,2722][nfsstore.cc:109,ShowConfig]
[2025-09-26 10:43:28.608865][UC][I] Set UC::IOSize to 147456. [2722,2722][nfsstore.cc:110,ShowConfig]
[2025-09-26 10:43:28.608876][UC][I] Set UC::BufferNumber to 512. [2722,2722][nfsstore.cc:111,ShowConfig]
[2025-09-26 10:43:28.608886][UC][I] Set UC::TimeoutMs to 30000. [2722,2722][nfsstore.cc:112,ShowConfig]
[2025-09-26 10:43:35.855693][UC][I] Task(1,NFS::S2D,15616,2302672896) finished, elapsed=0.283991s, bw=7.551408GB/s. [2722,2881][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:36.212878][UC][I] Task(2,NFS::S2D,15616,2302672896) finished, elapsed=0.284884s, bw=7.527729GB/s. [2722,2881][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:36.544803][UC][I] Task(3,NFS::S2D,15616,2302672896) finished, elapsed=0.259972s, bw=8.249081GB/s. [2722,2860][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:36.846531][UC][I] Task(4,NFS::S2D,15616,2302672896) finished, elapsed=0.224176s, bw=9.566276GB/s. [2722,2797][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:37.288623][UC][I] Task(5,NFS::S2D,15616,2302672896) finished, elapsed=0.372632s, bw=5.755094GB/s. [2722,2866][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:37.672640][UC][I] Task(6,NFS::S2D,15616,2302672896) finished, elapsed=0.316234s, bw=6.781463GB/s. [2722,2803][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:37.957879][UC][I] Task(7,NFS::S2D,15616,2302672896) finished, elapsed=0.216406s, bw=9.909739GB/s. [2722,2842][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:38.322231][UC][I] Task(8,NFS::S2D,15616,2302672896) finished, elapsed=0.295435s, bw=7.258901GB/s. [2722,2857][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:38.679367][UC][I] Task(9,NFS::S2D,15616,2302672896) finished, elapsed=0.288868s, bw=7.423904GB/s. [2722,2860][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:38.973281][UC][I] Task(10,NFS::S2D,15616,2302672896) finished, elapsed=0.225151s, bw=9.524865GB/s. [2722,2803][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:39.414625][UC][I] Task(11,NFS::S2D,15616,2302672896) finished, elapsed=0.364177s, bw=5.888714GB/s. [2722,2806][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:39.733225][UC][I] Task(12,NFS::S2D,15616,2302672896) finished, elapsed=0.249241s, bw=8.604257GB/s. [2722,2842][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:40.062745][UC][I] Task(13,NFS::S2D,15616,2302672896) finished, elapsed=0.258837s, bw=8.285252GB/s. [2722,2821][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:40.508624][UC][I] Task(14,NFS::S2D,15616,2302672896) finished, elapsed=0.372982s, bw=5.749684GB/s. [2722,2842][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:40.841239][UC][I] Task(15,NFS::S2D,15616,2302672896) finished, elapsed=0.257153s, bw=8.339499GB/s. [2722,2806][tsf_task_waiter.h:43,Done]
[2025-09-26 10:43:41.130442][UC][I] Task(16,NFS::S2D,15616,2302672896) finished, elapsed=0.216894s, bw=9.887468GB/s. [2722,2848][tsf_task_waiter.h:43,Done]
```

<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->