### PR TITLE
[Feat] add batch interface for device ops and implement `ScatterGather` with CUDA

### DIFF
--- a/ucm/store/device/ascend/ascend_device.cc
+++ b/ucm/store/device/ascend/ascend_device.cc
@@ -120,6 +120,24 @@ public:
                           this->stream_);
     }
     Status Synchronized() override { return ASCEND_API(aclrtSynchronizeStream, this->stream_); }
+    Status H2DBatchSync(std::byte* dArr[], const std::byte* hArr[], const size_t number,
+                        const size_t count) override
+    {
+        for (size_t i = 0; i < number; i++) {
+            auto status = this->H2DSync(dArr[i], hArr[i], count);
+            if (status.Failure()) { return status; }
+        }
+        return Status::OK();
+    }
+    Status D2HBatchSync(std::byte* hArr[], const std::byte* dArr[], const size_t number,
+                        const size_t count) override
+    {
+        for (size_t i = 0; i < number; i++) {
+            auto status = this->D2HSync(hArr[i], dArr[i], count);
+            if (status.Failure()) { return status; }
+        }
+        return Status::OK();
+    }
 
 protected:
     std::shared_ptr<std::byte> MakeBuffer(const size_t size) override

--- a/ucm/store/device/cuda/CMakeLists.txt
+++ b/ucm/store/device/cuda/CMakeLists.txt
@@ -1,9 +1,10 @@
 set(CUDA_ROOT "/usr/local/cuda/" CACHE PATH "Path to CUDA root directory")
-add_library(Cuda::cudart UNKNOWN IMPORTED)
-set_target_properties(Cuda::cudart PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${CUDA_ROOT}/include"
-    IMPORTED_LOCATION "${CUDA_ROOT}/lib64/libcudart.so"
+set(CMAKE_CUDA_COMPILER ${CUDA_ROOT}/bin/nvcc)
+set(CMAKE_CUDA_ARCHITECTURES 75 80 86 89 90)
+enable_language(CUDA)
+add_library(storedevice STATIC cuda_device.cu)
+target_link_libraries(storedevice PUBLIC storeinfra)
+target_compile_options(storedevice PRIVATE
+    --diag-suppress=128 --diag-suppress=2417 --diag-suppress=2597
+    -Wall -fPIC
 )
-
-add_library(storedevice STATIC cuda_device.cc)
-target_link_libraries(storedevice PUBLIC storeinfra Cuda::cudart)

--- a/ucm/store/device/cuda/cuda_device.cu
+++ b/ucm/store/device/cuda/cuda_device.cu
@@ -25,6 +25,61 @@
 #include "ibuffered_device.h"
 #include "logger/logger.h"
 
+#define CUDA_TRANS_UNIT_SIZE (sizeof(uint64_t) * 2)
+#define CUDA_TRANS_BLOCK_NUMBER (32)
+#define CUDA_TRANS_BLOCK_SIZE (256)
+#define CUDA_TRANS_THREAD_NUMBER (CUDA_TRANS_BLOCK_NUMBER * CUDA_TRANS_BLOCK_SIZE)
+
+inline __device__ void H2DUnit(uint8_t* __restrict__ dst, const volatile uint8_t* __restrict__ src)
+{
+    uint64_t a, b;
+    asm volatile("ld.global.cs.v2.u64 {%0, %1}, [%2];" : "=l"(a), "=l"(b) : "l"(src));
+    asm volatile("st.global.cg.v2.u64 [%0], {%1, %2};" ::"l"(dst), "l"(a), "l"(b));
+}
+
+inline __device__ void D2HUnit(volatile uint8_t* __restrict__ dst, const uint8_t* __restrict__ src)
+{
+    uint64_t a, b;
+    asm volatile("ld.global.cs.v2.u64 {%0, %1}, [%2];" : "=l"(a), "=l"(b) : "l"(src));
+    asm volatile("st.volatile.global.v2.u64 [%0], {%1, %2};" ::"l"(dst), "l"(a), "l"(b));
+}
+
+__global__ void H2DKernel(uintptr_t* dst, const volatile uintptr_t* src, size_t num, size_t size)
+{
+    auto length = num * size;
+    auto offset = (blockIdx.x * blockDim.x + threadIdx.x) * CUDA_TRANS_UNIT_SIZE;
+    while (offset + CUDA_TRANS_UNIT_SIZE <= length) {
+        auto idx = offset / size;
+        auto off = offset % size;
+        H2DUnit(((uint8_t*)dst[idx]) + off, ((const uint8_t*)src[idx]) + off);
+        offset += CUDA_TRANS_THREAD_NUMBER * CUDA_TRANS_UNIT_SIZE;
+    }
+}
+
+__global__ void D2HKernel(volatile uintptr_t* dst, const uintptr_t* src, size_t num, size_t size)
+{
+    auto length = num * size;
+    auto offset = (blockIdx.x * blockDim.x + threadIdx.x) * CUDA_TRANS_UNIT_SIZE;
+    while (offset + CUDA_TRANS_UNIT_SIZE <= length) {
+        auto idx = offset / size;
+        auto off = offset % size;
+        D2HUnit(((uint8_t*)dst[idx]) + off, ((const uint8_t*)src[idx]) + off);
+        offset += CUDA_TRANS_THREAD_NUMBER * CUDA_TRANS_UNIT_SIZE;
+    }
+}
+
+inline __host__ void H2DBatch(uintptr_t* dst, const volatile uintptr_t* src, size_t num,
+                              size_t size, cudaStream_t stream)
+{
+    H2DKernel<<<CUDA_TRANS_BLOCK_NUMBER, CUDA_TRANS_BLOCK_SIZE, 0, stream>>>(dst, src, num, size);
+}
+
+inline __host__ void D2HBatch(volatile uintptr_t* dst, const uintptr_t* src, size_t num,
+                              size_t size, cudaStream_t stream)
+{
+    D2HKernel<<<CUDA_TRANS_BLOCK_NUMBER, CUDA_TRANS_BLOCK_SIZE, 0, stream>>>(dst, src, num, size);
+}
+
 template <>
 struct fmt::formatter<cudaError_t> : formatter<int32_t> {
     auto format(cudaError_t err, format_context& ctx) const -> format_context::iterator
@@ -39,7 +94,7 @@ template <typename Api, typename... Args>
 Status CudaApi(const char* caller, const char* file, const size_t line, const char* name, Api&& api,
                Args&&... args)
 {
-    auto ret = api(args...);
+    auto ret = std::invoke(api, args...);
     if (ret != cudaSuccess) {
         UC_ERROR("CUDA ERROR: api={}, code={}, err={}, caller={},{}:{}.", name, ret,
                  cudaGetErrorString(ret), caller, basename(file), line);
@@ -62,6 +117,22 @@ class CudaDevice : public IBufferedDevice {
         c->cb(ret == cudaSuccess);
         delete c;
     }
+    static void* MakeDeviceArray(const void* hostArray[], const size_t number)
+    {
+        auto size = sizeof(void*) * number;
+        void* deviceArray = nullptr;
+        auto ret = cudaMalloc(&deviceArray, size);
+        if (ret != cudaSuccess) {
+            UC_ERROR("Failed({},{}) to alloc({}) on device.", ret, cudaGetErrorString(ret), size);
+            return nullptr;
+        }
+        if (CUDA_API(cudaMemcpy, deviceArray, hostArray, size, cudaMemcpyHostToDevice).Success()) {
+            return deviceArray;
+        }
+        ReleaseDeviceArray(deviceArray);
+        return nullptr;
+    }
+    static void ReleaseDeviceArray(void* deviceArray) { CUDA_API(cudaFree, deviceArray); }
 
 public:
     CudaDevice(const int32_t deviceId, const size_t bufferSize, const size_t bufferNumber)
@@ -88,13 +159,11 @@ public:
     }
     Status H2DAsync(std::byte* dst, const std::byte* src, const size_t count) override
     {
-        return CUDA_API(cudaMemcpyAsync, dst, src, count, cudaMemcpyHostToDevice,
-                        (cudaStream_t)this->stream_);
+        return CUDA_API(cudaMemcpyAsync, dst, src, count, cudaMemcpyHostToDevice, this->stream_);
     }
     Status D2HAsync(std::byte* dst, const std::byte* src, const size_t count) override
     {
-        return CUDA_API(cudaMemcpyAsync, dst, src, count, cudaMemcpyDeviceToHost,
-                        (cudaStream_t)this->stream_);
+        return CUDA_API(cudaMemcpyAsync, dst, src, count, cudaMemcpyDeviceToHost, this->stream_);
     }
     Status AppendCallback(std::function<void(bool)> cb) override
     {
@@ -103,14 +172,42 @@ public:
             UC_ERROR("Failed to make closure for append cb.");
             return Status::OutOfMemory();
         }
-        auto status =
-            CUDA_API(cudaStreamAddCallback, (cudaStream_t)this->stream_, Trampoline, (void*)c, 0);
+        auto status = CUDA_API(cudaStreamAddCallback, this->stream_, Trampoline, (void*)c, 0);
         if (status.Failure()) { delete c; }
         return status;
     }
-    Status Synchronized() override
+    Status Synchronized() override { return CUDA_API(cudaStreamSynchronize, this->stream_); }
+    Status H2DBatchSync(std::byte* dArr[], const std::byte* hArr[], const size_t number,
+                        const size_t count) override
     {
-        return CUDA_API(cudaStreamSynchronize, (cudaStream_t)this->stream_);
+        auto src = MakeDeviceArray((const void**)hArr, number);
+        if (!src) { return Status::OutOfMemory(); }
+        auto dst = MakeDeviceArray((const void**)dArr, number);
+        if (!dst) {
+            ReleaseDeviceArray(src);
+            return Status::OutOfMemory();
+        }
+        H2DBatch((uintptr_t*)dst, (const volatile uintptr_t*)src, number, count, this->stream_);
+        auto status = this->Synchronized();
+        ReleaseDeviceArray(src);
+        ReleaseDeviceArray(dst);
+        return status;
+    }
+    Status D2HBatchSync(std::byte* hArr[], const std::byte* dArr[], const size_t number,
+                        const size_t count) override
+    {
+        auto src = MakeDeviceArray((const void**)dArr, number);
+        if (!src) { return Status::OutOfMemory(); }
+        auto dst = MakeDeviceArray((const void**)hArr, number);
+        if (!dst) {
+            ReleaseDeviceArray(src);
+            return Status::OutOfMemory();
+        }
+        D2HBatch((volatile uintptr_t*)dst, (const uintptr_t*)src, number, count, this->stream_);
+        auto status = this->Synchronized();
+        ReleaseDeviceArray(src);
+        ReleaseDeviceArray(dst);
+        return status;
     }
 
 protected:
@@ -126,7 +223,7 @@ protected:
     }
 
 private:
-    void* stream_;
+    cudaStream_t stream_;
 };
 
 std::unique_ptr<IDevice> DeviceFactory::Make(const int32_t deviceId, const size_t bufferSize,

--- a/ucm/store/device/idevice.h
+++ b/ucm/store/device/idevice.h
@@ -45,6 +45,10 @@ public:
     virtual Status D2HAsync(std::byte* dst, const std::byte* src, const size_t count) = 0;
     virtual Status AppendCallback(std::function<void(bool)> cb) = 0;
     virtual Status Synchronized() = 0;
+    virtual Status H2DBatchSync(std::byte* dArr[], const std::byte* hArr[], const size_t number,
+                                const size_t count) = 0;
+    virtual Status D2HBatchSync(std::byte* hArr[], const std::byte* dArr[], const size_t number,
+                                const size_t count) = 0;
 
 protected:
     virtual std::shared_ptr<std::byte> MakeBuffer(const size_t size) = 0;

--- a/ucm/store/device/simu/simu_device.cc
+++ b/ucm/store/device/simu/simu_device.cc
@@ -77,11 +77,29 @@ public:
         this->backend_.Push([=] { cb(true); });
         return Status::OK();
     }
-    virtual Status Synchronized()
+    Status Synchronized() override
     {
         Latch waiter{1};
         this->backend_.Push([&] { waiter.Done(nullptr); });
         waiter.Wait();
+        return Status::OK();
+    }
+    Status H2DBatchSync(std::byte* dArr[], const std::byte* hArr[], const size_t number,
+                        const size_t count) override
+    {
+        for (size_t i = 0; i < number; i++) {
+            auto status = this->H2DSync(dArr[i], hArr[i], count);
+            if (status.Failure()) { return status; }
+        }
+        return Status::OK();
+    }
+    Status D2HBatchSync(std::byte* hArr[], const std::byte* dArr[], const size_t number,
+                        const size_t count) override
+    {
+        for (size_t i = 0; i < number; i++) {
+            auto status = this->D2HSync(hArr[i], dArr[i], count);
+            if (status.Failure()) { return status; }
+        }
         return Status::OK();
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose

Add batch interface for device ops and implement `ScatterGather` with CUDA.

```c
virtual Status H2DBatchSync(std::byte* dArr[], const std::byte* hArr[], const size_t number, const size_t count) = 0;
virtual Status D2HBatchSync(std::byte* hArr[], const std::byte* dArr[], const size_t number, const size_t count) = 0;
```
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

# Modifications 

No _any_ user-facing change.
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

# Test

CI passed with new added/existing test.
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->