### PR TITLE
[Fix] Failed to start vLLM service using multi-node launch scripts under CUDA data parallelism

### DIFF
--- a/examples/deployments/scripts/vllm/common.sh
+++ b/examples/deployments/scripts/vllm/common.sh
@@ -38,13 +38,13 @@ ensure_ifconfig_installed() {
 
     if command -v apt-get >/dev/null 2>&1; then
         echo "Detected apt-get (Debian/Ubuntu). Installing net-tools..."
-        sudo apt-get update && sudo apt-get install -y net-tools
+        apt-get update && apt-get install -y net-tools
     elif command -v yum >/dev/null 2>&1; then
         echo "Detected yum (RHEL/CentOS). Installing net-tools..."
-        sudo yum install -y net-tools
+        yum install -y net-tools
     elif command -v dnf >/dev/null 2>&1; then
         echo "Detected dnf (Fedora). Installing net-tools..."
-        sudo dnf install -y net-tools
+        dnf install -y net-tools
     else
         echo "ERROR: No supported package manager (apt/yum/dnf) found."
         echo "Please install 'net-tools' manually, 'ifconfig' is required to get network interface information."

--- a/examples/deployments/scripts/vllm/run_vllm.sh
+++ b/examples/deployments/scripts/vllm/run_vllm.sh
@@ -25,7 +25,7 @@ start_server() {
     echo "pp_size                  = $pp_size"
     echo "enable_expert_parallel   = $enable_expert_parallel"
     echo "max_model_len            = $max_model_len"
-    echo "max_num_batched_tokens   = $max_num_batch_tokens"
+    echo "max_num_batched_tokens   = $max_num_batched_tokens"
     echo "max_num_seqs             = $max_num_seqs"
     echo "block_size               = $block_size"
     echo "gpu_memory_utilization   = $gpu_memory_utilization"
@@ -69,6 +69,10 @@ start_server() {
     fi
     
     # --- Boolean flags ---
+    if [[ "$distributed_executor_backend" == "ray" ]] && [[ "$dp_size" -gt 1 ]]; then 
+        CMD+=("--data-parallel-backend" "ray")
+        CMD+=("--data-parallel-size-local" "$((dp_size / node_num))");
+    fi
     if [[ "$async_scheduling" == "true" ]]; then CMD+=("--async-scheduling"); fi
     if [[ "$enable_expert_parallel" == "true" ]]; then CMD+=("--enable-expert-parallel"); fi
     if [[ "$enable_prefix_caching" == "false" ]]; then CMD+=("--no-enable-prefix-caching"); fi

--- a/examples/deployments/scripts/vllm/start_ray.sh
+++ b/examples/deployments/scripts/vllm/start_ray.sh
@@ -30,7 +30,7 @@ set_node_env(){
     export NCCL_SOCKET_IFNAME="$IFACE"
     export GLOO_SOCKET_IFNAME="$IFACE"
     export TP_SOCKET_IFNAME="$IFACE"
-    export NUM_GPUS=$((tp_size / node_num))
+    export NUM_GPUS=$((tp_size * dp_size * pp_size / node_num))
 
     echo ""
     echo "===== ray startup configuration ======"


### PR DESCRIPTION
…nder CUDA data parallelism

<!--  Thanks for sending a pull request!

BEFORE SUBMITTING, PLEASE READ OUR OFFICIAL WEBSITE.

-->

# Purpose
What this PR does / why we need it?

When launching a multi-node data-parallel service using run_vllm.sh, the startup fails due to missing `--data-parallel-backend` and `--data-parallel-size-local` arguments. This commit fixes the issue by adding the missing parameters.

# Test
How was this patch tested?
Verified that the script can successfully launch the service in a dual-node DP=4, TP=4 configuration.
<img width="1025" height="666" alt="image" src="https://github.com/user-attachments/assets/ab78fa07-ed96-493c-be5a-8df8bc65facc" />

