### PR TITLE
[Fix] fix save_speed core dump and loaded blocks num when task failed

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -511,6 +511,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
                 self._invalid_block_ids.update(
                     metadata.request_meta[request_id].load_block_ids[1]
                 )
+                num_loaded_block -= len(request.load_block_ids[0])
 
         for request_id, task in request_to_task.items():
             try:
@@ -519,6 +520,9 @@ class UCMDirectConnector(KVConnectorBase_V1):
                 logger.error(f"request {request_id} wait load task error. {e}")
                 self._invalid_block_ids.update(
                     metadata.request_meta[request_id].load_block_ids[1]
+                )
+                num_loaded_block -= len(
+                    metadata.request_meta[request_id].load_block_ids[0]
                 )
 
         load_end_time = time.perf_counter() * 1000
@@ -591,6 +595,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
                 dump_tasks.append(task)
             except RuntimeError as e:
                 logger.error(f"dump kv cache failed. {e}")
+                return
 
             try:
                 for task in dump_tasks:
@@ -598,6 +603,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
                 save_end_time = time.perf_counter() * 1000
             except RuntimeError as e:
                 logger.error(f"wait for dump kv cache failed.{e}")
+                return
 
             save_speed = (
                 num_saved_block


### PR DESCRIPTION
## Purpose
Fix the bug that when wait for dump tasks failed, it would end the service because no attribute save_end_time, and modify the current loaded blocks num.
## Modifications 
Return before calculate save_speed, as there is no blocks should be dumped. And change the loaded blocks num when load tasks failed.
## Test
Tested with offline script constructing the wait task throws a RuntimeError.
<img width="1277" height="861" alt="image" src="https://github.com/user-attachments/assets/f008e309-e526-42ea-bcae-53963a70b963" />
