### PR TITLE
[opt] Default depth of the waiting queue needs to be increased by nShard times for layer-wise

### DIFF
--- a/ucm/store/cache/cc/cache_store.cc
+++ b/ucm/store/cache/cc/cache_store.cc
@@ -74,8 +74,10 @@ private:
             return Status::InvalidParam("invalid size({},{},{})", config.tensorSize,
                                         config.shardSize, config.blockSize);
         }
-        if (config.bufferNumber < 1024) {
-            return Status::InvalidParam("too small buffer number({})", config.bufferNumber);
+        auto bufferNumber = config.bufferCapacity / config.shardSize;
+        if (bufferNumber < 1024) {
+            return Status::InvalidParam("too small buffer({}) on shard({})", config.bufferCapacity,
+                                        config.shardSize);
         }
         if (config.waitingQueueDepth <= 1 || config.runningQueueDepth <= 1) {
             return Status::InvalidParam("invalid queue depth({},{})", config.waitingQueueDepth,
@@ -98,7 +100,7 @@ private:
         UC_INFO("Set {}::TensorSize to {}.", ns, config.tensorSize);
         UC_INFO("Set {}::ShardSize to {}.", ns, config.shardSize);
         UC_INFO("Set {}::BlockSize to {}.", ns, config.blockSize);
-        UC_INFO("Set {}::BufferNumber to {}.", ns, config.bufferNumber);
+        UC_INFO("Set {}::BufferCapacity to {}GB.", ns, config.bufferCapacity >> 30);
         UC_INFO("Set {}::ShareBufferEnable to {}.", ns, config.shareBufferEnable);
         UC_INFO("Set {}::WaitingQueueDepth to {}.", ns, config.waitingQueueDepth);
         UC_INFO("Set {}::RunningQueueDepth to {}.", ns, config.runningQueueDepth);
@@ -118,8 +120,12 @@ Status CacheStore::Setup(const Detail::Dictionary& config)
     config.GetNumber("tensor_size", param.tensorSize);
     config.GetNumber("shard_size", param.shardSize);
     config.GetNumber("block_size", param.blockSize);
-    config.GetNumber("buffer_number", param.bufferNumber);
+    if (param.shardSize > 0) { param.waitingQueueDepth *= (param.blockSize / param.shardSize); }
     config.Get("share_buffer_enable", param.shareBufferEnable);
+    if (!param.shareBufferEnable) { param.bufferCapacity /= 8; }
+    size_t bufferCapacityGb = 0;
+    config.GetNumber("cache_buffer_capacity_gb", bufferCapacityGb);
+    if (bufferCapacityGb != 0) { param.bufferCapacity = bufferCapacityGb << 30; }
     config.GetNumber("waiting_queue_depth", param.waitingQueueDepth);
     config.GetNumber("running_queue_depth", param.runningQueueDepth);
     config.GetNumber("timeout_ms", param.timeoutMs);

--- a/ucm/store/cache/cc/global_config.h
+++ b/ucm/store/cache/cc/global_config.h
@@ -36,8 +36,8 @@ struct Config {
     size_t tensorSize{0};
     size_t shardSize{0};
     size_t blockSize{0};
-    size_t bufferNumber{16384};
-    bool shareBufferEnable{false};
+    size_t bufferCapacity{256ULL << 30};
+    bool shareBufferEnable{true};
     size_t waitingQueueDepth{8192};
     size_t runningQueueDepth{32768};
     size_t timeoutMs{30000};

--- a/ucm/store/cache/cc/posix_shm.h
+++ b/ucm/store/cache/cc/posix_shm.h
@@ -51,6 +51,7 @@ public:
     {
         if (handle_ != -1) { close(handle_); }
     }
+    const std::string& ShmName() { return name_; }
     Status ShmOpen(const uint32_t flags)
     {
         static constexpr auto NewFilePerm = (S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);

--- a/ucm/store/cache/cc/trans_buffer.cc
+++ b/ucm/store/cache/cc/trans_buffer.cc
@@ -92,8 +92,10 @@ class LocalBufferStrategy : public BufferStrategy {
     std::shared_ptr<void> data_;
 
 public:
-    Status Setup(const std::string& uuid, int32_t deviceId, size_t nodeSize, size_t nNode) override
+    Status Setup(const std::string& uuid, int32_t deviceId, size_t nodeSize,
+                 size_t totalSize) override
     {
+        auto nNode = totalSize / nodeSize;
         try {
             meta_ = std::make_unique<BufferMetaNode[]>(nNode);
         } catch (const std::exception& e) {
@@ -173,6 +175,7 @@ protected:
     struct BufferHeader {
         std::atomic<size_t> magic;
         ShareLock lock;
+        size_t nNode;
         size_t freeHead;
         size_t buckets[nHashTableBucket];
         ShareMutex bucketLocks[nHashTableBucket];
@@ -184,10 +187,10 @@ protected:
     std::byte* data_{nullptr};
     std::byte* dataOnDevice_{nullptr};
     std::string shmName_;
-    size_t nodeSize_;
-    size_t nNode_;
+    size_t nodeSize_{0};
+    size_t nNode_{0};
     void* addrress_{nullptr};
-    size_t totalSize_;
+    size_t totalSize_{0};
 
     size_t MetaOffset() const noexcept { return sizeof(BufferHeader) + sizeof(ShareLock) * nNode_; }
     size_t DataOffset() const noexcept
@@ -197,12 +200,12 @@ protected:
         return (size + pageSize - 1) & ~(pageSize - 1);
     }
     size_t DataSize() const noexcept { return nodeSize_ * nNode_; }
-    const std::string& ShmPrefix() const noexcept
+    static const std::string& ShmPrefix() noexcept
     {
         static std::string prefix{"uc_shm_cache_"};
         return prefix;
     }
-    void CleanUpShmFileExceptMe()
+    static void CleanUpShmFileExceptMe(const std::string& me)
     {
         namespace fs = std::filesystem;
         std::string_view prefix = ShmPrefix();
@@ -214,7 +217,7 @@ protected:
             const auto& path = entry.path();
             const auto& name = path.filename().string();
             if (!entry.is_regular_file() || name.compare(0, prefix.size(), prefix) != 0 ||
-                name == shmName_) {
+                name == me) {
                 continue;
             }
             try {
@@ -225,30 +228,45 @@ protected:
             }
         }
     }
-    Status MmapShmFile(PosixShm& shmFile, bool needTrunc = true)
+    static Status MmapShmFile(PosixShm& shmFile, const size_t size, void*& addr,
+                              bool needTrunc = true)
     {
         auto s = Status::OK();
         if (needTrunc) {
-            s = shmFile.Truncate(totalSize_);
+            s = shmFile.Truncate(size);
             if (s.Failure()) [[unlikely]] {
-                UC_ERROR("Failed({}) to truncate file({}) with size({}).", s, shmName_, totalSize_);
+                UC_ERROR("Failed({}) to trunc file({}) with size({}).", s, shmFile.ShmName(), size);
                 return s;
             }
         }
-        s = shmFile.MMap(addrress_, totalSize_, true, true, true);
+        s = shmFile.MMap(addr, size, true, true, true);
         if (s.Failure()) [[unlikely]] {
-            UC_ERROR("Failed({}) to mmap file({}) with size({}).", s, shmName_, totalSize_);
+            UC_ERROR("Failed({}) to mmap file({}) with size({}).", s, shmFile.ShmName(), size);
             return s;
         }
-        header_ = (BufferHeader*)addrress_;
+        return Status::OK();
+    }
+    static Status WaitShmHeaderReady(BufferHeader* header)
+    {
+        constexpr auto retryInterval = std::chrono::milliseconds(100);
+        constexpr auto maxTryTime = 100;
+        auto tryTime = 0;
+        do {
+            if (header->magic == sharedBufferMagic) { break; }
+            if (tryTime > maxTryTime) { return Status::Retry(); }
+            std::this_thread::sleep_for(retryInterval);
+            tryTime++;
+        } while (true);
         return Status::OK();
     }
     Status InitShmBuffer(PosixShm& shmFile)
     {
-        auto s = MmapShmFile(shmFile);
+        auto s = MmapShmFile(shmFile, totalSize_, addrress_);
         if (s.Failure()) [[unlikely]] { return s; }
+        header_ = static_cast<BufferHeader*>(addrress_);
         meta_ = (BufferMetaNode*)(static_cast<std::byte*>(addrress_) + MetaOffset());
         header_->lock.Init();
+        header_->nNode = nNode_;
         header_->freeHead = 0;
         for (size_t i = 0; i < nHashTableBucket; i++) {
             header_->buckets[i] = invalidIndex;
@@ -265,23 +283,17 @@ protected:
     {
         auto s = shmFile.ShmOpen(PosixShm::OpenFlag::READ_WRITE);
         if (s.Failure()) {
-            UC_ERROR("Failed({}) to open file({}).", s, shmName_);
+            UC_ERROR("Failed({}) to open file({}).", s, shmFile.ShmName());
             return s;
         }
-        s = MmapShmFile(shmFile, false);
+        s = MmapShmFile(shmFile, totalSize_, addrress_, false);
         if (s.Failure()) [[unlikely]] { return s; }
-        constexpr auto retryInterval = std::chrono::milliseconds(100);
-        constexpr auto maxTryTime = 100;
-        auto tryTime = 0;
-        do {
-            if (header_->magic == sharedBufferMagic) { break; }
-            if (tryTime > maxTryTime) {
-                UC_ERROR("Shm file({}) not ready.", shmName_);
-                return Status::Retry();
-            }
-            std::this_thread::sleep_for(retryInterval);
-            tryTime++;
-        } while (true);
+        header_ = static_cast<BufferHeader*>(addrress_);
+        s = WaitShmHeaderReady(header_);
+        if (s.Failure()) [[unlikely]] {
+            UC_ERROR("Shm file({}) not ready.", shmFile.ShmName());
+            return s;
+        }
         meta_ = (BufferMetaNode*)(static_cast<std::byte*>(addrress_) + MetaOffset());
         return Status::OK();
     }
@@ -310,12 +322,13 @@ public:
         if (addrress_) { PosixShm::MUnmap(addrress_, totalSize_); }
         PosixShm{shmName_}.ShmUnlink();
     }
-    Status Setup(const std::string& uuid, int32_t deviceId, size_t nodeSize, size_t nNode) override
+    Status Setup(const std::string& uuid, int32_t deviceId, size_t nodeSize,
+                 size_t totalSize) override
     {
         shmName_ = ShmPrefix() + uuid;
         nodeSize_ = nodeSize;
-        nNode_ = nNode;
-        CleanUpShmFileExceptMe();
+        nNode_ = totalSize / nodeSize;
+        CleanUpShmFileExceptMe(shmName_);
         PosixShm shmFile{shmName_};
         const auto dataOffset = DataOffset();
         totalSize_ = dataOffset + DataSize();
@@ -352,15 +365,34 @@ public:
 
 class SharedBufferWatcherStrategy : public SharedBufferStrategy {
 public:
-    Status Setup(const std::string& uuid, int32_t deviceId, size_t nodeSize, size_t nNode) override
+    Status Setup(const std::string& uuid, int32_t deviceId, size_t, size_t) override
     {
         shmName_ = ShmPrefix() + uuid;
-        nodeSize_ = nodeSize;
-        nNode_ = nNode;
-        totalSize_ = DataOffset();
-        CleanUpShmFileExceptMe();
+        CleanUpShmFileExceptMe(shmName_);
         PosixShm shmFile{shmName_};
-        return LoadShmBuffer(shmFile);
+        auto s = shmFile.ShmOpen(PosixShm::OpenFlag::READ_WRITE);
+        if (s.Failure()) {
+            UC_ERROR("Failed({}) to open file({}).", s, shmFile.ShmName());
+            return s;
+        }
+        void* addr = nullptr;
+        auto size = sizeof(BufferHeader);
+        s = MmapShmFile(shmFile, size, addr, false);
+        if (s.Failure()) [[unlikely]] { return s; }
+        auto header = static_cast<BufferHeader*>(addr);
+        s = WaitShmHeaderReady(header);
+        if (s.Failure()) [[unlikely]] {
+            UC_ERROR("Shm file({}) not ready.", shmFile.ShmName());
+            return s;
+        }
+        nNode_ = header->nNode;
+        shmFile.MUnmap(addr, size);
+        totalSize_ = DataOffset();
+        s = MmapShmFile(shmFile, totalSize_, addrress_, false);
+        if (s.Failure()) [[unlikely]] { return s; }
+        header_ = static_cast<BufferHeader*>(addrress_);
+        meta_ = (BufferMetaNode*)(static_cast<std::byte*>(addrress_) + MetaOffset());
+        return Status::OK();
     }
     void* DataAt(size_t iNode) override { return nullptr; }
 };
@@ -379,7 +411,7 @@ Status TransBuffer::Setup(const Config& config)
         return Status::Error(fmt::format("failed({}) to make buffer strategy", e.what()));
     }
     return strategy_->Setup(config.uniqueId, config.deviceId, config.shardSize,
-                            config.bufferNumber);
+                            config.bufferCapacity);
 }
 
 TransBuffer::Handle TransBuffer::Get(const Detail::BlockId& blockId, size_t shardIdx)

--- a/ucm/store/test/case/cache/cache_buffer_manager_test.cc
+++ b/ucm/store/test/case/cache/cache_buffer_manager_test.cc
@@ -53,7 +53,7 @@ TEST_F(UCCacheBufferManagerTest, Lookup)
     config.shardSize = config.tensorSize;
     config.blockSize = config.shardSize;
     config.deviceId = 0;
-    config.bufferNumber = 1024;
+    config.bufferCapacity = config.shardSize * 1024;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
     ASSERT_TRUE(bufferMgr.Setup(config).Success());

--- a/ucm/store/test/case/cache/cache_dump_queue_test.cc
+++ b/ucm/store/test/case/cache/cache_dump_queue_test.cc
@@ -56,7 +56,7 @@ TEST_F(UCCacheDumpQueueTest, DumpOneBlock)
     config.shardSize = config.tensorSize;
     config.blockSize = config.shardSize;
     config.deviceId = 0;
-    config.bufferNumber = 2048;
+    config.bufferCapacity = config.shardSize * 1024;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
     TransBuffer buffer;
@@ -92,7 +92,7 @@ TEST_F(UCCacheDumpQueueTest, DumpBlockWhileBackendSubmitFailed)
     config.shardSize = config.tensorSize;
     config.blockSize = config.shardSize;
     config.deviceId = 0;
-    config.bufferNumber = 2048;
+    config.bufferCapacity = config.shardSize * 1024;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
     TransBuffer buffer;

--- a/ucm/store/test/case/cache/cache_load_queue_test.cc
+++ b/ucm/store/test/case/cache/cache_load_queue_test.cc
@@ -51,7 +51,7 @@ TEST_F(UCCacheLoadQueueTest, LoadSameBlockTwice)
     config.shardSize = config.tensorSize;
     config.blockSize = config.shardSize;
     config.deviceId = 0;
-    config.bufferNumber = 2048;
+    config.bufferCapacity = config.shardSize * 1024;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
     TransBuffer buffer;
@@ -92,7 +92,7 @@ TEST_F(UCCacheLoadQueueTest, LoadWhileBackendSubmitFailed)
     config.shardSize = config.tensorSize;
     config.blockSize = config.shardSize;
     config.deviceId = 0;
-    config.bufferNumber = 2048;
+    config.bufferCapacity = config.shardSize * 1024;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
     TransBuffer buffer;
@@ -129,7 +129,7 @@ TEST_F(UCCacheLoadQueueTest, LoadWhileBackendWaitFailed)
     config.shardSize = config.tensorSize;
     config.blockSize = config.shardSize;
     config.deviceId = 0;
-    config.bufferNumber = 2048;
+    config.bufferCapacity = config.shardSize * 1024;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
     TransBuffer buffer;

--- a/ucm/store/test/case/cache/cache_trans_buffer_test.cc
+++ b/ucm/store/test/case/cache/cache_trans_buffer_test.cc
@@ -39,7 +39,7 @@ TEST_P(UCCacheTransBufferTest, GetFirstNode)
     UC::CacheStore::Config config;
     config.uniqueId = rd.RandomString(10);
     config.shardSize = 32768;
-    config.bufferNumber = 32768;
+    config.bufferCapacity = config.shardSize * 32768;
     config.shareBufferEnable = GetParam();
     config.deviceId = 0;
     auto s = transBuffer.Setup(config);
@@ -68,7 +68,7 @@ TEST_P(UCCacheTransBufferTest, InsertDifferentDataRepeatedly)
     UC::CacheStore::Config config;
     config.uniqueId = rd.RandomString(10);
     config.shardSize = 4096;
-    config.bufferNumber = nBlock * nShard;
+    config.bufferCapacity = nBlock * nShard * config.shardSize;
     config.shareBufferEnable = GetParam();
     config.deviceId = 0;
     auto s = transBuffer.Setup(config);

--- a/ucm/store/test/case/cache/cache_trans_manager_test.cc
+++ b/ucm/store/test/case/cache/cache_trans_manager_test.cc
@@ -54,7 +54,7 @@ TEST_F(UCCacheTransManagerTest, DumpThenLoad)
     config.shardSize = config.tensorSize;
     config.blockSize = config.shardSize;
     config.deviceId = 0;
-    config.bufferNumber = 2048;
+    config.bufferCapacity = config.shardSize * 1024;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
     TransBuffer buffer;
@@ -110,7 +110,7 @@ TEST_F(UCCacheTransManagerTest, DumpThenLoadWithLayerWise)
     config.shardSize = shardSize;
     config.blockSize = blockSize;
     config.deviceId = 0;
-    config.bufferNumber = 2048;
+    config.bufferCapacity = shardSize * 1024;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
     config.timeoutMs = 10 * 60 * 1000;
@@ -178,7 +178,7 @@ TEST_F(UCCacheTransManagerTest, DumpThenLoadWithLayerAndChunk)
     config.shardSize = shardSize;
     config.blockSize = blockSize;
     config.deviceId = 0;
-    config.bufferNumber = 2048;
+    config.bufferCapacity = shardSize * 1024;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
     config.timeoutMs = 10 * 60 * 1000;


### PR DESCRIPTION
## Purpose

Different models have different `BlockSize`, and the same model will have different `ShardSize` depending on whether `Layer-Wise` is used or not. Therefore, if we specify the default `BufferNumber`, the final total memory usage will be different. Furthermore, in `Layer-Wise` scenarios with large models, the default `BufferNumber` may be insufficient.

## Modifications 

- Replace `buffer_number` with `cache_buffer_capacity_gb` in CacheStore configurations.
- Default depth of the waiting queue needs to be increased by `nShard` times for `Layer-Wise`