### PR TITLE
[fix] pack whl with so files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ import os
 import subprocess
 import sys
 import sysconfig
+from glob import glob
 
 import pybind11
 import torch
@@ -104,17 +105,37 @@ class CMakeBuild(build_ext):
         )
 
 
+def _get_package_data_with_so():
+    """Automatically discover all packages and include .so files."""
+    packages = find_packages()
+    package_data = {}
+
+    for package in packages:
+        # Convert package name to directory path
+        package_dir = os.path.join(ROOT_DIR, package.replace(".", os.sep))
+
+        # Check if this package directory contains .so files
+        so_files = glob(os.path.join(package_dir, "*.so"))
+        if so_files:
+            package_data[package] = ["*.so"]
+            print(f"[INFO] Including .so files for package: {package}")
+
+    print(f"[INFO] Package data: {package_data}")
+    return package_data
+
+
 ext_modules = []
 ext_modules.append(CMakeExtension(name="ucm", sourcedir=ROOT_DIR))
 
 setup(
     name="ucm",
-    version="0.0.2",
+    version="0.1.0",
     description="Unified Cache Management",
     author="Unified Cache Team",
     packages=find_packages(),
     python_requires=">=3.10",
     ext_modules=ext_modules,
     cmdclass={"build_ext": CMakeBuild},
+    package_data=_get_package_data_with_so(),
     zip_safe=False,
 )


### PR DESCRIPTION

# Purpose
Modifications for pack `.whl` with so files

# Modifications 
- update version to `0.1.0`
-  pack `.whl` with `.so` files

# Test
- `python3 setup.py bdist_wheel` to pack the whl file
- `pip install dist/ucm-0.1.0-cp312-cp312-linux_x86_64.whl` to install the package
- so files will be set in the site-package directory <img width="1051" height="159" alt="image" src="https://github.com/user-attachments/assets/ba233d13-b866-4aa4-b8fe-3a1f6fb2db7b" />
- test the offline inference <img width="1637" height="234" alt="image" src="https://github.com/user-attachments/assets/2eba43a8-3f1a-45a4-93c9-bb23f654ee43" />
