### PR TITLE
[opt] enable Ascend register pin optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ option(BUILD_UCM_STORE "build ucm store module." ON)
 option(BUILD_UCM_SPARSE "build ucm sparse module." OFF)
 option(BUILD_UNIT_TESTS "build all unit test suits." OFF)
 option(BUILD_NUMA "build numactl library." OFF)
+option(ASCEND_SUPPORTS_REGISTER_PIN "enable Ascend register pin optimization (requires CANN >= 8.5)" OFF)
 option(DOWNLOAD_DEPENDENCE "download dependence by cmake." ON)
 set(RUNTIME_ENVIRONMENT "simu" CACHE STRING "runtime: simu, ascend, musa or cuda.")
 

--- a/ucm/shared/trans/ascend/CMakeLists.txt
+++ b/ucm/shared/trans/ascend/CMakeLists.txt
@@ -9,6 +9,9 @@ add_library(trans STATIC
     ascend_buffer.cc
     ascend_stream.cc
 )
+if(ASCEND_SUPPORTS_REGISTER_PIN)
+    target_compile_definitions(trans PRIVATE ASCEND_SUPPORTS_REGISTER_PIN=1)
+endif()
 target_link_libraries(trans PUBLIC
     fmt
     Ascend::ascendcl

--- a/ucm/shared/trans/ascend/ascend_buffer.cc
+++ b/ucm/shared/trans/ascend/ascend_buffer.cc
@@ -45,7 +45,13 @@ std::shared_ptr<void> Trans::AscendBuffer::MakeHostBuffer(size_t size)
 Status Buffer::RegisterHostBuffer(void* host, size_t size, void** pDevice)
 {
     void* device = nullptr;
+#if ASCEND_SUPPORTS_REGISTER_PIN
+    auto ret = aclrtHostRegisterV2(host, size, ACL_HOST_REG_MAPPED | ACL_HOST_REG_PINNED);
+    if (ret != ACL_SUCCESS) [[unlikely]] { return Status{ret, std::to_string(ret)}; }
+    if (pDevice) { ret = aclrtHostGetDevicePointer(host, &device, 0); }
+#else
     auto ret = aclrtHostRegister(host, size, ACL_HOST_REGISTER_MAPPED, &device);
+#endif
     if (ret != ACL_SUCCESS) [[unlikely]] { return Status{ret, std::to_string(ret)}; }
     if (pDevice) { *pDevice = device; }
     return Status::OK();


### PR DESCRIPTION
add `ASCEND_SUPPORTS_REGISTER_PIN` option

- Add CMake option to conditionally compile Ascend register pinned optimization.
- When enabled (default: OFF), uses aclrtHostRegisterV2 to PIN host buffer.
- Maintains compatibility with CANN versions prior to 8.5.