### PR TITLE
[feat] enable external PC hit for MLA on CUDA and NPU

### DIFF
--- a/ucm/sparse/gsa_on_device/gsa_on_device.py
+++ b/ucm/sparse/gsa_on_device/gsa_on_device.py
@@ -344,6 +344,11 @@ class GSAOnDevice(UcmSparseBase):
                 device=self.device,
                 dtype=torch.int32,
             )
+            self.prefix_token_len_full = torch.zeros(
+                (self.max_batch_size,),
+                dtype=torch.int32,
+                device=self.device,
+            )
         self.prefix_block_ids_buf = torch.empty(
             cdiv(self.max_num_tokens * self.max_batch_size, self.block_size),
             device=self.device,
@@ -351,11 +356,6 @@ class GSAOnDevice(UcmSparseBase):
         )
         self.token_idx_buf = torch.arange(
             self.max_num_tokens, device=self.device, dtype=torch.int64
-        )
-        self.prefix_token_len_full = torch.zeros(
-            (self.max_batch_size,),
-            dtype=torch.int32,
-            device=self.device,
         )
 
     def _make_buffer(
@@ -1327,7 +1327,8 @@ class GSAOnDevice(UcmSparseBase):
                     self.prefix_block_ids_buf[
                         all_prefix_blocks : all_prefix_blocks + num_prefix_blocks
                     ] = prefix_block_ids
-                    self.prefix_token_len_full[num_pc_hit] = num_prefix_tokens
+                    if not self.is_cuda:
+                        self.prefix_token_len_full[num_pc_hit] = num_prefix_tokens
 
                     all_prefix_tokens += num_prefix_tokens
                     all_prefix_blocks += num_prefix_blocks


### PR DESCRIPTION
## Purpose
Support external prefix cache hit for MLA and GQA on CUDA and NPU
## Modifications 
- Rebuild prefix_block_ids and prefix_slot_mapping in build_sparse_meta when an external prefix cache hit occurs.
- Recover keys (`k_nope`, `k_rope`) from KV cache and recompute `k_hash` in `cache_k_hash_mla_cuda`.
-  Add handling for `self.has_pc_hit` in `cache_k_hash_gqa_npu` and `cache_k_hash_mla_npu`.
## Test
python examples/offline_inference_gsaondevice.py
<img width="1421" height="738" alt="image" src="https://github.com/user-attachments/assets/105b5e77-fa99-408f-b0f0-def33ee7933e" />
