### PR TITLE
[bugfix] kvcomp for qwen

### DIFF
--- a/ucm/sparse/kvcomp/kvcomp_hbm.py
+++ b/ucm/sparse/kvcomp/kvcomp_hbm.py
@@ -250,8 +250,9 @@ class KvCompOnDevice(UcmSparseBase):
                 k_hash_compute = self.hash_encoder.compute_hash(key).view(
                     torch.bfloat16
                 )
+                valid_k_hash_token = attn_metadata.slot_mapping.flatten().numel()
                 reshape_and_cache_khash_triton(
-                    k_hash_compute,
+                    k_hash_compute[:valid_k_hash_token],
                     attn_metadata.slot_mapping.flatten(),
                     k_hash,
                     block_size=self.block_size,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose

What this PR does / why we need it?
Fix token count mismatch between k_hash_compute and slot_mapping on H100 GPUs by aligning hash outputs to the number of valid KV-cache slots before reshape-and-cache.

<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->

# Modifications 

Does this PR introduce _any_ user-facing change?
- unified-cache-management/ucm/sparse/kvcomp/kvcomp_hbm.py
<img width="668" height="194" alt="image" src="https://github.com/user-attachments/assets/bb21bcca-608c-40c2-a94c-d5078e7d11db" />

<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->

# Test

How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->