### PR TITLE
[wip][bugfix]when number of  task shards larger than buffer number it shouldn't use sharedqueue

### DIFF
--- a/ucm/store/pcstore/cc/domain/trans/trans_manager.cc
+++ b/ucm/store/pcstore/cc/domain/trans/trans_manager.cc
@@ -43,6 +43,7 @@ Status TransManager::Setup(const size_t rankSize, const int32_t deviceId, const 
     if (s.Failure()) { return s; }
     this->rankSize_ = rankSize;
     this->timeoutMs_ = timeoutMs;
+    this->bufferNumber_ = bufferNumber;
     return Status::OK();
 }
 
@@ -67,7 +68,8 @@ Status TransManager::Submit(TransTask task, size_t& taskId) noexcept
         return Status::OutOfMemory();
     }
     lg.unlock();
-    if (this->rankSize_ > 1 && iter->second.first->type == TransTask::Type::LOAD) {
+    if (this->rankSize_ > 1 && iter->second.first->type == TransTask::Type::LOAD &&
+        iter->second.first->AddressNumber() <= this->bufferNumber_) {
         this->shareQueue_.Dispatch(iter->second.first, iter->second.second);
         return Status::OK();
     }

--- a/ucm/store/pcstore/cc/domain/trans/trans_manager.h
+++ b/ucm/store/pcstore/cc/domain/trans/trans_manager.h
@@ -50,6 +50,7 @@ private:
     std::mutex mutex_;
     std::unordered_map<size_t, TaskPair> tasks_;
     TaskSet failureSet_;
+    size_t bufferNumber_;
 };
 
 }  // namespace UC

--- a/ucm/store/pcstore/cc/domain/trans/trans_task.h
+++ b/ucm/store/pcstore/cc/domain/trans/trans_task.h
@@ -65,6 +65,7 @@ public:
     }
     auto Str() const noexcept { return fmt::format("{},{},{}", id, brief_, number_); }
     size_t GroupNumber() const { return grouped_.size(); }
+    size_t AddressNumber() const { return number_; }
     void ForEachGroup(std::function<void(const std::string&, std::vector<uintptr_t>&)> fn)
     {
         for (auto& [block, shards] : grouped_) { fn(block, shards); }
@@ -84,6 +85,6 @@ private:
     std::unordered_map<std::string, std::vector<uintptr_t>> grouped_;
 };
 
-} // namespace UC
+}  // namespace UC
 
 #endif


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose

when then number of  task's total shards is larger than buffer number it shouldn't use sharedqueue, otherwise AcquireBlock and MakeReader will never succeed, then the whole progress will be stuck.

# Modifications 

# Test

set buffer number to 2, and load 5 blocks, it succeed finally.
<img width="1220" height="337" alt="image" src="https://github.com/user-attachments/assets/49137443-255b-4e7d-a305-e5c3c37a1327" />

<img width="2071" height="178" alt="image" src="https://github.com/user-attachments/assets/a801b3ab-2fbe-4ff7-8427-e1a1c4b1aa94" />


How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->