### PR TITLE
[fix] fix zlib gitcode url

### DIFF
--- a/ucm/shared/vendor/dep-zlib.cmake
+++ b/ucm/shared/vendor/dep-zlib.cmake
@@ -7,7 +7,7 @@ if(DOWNLOAD_DEPENDENCE)
     set(DEP_ZLIB_TAG v1.3.1)
     set(DEP_ZLIB_GIT_URLS
         https://github.com/madler/zlib.git
-        https://gitcode.com/GitHub_Trending/sp/ZLIB.git
+        https://gitcode.com/gh_mirrors/zl/zlib.git
     )
     include(helper.cmake)
     find_reachable_git_url(REACHABLE_URL DEP_ZLIB_GIT_URLS)


### PR DESCRIPTION
## Purpose
fix zlib gitcode url


## Test
<img width="760" height="158" alt="image" src="https://github.com/user-attachments/assets/243e5bd6-720a-41b7-8175-99f52191af82" />
