### PR TITLE
[perf] Modify CUDA SIMD and add Triton hash encoder

### DIFF
--- a/ucm/sparse/esa/retrieval/cpy/retrieval_backend.cpp
+++ b/ucm/sparse/esa/retrieval/cpy/retrieval_backend.cpp
@@ -58,8 +58,6 @@ public:
                 if (rc != 0) {
                     std::cerr << "Error binding memory to NUMA node " << numaId << std::endl;
                 }
-            #else
-                std::cerr << "NUMA support is disabled." << std::endl;
             #endif
             }
 

--- a/ucm/sparse/kvcomp/kvcomp.py
+++ b/ucm/sparse/kvcomp/kvcomp.py
@@ -186,10 +186,10 @@ class KvComp(ESA):
 
         if hasattr(torch, "npu") and torch.npu.is_available():
             device = torch.device(f"npu:{self.rank}")
-        elif torch.cuda.is_available():
+        elif hasattr(torch, "cuda") and torch.cuda.is_available():
             device = torch.device(f"cuda:{self.rank}")
         else:
-            device = torch.device("npu")
+            device = torch.device("cpu")
 
         self.hash_encoder = HashEncoder(
             input_dim=self.kvcomp_config.head_dim,

--- a/ucm/sparse/kvstar/retrieve/core/domain/retrieve_task/retrieve_task_queue.cpp
+++ b/ucm/sparse/kvstar/retrieve/core/domain/retrieve_task/retrieve_task_queue.cpp
@@ -37,8 +37,6 @@ void RetrieveTaskQueue::Worker(const int numaId, const int bindCoreId, std::prom
         started.set_value(Status::OsApiError());
         return;
     }
-#else
-    KVSTAR_DEBUG("NUMA support is disabled.");
 #endif
 
     KVSTAR_DEBUG("Bind current thread {} to numa {} core {} and set memory affinity success.", thread, numaId, bindCoreId);


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose
What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
Optimize the kvcomp performance on CUDA by modifying CUDA SIMD and adding the Triton hash encoder.

# Modifications 

Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

# Test

How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
1.Compare the performance of the old and new hash retrieval backend.
<img width="895" height="619" alt="image" src="https://github.com/user-attachments/assets/a90398e5-55c1-488a-87e6-0fec2fa94bea" />
new hash retrieval backend spent 0.17117667198181152 s
old hash retrieval backend spent 0.4427645206451416 s

2.Benchmark testing of triton_hash_code and torch_hash_code
<img width="893" height="467" alt="image" src="https://github.com/user-attachments/assets/c4ee167a-367b-4f8e-89d1-f781ecb715f6" />

3.E2E test
old:
<img width="1551" height="1001" alt="image" src="https://github.com/user-attachments/assets/309bd733-2be3-4135-b5af-88424dff09fa" />
new:
<img width="1298" height="545" alt="image" src="https://github.com/user-attachments/assets/593784e1-da24-4426-b42c-0f82a44bd787" />
