### PR TITLE
[bugfix]Fix KeyError when VLLM_HASH_ATTENTION environment variable is not set

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ class CMakeBuild(build_ext):
 
 setup(
     name="uc-manager",
-    version="0.2.0rc1",
+    version="0.2.0rc2",
     description="Unified Cache Management",
     author="Unified Cache Team",
     packages=find_packages(),

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -232,7 +232,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
             return [path for path in storage_backends.split(":") if path]
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
-        if os.environ["VLLM_HASH_ATTENTION"] == "1":
+        if os.getenv("VLLM_HASH_ATTENTION") == "1":
             for layer_name, value in kv_caches.items():
                 kv_cache, k_hash = value
                 self.kv_caches[layer_name] = kv_cache


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose
os.getenv("VLLM_HASH_ATTENTION") rather than os.environ["VLLM_HASH_ATTENTION"], otherwise it could cause crash
What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

# Modifications 

Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

# Test

How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->