### PR TITLE
[Bugfix] Fix incorrect fallback in GetHostBuffer: use MakeHostBuffer instead of MakeDeviceBuffer

### DIFF
--- a/ucm/shared/trans/detail/reserved_buffer.h
+++ b/ucm/shared/trans/detail/reserved_buffer.h
@@ -90,7 +90,7 @@ public:
             auto buffer = GetBufferFrom(this->hostBuffers_);
             if (buffer) { return buffer; }
         }
-        return this->MakeDeviceBuffer(size);
+        return this->MakeHostBuffer(size);
     }
 };
 


### PR DESCRIPTION
When the host-side buffer pool is exhausted, `GetHostBuffer` wrongly falls back to `MakeDeviceBuffer`, breaking its promise of returning a host-accessible allocation.
Replace the call with `MakeHostBuffer` to keep the returned buffer host-visible.

Closes #567 