### PR TITLE
[Bugfix] Modify worker_id set to separate different worker

### DIFF
--- a/examples/metrics/grafana.json
+++ b/examples/metrics/grafana.json
@@ -124,7 +124,7 @@
           "expr": "rate(ucm:interval_lookup_hit_rates_sum{model_name=\"$model_name\"}[$__rate_interval])\n/\nrate(ucm:interval_lookup_hit_rates_count{model_name=\"$model_name\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
-          "legendFormat": "Average",
+          "legendFormat": "worker-{{worker_id}}",
           "range": true,
           "refId": "A"
         }

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -147,10 +147,18 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
         self.metrics_config = self.launch_config.get("metrics_config_path", "")
         if self.metrics_config:
+            worker_id = (
+                get_world_group().rank
+                if role == KVConnectorRole.WORKER
+                else self.engine_id
+            )
             self.stats_logger = PrometheusStatsLogger(
                 vllm_config.model_config.served_model_name,
-                self.global_rank,
+                worker_id,
                 self.metrics_config,
+            )
+            logger.info(
+                f"metrics_config_path: {self.metrics_config}, set worker_id: {worker_id}"
             )
 
         self.synchronize = lambda: (


### PR DESCRIPTION
## Purpose
Use get_world_group().rank to mark worker's connector metrics, use engine_id to mark scheduler's connector metrics.
## Modifications 
When using DP, metrics could not figure out which worker the stats belong to.
## Test
<img width="1457" height="751" alt="image" src="https://github.com/user-attachments/assets/3c7c8889-d4bb-48cb-a0e0-f81d6b12e8bd" />

