### PR TITLE
[opt] Data shard bytes configurable, default to 4

### DIFF
--- a/ucm/store/posix/cc/global_config.h
+++ b/ucm/store/posix/cc/global_config.h
@@ -38,7 +38,7 @@ struct Config {
     bool ioDirect{false};
     size_t streamNumber{8};
     size_t timeoutMs{30000};
-    bool shardDataDir{true};
+    size_t dataDirShardBytes{4};
 };
 
 }  // namespace UC::PosixStore

--- a/ucm/store/posix/cc/posix_store.cc
+++ b/ucm/store/posix/cc/posix_store.cc
@@ -89,7 +89,7 @@ private:
         UC_INFO("Set {}::IoDirect to {}.", ns, config.ioDirect);
         UC_INFO("Set {}::StreamNumber to {}.", ns, config.streamNumber);
         UC_INFO("Set {}::TimeoutMs to {}.", ns, config.timeoutMs);
-        UC_INFO("Set {}::ShardDataDir to {}.", ns, config.shardDataDir);
+        UC_INFO("Set {}::DataDirShardBytes to {}.", ns, config.dataDirShardBytes);
     }
 };
 

--- a/ucm/store/posix/cc/space_layout.h
+++ b/ucm/store/posix/cc/space_layout.h
@@ -32,7 +32,8 @@ namespace UC::PosixStore {
 
 class SpaceLayout {
     std::vector<std::string> storageBackends_;
-    bool shardDataDir_;
+    bool dataDirShard_;
+    size_t dataDirShardBytes_;
 
 public:
     Status Setup(const Config& config);
@@ -45,6 +46,10 @@ private:
     Status AddFirstStorageBackend(const std::string& path);
     Status AddSecondaryStorageBackend(const std::string& path);
     std::string StorageBackend(const Detail::BlockId& blockId) const;
+    std::string FileShardName(const std::string& fileName) const
+    {
+        return fileName.substr(0, dataDirShardBytes_);
+    }
 };
 
 }  // namespace UC::PosixStore

--- a/ucm/store/posix/connector.py
+++ b/ucm/store/posix/connector.py
@@ -50,7 +50,7 @@ class UcmPosixStore(UcmKVStoreBaseV1):
             "io_direct": "ioDirect",
             "stream_number": "streamNumber",
             "timeout_ms": "timeoutMs",
-            "shard_data_dir": "shardDataDir",
+            "data_dir_shard_bytes": "dataDirShardBytes",
         }
         self.store = ucmposixstore.PosixStore()
         param = ucmposixstore.PosixStore.Config()

--- a/ucm/store/posix/cpy/posix_store.py.cc
+++ b/ucm/store/posix/cpy/posix_store.py.cc
@@ -44,7 +44,7 @@ PYBIND11_MODULE(ucmposixstore, module)
     config.def_readwrite("ioDirect", &Config::ioDirect);
     config.def_readwrite("streamNumber", &Config::streamNumber);
     config.def_readwrite("timeoutMs", &Config::timeoutMs);
-    config.def_readwrite("shardDataDir", &Config::shardDataDir);
+    config.def_readwrite("dataDirShardBytes", &Config::dataDirShardBytes);
     store.def(py::init<>());
     store.def("Self", &PosixStorePy::Self);
     store.def("Setup", &PosixStorePy::Setup);

--- a/ucm/store/test/case/posix/posix_space_manager_test.cc
+++ b/ucm/store/test/case/posix/posix_space_manager_test.cc
@@ -66,7 +66,7 @@ TEST_F(UCPosixSpaceManagerTest, DataFilePath)
     using namespace UC::PosixStore;
     SpaceManager spaceMgr;
     Config config;
-    config.shardDataDir = false;
+    config.dataDirShardBytes = 0;
     config.storageBackends.push_back(this->Path());
     auto s = spaceMgr.Setup(config);
     ASSERT_EQ(s, UC::Status::OK());
@@ -90,7 +90,7 @@ TEST_F(UCPosixSpaceManagerTest, ShardFilePath)
     using namespace UC::PosixStore;
     SpaceManager spaceMgr;
     Config config;
-    config.shardDataDir = true;
+    config.dataDirShardBytes = 2;
     config.storageBackends.push_back(this->Path());
     auto s = spaceMgr.Setup(config);
     ASSERT_EQ(s, UC::Status::OK());
@@ -106,7 +106,7 @@ TEST_F(UCPosixSpaceManagerTest, ShardFilePath)
     ASSERT_EQ(PosixFile{activated}.Access(PosixFile::AccessMode::EXIST), UC::Status::NotFound());
     auto archived = spaceMgr.GetLayout()->DataFilePath(blockId, false);
     const auto& file = fmt::format("{:02x}", fmt::join(blockId, ""));
-    const auto& shard = file.substr(0, 8);
+    const auto& shard = file.substr(0, config.dataDirShardBytes);
     ASSERT_EQ(archived, fmt::format("{}{}/{}", this->Path(), shard, file));
     ASSERT_EQ(PosixFile{archived}.Access(PosixFile::AccessMode::EXIST), UC::Status::OK());
 }


### PR DESCRIPTION
# Purpose

When data is shuffled, the first N characters of the Block's hash are used as subdirectories. The current implementation is fixed at 8, meaning there can be a maximum of 16^8 subdirectories, which is too large for storage.

# Modifications 

A configuration option `data_dir_shard_bytes` is provided, allowing users to configure the character length of subdirectories. The default value is `4`, meaning there can be a maximum of 16^4 = 65536 subdirectories.

# Test

CI passed with new added/existing test.