### PR TITLE
[feat] KvCompOnDevice: per-KV-head Top-K for Qwen

### DIFF
--- a/ucm/sparse/kvcomp/ham_dist/paged_ham_dist_mla.cu
+++ b/ucm/sparse/kvcomp/ham_dist/paged_ham_dist_mla.cu
@@ -59,6 +59,21 @@
       {                                         \
         __VA_ARGS__                             \
       }                                         \
+    } else if ((val) == 2) {                   \
+      constexpr int NumKVHead = 2;              \
+      {                                        \
+        __VA_ARGS__                            \
+      }                                        \
+    } else if ((val) == 4) {                   \
+      constexpr int NumKVHead = 4;              \
+      {                                        \
+        __VA_ARGS__                            \
+      }                                        \
+    } else if ((val) == 8) {                     \
+      constexpr int NumKVHead = 8;              \
+      {                                        \
+        __VA_ARGS__                            \
+      }                                        \
     } else {                                    \
       LOG(FATAL) << "NumKVHead is not support"; \
     }                                           \
@@ -295,7 +310,7 @@ torch::Tensor HammingScoreContiCUDA(torch::Tensor& key_codes,
   bool is_block_mode = block_table_opt.has_value();
  
   int32_t bsz = query_code.size(0);
-  int32_t num_kv_head = is_block_mode ? key_codes.size(1) : key_codes.size(2);
+  int32_t num_kv_head = key_codes.size(2);
   int32_t num_chunk = key_codes.size(3);
  
   int32_t num_head = query_code.size(2);
@@ -309,7 +324,7 @@ torch::Tensor HammingScoreContiCUDA(torch::Tensor& key_codes,
  
   if(is_block_mode) {
     int32_t num_blocks = key_codes.size(0);
-    int32_t block_size = key_codes.size(2);
+    int32_t block_size = key_codes.size(1);
     const auto& block_table = block_table_opt.value(); // *block_table_opt;
     int32_t max_num_block_per_seq = block_table.size(1);
     TORCH_CHECK(bsz == block_table.size(0), "batch size mismatch between query_code and block_table");

--- a/ucm/sparse/state.py
+++ b/ucm/sparse/state.py
@@ -41,7 +41,7 @@ def ensure_ucm_sparse_initialized(
 
     # Check if UCM sparse is enabled
     ucm_config = Config(vllm_config.kv_transfer_config)
-    ucm_sparse_config = ucm_config.get_config().get("ucm_sparse_method")
+    ucm_sparse_config = ucm_config.get_config().get("ucm_sparse_config")
     if not ucm_sparse_config:
         return
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose

What this PR does / why we need it?
Enable per-KV-head Top-K selection to support Qwen models with multiple KV heads (GQA) in KvCompOnDevice.

<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

# Modifications 

Does this PR introduce _any_ user-facing change?
- unified-cache-management/ucm/sparse/kvcomp/ham_dist/paged_ham_dist_mla.cu
Ensure the Hamming distance kernel correctly outputs scores for each KV head.
- unified-cache-management/ucm/sparse/kvcomp/hamming_topk.py
Update the Top-K selection logic to handle multi-KV-head outputs from the Hamming distance operator
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

# Test

How was this patch tested?
python examples/offline_inference_kvcomphbm.py
<img width="1359" height="981" alt="image" src="https://github.com/user-attachments/assets/92f7a730-fb87-425c-a894-10ee01194e10" />

<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->