### PR TITLE
[bugfix] batch trans on cuda with SM return 700 error

### DIFF
--- a/ucm/shared/test/case/trans/trans_test.cc
+++ b/ucm/shared/test/case/trans/trans_test.cc
@@ -92,3 +92,50 @@ TEST_F(UCTransUnitTest, CopyDataWithSM)
         ASSERT_EQ(*(size_t*)(((char*)hPtr2.get()) + size * i), i);
     }
 }
+
+TEST_F(UCTransUnitTest, CopyDataBatchWithSM)
+{
+    const auto ok = UC::Status::OK();
+    constexpr int32_t deviceId = 0;
+    constexpr size_t size = 36 * 1024;
+    constexpr size_t number = 64 * 61;
+    UC::Trans::Device device;
+    ASSERT_EQ(device.Setup(deviceId), ok);
+    auto stream = device.MakeSMStream();
+    if (!stream) { return; }
+    auto bDev = device.MakeBuffer();
+    auto bHost1 = device.MakeBuffer();
+    auto bHost2 = device.MakeBuffer();
+    ASSERT_EQ(bDev->MakeDeviceBuffers(size, number), ok);
+    ASSERT_EQ(bHost1->MakeHostBuffers(size, number), ok);
+    ASSERT_EQ(bHost2->MakeHostBuffers(size, number), ok);
+    std::vector<std::shared_ptr<void>> devPtrHolder, host1PtrHolder, host2PtrHolder;
+    void *dPtrArr[number], *h1PtrArr[number], *h2PtrArr[number];
+    for (size_t i = 0; i < number; i++) {
+        auto d = bDev->GetDeviceBuffer(size);
+        auto h1 = bHost1->GetHostBuffer(size);
+        auto h2 = bHost2->GetHostBuffer(size);
+        dPtrArr[i] = d.get();
+        h1PtrArr[i] = h1.get();
+        *(size_t*)h1PtrArr[i] = i;
+        h2PtrArr[i] = h2.get();
+        devPtrHolder.emplace_back(d);
+        host1PtrHolder.emplace_back(h1);
+        host2PtrHolder.emplace_back(h2);
+    }
+    constexpr const auto arrSize = sizeof(void*) * number;
+    auto dPtrArrOnDev = bDev->MakeDeviceBuffer(arrSize);
+    auto h1PtrArrOnDev = bHost1->MakeDeviceBuffer(arrSize);
+    auto h2PtrArrOnDev = bHost2->MakeDeviceBuffer(arrSize);
+    ASSERT_EQ(stream->HostToDeviceAsync((void*)dPtrArr, dPtrArrOnDev.get(), arrSize), ok);
+    ASSERT_EQ(stream->HostToDeviceAsync((void*)h1PtrArr, h1PtrArrOnDev.get(), arrSize), ok);
+    ASSERT_EQ(stream->HostToDeviceAsync((void*)h2PtrArr, h2PtrArrOnDev.get(), arrSize), ok);
+    auto src = (void**)h1PtrArrOnDev.get();
+    auto dst = (void**)dPtrArrOnDev.get();
+    ASSERT_EQ(stream->HostToDeviceAsync(src, dst, size, number), ok);
+    src = (void**)dPtrArrOnDev.get();
+    dst = (void**)h2PtrArrOnDev.get();
+    ASSERT_EQ(stream->DeviceToHostAsync(src, dst, size, number), ok);
+    ASSERT_EQ(stream->Synchronized().Underlying(), ok.Underlying());
+    for (size_t i = 0; i < number; i++) { ASSERT_EQ(*(size_t*)h2PtrArr[i], i); }
+}

--- a/ucm/shared/trans/cuda/cuda_sm_kernel.cu
+++ b/ucm/shared/trans/cuda/cuda_sm_kernel.cu
@@ -94,8 +94,8 @@ __global__ void CudaCopyKernel(const void* src, void** dst, size_t size, size_t 
 cudaError_t CudaSMCopyAsync(void* src[], void* dst[], size_t size, size_t number,
                             cudaStream_t stream)
 {
-    CudaCopyKernel<<<CUDA_TRANS_BLOCK_NUMBER, CUDA_TRANS_BLOCK_SIZE, 0, stream>>>(src, dst, size,
-                                                                                  number);
+    CudaCopyKernel<<<CUDA_TRANS_BLOCK_NUMBER, CUDA_TRANS_BLOCK_SIZE, 0, stream>>>(
+        (const void**)src, dst, size, number);
     return cudaGetLastError();
 }
 
@@ -108,8 +108,8 @@ cudaError_t CudaSMCopyAsync(void* src[], void* dst, size_t size, size_t number, 
 
 cudaError_t CudaSMCopyAsync(void* src, void* dst[], size_t size, size_t number, cudaStream_t stream)
 {
-    CudaCopyKernel<<<CUDA_TRANS_BLOCK_NUMBER, CUDA_TRANS_BLOCK_SIZE, 0, stream>>>(src, dst, size,
-                                                                                  number);
+    CudaCopyKernel<<<CUDA_TRANS_BLOCK_NUMBER, CUDA_TRANS_BLOCK_SIZE, 0, stream>>>(
+        (const void*)src, dst, size, number);
     return cudaGetLastError();
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose

[bugfix] batch trans on cuda with SM return 700 error.

<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

# Modifications 

No _any_ user-facing changed.
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

# Test

add unit test: `ucm/shared/test/case/trans/trans_test.cc`
add example: `ucm/shared/test/example/trans/trans_on_cuda_example.py`

Run example on H20:
```
python3 ucm/shared/test/example/trans/trans_on_cuda_example.py
INFO 11-28 18:49:09 [__init__.py:244] Automatically detected platform cuda.
[2025-11-28 18:49:14] - ucm.integration.vllm.patch.apply_patch - INFO [apply_patch.py:106] All vLLM patches applied successfully for version 0.9.2
ucmtrans: fdc31dfc13d6e76987d4c55e7c1f3acfc1e83dd4-Debug
========>> Running in trans_with_ce:
make: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]
make: (18432,) 2 [0. 0. 0. ... 0. 0. 0.]
cost: 0.025137220975011587s
bandwidth: 5.725257224856523GB/s
compare[1]: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]
compare[2]: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]

========>> Running in trans_with_sm:
make: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]
make: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]
cost: 0.006038442254066467s
bandwidth: 23.83347392335862GB/s
compare[1]: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]
compare[2]: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]

========>> Running in trans_with_ce_async:
make: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]
make: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]
cost: 0.024610714055597782s
bandwidth: 5.847739958900771GB/s
compare[1]: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]
compare[2]: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]

========>> Running in trans_with_sm_async:
make: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]
make: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]
cost: 0.005752581637352705s
bandwidth: 25.017820706014273GB/s
compare[1]: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]
compare[2]: (18432,) 2 [0. 1. 2. ... 0. 0. 0.]

========>> Running in trans_batch_with_ce:
make: (18432,) 2 [1023.    0.    0. ...    0.    0. 1023.]
make: (18432,) 2 [0. 0. 0. ... 0. 0. 0.]
cost: 0.025805798824876547s
bandwidth: 5.576926991357668GB/s

========>> Running in trans_batch_with_sm:
make: (18432,) 2 [1023.    0.    0. ...    0.    0. 1023.]
make: (18432,) 2 [4924.    0.    0. ...    0.    0. 4924.]
cost: 0.005966973956674337s
bandwidth: 24.11893483111688GB/s

========>> Running in trans_batch_with_ce_async:
make: (18432,) 2 [1023.    0.    0. ...    0.    0. 1023.]
make: (18432,) 2 [4924.    0.    0. ...    0.    0. 4924.]
cost: 0.025461182929575443s
bandwidth: 5.652410431913886GB/s

========>> Running in trans_batch_with_sm_async:
make: (18432,) 2 [1023.    0.    0. ...    0.    0. 1023.]
make: (18432,) 2 [4924.    0.    0. ...    0.    0. 4924.]
cost: 0.005798668134957552s
bandwidth: 24.81898474796118GB/s
```

<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->