### PR TITLE
[feat] Shard block files into subdirs by hash prefix, with opt-out switch

### DIFF
--- a/ucm/store/pcstore/cc/api/pcstore.cc
+++ b/ucm/store/pcstore/cc/api/pcstore.cc
@@ -34,7 +34,8 @@ class PcStoreImpl : public PcStore {
 public:
     int32_t Setup(const Config& config)
     {
-        auto status = this->spaceMgr_.Setup(config.storageBackends, config.kvcacheBlockSize);
+        auto status = this->spaceMgr_.Setup(config.storageBackends, config.kvcacheBlockSize,
+                                            config.shardDataDir);
         if (status.Failure()) { return status.Underlying(); }
         if (config.transferEnable) {
             if (config.uniqueId.empty()) {
@@ -89,7 +90,6 @@ private:
         UC_INFO("Set UC::StorageBackends to {}.", config.storageBackends);
         UC_INFO("Set UC::BlockSize to {}.", config.kvcacheBlockSize);
         UC_INFO("Set UC::TransferEnable to {}.", config.transferEnable);
-        if (!config.transferEnable) { return; }
         UC_INFO("Set UC::UniqueId to {}.", config.uniqueId);
         UC_INFO("Set UC::IoSize to {}.", config.transferIoSize);
         UC_INFO("Set UC::IoDirect to {}.", config.transferIoDirect);
@@ -99,6 +99,7 @@ private:
         UC_INFO("Set UC::BufferNumber to {}.", config.transferBufferNumber);
         UC_INFO("Set UC::TimeoutMs to {}.", config.transferTimeoutMs);
         UC_INFO("Set UC::ScatterGatherEnable to {}.", config.transferScatterGatherEnable);
+        UC_INFO("Set UC::ShardDataDir to {}.", config.shardDataDir);
     }
 
 private:

--- a/ucm/store/pcstore/cc/api/pcstore.h
+++ b/ucm/store/pcstore/cc/api/pcstore.h
@@ -44,6 +44,7 @@ public:
         size_t transferBufferNumber{4096};
         size_t transferTimeoutMs{30000};
         bool transferScatterGatherEnable{false};
+        bool shardDataDir{true};
 
         Config(const std::vector<std::string>& storageBackends, const size_t kvcacheBlockSize,
                const bool transferEnable)

--- a/ucm/store/pcstore/cc/domain/space/space_layout.h
+++ b/ucm/store/pcstore/cc/domain/space/space_layout.h
@@ -32,7 +32,7 @@ namespace UC {
 
 class SpaceLayout {
 public:
-    Status Setup(const std::vector<std::string>& storageBackends);
+    Status Setup(const std::vector<std::string>& storageBackends, bool shardDataDir);
     std::string DataFilePath(const std::string& blockId, bool activated) const;
     Status Commit(const std::string& blockId, bool success) const;
 
@@ -42,14 +42,16 @@ private:
     Status AddFirstStorageBackend(const std::string& path);
     Status AddSecondaryStorageBackend(const std::string& path);
     std::string StorageBackend(const std::string& blockId) const;
+    std::string DataParentName(const std::string& blockFile, bool activated) const;
     std::string DataFileRoot() const;
     std::string TempFileRoot() const;
-    void ShardBlockId(const std::string& blockId, uint64_t& front, uint64_t& back) const;
+    std::string DataFileName(const std::string& blockId) const;
 
 private:
     std::vector<std::string> storageBackends_;
+    bool shardDataDir_;
 };
 
-} // namespace UC
+}  // namespace UC
 
 #endif

--- a/ucm/store/pcstore/cc/domain/space/space_manager.cc
+++ b/ucm/store/pcstore/cc/domain/space/space_manager.cc
@@ -28,9 +28,10 @@
 
 namespace UC {
 
-Status SpaceManager::Setup(const std::vector<std::string>& storageBackends, const size_t blockSize)
+Status SpaceManager::Setup(const std::vector<std::string>& storageBackends, const size_t blockSize,
+                           bool shardDataDir)
 {
-    auto status = this->layout_.Setup(storageBackends);
+    auto status = this->layout_.Setup(storageBackends, shardDataDir);
     if (status.Failure()) { return status; }
     this->blockSize_ = blockSize;
     return Status::OK();

--- a/ucm/store/pcstore/cc/domain/space/space_manager.h
+++ b/ucm/store/pcstore/cc/domain/space/space_manager.h
@@ -30,7 +30,8 @@ namespace UC {
 
 class SpaceManager {
 public:
-    Status Setup(const std::vector<std::string>& storageBackends, const size_t blockSize);
+    Status Setup(const std::vector<std::string>& storageBackends, const size_t blockSize,
+                 bool shardDataDir);
     Status NewBlock(const std::string& blockId);
     Status CommitBlock(const std::string& blockId, bool success);
     bool LookupBlock(const std::string& blockId) const;

--- a/ucm/store/pcstore/cpy/pcstore.py.cc
+++ b/ucm/store/pcstore/cpy/pcstore.py.cc
@@ -155,6 +155,7 @@ PYBIND11_MODULE(ucmpcstore, module)
     config.def_readwrite("transferTimeoutMs", &UC::PcStorePy::Config::transferTimeoutMs);
     config.def_readwrite("transferScatterGatherEnable",
                          &UC::PcStorePy::Config::transferScatterGatherEnable);
+    config.def_readwrite("shardDataDir", &UC::PcStorePy::Config::shardDataDir);
     store.def(py::init<>());
     store.def("CCStoreImpl", &UC::PcStorePy::CCStoreImpl);
     store.def("Setup", &UC::PcStorePy::SetupPy);

--- a/ucm/store/pcstore/pcstore_connector_v1.py
+++ b/ucm/store/pcstore/pcstore_connector_v1.py
@@ -55,6 +55,7 @@ class UcmPcStoreV1(UcmKVStoreBaseV1):
             "buffer_number": "transferBufferNumber",
             "timeout_ms": "transferTimeoutMs",
             "use_scatter_gather": "transferScatterGatherEnable",
+            "shard_data_dir": "shardDataDir",
         }
         for key, value in config.items():
             attr = key_mapping.get(key)


### PR DESCRIPTION

# Purpose

- Introduces optional directory sharding to keep single-directory inode pressure under control when the number of files grows into the hundreds of thousands or more.
- When new config key `shard_data_dir = true` (default) we split files into sub-directories using the first eight hex characters of the file’s hash.
- Set `shard_data_dir = false` to keep the legacy flat-directory layout and avoid any behaviour change on existing repositories.

# Config snippet
```yaml
  shard_data_dir: true   # set to false to disable sharding
```

# Test

CI passed with new added/existing test.
