### PR TITLE
[opt] layer-wise on CacheStore

### DIFF
--- a/ucm/store/cache/cc/load_queue.h
+++ b/ucm/store/cache/cc/load_queue.h
@@ -59,6 +59,7 @@ private:
     SpscRingQueue<ShardTask> running_;
     std::thread dispatcher_;
     std::thread transfer_;
+    std::vector<ShardTask> holder_;
 
 public:
     ~LoadQueue();


### PR DESCRIPTION
# Purpose

In a layerwise scenario, CacheStore calls the asynchronous stream API to execute a Load task. Before the asynchronous task completes, the task-related resources cannot be reclaimed. Therefore, we need to extend the lifecycle of the task context to the stream synchronization point.

# Modifications 

Place the task context being asynchronously transmitted into a holder, and release the holder after the asynchronous task synchronization point.

# Test

CI passed with new added/existing test.
