### PR TITLE
[Feat]Add layerwise and log_path config in run.sh

### DIFF
--- a/examples/deployments/scripts/vllm/config.properties
+++ b/examples/deployments/scripts/vllm/config.properties
@@ -58,10 +58,10 @@ enable_prefix_caching=false
 max_model_len=20000
 # max_num_batched_tokens=2048
 # max_num_seqs=20
-# block_size=128
+block_size=128
 gpu_memory_utilization=0.87
 # NONE | PIECEWISE | FULL | FULL_DECODE_ONLY | FULL_AND_PIECEWISE
-graph_mode=FULL_DECODE_ONLY
+graph_mode=FULL_AND_PIECEWISE
 quantization=NONE
 # mp | ray ; mp for single-node inference, ray for multi-node inference
 distributed_executor_backend=mp
@@ -85,7 +85,13 @@ enable_ascend_scheduler=false
 #          UCM  Configuration           *
 #****************************************
 # set true to enable UCM
-ucm_enable=false
+ucm_enable=true
+use_layerwise=false
 ucm_config_yaml_path=/vllm-workspace/unified-cache-management/examples/ucm_config_example.yaml
+
+#****************************************
+#          LOG  Configuration           *
+#****************************************
+vllm_log_path=.
 
 

--- a/examples/deployments/scripts/vllm/run_vllm.sh
+++ b/examples/deployments/scripts/vllm/run_vllm.sh
@@ -11,9 +11,9 @@ start_server() {
             echo "ERROR: ucm_config_yaml_path not set but ucm_enable=true" >&2
             exit 1
         }
-        LOG_FILE="vllm_ucm.log"
+        LOG_FILE="${vllm_log_path}/vllm_ucm.log"
     else
-        LOG_FILE="vllm.log"
+        LOG_FILE="${vllm_log_path}/vllm.log"
     fi
 
     echo ""
@@ -36,6 +36,7 @@ start_server() {
     echo "enable_prefix_caching    = $enable_prefix_caching"
     echo "async_scheduling         = $async_scheduling"
     echo "graph_mode               = $graph_mode"
+    echo "use_layerwise            = $use_layerwise"
     if [[ "$ucm_enable" == "true" ]]; then
         echo "ucm_config_file          = $ucm_config_yaml_path"
     fi
@@ -101,7 +102,10 @@ start_server() {
             \"kv_connector\":\"UCMConnector\",
             \"kv_connector_module_path\":\"ucm.integration.vllm.ucm_connector\",
             \"kv_role\":\"kv_both\",
-            \"kv_connector_extra_config\":{\"UCM_CONFIG_FILE\":\"$ucm_config_yaml_path\"}
+            \"kv_connector_extra_config\":{
+                \"use_layerwise\": $use_layerwise,  
+                \"UCM_CONFIG_FILE\":\"$ucm_config_yaml_path\"
+            }
         }"
         CMD+=("--kv-transfer-config" "$KV_CONFIG_JSON")
     fi

--- a/examples/deployments/scripts/vllm/run_vllm_dp.sh
+++ b/examples/deployments/scripts/vllm/run_vllm_dp.sh
@@ -41,9 +41,9 @@ start_server() {
             echo "ERROR: ucm_config_yaml_path not set but ucm_enable=true" >&2
             exit 1
         }
-        LOG_FILE="vllm_ucm.log"
+        LOG_FILE="${vllm_log_path}/vllm_ucm.log"
     else
-        LOG_FILE="vllm.log"
+        LOG_FILE="${vllm_log_path}/vllm.log"
     fi
 
     echo ""
@@ -72,6 +72,7 @@ start_server() {
     echo "enable_prefix_caching    = $enable_prefix_caching"
     echo "async_scheduling         = $async_scheduling"
     echo "graph_mode               = $graph_mode"
+    echo "use_layerwise            = $use_layerwise"
     if [[ "$ucm_enable" == "true" ]]; then
         echo "ucm_config_file          = $ucm_config_yaml_path"
     fi
@@ -138,7 +139,10 @@ start_server() {
             \"kv_connector\":\"UCMConnector\",
             \"kv_connector_module_path\":\"ucm.integration.vllm.ucm_connector\",
             \"kv_role\":\"kv_both\",
-            \"kv_connector_extra_config\":{\"UCM_CONFIG_FILE\":\"$ucm_config_yaml_path\"}
+            \"kv_connector_extra_config\":{
+                \"use_layerwise\":$use_layerwise,
+                \"UCM_CONFIG_FILE\":\"$ucm_config_yaml_path\"
+            }
         }"
         CMD+=("--kv-transfer-config" "$KV_CONFIG_JSON")
     fi


### PR DESCRIPTION
## Purpose
Add layerwise config in run_vllm.sh/run_vllm_dp.sh since Layerwise Connetor is ready.
## Modifications 
Add layerwise config and log_path config
Change block_size to 128
Chage defult graph mode to FULL_AND_PIECEWISE. 
## Test
vllm online service can be pulled successfully , and log print as expected
<img width="822" height="578" alt="image" src="https://github.com/user-attachments/assets/736c676b-1932-4157-bede-91d7ce8fb305" />
<img width="720" height="349" alt="image" src="https://github.com/user-attachments/assets/0774e916-d2ba-4455-8f78-2115c02646af" />
