### PR TITLE
[fix]fix clean code

### DIFF
--- a/ucm/store/pcstore/cc/domain/trans/trans_task.h
+++ b/ucm/store/pcstore/cc/domain/trans/trans_task.h
@@ -39,8 +39,8 @@ namespace UC {
 class TransTask {
     static size_t NextId() noexcept
     {
-        static std::atomic<size_t> id{invalid + 1};
-        return id.fetch_add(1, std::memory_order_relaxed);
+        static std::atomic<size_t> idSeed{invalid + 1};
+        return idSeed.fetch_add(1, std::memory_order_relaxed);
     };
     static double NowTp() noexcept
     {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose

variable 'id' declared in function 'UC::TransTask::NextId' hides a field with full name 'UC::TransTask::id'

# Modifications 

use idSeed instead of id

# Test

examples works fine.
<img width="1926" height="463" alt="image" src="https://github.com/user-attachments/assets/e1017aa7-c68f-4687-ba7c-b2e9a05eca5a" />
<img width="1908" height="380" alt="image" src="https://github.com/user-attachments/assets/333ee1bc-340c-4bbb-b372-a15825eda9f1" />
