### PR TITLE
[bugfix][#280] MLA layer size calculated wrong

### DIFF
--- a/ucm/integration/vllm/uc_connector.py
+++ b/ucm/integration/vllm/uc_connector.py
@@ -187,9 +187,9 @@ class UnifiedCacheConnectorV1(KVConnectorBase_V1):
             kv_layer[1][0].numel() if not self.is_mla else 0
         ) * elem_size
         # When tp > 1 layer_size = (k_min_data_block_size + v_min_data_block_size) * tp_size
-        layer_size = (
-            k_min_data_block_size + v_min_data_block_size
-        ) * (self.total_tp_size if not self.is_mla else 1)
+        layer_size = (k_min_data_block_size + v_min_data_block_size) * (
+            self.total_tp_size if not self.is_mla else 1
+        )
         if is_v:
             # Offset of v = Offset of k + k_min_data_block_size
             return int(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose

Fix #280
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

# Modifications 

Correct the layer_size while is_mla is True, treat tp to 1 always for MLA.

# Test

How was this patch tested?

Tested locally, the file size is as expected.

```bash
(base) [root@TENCENT64 ~]# ll /data1/baoloongmao/test_nfsstore/data/3032383531363031
total 1944
-rwxr-xr-x 1 root root 1990656 Oct 11 15:57 3435353836373035.dat
```