### PR TITLE
[Bugfix] skip fresh shm files to avoid race between multiple instances

### DIFF
--- a/ucm/store/cache/cc/trans_buffer.cc
+++ b/ucm/store/cache/cc/trans_buffer.cc
@@ -204,11 +204,20 @@ private:
         std::string_view prefix = ShmPrefix();
         fs::path shmDir = "/dev/shm";
         if (!fs::exists(shmDir)) { return; }
+        const auto now = fs::file_time_type::clock::now();
+        const auto keepThreshold = std::chrono::minutes(10);
         for (const auto& entry : fs::directory_iterator(shmDir)) {
-            const auto& name = entry.path().filename().string();
-            if (entry.is_regular_file() && (name.compare(0, prefix.length(), prefix) == 0) &&
-                name != shmName_) {
-                fs::remove(entry.path());
+            const auto& path = entry.path();
+            const auto& name = path.filename().string();
+            if (!entry.is_regular_file() || name.compare(0, prefix.size(), prefix) != 0 ||
+                name == shmName_) {
+                continue;
+            }
+            try {
+                const auto lwt = fs::last_write_time(path);
+                if (now - lwt <= keepThreshold) { continue; }
+                fs::remove(path);
+            } catch (...) {
             }
         }
     }


### PR DESCRIPTION
When several service instances start almost simultaneously, the existing `CleanUpShmFileExceptMe` routine may delete a peer's shared-memory file that is still in use.  
This patch adds a 10-minute “freshness” check: any `/dev/shm` file whose last-write-time is newer than 10 min is left untouched, eliminating the race while still removing truly stale segments.  

Closes #563 