### PR TITLE
[Fix] coredump if add new c++ metrics

### DIFF
--- a/ucm/shared/metrics/cc/api/metrics_api.cc
+++ b/ucm/shared/metrics/cc/api/metrics_api.cc
@@ -24,7 +24,7 @@
 #include "metrics_api.h"
 namespace UC::Metrics {
 
-void SetUp(size_t maxVectorLen) { Metrics::SetUp(maxVectorLen); }
+void SetUp(size_t maxVectorLen) { Metrics::GetInstance().SetUp(maxVectorLen); }
 
 void CreateStats(const std::string& name, const std::string& type)
 {

--- a/ucm/shared/metrics/cc/domain/metrics.cc
+++ b/ucm/shared/metrics/cc/domain/metrics.cc
@@ -29,14 +29,14 @@ thread_local std::shared_ptr<MetricBuffer> Metrics::threadBuffer_ =
     std::make_shared<MetricBuffer>();
 thread_local bool Metrics::isRegisteredThread_ = false;
 
-std::atomic<bool> Metrics::isInited_{false};
-size_t Metrics::maxVectorLen_{10000};
-
 void Metrics::CreateStats(const std::string& name, const std::string& type)
 {
-    std::unique_lock<std::shared_mutex> lock(mutex_);
+    if (!isInited_.load(std::memory_order_acquire)) {
+        throw std::runtime_error("Please call SetUp() first!");
+    }
     std::string typeUpper = type;
     std::transform(typeUpper.begin(), typeUpper.end(), typeUpper.begin(), ::toupper);
+    std::unique_lock<std::shared_mutex> lock(mutex_);
     if (statsType_.count(name)) {
         return;
     } else {

--- a/ucm/shared/metrics/cc/domain/metrics.h
+++ b/ucm/shared/metrics/cc/domain/metrics.h
@@ -35,7 +35,6 @@
 #include <tuple>
 #include <unordered_map>
 #include <vector>
-
 namespace UC::Metrics {
 struct MetricBuffer {
     struct InnerBuffer {
@@ -74,13 +73,13 @@ class Metrics {
 public:
     static Metrics& GetInstance()
     {
-        if (!isInited_) { throw std::runtime_error("Please call SetUp() first!"); }
         static Metrics inst;
         return inst;
     }
 
-    static void SetUp(size_t maxVectorLen)
+    void SetUp(size_t maxVectorLen)
     {
+        std::unique_lock<std::shared_mutex> lock(mutex_);
         if (isInited_.load(std::memory_order_acquire)) { return; }
         bool expected = false;
         if (isInited_.compare_exchange_strong(expected, true, std::memory_order_release,
@@ -113,8 +112,8 @@ private:
     Metrics() = default;
     Metrics(const Metrics&) = delete;
     Metrics& operator=(const Metrics&) = delete;
-    static std::atomic<bool> isInited_;
-    static size_t maxVectorLen_;
+    std::atomic<bool> isInited_{false};
+    size_t maxVectorLen_{10000};
 };
 }  // namespace UC::Metrics
 

--- a/ucm/shared/test/case/metrics/metrics_test.cc
+++ b/ucm/shared/test/case/metrics/metrics_test.cc
@@ -35,7 +35,7 @@ protected:
     void SetUp() override
     {
         try {
-            Metrics::SetUp(1000000);
+            UC::Metrics::SetUp(1000000);
             CreateStats("stats1", "counter");
             CreateStats("stats2", "gauge");
             CreateStats("stats3", "histogram");


### PR DESCRIPTION
<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose

What this PR does / why we need it?
<!--
- Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue.
If possible, please consider writing useful notes for better and faster reviews in your PR.

- Please clarify why the changes are needed. For instance, the use case and bug description.

- Fixes #
-->
When adding new metric in c++, it would core dump and print "Please call SetUp() first!"
# Modifications 

Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as API, interface or other behavior changes.
Documentation-only updates are not considered user-facing changes.
-->
No using changes
# Test

How was this patch tested?
<!--
CI passed with new added/existing test.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Tested with adding new metrics and online services
![img_v3_02u6_5dd8aa32-f951-44dd-8de8-fc22d634f34g](https://github.com/user-attachments/assets/31d12621-a885-44c2-97e9-43decc130ad8)
![img_v3_02u6_e73f6c7e-7f3f-416a-8852-f6f0eacdd6dg](https://github.com/user-attachments/assets/bdc1fc96-0ad8-49ec-8f64-8def75fa7a88)

