### PR TITLE
chore(test): Ensure that unnecessary import failures do not affect test execution

### DIFF
--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -7,6 +7,7 @@ python_functions = test_*
 addopts =
     -ra
     --capture=no
+    --continue-on-collection-errors
 filterwarnings =
     ignore::pytest.PytestReturnNotNoneWarning
 


### PR DESCRIPTION

## PR Title
Add `--continue-on-collection-errors` to pytest.ini to prevent collection failures from aborting test execution

## Description
### Problem
Currently, when pytest encounters import errors or other failures during the test collection phase (e.g., missing optional dependencies, conditional imports, or environment-specific modules), the entire test suite aborts immediately [[7]]. This behavior prevents execution of valid tests that could otherwise pass, reducing test coverage and making CI/CD pipelines unnecessarily fragile.

### Solution
This PR adds the `--continue-on-collection-errors` option to `pytest.ini`, enabling pytest to continue test execution even when collection errors occur [[5]]. Failed test files/modules will be skipped and reported as errors, while all other discoverable tests will still run to completion.
<img width="1383" height="1083" alt="image" src="https://github.com/user-attachments/assets/77deef12-c957-4df6-9c01-2dda7abfaa8f" />

<img width="1425" height="1074" alt="image" src="https://github.com/user-attachments/assets/03ed0db1-0645-446e-985b-3bf1dd9b8b76" />
