### PR TITLE
[Fix]Set the multiprocessing start method of the test tool to 'spawn'

### DIFF
--- a/ucm/store/test/e2e/nfsstore_embed_fetch.py
+++ b/ucm/store/test/e2e/nfsstore_embed_fetch.py
@@ -271,9 +271,10 @@ def run(
             if r == 0:
                 store_all_hashes(hashes[:batch_size])
 
-            w_bw_list.append(w_bw)
-            w_time_list.append(w_time)
-            w_size_sum += w_size
+            if r != 0:
+                w_bw_list.append(w_bw)
+                w_time_list.append(w_time)
+                w_size_sum += w_size
 
             if operation_mode == "write_only":
                 del kvcaches, hashes
@@ -313,9 +314,10 @@ def run(
                     mla,
                 )
 
-            r_bw_list.append(r_bw)
-            r_time_list.append(r_time)
-            r_size_sum += r_size
+            if r != 0:
+                r_bw_list.append(r_bw)
+                r_time_list.append(r_time)
+                r_size_sum += r_size
 
             if operation_mode == "read_only":
                 del kvcaches
@@ -339,3 +341,33 @@ def run(
     avg_r_size = r_size_sum / (1024**3) / len(r_time_list) if r_time_list else 0.0
 
     return avg_w_size, avg_w_time, avg_w_bw, avg_r_time, avg_r_bw, avg_r_size
+
+
+if __name__ == "__main__":
+    os.environ["UC_LOGGER_LEVEL"] = "debug"
+
+    try:
+        result = run(
+            storage_backends="/home/zht2/test_data/ucm_data",
+            device_id=1,
+            repeat=1,
+            num_head=1,
+            block_len=128,
+            transferStreamNumber=32,
+            num_tokens=4096,
+            block_layer=61,
+            head_size=576,
+            block_elem_size=2,
+            kv=1,
+            mla=True,
+            transferIoDirect=False,
+            operation_mode="both",
+        )
+
+        avg_w_size, avg_w_time, avg_w_bw, avg_r_time, avg_r_bw, avg_r_size = result
+
+    except Exception as e:
+        print(f"Error: {e}")
+        import traceback
+
+        traceback.print_exc()

--- a/ucm/store/test/e2e/nfsstore_embed_fetch_run.py
+++ b/ucm/store/test/e2e/nfsstore_embed_fetch_run.py
@@ -55,7 +55,7 @@ def main():
 
     storage_backends = "."
     device_id = 1
-    repeat = 3
+    repeat = 3  # This parameter must be greater than 1; the results from the first round of testing are not included in the bandwidth calculation.
     num_tokens_list = [2048, 4096, 8192, 16384, 32768]
     transferStreamNumbers = [32, 64, 128]
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose

Set the multiprocessing start method of the test tool to 'spawn'
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

# Modifications 

Set the multiprocessing start method of the test tool to 'spawn'
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

# Test

Set the multiprocessing start method of the test tool to 'spawn'
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->