### PR TITLE
[Fix] Fix the excessive TPOT latency by modifying update_attn_params

### DIFF
--- a/ucm/integration/vllm/patch/v0110/vllm/pc/v1/core/sched/scheduler.py
+++ b/ucm/integration/vllm/patch/v0110/vllm/pc/v1/core/sched/scheduler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import itertools
 from collections import defaultdict
 from collections.abc import Iterable
 from typing import Any, Optional, Union
@@ -356,8 +357,6 @@ class Scheduler(SchedulerInterface):
         num_computed_tokens: list[int] = []
         num_output_tokens: list[int] = []
 
-        import itertools
-
         use_connector = self.connector is not None
         for req in itertools.chain(running_reqs, resumed_reqs):
             req_id = req.request_id
@@ -414,7 +413,6 @@ class Scheduler(SchedulerInterface):
         kv_connector_output = model_runner_output.kv_connector_output
 
         outputs: dict[int, list[EngineCoreOutput]] = defaultdict(list)
-        from vllm.v1.spec_decode.metrics import SpecDecodingStats
 
         spec_decoding_stats: Optional[SpecDecodingStats] = None
         kv_connector_stats = (

--- a/ucm/integration/vllm/patch/v0110/vllm_ascend/pc/attention/layer.py
+++ b/ucm/integration/vllm/patch/v0110/vllm_ascend/pc/attention/layer.py
@@ -1,11 +1,12 @@
-def wait_for_kv_layer_from_connector(layer_name: str):
-    from vllm.distributed.kv_transfer import (
-        get_kv_transfer_group,
-        has_kv_transfer_group,
-        is_v1_kv_transfer_group,
-    )
-    from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.distributed.kv_transfer import (
+    get_kv_transfer_group,
+    has_kv_transfer_group,
+    is_v1_kv_transfer_group,
+)
+from vllm.forward_context import ForwardContext, get_forward_context
 
+
+def wait_for_kv_layer_from_connector(layer_name: str):
     if not has_kv_transfer_group() or not is_v1_kv_transfer_group():
         return
 
@@ -28,13 +29,6 @@ def maybe_save_kv_layer_to_connector(
     layer_name: str,
     kv_cache_layer: "list[object]",
 ) -> None:
-    from vllm.distributed.kv_transfer import (
-        get_kv_transfer_group,
-        has_kv_transfer_group,
-        is_v1_kv_transfer_group,
-    )
-    from vllm.forward_context import ForwardContext, get_forward_context
-
     if not has_kv_transfer_group() or not is_v1_kv_transfer_group():
         return
 

--- a/ucm/integration/vllm/patch/v0110/vllm_ascend/pc/compilation/acl_graph.py
+++ b/ucm/integration/vllm/patch/v0110/vllm_ascend/pc/compilation/acl_graph.py
@@ -1,0 +1,56 @@
+import torch
+import torch_npu
+from vllm_ascend.compilation.acl_graph import get_graph_params
+
+
+def update_attn_params(
+    update_stream, forward_context, runtime_shape, kv_transfer_config=None
+):
+    graph_params = get_graph_params()
+    with torch.npu.stream(update_stream):
+        for key, param, handle, event in zip(
+            forward_context.attn_metadata,
+            graph_params.attn_params[runtime_shape],
+            graph_params.handles[runtime_shape],
+            graph_params.events[runtime_shape],
+        ):
+            (
+                query,
+                key_cache,
+                value_cache,
+                num_kv_heads,
+                num_heads,
+                scale,
+                block_table,
+                seq_lens,
+                output,
+            ) = param
+            seq_lens = forward_context.attn_metadata[key].seq_lens
+
+            workspace = torch_npu._npu_paged_attention_get_workspace(
+                query=query,
+                key_cache=key_cache,
+                value_cache=value_cache,
+                num_kv_heads=num_kv_heads,
+                num_heads=num_heads,
+                scale_value=scale,
+                block_table=block_table,
+                context_lens=seq_lens,
+                out=output,
+            )
+            torch.npu.graph_task_update_begin(update_stream, handle)
+            torch_npu._npu_paged_attention(
+                query=query,
+                key_cache=key_cache,
+                value_cache=value_cache,
+                num_kv_heads=num_kv_heads,
+                num_heads=num_heads,
+                scale_value=scale,
+                block_table=block_table,
+                context_lens=seq_lens,
+                out=output,
+                workspace=workspace,
+            )
+            torch.npu.graph_task_update_end(update_stream)
+
+            event.record(update_stream)

--- a/ucm/integration/vllm/patch/v0110/vllm_ascend/pc_ascend_patch.py
+++ b/ucm/integration/vllm/patch/v0110/vllm_ascend/pc_ascend_patch.py
@@ -53,3 +53,11 @@ def patch_worker_npu_worker(mod):
         "execute_model",
         npu_worker.NPUWorker.execute_model,
     )
+
+
+@when_imported("vllm_ascend.compilation.acl_graph")
+def patch_ascend_acl_worker(mod):
+    logger.debug(f"Patched {mod} called")
+    from ucm.integration.vllm.patch.v0110.vllm_ascend.pc.compilation import acl_graph
+
+    patch_or_inject(mod, "update_attn_params", acl_graph.update_attn_params)


### PR DESCRIPTION
## Purpose
Fix the issue of TPOT degradation when using graph mode with FULL_DECODE_ONLY enabled.
vLLM-ascend related pr:
https://github.com/vllm-project/vllm-ascend/pull/3985
https://github.com/vllm-project/vllm-ascend/pull/4437

## Modifications 
Add a patch file acl_graph.py to modify func update_attn_params

## Test
Tested with offline script and benchmarks. 
4k input, 1k output using Llama3.1-70B
modifyupdate_attn_params | mean ttft | tpot | e2e
-- | -- | -- | --
vllm with no   prefix cache | 621.15 | 28.19 | 28778.34
0.8   hit+layerwise | 332.33 | 28.16 | 28466.69
