### PR TITLE
[Feat] adapt dcp&pcp

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -749,13 +749,12 @@ class UCMLayerWiseConnector(UCMDirectConnector):
 class UCMCPConnector(UCMLayerWiseConnector):
     def __init__(self, vllm_config: "VllmConfig", role: KVConnectorRole):
         super().__init__(vllm_config, role)
-        # [k_task, k_task, ...] for mla
-        # [k_task, v_task/rope_task, k_task, vtask/rope_task, ...] for dsa or gqa
         self.use_layerwise = (
             self._vllm_config.kv_transfer_config.kv_connector_extra_config.get(
                 "use_layerwise", False
             )
         )
+
         try:
             from vllm.distributed import get_dcp_group, get_pcp_group
         except ImportError as e:
@@ -776,11 +775,14 @@ class UCMCPConnector(UCMLayerWiseConnector):
             self.dcp_rank = 0
             self.pcp_world_size = 1
             self.pcp_rank = 0
-        self.cp_world_size = self.pcp_world_size * self.dcp_world_size
+        self.cp_world_size = (
+            self._vllm_config.parallel_config.prefill_context_parallel_size
+            * self._vllm_config.parallel_config.decode_context_parallel_size
+        )
         self.current_rank = self.dcp_world_size * self.pcp_rank + self.dcp_rank
         old_tp_size = vllm_config.parallel_config.tensor_parallel_size
         logger.info(
-            f"pcp_world_size: {self.pcp_world_size}, pcp_rank: {self.pcp_rank}, dcp_world_size: {self.dcp_world_size}, dcp_rank: {self.dcp_rank}, old_tp_size: {old_tp_size}"
+            f"pcp_world_size: {self.pcp_world_size}, pcp_rank: {self.pcp_rank}, dcp_world_size: {self.dcp_world_size}, dcp_rank: {self.dcp_rank}"
         )
 
         self.tp_rank %= self.tp_size
@@ -796,37 +798,119 @@ class UCMCPConnector(UCMLayerWiseConnector):
         else:
             self.request_hasher = RequestHasher(vllm_config, self.tp_rank)
         vllm_config.parallel_config.tensor_parallel_size = old_tp_size
+        self.hash_block_size = self.block_size
+        self.block_size *= self.cp_world_size
         logger.info("Init UCMCPConnector.")
 
+    def get_num_new_matched_tokens(
+        self,
+        request: "Request",
+        num_computed_tokens: int,
+    ) -> tuple[int, bool]:
+        assert num_computed_tokens % self.block_size == 0
+        hbm_hit_block_num = num_computed_tokens // self.block_size
+
+        ucm_block_ids = self.generate_hash(
+            self.hash_block_size, request.all_token_ids, self._seed
+        )
+
+        external_block_ids = ucm_block_ids[hbm_hit_block_num * self.cp_world_size :]
+        if not external_block_ids:
+            return 0, False
+        try:
+            external_hit_blocks = self.store.lookup_on_prefix(external_block_ids) + 1
+            external_hit_blocks //= self.cp_world_size
+        except RuntimeError as e:
+            external_hit_blocks = 0
+            logger.error(f"request {request.request_id} look up error. {e}")
+        logger.info(
+            f"request_id: {request.request_id}, "
+            f"total_blocks_num: {len(ucm_block_ids)}, "
+            f"hit hbm: {hbm_hit_block_num * self.cp_world_size}, "
+            f"hit external: {external_hit_blocks * self.cp_world_size}"
+        )
+        if self.metrics_config:
+            ucmmetrics.update_stats(
+                {
+                    "interval_lookup_hit_rates": external_hit_blocks
+                    * self.cp_world_size
+                    / len(ucm_block_ids)
+                },
+            )
+
+        total_hit_block_num = hbm_hit_block_num + external_hit_blocks
+
+        external_hit_tokens = external_hit_blocks * self.block_size
+
+        # When all the tokens are cached in ssd or hbm,
+        # we need to recompute the last token. This if condition will be removed
+        # once vLLM scheduler provides a better solution in the future.
+        num_total_hit_tokens = total_hit_block_num * self.block_size
+        if num_total_hit_tokens == request.num_tokens:
+            external_hit_tokens -= 1
+
+        self.requests_meta[request.request_id] = RequestMeta(
+            ucm_block_ids=ucm_block_ids,
+            hbm_hit_block_num=hbm_hit_block_num,
+            total_hit_block_num=total_hit_block_num,
+            num_token_ids=len(request.all_token_ids),
+            token_processed=num_total_hit_tokens,
+        )
+
+        return external_hit_tokens, False
+
+    def _generate_dispatch_meta(
+        self,
+        req_meta: RequestMeta,
+        new_tokens: int,
+        vllm_block_ids: list[int],
+        need_load: bool = True,
+    ) -> RequestDispatchMeta:
+        # Since the block_size on the scheduler side is multiplied by cp_world_size,
+        # while the block_size on the UCM side remains unchanged,
+        # the selected ucm_blocks need to be expanded by a factor of cp_world_size.
+        hbm_hit_block_num = req_meta.hbm_hit_block_num
+        total_hit_block_num = req_meta.total_hit_block_num
+        ucm_block_ids = req_meta.ucm_block_ids
+        req_meta.vllm_block_ids.extend(vllm_block_ids)
+
+        load_ucm_block_ids, load_vllm_block_ids = [], []
+        dump_ucm_block_ids, dump_vllm_block_ids = [], []
+        if need_load:
+            load_ucm_block_ids = ucm_block_ids[
+                hbm_hit_block_num
+                * self.cp_world_size : total_hit_block_num
+                * self.cp_world_size
+            ]
+            load_vllm_block_ids = vllm_block_ids[hbm_hit_block_num:total_hit_block_num]
+
+        if req_meta.token_processed < req_meta.num_token_ids:
+            start_idx = req_meta.token_processed // self.block_size
+            end_idx = (req_meta.token_processed + new_tokens) // self.block_size
+            dump_ucm_block_ids = ucm_block_ids[
+                start_idx * self.cp_world_size : end_idx * self.cp_world_size
+            ]
+            dump_vllm_block_ids = req_meta.vllm_block_ids[start_idx:end_idx]
+            req_meta.token_processed += new_tokens
+
+        return RequestDispatchMeta(
+            (load_ucm_block_ids, load_vllm_block_ids),
+            (dump_ucm_block_ids, dump_vllm_block_ids),
+        )
+
     def bind_connector_metadata(self, connector_metadata: KVConnectorMetadata) -> None:
-        """Set the connector metadata from the scheduler.
-
-        This function should be called by the model runner every time
-        before the model execution. The metadata will be used for runtime
-        KV cache loading and saving.
-
-        Args:
-            connector_metadata (dict): the connector metadata.
-        """
+        # When DCP/PCP features are enabled,
+        # the blocks that each device can process are [current_rank :: cp_world_size],
+        # where current_rank = self.dcp_world_size * self.pcp_rank + self.dcp_rank.
         for _, request in connector_metadata.request_meta.items():
             if len(request.load_block_ids[0]) > 0:
                 ucm_block_ids, vllm_block_ids = request.load_block_ids
-                if self.cp_world_size > 1:
-                    ucm_block_ids = ucm_block_ids[
-                        self.current_rank :: self.cp_world_size
-                    ]
-                current_loaded_block = len(ucm_block_ids)
-                vllm_block_ids = vllm_block_ids[:current_loaded_block]
+                ucm_block_ids = ucm_block_ids[self.current_rank :: self.cp_world_size]
                 request.load_block_ids = (ucm_block_ids, vllm_block_ids)
 
             if len(request.dump_block_ids[0]) > 0:
                 ucm_block_ids, vllm_block_ids = request.dump_block_ids
-                if self.cp_world_size > 1:
-                    ucm_block_ids = ucm_block_ids[
-                        self.current_rank :: self.cp_world_size
-                    ]
-                current_dumped_block = len(ucm_block_ids)
-                vllm_block_ids = vllm_block_ids[:current_dumped_block]
+                ucm_block_ids = ucm_block_ids[self.current_rank :: self.cp_world_size]
                 request.dump_block_ids = (ucm_block_ids, vllm_block_ids)
         super().bind_connector_metadata(connector_metadata)
 


### PR DESCRIPTION
## Purpose
This PR provides adaptation for the PCP (Prefill Context Parallel) / DCP (Decode Context Parallel) features in the vllm Ascend implementation. For a detailed introduction to these features, please refer to https://docs.vllm.ai/projects/ascend/en/latest/user_guide/feature_guide/context_parallel.html.

When the CP (Context Parallel) feature is enabled, each device is allocated a corresponding current_rank, calculated as: **current_rank = dcp_world_size * pcp_rank + dcp_rank**. The tokens of a request are interleaved and distributed across each card following the rule of **[current_rank :: cp_kv_cache_interleave_size * cp_world_size]**, cp_world_size calculated as: **cp_world_size = dcp_world_size * pcp_world_size**. In scenarios where KV pooling and PD disaggregation are used, cp_kv_cache_interleave_size is equal to block_size (cp_kv_cache_interleave_size == block_size).

For UCM, this means that blocks are interleaved across each card in the form of [current_rank :: cp_world_size].

## Modifications 
Added a new connector class **UCMCPConnector** that inherits from **UCMLayerwiseConnector**.
- ucm/integration/sglang/ucm_connector.py

## Notice

- For MLA scenarios, the number of blocks saved with CP enabled is the same as the number of identical TP; for GQA scenarios, the number of blocks saved with CP enabled is the same as tp // dcp_size.
- After CP is enabled, the number of saved blocks satisfies: blocks // cp_world_size * cp_world_size.

## Test
Tested with offline_inference.py and online test using deepseek-v2-lite and Qwen3-30B-A3B models base on vLLM-Ascend
 v0.13.0
