### PR TITLE
[fix]clean code and set local_rank_size to tp_size

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -213,6 +213,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
             config["block_size"] = chunk_block_size
             if self.is_dsa or self.is_mla:
                 config["share_buffer_enable"] = True
+                config["local_rank_size"] = self.tp_size
             else:
                 config["share_buffer_enable"] = False
             store = UcmConnectorFactoryV1.create_connector(name, config)

--- a/ucm/store/pcstore/cc/domain/file/ifile.h
+++ b/ucm/store/pcstore/cc/domain/file/ifile.h
@@ -52,7 +52,7 @@ public:
     using FileStat = struct stat64;
 
 public:
-    IFile(const std::string& path) : path_{path} {}
+    explicit IFile(const std::string& path) : path_{path} {}
     virtual ~IFile() = default;
     const std::string& Path() const { return this->path_; }
     virtual Status MkDir() = 0;

--- a/ucm/store/pcstore/cc/domain/file/posix_file.h
+++ b/ucm/store/pcstore/cc/domain/file/posix_file.h
@@ -30,7 +30,7 @@ namespace UC {
 
 class PosixFile : public IFile {
 public:
-    PosixFile(const std::string& path) : IFile{path}, handle_{-1} {}
+    explicit PosixFile(const std::string& path) : IFile{path}, handle_{-1} {}
     ~PosixFile() override;
     Status MkDir() override;
     Status RmDir() override;

--- a/ucm/store/pcstore/cc/domain/trans/share_buffer.cc
+++ b/ucm/store/pcstore/cc/domain/trans/share_buffer.cc
@@ -136,6 +136,7 @@ void CleanUpShmFileExceptMe(const std::string& me)
             if (now - lwt <= keepThreshold) { continue; }
             fs::remove(path);
         } catch (...) {
+            // Ignore filesystem errors;
         }
     }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose
clean code and set local_rank_size to tp_size

# Modifications 
set local_rank_size to tp_size
fix clean code

# Test
example works fine for both qwen and ds
<img width="1962" height="414" alt="image" src="https://github.com/user-attachments/assets/20bf85c3-d86b-4b5a-b22a-0d7ebe20a49c" />
<img width="1925" height="448" alt="image" src="https://github.com/user-attachments/assets/4a4c218f-21ed-4157-bf39-d672ebdcbd0d" />
The local rank size is set to the expected value even though it is not explicitly configured or shown in the configuration file.
<img width="1202" height="492" alt="image" src="https://github.com/user-attachments/assets/78d2613f-e190-4826-9490-655c0d4ef47a" />
