### PR TITLE
[Bugfix] Cherry-pick modify worker_id to distinguish diff workers(#691)

### DIFF
--- a/examples/metrics/grafana.json
+++ b/examples/metrics/grafana.json
@@ -124,7 +124,7 @@
           "expr": "rate(ucm:interval_lookup_hit_rates_sum{model_name=\"$model_name\"}[$__rate_interval])\n/\nrate(ucm:interval_lookup_hit_rates_count{model_name=\"$model_name\"}[$__rate_interval])",
           "hide": false,
           "instant": false,
-          "legendFormat": "Average",
+          "legendFormat": "worker-{{worker_id}}",
           "range": true,
           "refId": "A"
         }

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -141,10 +141,18 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
         self.metrics_config = self.launch_config.get("metrics_config_path", "")
         if self.metrics_config:
+            worker_id = (
+                get_world_group().rank
+                if role == KVConnectorRole.WORKER
+                else self.engine_id
+            )
             self.stats_logger = PrometheusStatsLogger(
                 vllm_config.model_config.served_model_name,
-                self.tp_rank,
+                worker_id,
                 self.metrics_config,
+            )
+            logger.info(
+                f"metrics_config_path: {self.metrics_config}, set worker_id: {worker_id}"
             )
 
         self.synchronize = lambda: (


### PR DESCRIPTION
## Purpose
Cherry pick from release-0.3.0
Use get_world_group().rank to mark worker's connector metrics, use engine_id to mark scheduler's connector metrics.
## Modifications 
When using DP, metrics could not figure out which worker the stats belong to.
## Test
See #691