### PR TITLE
[Test] Remove memory manager abstraction in PosixStore e2e test

### DIFF
--- a/ucm/store/test/e2e/posixstore_embed.py
+++ b/ucm/store/test/e2e/posixstore_embed.py
@@ -24,7 +24,6 @@ import mmap
 import os
 import secrets
 import time
-from abc import ABC, abstractmethod
 
 import numpy as np
 
@@ -52,53 +51,19 @@ def setup(
     return UcmPipelineStore(config)
 
 
-class AlignedPinnedArray(np.ndarray):
-    def __new__(cls, input_array, handle=None):
-        obj = np.asarray(input_array).view(cls)
-        obj._handle = handle
-        return obj
-
-    def __array_finalize__(self, obj):
-        if obj is None:
-            return
-        self._handle = getattr(obj, "_handle", None)
-
-
-class BaseMemoryManager(ABC):
-    @abstractmethod
-    def make_array(self, size, alignment=4096, dtype=np.uint8) -> AlignedPinnedArray:
-        pass
-
-    def release_array(self, array: AlignedPinnedArray) -> None:
-        if hasattr(array, "_handle"):
-            self._perform_release(array._handle)
-            array._handle = None
-        else:
-            print("Warning: No handle found for release.")
-
-    @abstractmethod
-    def _perform_release(self, handle) -> None:
-        pass
-
-
-class CPUMemoryManager(BaseMemoryManager):
-    def make_array(self, size, alignment=4096, dtype=np.uint8) -> AlignedPinnedArray:
-        itemsize = np.dtype(dtype).itemsize
-        total_bytes = size * itemsize
-        mm = mmap.mmap(-1, total_bytes + alignment)
-        raw_array = np.frombuffer(mm, dtype=np.uint8, count=total_bytes + alignment)
-        raw_ptr = raw_array.__array_interface__["data"][0]
-        aligned_addr = (raw_ptr + alignment - 1) & ~(alignment - 1)
-        offset = aligned_addr - raw_ptr
-        array = raw_array[offset : offset + total_bytes].view(dtype=dtype)
-        return AlignedPinnedArray(array, handle=mm)
-
-    def _perform_release(self, handle) -> None:
-        del handle
+def make_array(size, alignment=4096, dtype=np.uint8) -> np.ndarray:
+    itemsize = np.dtype(dtype).itemsize
+    total_bytes = size * itemsize
+    mm = mmap.mmap(-1, total_bytes + alignment)
+    raw_array = np.frombuffer(mm, dtype=np.uint8, count=total_bytes + alignment)
+    raw_ptr = raw_array.__array_interface__["data"][0]
+    aligned_addr = (raw_ptr + alignment - 1) & ~(alignment - 1)
+    offset = aligned_addr - raw_ptr
+    array = raw_array[offset : offset + total_bytes].view(dtype=dtype)
+    return array
 
 
 def main():
-    mem_mgr = CPUMemoryManager()
     backends = ["./build/data"]
     block_size = 1048576
     data_trans_concur = 8
@@ -113,8 +78,8 @@ def main():
     batch_number = 64
     batch_size = 1024
     data_size = block_size * batch_size
-    raw_data1 = [mem_mgr.make_array(block_size) for _ in range(batch_size)]
-    raw_data2 = [mem_mgr.make_array(block_size) for _ in range(batch_size)]
+    raw_data1 = [make_array(block_size) for _ in range(batch_size)]
+    raw_data2 = [make_array(block_size) for _ in range(batch_size)]
     data1 = [[d.ctypes.data] for d in raw_data1]
     data2 = [[d.ctypes.data] for d in raw_data2]
     for idx in range(batch_number):


### PR DESCRIPTION
## Purpose
Simplify the memory allocation logic in the PosixStore e2e test and remove unnecessary abstraction to avoid potential resource leak risks caused by manual release handling.
## Modifications 

- Removed BaseMemoryManager and CPUMemoryManager.
- Removed manual release logic.
- Replaced with a simple make_array() helper.
- Rely on Python GC to manage mmap lifecycle.

## Test
the same to https://github.com/ModelEngine-Group/unified-cache-management/pull/751