### PR TITLE
[Feat] Adapt to vllm-ascend0.11.0

### DIFF
--- a/ucm/integration/vllm/uc_connector.py
+++ b/ucm/integration/vllm/uc_connector.py
@@ -179,6 +179,7 @@ class UnifiedCacheConnectorV1(KVConnectorBase_V1):
     def DataOffset(self, kv_layer, rank, layer_id, is_v):
         # Non-MLA scene: one layer shape is (2, num_blocks, block_size, num_kv_heads, head_size)
         # MLA scene: one layer shape is (num_blocks, block_size, head_size)
+        # However, when vllm_ascend version ≥ 0.10.0, MLA models' shape change to: (2, num_blocks, block_size, num_kv_heads, nope_dim/rope_dim)
         # Element size
         elem_size = kv_layer[0].element_size()
         logger.debug(
@@ -263,6 +264,8 @@ class UnifiedCacheConnectorV1(KVConnectorBase_V1):
 
         if len(self.kv_caches) == 0:
             self._init_kv_caches_from_forward_context(forward_context)
+            if len(list(self.kv_caches.values())[0]) == 2:
+                self.is_mla = False
 
         self.layerwise_load_tasks.clear()
         self.current_layer = 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose

Adapt to changes in the shape of MLA models in vllm-ascend0.11.0
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

# Modifications 

Modify the uc_connector to adapt to changes in the shape of MLA models. Add a check on the shape during the initialization of kv_cache to determine whether to take the MLA path.
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

# Test

Run offline_inference.py or online service
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->