### PR TITLE
[Fix]Add import checking to trace_replay and fix the issue of unclose…

### DIFF
--- a/benchmarks/trace_replay.py
+++ b/benchmarks/trace_replay.py
@@ -540,13 +540,15 @@ async def replay_trace_by_time(
         flat_requests.extend(reqs)
 
     group_results = await asyncio.gather(*tasks)
+
+    if pbar is not None:
+        pbar.close()
+    await session.close()
+
     outputs = []
     for res in group_results:
         if isinstance(res, list):
             outputs.extend(res)
-
-    if pbar is not None:
-        pbar.close()
 
     benchmark_duration = time.perf_counter() - start_time
     metrics, actual_output_lens = calculate_metrics(
@@ -678,6 +680,14 @@ def main(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
+    # Check openpyxl for Excel export
+    try:
+        import openpyxl
+    except ImportError:
+        print("\nMissing package: openpyxl")
+        print("Please install openpyxl via pip install.\n")
+        sys.exit(1)
+
     parser = create_argument_trace()
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
…d network resources

<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose

Add import checking functionality to trace_replay and fix the issue of unclosed network resources
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

# Modifications 

Add import checking functionality to trace_replay and fix the issue of unclosed network resources
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

# Test

You can run trace_replay.py. 
If you haven't installed openpyxl, you will be prompted to install it at the start of the run, instead of being reminded to install it at the end as before.
Meanwhile, the "unclosed client session" warning will no longer appear.
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->