### PR TITLE
[Fix]Set the multiprocessing start method of the test tool to 'spawn'

### DIFF
--- a/ucm/store/test/e2e/nfsstore_embed_fetch_run.py
+++ b/ucm/store/test/e2e/nfsstore_embed_fetch_run.py
@@ -47,6 +47,12 @@ def get_user_input(prompt, default=None):
 
 
 def main():
+
+    try:
+        multiprocessing.set_start_method("spawn", force=True)
+    except RuntimeError:
+        pass
+
     storage_backends = "."
     device_id = 1
     repeat = 3


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose

Set the multiprocessing start method of the test tool to 'spawn' to resolve the issue of multiprocessing launch failures.
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

# Modifications 

Set the multiprocessing start method of the test tool to 'spawn'
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

# Test

Set the multiprocessing start method of the test tool to 'spawn'
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->