### PR TITLE
[fix]Submit layerwise KV load tasks one layer at a time

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -18,6 +18,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
 )
 from vllm.distributed.parallel_state import get_tp_group, get_world_group
+from vllm.model_executor.models.utils import extract_layer_index
 from vllm.platforms import current_platform
 from vllm.v1.core.sched.output import SchedulerOutput
 
@@ -336,12 +337,10 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self.block_data_size = self.kv_cache_layout.block_size
 
         self.layer_name_to_id = {
-            name: self._extract_layer_index(name) for name in self.kv_caches.keys()
+            name: extract_layer_index(name) for name in self.kv_caches.keys()
         }
-        self.layer_id_to_name = {
-            layer_id: name for name, layer_id in self.layer_name_to_id.items()
-        }
-        self.first_layer_id = next(iter(self.layer_name_to_id.values()))
+        self.layer_ids = sorted(set(self.layer_name_to_id.values()))
+        self.first_layer_id = self.layer_ids[0]
 
         self.device = create_device()
 
@@ -523,16 +522,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
         return UCMConnectorMetadata(requests_dispatch_meta)
 
-    @staticmethod
-    def _extract_layer_index(layer_name: str) -> Optional[int]:
-        """
-        Extract the layer index from the layer name.
-        """
-        for chunk in layer_name.split("."):
-            if chunk.isdigit():
-                return int(chunk)
-        return None
-
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, UCMConnectorMetadata)
@@ -711,8 +700,8 @@ class UCMLayerWiseConnector(UCMDirectConnector):
 
     def __init__(self, vllm_config: "VllmConfig", role: KVConnectorRole):
         super().__init__(vllm_config, role)
-        # {layer_name: {request_id: Task}}
-        self.load_tasks: dict[str, dict[str, Task]] = defaultdict(dict)
+        # {layer_id: {request_id: Task}}
+        self.load_tasks: dict[int, dict[str, Task]] = defaultdict(dict)
         self.dump_tasks: dict[str, Task] = {}
         self.use_layerwise = True
         self.is_save = False
@@ -723,7 +712,6 @@ class UCMLayerWiseConnector(UCMDirectConnector):
 
     def _submit_request_load_tasks_for_layer(
         self,
-        layer_name: str,
         layer_id: int,
         local_row: int,
         metadata: "UCMConnectorMetadata",
@@ -733,7 +721,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                 shard_indexs = [layer_id] * len(ucm_block_ids)
                 layer_ptrs = total_ptrs[local_row]
                 task = self.store.load_data(ucm_block_ids, shard_indexs, layer_ptrs)
-                self.load_tasks[layer_name][request_id] = task
+                self.load_tasks[layer_id][request_id] = task
             except RuntimeError as e:
                 logger.error(f"request {request_id} submit load task error. {e}")
                 self._invalid_block_ids.update(
@@ -761,17 +749,15 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             self.request_data.append((request_id, ucm_block_ids, total_ptrs))
 
         if self.need_load:
-            first_layer_name = self.layer_id_to_name.get(self.first_layer_id)
-            self._submit_request_load_tasks_for_layer(
-                first_layer_name, self.first_layer_id, 0, metadata
-            )
+            self._submit_request_load_tasks_for_layer(self.first_layer_id, 0, metadata)
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         if not self.need_load:
             return
         metadata = self._get_connector_metadata()
+        current_layer_id = self.layer_name_to_id[layer_name]
 
-        for request_id, task in self.load_tasks.get(layer_name, {}).items():
+        for request_id, task in self.load_tasks.get(current_layer_id, {}).items():
             try:
                 self.store.wait(task)
             except RuntimeError as e:
@@ -780,14 +766,13 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                     metadata.request_meta[request_id].load_block_ids[1]
                 )
 
-        next_layer_id = self.layer_name_to_id.get(layer_name) + 1
-        if next_layer_id not in self.layer_id_to_name:
+        next_layer_id = current_layer_id + 1
+        if next_layer_id not in self.layer_ids:
             return
-        next_layer_name = self.layer_id_to_name.get(next_layer_id)
         next_local_row = next_layer_id - self.first_layer_id
 
         self._submit_request_load_tasks_for_layer(
-            next_layer_name, next_layer_id, next_local_row, metadata
+            next_layer_id, next_local_row, metadata
         )
 
     def save_kv_layer(

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -708,6 +708,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
         self.need_load = False
         self.dump_total_ptrs: np.ndarray | None = None
         self.request_data: list[tuple[str, list, np.ndarray]] = []
+        self._failure_req_ids: set[str] = set()
         logger.info("Init UCMLayerWiseConnector.")
 
     def _submit_request_load_tasks_for_layer(
@@ -717,6 +718,8 @@ class UCMLayerWiseConnector(UCMDirectConnector):
         metadata: "UCMConnectorMetadata",
     ) -> None:
         for request_id, ucm_block_ids, total_ptrs in self.request_data:
+            if request_id in self._failure_req_ids:
+                continue
             try:
                 shard_indexs = [layer_id] * len(ucm_block_ids)
                 layer_ptrs = total_ptrs[local_row]
@@ -727,11 +730,13 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                 self._invalid_block_ids.update(
                     metadata.request_meta[request_id].load_block_ids[1]
                 )
+                self._failure_req_ids.add(request_id)
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         metadata = self._get_connector_metadata()
         self.load_tasks.clear()
         self.request_data.clear()
+        self._failure_req_ids.clear()
         self.need_load = False
 
         for request_id, request in metadata.request_meta.items():
@@ -765,6 +770,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                 self._invalid_block_ids.update(
                     metadata.request_meta[request_id].load_block_ids[1]
                 )
+                self._failure_req_ids.add(request_id)
 
         next_layer_id = current_layer_id + 1
         if next_layer_id not in self.layer_ids:

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -119,13 +119,20 @@ class KVCacheLayout:
             f"base_ptrs: {self.base_ptrs.shape}, tensor_size_lists: {self.tensor_size_lists.shape}"
         )
 
-    def extract_block_addrs(self, vllm_block_ids: List[int]) -> np.ndarray:
+    def extract_block_addrs(
+        self, vllm_block_ids: List[int], layer_first: bool = False
+    ) -> np.ndarray:
         vllm_block_ids_np = np.array(vllm_block_ids, np.uint64)
-        block_addrs = (
+        if layer_first:
+            # (n_layers, num_blocks, n_ptrs)
+            return (
+                self.tensor_size_lists[:, None, :] * vllm_block_ids_np[None, :, None]
+                + self.base_ptrs[:, None, :]
+            )
+        return (
             vllm_block_ids_np[:, None, None] * self.tensor_size_lists[None, :, :]
             + self.base_ptrs[None, :, :]
         )  # (num_blocks, n_layers, n_ptrs)
-        return block_addrs
 
     @property
     def tensor_size_list(self) -> list[int]:
@@ -330,6 +337,9 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
         self.layer_name_to_id = {
             name: self._extract_layer_index(name) for name in self.kv_caches.keys()
+        }
+        self.layer_id_to_name = {
+            layer_id: name for name, layer_id in self.layer_name_to_id.items()
         }
         self.first_layer_id = next(iter(self.layer_name_to_id.values()))
 
@@ -701,52 +711,84 @@ class UCMLayerWiseConnector(UCMDirectConnector):
 
     def __init__(self, vllm_config: "VllmConfig", role: KVConnectorRole):
         super().__init__(vllm_config, role)
+        # {layer_name: {request_id: Task}}
         self.load_tasks: dict[str, dict[str, Task]] = defaultdict(dict)
         self.dump_tasks: dict[str, Task] = {}
         self.use_layerwise = True
         self.is_save = False
+        self.need_load = False
+        self.dump_total_ptrs: np.ndarray | None = None
+        self.request_data: list[tuple[str, list, np.ndarray]] = []
         logger.info("Init UCMLayerWiseConnector.")
 
-    def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
-        metadata = self._get_connector_metadata()
-        self.load_tasks.clear()
-
-        for request_id, request in metadata.request_meta.items():
-            if len(request.load_block_ids[0]) == 0:
-                continue
-
-            ucm_block_ids, vllm_block_ids = request.load_block_ids
-            if self.tp_rank % self.tp_size != 0 and not self.is_mla:
-                for i, ucm_block_id in enumerate(ucm_block_ids):
-                    ucm_block_ids[i] = self.request_hasher(ucm_block_id)
+    def _submit_request_load_tasks_for_layer(
+        self,
+        layer_name: str,
+        layer_id: int,
+        local_row: int,
+        metadata: "UCMConnectorMetadata",
+    ) -> None:
+        for request_id, ucm_block_ids, total_ptrs in self.request_data:
             try:
-                total_ptrs = self.kv_cache_layout.extract_block_addrs(vllm_block_ids)
-
-                for layer_name in self.kv_caches:
-                    layer_id = self.layer_name_to_id[layer_name]
-                    local_layer_id = layer_id - self.first_layer_id
-                    shard_indexs = [layer_id] * len(ucm_block_ids)
-                    layer_ptrs = np.ascontiguousarray(total_ptrs[:, local_layer_id, :])
-                    task = self.store.load_data(ucm_block_ids, shard_indexs, layer_ptrs)
-                    self.load_tasks[request_id][layer_name] = task
+                shard_indexs = [layer_id] * len(ucm_block_ids)
+                layer_ptrs = total_ptrs[local_row]
+                task = self.store.load_data(ucm_block_ids, shard_indexs, layer_ptrs)
+                self.load_tasks[layer_name][request_id] = task
             except RuntimeError as e:
                 logger.error(f"request {request_id} submit load task error. {e}")
                 self._invalid_block_ids.update(
                     metadata.request_meta[request_id].load_block_ids[1]
                 )
 
+    def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
+        metadata = self._get_connector_metadata()
+        self.load_tasks.clear()
+        self.request_data.clear()
+        self.need_load = False
+
+        for request_id, request in metadata.request_meta.items():
+            if len(request.load_block_ids[0]) == 0:
+                continue
+
+            self.need_load = True
+            ucm_block_ids, vllm_block_ids = request.load_block_ids
+            if self.tp_rank % self.tp_size != 0 and not self.is_mla:
+                for i, ucm_block_id in enumerate(ucm_block_ids):
+                    ucm_block_ids[i] = self.request_hasher(ucm_block_id)
+            total_ptrs = self.kv_cache_layout.extract_block_addrs(
+                vllm_block_ids, layer_first=True
+            )
+            self.request_data.append((request_id, ucm_block_ids, total_ptrs))
+
+        if self.need_load:
+            first_layer_name = self.layer_id_to_name.get(self.first_layer_id)
+            self._submit_request_load_tasks_for_layer(
+                first_layer_name, self.first_layer_id, 0, metadata
+            )
+
     def wait_for_layer_load(self, layer_name: str) -> None:
+        if not self.need_load:
+            return
         metadata = self._get_connector_metadata()
 
-        for request_id, tasks in self.load_tasks.items():
+        for request_id, task in self.load_tasks.get(layer_name, {}).items():
             try:
-                if layer_name in tasks:
-                    self.store.wait(tasks[layer_name])
+                self.store.wait(task)
             except RuntimeError as e:
-                logger.error(f"request {request_id} wait load failed. {e}")
+                logger.error(f"request {request_id} wait {layer_name} load failed. {e}")
                 self._invalid_block_ids.update(
                     metadata.request_meta[request_id].load_block_ids[1]
                 )
+
+        next_layer_id = self.layer_name_to_id.get(layer_name) + 1
+        if next_layer_id not in self.layer_id_to_name:
+            return
+        next_layer_name = self.layer_id_to_name.get(next_layer_id)
+        next_local_row = next_layer_id - self.first_layer_id
+
+        self._submit_request_load_tasks_for_layer(
+            next_layer_name, next_layer_id, next_local_row, metadata
+        )
 
     def save_kv_layer(
         self,
@@ -777,10 +819,13 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             total_vllm_block_ids.extend(vllm_block_ids)
 
         if self.is_save:
-            total_ptrs = self.kv_cache_layout.extract_block_addrs(total_vllm_block_ids)
+            if self.dump_total_ptrs is None:
+                self.dump_total_ptrs = self.kv_cache_layout.extract_block_addrs(
+                    total_vllm_block_ids, layer_first=True
+                )
             shard_indexs = [layer_id] * len(total_ucm_block_ids)
             try:
-                layer_ptrs = np.ascontiguousarray(total_ptrs[:, local_layer_id, :])
+                layer_ptrs = np.ascontiguousarray(self.dump_total_ptrs[local_layer_id])
                 event_handle = self._get_dump_event_handle()
                 task = self.store.dump_data(
                     total_ucm_block_ids, shard_indexs, layer_ptrs, event_handle
@@ -800,6 +845,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             logger.error(f"wait for dump kv cache failed. {e}")
         self.dump_tasks.clear()
         self.is_save = False
+        self.dump_total_ptrs = None
         if self.enable_event_sync:
             self.device.destroy_event_handles()
 


### PR DESCRIPTION
## Purpose
UCMLayerwise connector previously submitted async KV load tasks for every layer inside start_load_kv. In some cases, it may interrupt thr intended load → forward → load-next overlap.
## Modifications 
- **`load_tasks` structure**: Reorganized from `{request_id: {layer_name: Task}}` to `{layer_name: {request_id: Task}}`, so tasks are grouped by layer for easier lookup in `wait_for_layer_load`.
- **`KVCacheLayout.extract_block_addrs`**: Added `layer_first` parameter to support both memory layouts:
  - `layer_first=True`: returns `(n_layers, num_blocks, n_ptrs)` for layer-first iteration
  - `layer_first=False`: keeps original `(num_blocks, n_layers, n_ptrs)` layout
- **Dump optimization**: Cached `dump_total_ptrs` and reused it across layers during save, with proper cleanup after dump completion.
- `start_load_kv`: load only first layer's require block.
- `wait_for_layer_load`: waits all tasks under `load_tasks[layer_name]`, submits the next layer's task.
## Test
<img width="1240" height="784" alt="image" src="https://github.com/user-attachments/assets/37cf9e6d-1966-49bb-9325-757dbab15ea4" />
<img width="1207" height="766" alt="image" src="https://github.com/user-attachments/assets/8ca8a1a0-09d9-4a4f-b437-8aceb9b9b4f1" />


