### PR TITLE
[Opt] Add log timestamp in run_vllm.sh

### DIFF
--- a/examples/deployments/scripts/vllm/run_vllm.sh
+++ b/examples/deployments/scripts/vllm/run_vllm.sh
@@ -6,14 +6,15 @@ source "$SCRIPT_DIR/common.sh"
 start_server() {
     [[ -z "$model" ]] && { echo "ERROR: model not set in config.properties" >&2; exit 1; }
 
+    LOG_TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
     if [[ "$ucm_enable" == "true" ]]; then
         [[ -z "$ucm_config_yaml_path" ]] && {
             echo "ERROR: ucm_config_yaml_path not set but ucm_enable=true" >&2
             exit 1
         }
-        LOG_FILE="${vllm_log_path}/vllm_ucm.log"
+        LOG_FILE="${vllm_log_path}/vllm_ucm_${LOG_TIMESTAMP}.log"
     else
-        LOG_FILE="${vllm_log_path}/vllm.log"
+        LOG_FILE="${vllm_log_path}/vllm_${LOG_TIMESTAMP}.log"
     fi
 
     echo ""

--- a/examples/deployments/scripts/vllm/run_vllm_dp.sh
+++ b/examples/deployments/scripts/vllm/run_vllm_dp.sh
@@ -36,14 +36,15 @@ start_server() {
     # vLLM parameters 
     [[ -z "$model" ]] && { echo "ERROR: model not set in config.properties" >&2; exit 1; }
 
+    LOG_TIMESTAMP="$(date +%Y%m%d_%H%M%S)"
     if [[ "$ucm_enable" == "true" ]]; then
         [[ -z "$ucm_config_yaml_path" ]] && {
             echo "ERROR: ucm_config_yaml_path not set but ucm_enable=true" >&2
             exit 1
         }
-        LOG_FILE="${vllm_log_path}/vllm_ucm.log"
+        LOG_FILE="${vllm_log_path}/vllm_ucm_${LOG_TIMESTAMP}.log"
     else
-        LOG_FILE="${vllm_log_path}/vllm.log"
+        LOG_FILE="${vllm_log_path}/vllm_${LOG_TIMESTAMP}.log"
     fi
 
     echo ""


### PR DESCRIPTION
## Purpose
Avoid overwriting logs when the server is started multiple times, so logs can be kept and distinguished by start time.
## Modifications 
added `LOG_TIMESTAMP="$(date +%Y%m%d_%H%M%S)"` and changed LOG_FILE from a fixed name to a timestamped one: `vllm_ucm_${LOG_TIMESTAMP}.log` or `vllm_${LOG_TIMESTAMP}.log`
## Test
Run once with `ucm_enable=true` ，confirmed that log path and naming are correct in both cases.