### PR TITLE
[Feat] sparse patch for vllm-ascend v0.11.0

### DIFF
--- a/ucm/integration/vllm/patch/0.11.0/vllm-adapt-sparse.patch
+++ b/ucm/integration/vllm/patch/0.11.0/vllm-adapt-sparse.patch
@@ -1,7 +1,7 @@
-From 689b24211e2f30c5e30af7f6b3f56ebc7273aabc Mon Sep 17 00:00:00 2001
+From f6ed6d979885a599cb8641c4b46d106ee80f7759 Mon Sep 17 00:00:00 2001
 From: AooooooA-C <chenaozhu@outlook.com>
 Date: Mon, 19 Jan 2026 23:03:08 -0800
-Subject: [PATCH] apply sparse method patches
+Subject: [PATCH 1/2] apply sparse method patches
 
 ---
  vllm/attention/layer.py                    | 63 +++++++++++++++
@@ -19,7 +19,7 @@ Subject: [PATCH] apply sparse method patches
  12 files changed, 318 insertions(+), 14 deletions(-)
 
 diff --git a/vllm/attention/layer.py b/vllm/attention/layer.py
-index 79879b680..23124edea 100644
+index 79879b680..c5324e47e 100644
 --- a/vllm/attention/layer.py
 +++ b/vllm/attention/layer.py
 @@ -3,6 +3,7 @@
@@ -241,7 +241,7 @@ index c536b0f60..38a28fd1f 100644
              return IntermediateTensors({
                  "hidden_states": hidden_states,
 diff --git a/vllm/v1/attention/backends/mla/common.py b/vllm/v1/attention/backends/mla/common.py
-index 963f1c5ab..c6c8af5d2 100755
+index 963f1c5ab..71f147ba1 100755
 --- a/vllm/v1/attention/backends/mla/common.py
 +++ b/vllm/v1/attention/backends/mla/common.py
 @@ -194,6 +194,7 @@ from typing import Generic, Optional, TypeVar, Union
@@ -861,6 +861,118 @@ index 8c75e8914..c3e9e781f 100644
  
      ensure_kv_transfer_initialized(vllm_config)
 +    ensure_ucm_sparse_initialized(vllm_config)
+-- 
+2.34.1
+
+
+From dd79760faf6eb162b5ab39486678675e079b4b60 Mon Sep 17 00:00:00 2001
+From: Qiong Wu <wq674452797@gmail.com>
+Date: Sat, 31 Jan 2026 16:06:09 +0800
+Subject: [PATCH 2/2] update sparse patch for vllm
+
+---
+ vllm/attention/layer.py                  | 51 ++----------------------
+ vllm/v1/attention/backends/mla/common.py |  5 ++-
+ vllm/v1/core/kv_cache_coordinator.py     |  2 +-
+ 3 files changed, 8 insertions(+), 50 deletions(-)
+
+diff --git a/vllm/attention/layer.py b/vllm/attention/layer.py
+index c5324e47e..17924dd15 100644
+--- a/vllm/attention/layer.py
++++ b/vllm/attention/layer.py
+@@ -31,7 +31,9 @@ from vllm.model_executor.models.vision import get_vit_attn_backend
+ from vllm.platforms import _Backend, current_platform
+ from vllm.utils import GiB_bytes, direct_register_custom_op
+ 
+-from ucm.sparse.state import get_ucm_sparse, has_ucm_sparse
++from ucm.sparse.state import (maybe_execute_sparse_attention_begin,
++                              maybe_execute_sparse_attention_finished)
++
+ 
+ logger = init_logger(__name__)
+ USE_XFORMERS_OPS = None
+@@ -660,49 +662,4 @@ direct_register_custom_op(
+     mutates_args=["output", "output_block_scale"],
+     fake_impl=unified_attention_with_output_fake,
+     tags=tag_cudagraph_unsafe,
+-)
+-
+-def maybe_execute_sparse_attention_begin(
+-        query: torch.Tensor,
+-        key: torch.Tensor,
+-        value: torch.Tensor,
+-        layer_name: str,
+-        forward_context: ForwardContext,
+-        output: Optional[torch.Tensor] = None,
+-        phase: Optional[str] = None,
+-        k_hash: Optional[torch.Tensor] = None,
+-        decode_ql_nope: Optional[torch.Tensor] = None,
+-        decode_q_pe: Optional[torch.Tensor] = None,
+-):
+-    if not has_ucm_sparse():
+-        return query, key, value, output
+-
+-    ucm_sparse = get_ucm_sparse()
+-
+-    attn_metadata = forward_context.attn_metadata
+-    if attn_metadata is None:
+-        return query, key, value, output
+-
+-    return ucm_sparse.attention_begin(
+-        query, key, value, layer_name, forward_context, output, phase, k_hash, decode_ql_nope, decode_q_pe
+-    )
+-
+-def maybe_execute_sparse_attention_finished(
+-        query: torch.Tensor,
+-        key: torch.Tensor,
+-        value: torch.Tensor,
+-        attn_output: torch.Tensor,
+-        layer_name: str,
+-        forward_context: ForwardContext,
+-        phase: Optional[str] = None,
+-):
+-    if not has_ucm_sparse():
+-        return
+-
+-    ucm_sparse = get_ucm_sparse()
+-
+-    attn_metadata = forward_context.attn_metadata
+-    if attn_metadata is None:
+-        return
+-
+-    ucm_sparse.attention_finished(query, key, value, attn_output, layer_name, forward_context, phase)
+\ No newline at end of file
++)
+\ No newline at end of file
+diff --git a/vllm/v1/attention/backends/mla/common.py b/vllm/v1/attention/backends/mla/common.py
+index 71f147ba1..4afd65376 100755
+--- a/vllm/v1/attention/backends/mla/common.py
++++ b/vllm/v1/attention/backends/mla/common.py
+@@ -222,8 +222,9 @@ from vllm.v1.attention.backends.utils import (AttentionMetadataBuilder,
+ from vllm.v1.kv_cache_interface import AttentionSpec
+ 
+ from vllm.forward_context import ForwardContext, get_forward_context
+-from vllm.attention.layer import (maybe_execute_sparse_attention_begin,
+-                                  maybe_execute_sparse_attention_finished)
++
++from ucm.sparse.state import (maybe_execute_sparse_attention_begin,
++                              maybe_execute_sparse_attention_finished)
+ 
+ try:
+     from vllm.vllm_flash_attn import flash_attn_varlen_func
+diff --git a/vllm/v1/core/kv_cache_coordinator.py b/vllm/v1/core/kv_cache_coordinator.py
+index 86771060c..f2bac0202 100644
+--- a/vllm/v1/core/kv_cache_coordinator.py
++++ b/vllm/v1/core/kv_cache_coordinator.py
+@@ -47,7 +47,7 @@ class KVCacheCoordinator(ABC):
+     def get_num_blocks_to_allocate(self, request_id: str, num_tokens: int,
+                                    new_computed_blocks: tuple[
+                                        list[KVCacheBlock], ...],
+-                                   num_encoder_tokens: int) -> int:
++                                   num_encoder_tokens: int = 0) -> int:
+         """
+         Get the number of blocks needed to be allocated for the request.
+ 
 -- 
 2.34.1
 

--- a/ucm/integration/vllm/patch/0.11.0/vllm-adapt.patch
+++ b/ucm/integration/vllm/patch/0.11.0/vllm-adapt.patch
@@ -1,7 +1,7 @@
-From c445c9b11bbfa3047335b78ebff99a40257cd09b Mon Sep 17 00:00:00 2001
+From 0c66695238a30aa2d360b816eb7741d03dfa69b6 Mon Sep 17 00:00:00 2001
 From: AooooooA-C <chenaozhu@outlook.com>
 Date: Mon, 19 Jan 2026 23:03:08 -0800
-Subject: [PATCH 1/2] apply sparse method patches
+Subject: [PATCH 1/3] apply sparse method patches
 
 ---
  vllm/attention/layer.py                    | 63 +++++++++++++++
@@ -865,10 +865,10 @@ index 8c75e8914..c3e9e781f 100644
 2.34.1
 
 
-From 90cc03951b8ee1a060349993b1563110f3d04103 Mon Sep 17 00:00:00 2001
+From 430345de16fa2cd33d2ab8bac6c4434c261dfde5 Mon Sep 17 00:00:00 2001
 From: wangxin <1848802892@qq.com>
 Date: Wed, 28 Jan 2026 01:59:05 -0800
-Subject: [PATCH 2/2] feature rerope for vllm0110
+Subject: [PATCH 2/3] feature rerope for vllm0110
 
 apply sparse method patches
 ---
@@ -1678,6 +1678,118 @@ index d7c6a8e0a..d7bb0eec8 100644
                  block_table_tensor=blk_table_tensor,
                  slot_mapping=slot_mapping,
                  logits_indices_padded=logits_indices_padded,
+-- 
+2.34.1
+
+
+From 4cabc296c3cb113a48fe85f3e009f1bac46063bf Mon Sep 17 00:00:00 2001
+From: Qiong Wu <wq674452797@gmail.com>
+Date: Sat, 31 Jan 2026 16:02:31 +0800
+Subject: [PATCH 3/3] update sparse patch for vllm
+
+---
+ vllm/attention/layer.py                  | 51 ++----------------------
+ vllm/v1/attention/backends/mla/common.py |  5 ++-
+ vllm/v1/core/kv_cache_coordinator.py     |  2 +-
+ 3 files changed, 8 insertions(+), 50 deletions(-)
+
+diff --git a/vllm/attention/layer.py b/vllm/attention/layer.py
+index 1ca3fe9c1..fdcc4f32e 100644
+--- a/vllm/attention/layer.py
++++ b/vllm/attention/layer.py
+@@ -31,7 +31,9 @@ from vllm.model_executor.models.vision import get_vit_attn_backend
+ from vllm.platforms import _Backend, current_platform
+ from vllm.utils import GiB_bytes, direct_register_custom_op
+ 
+-from ucm.sparse.state import get_ucm_sparse, has_ucm_sparse
++from ucm.sparse.state import (maybe_execute_sparse_attention_begin,
++                              maybe_execute_sparse_attention_finished)
++
+ 
+ logger = init_logger(__name__)
+ USE_XFORMERS_OPS = None
+@@ -715,49 +717,4 @@ direct_register_custom_op(
+     mutates_args=["output", "output_block_scale"],
+     fake_impl=unified_attention_with_output_fake,
+     tags=tag_cudagraph_unsafe,
+-)
+-
+-def maybe_execute_sparse_attention_begin(
+-        query: torch.Tensor,
+-        key: torch.Tensor,
+-        value: torch.Tensor,
+-        layer_name: str,
+-        forward_context: ForwardContext,
+-        output: Optional[torch.Tensor] = None,
+-        phase: Optional[str] = None,
+-        k_hash: Optional[torch.Tensor] = None,
+-        decode_ql_nope: Optional[torch.Tensor] = None,
+-        decode_q_pe: Optional[torch.Tensor] = None,
+-):
+-    if not has_ucm_sparse():
+-        return query, key, value, output
+-
+-    ucm_sparse = get_ucm_sparse()
+-
+-    attn_metadata = forward_context.attn_metadata
+-    if attn_metadata is None:
+-        return query, key, value, output
+-
+-    return ucm_sparse.attention_begin(
+-        query, key, value, layer_name, forward_context, output, phase, k_hash, decode_ql_nope, decode_q_pe
+-    )
+-
+-def maybe_execute_sparse_attention_finished(
+-        query: torch.Tensor,
+-        key: torch.Tensor,
+-        value: torch.Tensor,
+-        attn_output: torch.Tensor,
+-        layer_name: str,
+-        forward_context: ForwardContext,
+-        phase: Optional[str] = None,
+-):
+-    if not has_ucm_sparse():
+-        return
+-
+-    ucm_sparse = get_ucm_sparse()
+-
+-    attn_metadata = forward_context.attn_metadata
+-    if attn_metadata is None:
+-        return
+-
+-    ucm_sparse.attention_finished(query, key, value, attn_output, layer_name, forward_context, phase)
+\ No newline at end of file
++)
+\ No newline at end of file
+diff --git a/vllm/v1/attention/backends/mla/common.py b/vllm/v1/attention/backends/mla/common.py
+index 71f147ba1..4afd65376 100755
+--- a/vllm/v1/attention/backends/mla/common.py
++++ b/vllm/v1/attention/backends/mla/common.py
+@@ -222,8 +222,9 @@ from vllm.v1.attention.backends.utils import (AttentionMetadataBuilder,
+ from vllm.v1.kv_cache_interface import AttentionSpec
+ 
+ from vllm.forward_context import ForwardContext, get_forward_context
+-from vllm.attention.layer import (maybe_execute_sparse_attention_begin,
+-                                  maybe_execute_sparse_attention_finished)
++
++from ucm.sparse.state import (maybe_execute_sparse_attention_begin,
++                              maybe_execute_sparse_attention_finished)
+ 
+ try:
+     from vllm.vllm_flash_attn import flash_attn_varlen_func
+diff --git a/vllm/v1/core/kv_cache_coordinator.py b/vllm/v1/core/kv_cache_coordinator.py
+index 86771060c..f2bac0202 100644
+--- a/vllm/v1/core/kv_cache_coordinator.py
++++ b/vllm/v1/core/kv_cache_coordinator.py
+@@ -47,7 +47,7 @@ class KVCacheCoordinator(ABC):
+     def get_num_blocks_to_allocate(self, request_id: str, num_tokens: int,
+                                    new_computed_blocks: tuple[
+                                        list[KVCacheBlock], ...],
+-                                   num_encoder_tokens: int) -> int:
++                                   num_encoder_tokens: int = 0) -> int:
+         """
+         Get the number of blocks needed to be allocated for the request.
+ 
 -- 
 2.34.1
 

--- a/ucm/integration/vllm/patch/0.11.0/vllm-ascend-adapt.patch
+++ b/ucm/integration/vllm/patch/0.11.0/vllm-ascend-adapt.patch
@@ -1,7 +1,7 @@
-From 5920c53af69dda81c009a83937dff0b5a3a5cacd Mon Sep 17 00:00:00 2001
+From a5aed06c6159473c30b31a2f0915d29b516c52c7 Mon Sep 17 00:00:00 2001
 From: AooooooA-C <chenaozhu@outlook.com>
 Date: Tue, 20 Jan 2026 01:22:14 -0800
-Subject: [PATCH] apply sparse method patches
+Subject: [PATCH 1/2] apply sparse method patches
 
 ---
  vllm_ascend/attention/attention_v1.py | 49 +++++++++++++++++-
@@ -12,7 +12,7 @@ Subject: [PATCH] apply sparse method patches
  5 files changed, 142 insertions(+), 8 deletions(-)
 
 diff --git a/vllm_ascend/attention/attention_v1.py b/vllm_ascend/attention/attention_v1.py
-index 7c5e247e..030bafa2 100644
+index 26caa47f..6b5c98e3 100644
 --- a/vllm_ascend/attention/attention_v1.py
 +++ b/vllm_ascend/attention/attention_v1.py
 @@ -41,7 +41,7 @@ from vllm_ascend.utils import (ACL_FORMAT_FRACTAL_NZ, aligned_16, is_310p,
@@ -24,7 +24,7 @@ index 7c5e247e..030bafa2 100644
  
  class AscendAttentionBackend(AttentionBackend):
      accept_output_buffer: bool = True
-@@ -696,6 +696,12 @@ def unified_ascend_attention_with_output(
+@@ -688,6 +688,12 @@ def unified_ascend_attention_with_output(
          attn_metadata = attn_metadata[layer_name]
      self = forward_context.no_compile_layers[layer_name]
      kv_cache = self.kv_cache[forward_context.virtual_engine]
@@ -37,7 +37,7 @@ index 7c5e247e..030bafa2 100644
      self.impl.forward(self,
                        query,
                        key,
-@@ -704,6 +710,11 @@ def unified_ascend_attention_with_output(
+@@ -696,6 +702,11 @@ def unified_ascend_attention_with_output(
                        attn_metadata,
                        output,
                        trace_flag=False)
@@ -49,7 +49,7 @@ index 7c5e247e..030bafa2 100644
      maybe_save_kv_layer_to_connector(layer_name, kv_cache)
      return
  
-@@ -717,6 +728,42 @@ def unified_attention_with_output_fake(
+@@ -709,6 +720,42 @@ def unified_attention_with_output_fake(
  ) -> None:
      return
  
@@ -93,7 +93,7 @@ index 7c5e247e..030bafa2 100644
  direct_register_custom_op(
      op_name="unified_ascend_attention_with_output",
 diff --git a/vllm_ascend/attention/mla_v1.py b/vllm_ascend/attention/mla_v1.py
-index c38a8c98..36085b54 100644
+index 4044126d..d971ce38 100644
 --- a/vllm_ascend/attention/mla_v1.py
 +++ b/vllm_ascend/attention/mla_v1.py
 @@ -2,6 +2,7 @@ from dataclasses import dataclass
@@ -112,7 +112,7 @@ index c38a8c98..36085b54 100644
  
  from vllm_ascend import envs
  from vllm_ascend.ascend_config import get_ascend_config
-@@ -1253,6 +1255,11 @@ class AscendMLAImpl(MLAAttentionImpl):
+@@ -1250,6 +1252,11 @@ class AscendMLAImpl(MLAAttentionImpl):
                                     dtype=hidden_states.dtype,
                                     device=hidden_states.device)
  
@@ -124,7 +124,7 @@ index c38a8c98..36085b54 100644
          # MLA Preprocess
          forward_context = get_forward_context()
          if (self.enable_mlapo and
-@@ -1266,6 +1273,8 @@ class AscendMLAImpl(MLAAttentionImpl):
+@@ -1263,6 +1270,8 @@ class AscendMLAImpl(MLAAttentionImpl):
  
          if decode_preprocess_res is not None:
              # MLA Preprocess for decoding
@@ -133,7 +133,7 @@ index c38a8c98..36085b54 100644
              output_decode = self._forward_decode(decode_preprocess_res.ql_nope,
                                                   decode_preprocess_res.q_pe,
                                                   decode_preprocess_res.k_nope,
-@@ -1279,11 +1288,13 @@ class AscendMLAImpl(MLAAttentionImpl):
+@@ -1276,11 +1285,13 @@ class AscendMLAImpl(MLAAttentionImpl):
                      current_ms_metadata.after_comm_event.record()
              else:
                  o_proj_input[:num_decode_tokens] = output_decode
@@ -147,7 +147,7 @@ index c38a8c98..36085b54 100644
              output_prefill = self._forward_prefill(
                  prefill_preprocess_res.q_nope, prefill_preprocess_res.q_pe,
                  prefill_preprocess_res.k_nope, prefill_preprocess_res.k_pe,
-@@ -1296,6 +1307,7 @@ class AscendMLAImpl(MLAAttentionImpl):
+@@ -1293,6 +1304,7 @@ class AscendMLAImpl(MLAAttentionImpl):
              else:
                  o_proj_input[
                      num_decode_tokens:num_actual_tokens] = output_prefill
@@ -187,10 +187,10 @@ index 307eb831..e1ea6d03 100644
          for i, block_table in enumerate(self.block_tables):
              block_table.add_row(block_ids[i], row_idx)
 diff --git a/vllm_ascend/worker/model_runner_v1.py b/vllm_ascend/worker/model_runner_v1.py
-index 4c3afed7..c77b6a1d 100644
+index 9d135c91..5a3159f8 100644
 --- a/vllm_ascend/worker/model_runner_v1.py
 +++ b/vllm_ascend/worker/model_runner_v1.py
-@@ -135,6 +135,9 @@ from vllm_ascend.utils import (ACL_FORMAT_FRACTAL_ND, ACL_FORMAT_FRACTAL_NZ,
+@@ -134,6 +134,9 @@ from vllm_ascend.utils import (ACL_FORMAT_FRACTAL_ND, ACL_FORMAT_FRACTAL_NZ,
                                 is_enable_nz, is_moe_model, lmhead_tp_enable)
  from vllm_ascend.worker.npu_input_batch import CachedRequestState, InputBatch
  
@@ -200,7 +200,7 @@ index 4c3afed7..c77b6a1d 100644
  if TYPE_CHECKING:
      import xgrammar as xgr  # type: ignore[import-untyped]
      from vllm.v1.core.sched.output import SchedulerOutput
-@@ -602,7 +605,9 @@ class NPUModelRunner(LoRAModelRunnerMixin):
+@@ -593,7 +596,9 @@ class NPUModelRunner(LoRAModelRunnerMixin):
  
      def _update_states(self, scheduler_output: "SchedulerOutput") -> None:
          # Remove finished requests from the cached states.
@@ -210,7 +210,7 @@ index 4c3afed7..c77b6a1d 100644
              self.requests.pop(req_id, None)
  
          # Remove the finished requests from the persistent batch.
-@@ -676,11 +681,13 @@ class NPUModelRunner(LoRAModelRunnerMixin):
+@@ -667,11 +672,13 @@ class NPUModelRunner(LoRAModelRunnerMixin):
          # Update the states of the running/resumed requests.
          is_last_rank = get_pp_group().is_last_rank
          req_data = scheduler_output.scheduled_cached_reqs
@@ -224,7 +224,7 @@ index 4c3afed7..c77b6a1d 100644
  
              # Update the cached states.
              req_state.num_computed_tokens = num_computed_tokens
-@@ -702,17 +709,16 @@ class NPUModelRunner(LoRAModelRunnerMixin):
+@@ -693,17 +700,16 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                          new_token_ids[-num_new_tokens:])
  
              # Update the block IDs.
@@ -247,7 +247,7 @@ index 4c3afed7..c77b6a1d 100644
  
              req_index = self.input_batch.req_id_to_index.get(req_id)
              if req_index is None:
-@@ -725,6 +731,10 @@ class NPUModelRunner(LoRAModelRunnerMixin):
+@@ -716,6 +722,10 @@ class NPUModelRunner(LoRAModelRunnerMixin):
              # Update the persistent batch.
              self.input_batch.num_computed_tokens_cpu[req_index] = (
                  num_computed_tokens)
@@ -258,7 +258,7 @@ index 4c3afed7..c77b6a1d 100644
              if new_block_ids is not None:
                  self.input_batch.block_table.append_row(
                      new_block_ids, req_index)
-@@ -1337,10 +1347,19 @@ class NPUModelRunner(LoRAModelRunnerMixin):
+@@ -1311,10 +1321,19 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                             torch.from_numpy(token_indices),
                             out=self.input_ids_cpu[:total_num_scheduled_tokens])
  
@@ -279,7 +279,7 @@ index 4c3afed7..c77b6a1d 100644
          self.input_batch.block_table.commit_slot_mapping(
              total_num_scheduled_tokens)
  
-@@ -1371,6 +1390,13 @@ class NPUModelRunner(LoRAModelRunnerMixin):
+@@ -1345,6 +1364,13 @@ class NPUModelRunner(LoRAModelRunnerMixin):
          positions_cpu = self.positions_cpu[:num_input_tokens]
          positions = self.positions[:num_input_tokens]
          seq_lens_cpu = self.seq_lens_cpu[:num_reqs]
@@ -293,7 +293,7 @@ index 4c3afed7..c77b6a1d 100644
          attn_state = self._build_attn_state(num_reqs, num_scheduled_tokens,
                                              num_valid_tokens)
          self.attn_mask = self._make_attention_mask(seq_lens=seq_lens_cpu,
-@@ -1977,12 +2003,15 @@ class NPUModelRunner(LoRAModelRunnerMixin):
+@@ -1943,12 +1969,15 @@ class NPUModelRunner(LoRAModelRunnerMixin):
                      model_instance=self.model,
                      weight_prefetch_method=self.weight_prefetch_method):
                  self.maybe_setup_kv_connector(scheduler_output)
@@ -309,7 +309,7 @@ index 4c3afed7..c77b6a1d 100644
              finished_sending, finished_recving = self.get_finished_kv_transfer(
                  scheduler_output)
  
-@@ -2267,6 +2296,36 @@ class NPUModelRunner(LoRAModelRunnerMixin):
+@@ -2233,6 +2262,36 @@ class NPUModelRunner(LoRAModelRunnerMixin):
          if has_kv_transfer_group():
              get_kv_transfer_group().wait_for_save()
  
@@ -347,7 +347,7 @@ index 4c3afed7..c77b6a1d 100644
      def get_finished_kv_transfer(
          scheduler_output: "SchedulerOutput",
 diff --git a/vllm_ascend/worker/worker_v1.py b/vllm_ascend/worker/worker_v1.py
-index 0816f269..04a7979c 100644
+index b6b60081..dffa2e19 100644
 --- a/vllm_ascend/worker/worker_v1.py
 +++ b/vllm_ascend/worker/worker_v1.py
 @@ -53,6 +53,8 @@ from vllm_ascend.utils import (init_ascend_soc_version, is_enable_nz,
@@ -367,6 +367,177 @@ index 0816f269..04a7979c 100644
  
      def _init_profiler(self):
          # Torch profiler. Enabled and configured through env vars:
+-- 
+2.34.1
+
+
+From e7d7451a8ffbf010b8d3561ae6383754529b74c5 Mon Sep 17 00:00:00 2001
+From: Qiong Wu <wq674452797@gmail.com>
+Date: Mon, 2 Feb 2026 10:50:32 +0800
+Subject: [PATCH 2/2] update sparse patch for vllm-ascend
+
+---
+ vllm_ascend/attention/attention_v1.py | 42 +++------------------------
+ vllm_ascend/attention/mla_v1.py       | 39 +++++++++++++++++++++----
+ vllm_ascend/worker/model_runner_v1.py |  2 +-
+ 3 files changed, 39 insertions(+), 44 deletions(-)
+
+diff --git a/vllm_ascend/attention/attention_v1.py b/vllm_ascend/attention/attention_v1.py
+index 6b5c98e3..9b9af65c 100644
+--- a/vllm_ascend/attention/attention_v1.py
++++ b/vllm_ascend/attention/attention_v1.py
+@@ -41,7 +41,10 @@ from vllm_ascend.utils import (ACL_FORMAT_FRACTAL_NZ, aligned_16, is_310p,
+                                nd_to_nz_2d, nd_to_nz_spec)
+ 
+ from ..utils import weak_ref_tensors
+-from ucm.sparse.state import get_ucm_sparse, has_ucm_sparse
++
++from ucm.sparse.state import (maybe_execute_sparse_attention_begin,
++                              maybe_execute_sparse_attention_finished)
++
+ 
+ class AscendAttentionBackend(AttentionBackend):
+     accept_output_buffer: bool = True
+@@ -720,43 +723,6 @@ def unified_attention_with_output_fake(
+ ) -> None:
+     return
+ 
+-def maybe_execute_sparse_attention_begin(
+-        query: torch.Tensor,
+-        key: torch.Tensor,
+-        value: torch.Tensor,
+-        layer_name: str,
+-        forward_context: ForwardContext,
+-):
+-    if not has_ucm_sparse():
+-        return
+-
+-    ucm_sparse = get_ucm_sparse()
+-
+-    attn_metadata = forward_context.attn_metadata
+-    if attn_metadata is None:
+-        return
+-
+-    ucm_sparse.attention_begin(query, key, value, layer_name, forward_context)
+-
+-def maybe_execute_sparse_attention_finished(
+-        query: torch.Tensor,
+-        key: torch.Tensor,
+-        value: torch.Tensor,
+-        attn_output: torch.Tensor,
+-        layer_name: str,
+-        forward_context: ForwardContext,
+-):
+-    if not has_ucm_sparse():
+-        return
+-
+-    ucm_sparse = get_ucm_sparse()
+-
+-    attn_metadata = forward_context.attn_metadata
+-    if attn_metadata is None:
+-        return
+-
+-    ucm_sparse.attention_finished(query, key, value, attn_output, layer_name, forward_context)
+-
+ direct_register_custom_op(
+     op_name="unified_ascend_attention_with_output",
+     op_func=unified_ascend_attention_with_output,
+diff --git a/vllm_ascend/attention/mla_v1.py b/vllm_ascend/attention/mla_v1.py
+index d971ce38..6d5b56d3 100644
+--- a/vllm_ascend/attention/mla_v1.py
++++ b/vllm_ascend/attention/mla_v1.py
+@@ -17,7 +17,6 @@ from vllm.model_executor.layers.linear import (LinearBase,
+                                                UnquantizedLinearMethod)
+ from vllm.utils import cdiv, round_down
+ from vllm.v1.attention.backends.utils import AttentionCGSupport
+-from vllm.attention.layer import maybe_execute_sparse_attention_begin, maybe_execute_sparse_attention_finished
+ 
+ from vllm_ascend import envs
+ from vllm_ascend.ascend_config import get_ascend_config
+@@ -38,6 +37,9 @@ from vllm_ascend.utils import (ACL_FORMAT_FRACTAL_ND, ACL_FORMAT_FRACTAL_NZ,
+                                is_enable_nz, weak_ref_tensors)
+ from vllm_ascend.worker.npu_input_batch import InputBatch
+ 
++from ucm.sparse.state import (maybe_execute_sparse_attention_begin,
++                              maybe_execute_sparse_attention_finished)
++
+ if TYPE_CHECKING:
+     from vllm.v1.core.sched.output import SchedulerOutput
+ 
+@@ -1270,7 +1272,16 @@ class AscendMLAImpl(MLAAttentionImpl):
+ 
+         if decode_preprocess_res is not None:
+             # MLA Preprocess for decoding
+-            _, _, _, _ = maybe_execute_sparse_attention_begin(torch.cat([decode_preprocess_res.ql_nope, decode_preprocess_res.q_pe],dim=-1), decode_preprocess_res.ql_nope, decode_preprocess_res.q_pe, layer_name, forward_context, output=output, phase="decode", k_hash=k_hash, decode_ql_nope=decode_preprocess_res.ql_nope, decode_q_pe=decode_preprocess_res.q_pe)
++            query, key, value, sp_out = maybe_execute_sparse_attention_begin(torch.cat([decode_preprocess_res.ql_nope, decode_preprocess_res.q_pe], dim=-1),
++                                                                             decode_preprocess_res.k_nope,
++                                                                             decode_preprocess_res.k_pe,
++                                                                             layer_name,
++                                                                             forward_context,
++                                                                             output=output,
++                                                                             phase="decode",
++                                                                             k_hash=k_hash,
++                                                                             decode_ql_nope=decode_preprocess_res.ql_nope,
++                                                                             decode_q_pe=decode_preprocess_res.q_pe)
+ 
+             output_decode = self._forward_decode(decode_preprocess_res.ql_nope,
+                                                  decode_preprocess_res.q_pe,
+@@ -1285,13 +1296,25 @@ class AscendMLAImpl(MLAAttentionImpl):
+                     current_ms_metadata.after_comm_event.record()
+             else:
+                 o_proj_input[:num_decode_tokens] = output_decode
+-            maybe_execute_sparse_attention_finished(torch.cat([decode_preprocess_res.ql_nope, decode_preprocess_res.q_pe],dim=-1), decode_preprocess_res.ql_nope, decode_preprocess_res.q_pe, output[:num_decode_tokens], layer_name, forward_context, phase="decode")
++            maybe_execute_sparse_attention_finished(torch.cat([decode_preprocess_res.ql_nope, decode_preprocess_res.q_pe], dim=-1),
++                                                    decode_preprocess_res.k_nope,
++                                                    decode_preprocess_res.k_pe,
++                                                    output[:num_decode_tokens],
++                                                    layer_name,
++                                                    forward_context,
++                                                    phase="decode")
+ 
+         if prefill_preprocess_res is not None:
+             # FIX: aicore move should be also placed on the comm stream in dbo,
+             # otherwise it may affect the accuracy
+             # TODO: use an elegant way to overlap
+-            _, _, _, _ = maybe_execute_sparse_attention_begin(torch.cat([prefill_preprocess_res.q_nope, prefill_preprocess_res.q_pe],dim=-1), prefill_preprocess_res.k_nope, prefill_preprocess_res.k_pe, layer_name, forward_context, phase="prefill", k_hash=k_hash)
++            query, key, value, sp_out = maybe_execute_sparse_attention_begin(torch.cat([prefill_preprocess_res.q_nope, prefill_preprocess_res.q_pe], dim=-1),
++                                                                             prefill_preprocess_res.k_nope,
++                                                                             prefill_preprocess_res.k_pe,
++                                                                             layer_name,
++                                                                             forward_context,
++                                                                             phase="prefill",
++                                                                             k_hash=k_hash)
+             output_prefill = self._forward_prefill(
+                 prefill_preprocess_res.q_nope, prefill_preprocess_res.q_pe,
+                 prefill_preprocess_res.k_nope, prefill_preprocess_res.k_pe,
+@@ -1304,7 +1327,13 @@ class AscendMLAImpl(MLAAttentionImpl):
+             else:
+                 o_proj_input[
+                     num_decode_tokens:num_actual_tokens] = output_prefill
+-            maybe_execute_sparse_attention_finished(torch.cat([prefill_preprocess_res.q_nope, prefill_preprocess_res.q_pe],dim=-1), prefill_preprocess_res.k_nope, prefill_preprocess_res.k_pe, output[num_decode_tokens:], layer_name, forward_context, phase="prefill")
++            maybe_execute_sparse_attention_finished(torch.cat([prefill_preprocess_res.q_nope, prefill_preprocess_res.q_pe], dim=-1),
++                                                              prefill_preprocess_res.k_nope,
++                                                              prefill_preprocess_res.k_pe,
++                                                              output[num_decode_tokens:],
++                                                              layer_name,
++                                                              forward_context,
++                                                              phase="prefill")
+         # O proj
+         current_ms_metadata = get_multistream_comm_context()
+         MAX_O_PROJ_PREFETCH_SIZE = 16 * 1024 * 1024
+diff --git a/vllm_ascend/worker/model_runner_v1.py b/vllm_ascend/worker/model_runner_v1.py
+index 5a3159f8..abfd6aba 100644
+--- a/vllm_ascend/worker/model_runner_v1.py
++++ b/vllm_ascend/worker/model_runner_v1.py
+@@ -1374,7 +1374,7 @@ class NPUModelRunner(LoRAModelRunnerMixin):
+         attn_state = self._build_attn_state(num_reqs, num_scheduled_tokens,
+                                             num_valid_tokens)
+         self.attn_mask = self._make_attention_mask(seq_lens=seq_lens_cpu,
+-                                                   position=positions_cpu,
++                                                   position=torch.tensor(sparsed_positions),
+                                                    attn_state=attn_state)
+         self.attn_state = attn_state  # type: ignore
+ 
 -- 
 2.34.1
 

--- a/ucm/integration/vllm/patch/0.9.2/vllm-ascend-adapt.patch
+++ b/ucm/integration/vllm/patch/0.9.2/vllm-ascend-adapt.patch
@@ -1,7 +1,7 @@
-From 93d2b945ec463d1f0b71d177aa9d6a0933e45746 Mon Sep 17 00:00:00 2001
+From c2c110eae94cda5f8955ee3ca2c348f8db42b561 Mon Sep 17 00:00:00 2001
 From: wenxinwang <wangwenxin21@huawei.com>
 Date: Tue, 23 Dec 2025 19:21:33 -0800
-Subject: [PATCH 1/5] sparse patch for vllm-ascend
+Subject: [PATCH 1/6] sparse patch for vllm-ascend
 
 ---
  vllm_ascend/attention/attention_v1.py | 80 ++++++++++++++++++++++
@@ -11,7 +11,7 @@ Subject: [PATCH 1/5] sparse patch for vllm-ascend
  4 files changed, 201 insertions(+), 16 deletions(-)
 
 diff --git a/vllm_ascend/attention/attention_v1.py b/vllm_ascend/attention/attention_v1.py
-index 7d7f488f..ea982244 100644
+index 7d7f488..ea98224 100644
 --- a/vllm_ascend/attention/attention_v1.py
 +++ b/vllm_ascend/attention/attention_v1.py
 @@ -24,6 +24,9 @@ import torch_npu
@@ -129,7 +129,7 @@ index 7d7f488f..ea982244 100644
  def unified_attention_with_output_fake(
      query: torch.Tensor,
 diff --git a/vllm_ascend/attention/mla_v1.py b/vllm_ascend/attention/mla_v1.py
-index f50fe56e..ae8f50bf 100644
+index f50fe56..ae8f50b 100644
 --- a/vllm_ascend/attention/mla_v1.py
 +++ b/vllm_ascend/attention/mla_v1.py
 @@ -13,10 +13,12 @@ from vllm.distributed import get_tensor_model_parallel_world_size
@@ -185,7 +185,7 @@ index f50fe56e..ae8f50bf 100644
  
          return output_padded
 diff --git a/vllm_ascend/worker/model_runner_v1.py b/vllm_ascend/worker/model_runner_v1.py
-index eabcdbcc..782b9a3b 100644
+index eabcdbc..782b9a3 100644
 --- a/vllm_ascend/worker/model_runner_v1.py
 +++ b/vllm_ascend/worker/model_runner_v1.py
 @@ -39,7 +39,10 @@ from vllm.config import CompilationLevel, VllmConfig
@@ -386,7 +386,7 @@ index eabcdbcc..782b9a3b 100644
 +        ucm_sparse.request_finished_in_worker(request_id)
 \ No newline at end of file
 diff --git a/vllm_ascend/worker/worker_v1.py b/vllm_ascend/worker/worker_v1.py
-index df03d508..5d5d9b5a 100644
+index df03d50..5d5d9b5 100644
 --- a/vllm_ascend/worker/worker_v1.py
 +++ b/vllm_ascend/worker/worker_v1.py
 @@ -17,6 +17,7 @@
@@ -461,17 +461,17 @@ index df03d508..5d5d9b5a 100644
 2.34.1
 
 
-From 35eb0e1c84ef9786a0c77561e3298002167c88c3 Mon Sep 17 00:00:00 2001
+From d27dbb12f5a22e2cc7fecd1b2d3f5d47f72ae4cb Mon Sep 17 00:00:00 2001
 From: ldeng <ldeng.sjtu@gmail.com>
 Date: Mon, 29 Dec 2025 17:59:28 +0800
-Subject: [PATCH 2/5] update attention_v1 for kvcomp in NPU
+Subject: [PATCH 2/6] update attention_v1 for kvcomp in NPU
 
 ---
  vllm_ascend/attention/attention_v1.py | 59 +++++++++++++++++++--------
  1 file changed, 43 insertions(+), 16 deletions(-)
 
 diff --git a/vllm_ascend/attention/attention_v1.py b/vllm_ascend/attention/attention_v1.py
-index ea982244..b924d8ea 100644
+index ea98224..b924d8e 100644
 --- a/vllm_ascend/attention/attention_v1.py
 +++ b/vllm_ascend/attention/attention_v1.py
 @@ -37,7 +37,7 @@ from vllm_ascend.utils import (ACL_FORMAT_FRACTAL_NZ, aligned_16, is_310p,
@@ -622,10 +622,10 @@ index ea982244..b924d8ea 100644
 2.34.1
 
 
-From 5c81688c4b5af2a474ac14c24e7c10abd7f9e4d2 Mon Sep 17 00:00:00 2001
+From 4167098c7f1c89c3c18b84bdcbdc879832e687b4 Mon Sep 17 00:00:00 2001
 From: ldeng <ldeng.sjtu@gmail.com>
 Date: Mon, 29 Dec 2025 18:04:02 +0800
-Subject: [PATCH 3/5] call initialize_kv_hash_cache_tensors_npu to allocate
+Subject: [PATCH 3/6] call initialize_kv_hash_cache_tensors_npu to allocate
  hashk cache in NPUModelRunner when VLLM_HASH_ATTENTION is enabled for KVComp
 
 ---
@@ -633,7 +633,7 @@ Subject: [PATCH 3/5] call initialize_kv_hash_cache_tensors_npu to allocate
  1 file changed, 5 insertions(+)
 
 diff --git a/vllm_ascend/worker/model_runner_v1.py b/vllm_ascend/worker/model_runner_v1.py
-index 782b9a3b..766316e1 100644
+index 782b9a3..766316e 100644
 --- a/vllm_ascend/worker/model_runner_v1.py
 +++ b/vllm_ascend/worker/model_runner_v1.py
 @@ -1993,6 +1993,11 @@ class NPUModelRunner(LoRAModelRunnerMixin):
@@ -652,17 +652,17 @@ index 782b9a3b..766316e1 100644
 2.34.1
 
 
-From 9d61017d7f144e4d8125b6cacb9dce39d5da45fc Mon Sep 17 00:00:00 2001
+From 68101432526d0a27fac8d1092aaca750b383dacd Mon Sep 17 00:00:00 2001
 From: ldeng <ldeng.sjtu@gmail.com>
 Date: Mon, 29 Dec 2025 18:04:50 +0800
-Subject: [PATCH 4/5] uncomment connector
+Subject: [PATCH 4/6] uncomment connector
 
 ---
  vllm_ascend/attention/attention_v1.py | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/vllm_ascend/attention/attention_v1.py b/vllm_ascend/attention/attention_v1.py
-index b924d8ea..ece7d173 100644
+index b924d8e..ece7d17 100644
 --- a/vllm_ascend/attention/attention_v1.py
 +++ b/vllm_ascend/attention/attention_v1.py
 @@ -468,7 +468,7 @@ def unified_ascend_attention_with_output(
@@ -687,17 +687,17 @@ index b924d8ea..ece7d173 100644
 2.34.1
 
 
-From 34cb655d94fc08f7853d6fd0fe95b78df978096b Mon Sep 17 00:00:00 2001
+From b1338d11c7dc16a42b679ebae94c88f611c563e8 Mon Sep 17 00:00:00 2001
 From: Clarence-1103 <indirashi@163.com>
 Date: Tue, 6 Jan 2026 19:31:40 -0800
-Subject: [PATCH 5/5] [bugfix] register_kv_caches
+Subject: [PATCH 5/6] register_kv_caches
 
 ---
  vllm_ascend/worker/model_runner_v1.py | 3 +++
  1 file changed, 3 insertions(+)
 
 diff --git a/vllm_ascend/worker/model_runner_v1.py b/vllm_ascend/worker/model_runner_v1.py
-index 766316e1..04b0f4e2 100644
+index 766316e..04b0f4e 100644
 --- a/vllm_ascend/worker/model_runner_v1.py
 +++ b/vllm_ascend/worker/model_runner_v1.py
 @@ -2003,6 +2003,9 @@ class NPUModelRunner(LoRAModelRunnerMixin):
@@ -710,6 +710,50 @@ index 766316e1..04b0f4e2 100644
      def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
          """
          Generates the KVCacheSpec by parsing the kv cache format from each
+-- 
+2.34.1
+
+
+From a517ae85600c6ee13b3031b1474bed8348219121 Mon Sep 17 00:00:00 2001
+From: Qiong Wu <wq674452797@gmail.com>
+Date: Sat, 31 Jan 2026 15:52:07 +0800
+Subject: [PATCH 6/6] update sparse patch for vllm-ascend
+
+---
+ vllm_ascend/attention/mla_v1.py | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/vllm_ascend/attention/mla_v1.py b/vllm_ascend/attention/mla_v1.py
+index ae8f50b..0ee999b 100644
+--- a/vllm_ascend/attention/mla_v1.py
++++ b/vllm_ascend/attention/mla_v1.py
+@@ -1196,7 +1196,7 @@ class AscendMLAImpl(MLAAttentionImpl):
+             # otherwise it may affect the accuracy
+             # TODO: use an elegant way to overlap
+             wait_for_kv_layer_from_connector(layer.layer_name)
+-            prefill_q, _, _, _ =  maybe_execute_sparse_attention_begin(prefill_q, prefill_k_c_normed, k_pe, layer.layer_name, forward_context, output=output, phase="prefill")
++            prefill_q, _, _, _ =  maybe_execute_sparse_attention_begin(prefill_q, prefill_k_c_normed, prefill_k_pe, layer.layer_name, forward_context, output=output, phase="prefill")
+             output_prefill = self._forward_prefill(prefill_q,
+                                                    prefill_k_c_normed,
+                                                    prefill_k_pe, kv_cache,
+@@ -1212,7 +1212,7 @@ class AscendMLAImpl(MLAAttentionImpl):
+             maybe_save_kv_layer_to_connector(layer.layer_name, kv_cache)
+         if has_decode:
+             wait_for_kv_layer_from_connector(layer.layer_name)
+-            _, _, _, _ = maybe_execute_sparse_attention_begin(torch.cat([decode_ql_nope, decode_q_pe],dim=-1), decode_k_nope, k_pe, layer.layer_name, forward_context, output=output, phase="decode")
++            _, _, _, _ = maybe_execute_sparse_attention_begin(torch.cat([decode_ql_nope, decode_q_pe],dim=-1), decode_k_nope, decode_k_pe, layer.layer_name, forward_context, output=output, phase="decode")
+             if self.running_in_graph:
+                 return self._forward_decode(decode_ql_nope, decode_q_pe,
+                                             decode_k_nope, decode_k_pe,
+@@ -1231,7 +1231,7 @@ class AscendMLAImpl(MLAAttentionImpl):
+                     current_ms_metadata.after_comm_event.record()
+             else:
+                 output[:num_decode_tokens] = output_decode
+-            maybe_execute_sparse_attention_finished(torch.cat([decode_ql_nope, decode_q_pe],dim=-1), decode_ql_nope, decode_q_pe, output[:num_decode_tokens], layer.layer_name, forward_context, "decode")
++            maybe_execute_sparse_attention_finished(torch.cat([decode_ql_nope, decode_q_pe],dim=-1), decode_k_nope, decode_k_pe, output[:num_decode_tokens], layer.layer_name, forward_context, "decode")
+             maybe_save_kv_layer_to_connector(layer.layer_name, kv_cache)
+ 
+         return output_padded
 -- 
 2.34.1
 

--- a/ucm/sparse/esa/esa.py
+++ b/ucm/sparse/esa/esa.py
@@ -12,7 +12,6 @@ from numpy.typing import NDArray
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer import get_kv_transfer_group
 from vllm.forward_context import ForwardContext
-from vllm.sequence import SequenceStage
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
 from vllm.v1.request import Request, RequestStatus
 
@@ -26,7 +25,7 @@ from ucm.sparse.base import (
 from ucm.sparse.esa.retrieval import retrieval_backend
 from ucm.sparse.esa.retrieval.retrieval_worker import RetrievalWorker
 from ucm.sparse.kvstar.utils import get_bind_cpus_for_rank
-from ucm.store.ucmstore import Task, UcmKVStoreBase
+from ucm.store.ucmstore_v1 import Task, UcmKVStoreBaseV1
 from ucm.utils import Config
 
 ReqType = Union[str, int]
@@ -173,7 +172,8 @@ class ReqStatePerLayer:
         layer_name: str,
         rank: int,
         tp_size: int,
-        store_instance: UcmKVStoreBase,
+        store: UcmKVStoreBaseV1,
+        rope_store: UcmKVStoreBaseV1,
         vllm_config: VllmConfig,
         retrieval_worker: Optional[RetrievalWorker] = None,
         repre_pool: Optional[ReprePool] = None,
@@ -184,7 +184,8 @@ class ReqStatePerLayer:
         self.slots = []
         self.slots_to_relative_indexes = {}
         self.repre_pool: ReprePool | None = repre_pool
-        self.store_instance = store_instance
+        self.store = store
+        self.rope_store = rope_store
         self.retrieval_worker: Optional[RetrievalWorker] = retrieval_worker
         self.retrieval_task = None
         self.req_meta = None
@@ -195,6 +196,7 @@ class ReqStatePerLayer:
         self.rank = rank
         self.tp_size = tp_size
         self.tasks: Dict[str, Task] = {}
+        self.rope_tasks: Dict[str, Task] = {}
         self.esa_cfg = esa_cfg
         self.indexes: Optional[NDArray[np.int64]] = None
         self.block_hashes = None
@@ -217,7 +219,7 @@ class ReqStatePerLayer:
         self.req_meta = req_meta
 
     def launch_transfer_task(self, transfer_type, block_hashes, vllm_block_ids):
-        # fn = getattr(self.store_instance, transfer_type)
+        # fn = getattr(self.store, transfer_type)
         length = len(block_hashes)
         precision = self.vllm_config.model_config.dtype.itemsize
         block_data_size = self.k_cache[0].numel() * precision
@@ -226,9 +228,7 @@ class ReqStatePerLayer:
 
         vllm_block_ids_np = np.array(vllm_block_ids, np.uint64)
         k_block_ptrs = vllm_block_ids_np * block_data_size + self.k_base_ptrs
-        task_k = self.store_instance.load_data(
-            block_hashes, shard_indexs, k_block_ptrs[:, None]
-        )
+        task_k = self.store.load_data(block_hashes, shard_indexs, k_block_ptrs[:, None])
         task_k_hash = task_hash_func(block_hashes, transfer_type, "key")
         self.tasks[task_k_hash] = task_k
 
@@ -236,13 +236,30 @@ class ReqStatePerLayer:
             v_shard_indexs = [self.layer_id + self.num_layers] * length
             v_block_ptrs = vllm_block_ids_np * block_data_size + self.v_base_ptrs
 
-            task_v = self.store_instance.load_data(
+            task_v = self.store.load_data(
                 block_hashes, v_shard_indexs, v_block_ptrs[:, None]
             )
             task_v_hash = task_hash_func(block_hashes, transfer_type, "value")
             self.tasks[task_v_hash] = task_v
+        elif self.v_cache is not None:
+            # vllm-ascend MLA rope_cache
+            block_data_size = self.v_cache[0].numel() * precision
+            v_block_ptrs = vllm_block_ids_np * block_data_size + self.v_base_ptrs
+            task_rope = self.rope_store.load_data(
+                block_hashes, shard_indexs, v_block_ptrs[:, None]
+            )
+            task_rope_hash = task_hash_func(block_hashes, transfer_type, "value")
+            self.rope_tasks[task_rope_hash] = task_rope
 
     def extract_block_repre(self, vllm_block_ids):
+        if self.is_mla and self.v_cache is not None:
+            return torch.cat(
+                [
+                    self.k_cache[vllm_block_ids].mean(1),
+                    self.v_cache[vllm_block_ids].mean(1),
+                ],
+                dim=-1,
+            )
         return self.k_cache[vllm_block_ids].mean(1)
 
     def maybe_register_static_data(self, forward_context: ForwardContext):
@@ -250,10 +267,12 @@ class ReqStatePerLayer:
             return
         attn = forward_context.no_compile_layers[self.layer_name]
         kv_cache = attn.kv_cache[forward_context.virtual_engine]
-        # TODO not mla
-        if self.is_mla:
+        # Since vllm_ascend >= 0.10.0, the MLA model's tensor shape has changed to Tuple
+        # [(num_blocks, block_size, num_kv_heads, nope_dim/rope_dim)]
+        if self.is_mla and not isinstance(kv_cache, Tuple):
             self.k_cache = kv_cache
             self.k_base_ptrs = np.array(self.k_cache.data_ptr(), dtype=np.uint64)
+            self.v_base_ptrs = None
         else:
             self.k_cache = kv_cache[0]
             self.v_cache = kv_cache[1]
@@ -264,10 +283,14 @@ class ReqStatePerLayer:
 
     def wait_transfer_task_done(self):
         # assert len(self.tasks) > 0
-        for task_hash, task in self.tasks.items():
+        for _, task in self.tasks.items():
             # TODO: handle exceptions
-            ret = self.store_instance.wait(task)
-        self.tasks.clear()  # reset
+            _ = self.store.wait(task)
+        for _, rope_task in self.rope_tasks.items():
+            # TODO: handle exceptions
+            _ = self.rope_store.wait(rope_task)
+        self.tasks.clear()
+        self.rope_tasks.clear()
 
     def start_retrieval(self, batch_query, forward_context):
         query_start_loc = self.req_meta.query_start_loc
@@ -344,7 +367,7 @@ class ReqStatePerLayer:
         # NOTE: in Preemption, local_window_start != -self.esa_cfg['local_window_sz']
         local_window_start = self.esa_cfg["init_window_sz"] + self.sparse_range
 
-        if not self.is_mla:
+        if not self.is_mla or self.v_cache is not None:
             self.init_window = (
                 self.k_cache[vllm_block_ids[: self.esa_cfg["init_window_sz"]]].clone(),
                 self.v_cache[vllm_block_ids[: self.esa_cfg["init_window_sz"]]].clone(),
@@ -373,7 +396,7 @@ class ReqStatePerLayer:
             if self.step == 1:
                 vllm_block_ids = self.req_meta.vllm_block_ids
                 # NOTE: in Preemption, local_window_start != -self.esa_cfg['local_window_sz']
-                if not self.is_mla:
+                if not self.is_mla or self.v_cache is not None:
                     local_window_sz = self.local_window[0].shape[0]
                     self.k_cache[vllm_block_ids[: self.esa_cfg["init_window_sz"]]] = (
                         self.init_window[0]
@@ -506,6 +529,7 @@ class ESA(UcmSparseBase):
                 self.rank,
                 self.tp_size,
                 self.connector.store,
+                self.connector.rope_store,
                 self._vllm_config,
                 self.retrieval_workers[layer_id],
                 self.layer_pools[layer_id],

--- a/ucm/sparse/state.py
+++ b/ucm/sparse/state.py
@@ -6,17 +6,16 @@ similar to KV connector pattern. It allows the scheduler and worker to access
 the same UCM sparse agent across different processes.
 """
 
-from typing import TYPE_CHECKING, Optional
+from typing import Optional
 
 import torch
+from vllm.config import VllmConfig
+from vllm.forward_context import ForwardContext
 
 from ucm.logger import init_logger
 from ucm.sparse.base import UcmSparseBase, UcmSparseRole
 from ucm.sparse.factory import UcmSparseFactory
 from ucm.utils import Config
-
-if TYPE_CHECKING:
-    from vllm.config import VllmConfig
 
 logger = init_logger(__name__)
 
@@ -107,3 +106,61 @@ def maybe_execute_sparse_ffn_finished(
         return hidden_states, residual
     ucm_spare = get_ucm_sparse()
     return ucm_spare.ffn_finished(hidden_states, residual)
+
+
+def maybe_execute_sparse_attention_begin(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    layer_name: str,
+    forward_context: ForwardContext,
+    output: Optional[torch.Tensor] = None,
+    phase: Optional[str] = None,
+    k_hash: Optional[torch.Tensor] = None,
+    decode_ql_nope: Optional[torch.Tensor] = None,
+    decode_q_pe: Optional[torch.Tensor] = None,
+):
+    if not has_ucm_sparse():
+        return query, key, value, output
+
+    ucm_sparse = get_ucm_sparse()
+
+    attn_metadata = forward_context.attn_metadata
+    if attn_metadata is None:
+        return query, key, value, output
+
+    return ucm_sparse.attention_begin(
+        query,
+        key,
+        value,
+        layer_name,
+        forward_context,
+        output,
+        phase,
+        k_hash,
+        decode_ql_nope,
+        decode_q_pe,
+    )
+
+
+def maybe_execute_sparse_attention_finished(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_output: torch.Tensor,
+    layer_name: str,
+    forward_context: ForwardContext,
+    phase: Optional[str] = None,
+):
+    if not has_ucm_sparse():
+        return
+
+    ucm_sparse = get_ucm_sparse()
+
+    attn_metadata = forward_context.attn_metadata
+    if attn_metadata is None:
+        return
+
+    ucm_sparse.attention_finished(
+        query, key, value, attn_output, layer_name, forward_context, phase
+    )


### PR DESCRIPTION
## Purpose
Add ESA git patch for vllm-ascend v0.11.0 version.

## Modifications 
1. Add hooks for sparse inside the patches.
2. Fix some wrong parameter passing in v0.9.2 patches.
3. Modification inside `esa.py` to deal with tuple mla kv_cache tensor in vllm-ascend.

## Test
Tested and passed `offline_inference_esa.py` for deepseek-v2-lite-chat and Qwen3-32B