### PR TITLE
[build]build sparse only if enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 option(BUILD_UCM_STORE "build ucm store module." ON)
-option(BUILD_UCM_SPARSE "build ucm sparse module." ON)
+option(BUILD_UCM_SPARSE "build ucm sparse module." OFF)
 option(BUILD_UNIT_TESTS "build all unit test suits." OFF)
 option(BUILD_NUMA "build numactl library." OFF)
 option(DOWNLOAD_DEPENDENCE "download dependence by cmake." ON)


### PR DESCRIPTION

# Purpose

build sparse only if set `export ENABLE_SPARSE=TRUE`

# Modifications 
- set the option `BUILD_UCM_SPARSE` to `OFF` by default
- modify `setup.py` to only pack sparse module if enable sparse

# Test
<img width="1811" height="1198" alt="image" src="https://github.com/user-attachments/assets/713e5a3e-ed3e-4b40-ba0b-97fe147c2996" />
