### PR TITLE
[Bugfix]Fix garbled output when tp > 1

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -508,39 +508,33 @@ class UCMDirectConnector(KVConnectorBase_V1):
                     ucm_block_ids[i] = self.request_hasher(ucm_block_id)
             total_tensors, rope_tensors = self._generate_task(vllm_block_ids)
             shard_indexs = [0] * len(ucm_block_ids)
-            if self.tp_rank == 0:
-                try:
-                    task = self.store.load_data(
-                        ucm_block_ids, shard_indexs, total_tensors
+            try:
+                task = self.store.load_data(ucm_block_ids, shard_indexs, total_tensors)
+                request_to_task[request_id] = [task]
+                if rope_tensors is not None and self.rope_store:
+                    rope_task = self.rope_store.load_data(
+                        ucm_block_ids, shard_indexs, rope_tensors
                     )
-                    request_to_task[request_id] = [task]
-                    if rope_tensors is not None and self.rope_store:
-                        rope_task = self.rope_store.load_data(
-                            ucm_block_ids, shard_indexs, rope_tensors
-                        )
-                        request_to_task[request_id].append(rope_task)
-                except RuntimeError as e:
-                    logger.error(f"request {request_id} load data error. {e}")
-                    self._invalid_block_ids.update(
-                        metadata.request_meta[request_id].load_block_ids[1]
-                    )
-            else:
-                request_to_task[request_id] = None
+                    request_to_task[request_id].append(rope_task)
+            except RuntimeError as e:
+                logger.error(f"request {request_id} load data error. {e}")
+                self._invalid_block_ids.update(
+                    metadata.request_meta[request_id].load_block_ids[1]
+                )
 
         for request_id, tasks in request_to_task.items():
             # TODO error handling
-            if self.tp_rank == 0:
-                try:
-                    self.store.wait(tasks[0])
-                    if len(tasks) > 1 and self.rope_store:
-                        self.rope_store.wait(tasks[1])
-                except RuntimeError as e:
-                    logger.error(f"request {request_id} load kv cache failed. {e}")
-                    self._invalid_block_ids.update(
-                        metadata.request_meta[request_id].load_block_ids[1]
-                    )
-                except IndexError as e:
-                    logger.error(f"request {request_id} load kv cache index error. {e}")
+            try:
+                self.store.wait(tasks[0])
+                if len(tasks) > 1 and self.rope_store:
+                    self.rope_store.wait(tasks[1])
+            except RuntimeError as e:
+                logger.error(f"request {request_id} load kv cache failed. {e}")
+                self._invalid_block_ids.update(
+                    metadata.request_meta[request_id].load_block_ids[1]
+                )
+            except IndexError as e:
+                logger.error(f"request {request_id} load kv cache index error. {e}")
 
         load_end_time = time.perf_counter() * 1000
         load_speed = (


### PR DESCRIPTION
## Purpose
Fix garbled output when tp > 1
## Modifications 
Previously, when the `load_only_first_rank` option was present, there was a condition that only rank 0 would load and `broadcast` to other ranks. However, now that the `load_only_first_rank` logic has been removed, this tp_rank == 0 judgement should also be removed accordingly.
Otherwise, when tp > 1, only rank 0 would load kvcache while other ranks would not, leading to garbage output .
This PR removes the unnecessary tp_rank == 0 check to ensure all tensor-parallel ranks correctly load their kvcaches.
## Test
Tested on qwe-2.5-14B with tp ==2.
First time
<img width="1840" height="815" alt="image" src="https://github.com/user-attachments/assets/48abd562-e1ce-44fa-af7d-8c14d7ef89a2" />
Second Time
<img width="1569" height="795" alt="image" src="https://github.com/user-attachments/assets/2ecc02d5-6c0f-4741-a652-d0e4036b99b5" />
