### PR TITLE
[build]fix spdlog use ext fmt

### DIFF
--- a/ucm/shared/vendor/CMakeLists.txt
+++ b/ucm/shared/vendor/CMakeLists.txt
@@ -28,7 +28,7 @@ function(EnableDept)
     set(${NAME_UPPER}_BUILD_EXAMPLES OFF CACHE INTERNAL "" FORCE)
     FetchContent_MakeAvailable(${DEPT_NAME})
 endfunction()
-
+set(SPDLOG_FMT_EXTERNAL ON CACHE INTERNAL "" FORCE)
 if(DOWNLOAD_DEPENDENCE)
     include(FetchContent)
     EnableDept(


### PR DESCRIPTION
# Purpose
avoids linking both spdlog's bundled fmt and the standalone fmt, which causes multiple definition errors at link time.

# Modifications 
Special handling for spdlog, force it to use the external fmt library that we also build in this project. 

