### PR TITLE
[bugfix] Fix CUDA full graph for DeepSeek implementation

### DIFF
--- a/ucm/integration/vllm/patch/0.11.0/vllm-adapt-sparse.patch
+++ b/ucm/integration/vllm/patch/0.11.0/vllm-adapt-sparse.patch
@@ -1,7 +1,7 @@
 From ce508dea471e7dd240e8bfaaaa6a29dfc73d53fc Mon Sep 17 00:00:00 2001
 From: AooooooA-C <chenaozhu@outlook.com>
 Date: Mon, 19 Jan 2026 23:03:08 -0800
-Subject: [PATCH 1/3] apply sparse method patches
+Subject: [PATCH 1/4] apply sparse method patches
 
 ---
  vllm/attention/layer.py                    | 63 +++++++++++++++
@@ -868,7 +868,7 @@ index 8c75e8914..c3e9e781f 100644
 From d9eed9606eb5bffcb14ef0c66a1697f5f4cc8319 Mon Sep 17 00:00:00 2001
 From: Qiong Wu <wq674452797@gmail.com>
 Date: Sat, 31 Jan 2026 16:06:09 +0800
-Subject: [PATCH 2/3] update sparse patch for vllm
+Subject: [PATCH 2/4] update sparse patch for vllm
 
 ---
  vllm/attention/layer.py                  | 51 ++----------------------
@@ -980,7 +980,7 @@ index 86771060c..f2bac0202 100644
 From 5175c05806154fbdf09af0d1f135fafd01367d5c Mon Sep 17 00:00:00 2001
 From: wenxinwang <wangwenxin21@huawei.com>
 Date: Wed, 4 Feb 2026 18:14:49 -0800
-Subject: [PATCH 3/3] [bugfix] gsa graph patch
+Subject: [PATCH 3/4] [bugfix] gsa graph patch
 
 ---
  vllm/v1/attention/backends/mla/flashmla.py |  2 +-
@@ -1044,6 +1044,35 @@ index dca14b5d3..964f8f0a4 100644
          kv_cache_tensors = []
          for i in range(group_size):
              shared_by = []
+-- 
+2.34.1
+
+
+From f635d244b74f308d55d703aa2e05684ec0db7c3e Mon Sep 17 00:00:00 2001
+From: wenxinwang <wangwenxin21@huawei.com>
+Date: Tue, 10 Mar 2026 06:10:44 -0700
+Subject: [PATCH 4/4] [bugfix] Fix CUDA full graph for DeepSeek implementation
+
+---
+ vllm/v1/attention/backends/mla/flashmla.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/vllm/v1/attention/backends/mla/flashmla.py b/vllm/v1/attention/backends/mla/flashmla.py
+index c4f4cf847..8f77eaea6 100644
+--- a/vllm/v1/attention/backends/mla/flashmla.py
++++ b/vllm/v1/attention/backends/mla/flashmla.py
+@@ -137,7 +137,10 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
+             #  it needs to monotonically increasing by 1)
+             self.cg_buf_num_splits[n:].fill_(num_splits[-1])
+             num_splits = num_splits_view
+-            topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens  = ucm_sparse.maybe_init_cudagraph_buffers_for_topk(n, tile_scheduler_metadata, topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens)
++            if has_ucm_sparse():
++                ucm_sparse = get_ucm_sparse()
++                if os.getenv("VLLM_HASH_ATTENTION") == "1":
++                    topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens  = ucm_sparse.maybe_init_cudagraph_buffers_for_topk(n, tile_scheduler_metadata, topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens)
+ 
+         return FlashMLADecodeMetadata(
+             block_table=block_table_tensor,
 -- 
 2.34.1
 

--- a/ucm/integration/vllm/patch/0.11.0/vllm-adapt.patch
+++ b/ucm/integration/vllm/patch/0.11.0/vllm-adapt.patch
@@ -1,7 +1,7 @@
 From 59753e5c7540b19f6c3a00657fa1778ea0b91456 Mon Sep 17 00:00:00 2001
 From: AooooooA-C <chenaozhu@outlook.com>
 Date: Mon, 19 Jan 2026 23:03:08 -0800
-Subject: [PATCH 1/4] apply sparse method patches
+Subject: [PATCH 1/5] apply sparse method patches
 
 ---
  vllm/attention/layer.py                    | 63 +++++++++++++++
@@ -868,7 +868,7 @@ index 8c75e8914..c3e9e781f 100644
 From 00851072c976618360065741a71b5fd8b96913ce Mon Sep 17 00:00:00 2001
 From: wangxin <1848802892@qq.com>
 Date: Wed, 28 Jan 2026 01:59:05 -0800
-Subject: [PATCH 2/4] feature rerope for vllm0110
+Subject: [PATCH 2/5] feature rerope for vllm0110
 
 apply sparse method patches
 ---
@@ -1685,7 +1685,7 @@ index d7c6a8e0a..d7bb0eec8 100644
 From 86f048a2a4db9f36a69636270b5d126ccc9d0270 Mon Sep 17 00:00:00 2001
 From: Qiong Wu <wq674452797@gmail.com>
 Date: Sat, 31 Jan 2026 16:02:31 +0800
-Subject: [PATCH 3/4] update sparse patch for vllm
+Subject: [PATCH 3/5] update sparse patch for vllm
 
 ---
  vllm/attention/layer.py                  | 51 ++----------------------
@@ -1797,7 +1797,7 @@ index 86771060c..f2bac0202 100644
 From e23062750e26810f2f558facc10c4777526dafb0 Mon Sep 17 00:00:00 2001
 From: wenxinwang <wangwenxin21@huawei.com>
 Date: Wed, 4 Feb 2026 18:42:00 -0800
-Subject: [PATCH 4/4] [bugfix] gsa graph patch
+Subject: [PATCH 4/5] [bugfix] gsa graph patch
 
 ---
  vllm/v1/attention/backends/flash_attn.py   |  7 ------
@@ -1899,6 +1899,35 @@ index dca14b5d3..41c90ffd1 100644
          kv_cache_tensors = []
          for i in range(group_size):
              shared_by = []
+-- 
+2.34.1
+
+
+From 9c9d4822d139a62fd9c639ba92ec6dd2d9a8f023 Mon Sep 17 00:00:00 2001
+From: wenxinwang <wangwenxin21@huawei.com>
+Date: Tue, 10 Mar 2026 06:24:39 -0700
+Subject: [PATCH 5/5] [bugfix] Fix CUDA full graph for DeepSeek implementation
+
+---
+ vllm/v1/attention/backends/mla/flashmla.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/vllm/v1/attention/backends/mla/flashmla.py b/vllm/v1/attention/backends/mla/flashmla.py
+index 5d603abbf..34ed8b8ad 100644
+--- a/vllm/v1/attention/backends/mla/flashmla.py
++++ b/vllm/v1/attention/backends/mla/flashmla.py
+@@ -137,7 +137,10 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
+             #  it needs to monotonically increasing by 1)
+             self.cg_buf_num_splits[n:].fill_(num_splits[-1])
+             num_splits = num_splits_view
+-            topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens = ucm_sparse.maybe_init_cudagraph_buffers_for_topk(n, tile_scheduler_metadata, topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens)
++            if has_ucm_sparse():
++                ucm_sparse = get_ucm_sparse()
++                if os.getenv("VLLM_HASH_ATTENTION") == "1":
++                    topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens = ucm_sparse.maybe_init_cudagraph_buffers_for_topk(n, tile_scheduler_metadata, topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens)
+ 
+         return FlashMLADecodeMetadata(
+             block_table=block_table_tensor,
 -- 
 2.34.1
 

--- a/ucm/integration/vllm/patch/0.9.2/vllm-adapt-sparse.patch
+++ b/ucm/integration/vllm/patch/0.9.2/vllm-adapt-sparse.patch
@@ -1,7 +1,7 @@
-From 6895341c5f7ee00d87bf9f6d261ad65c573e6c99 Mon Sep 17 00:00:00 2001
+From 63e268de099cf74c170bb046cbfd0bbf55d47b1e Mon Sep 17 00:00:00 2001
 From: wenxinwang <wangwenxin21@huawei.com>
 Date: Wed, 21 Jan 2026 00:53:52 -0800
-Subject: [PATCH 1/2] update for gsaondevice + sparse + cache blend
+Subject: [PATCH 1/3] update for gsaondevice + sparse + cache blend
 
 ---
  vllm/attention/layer.py                    | 63 +++++++++++++++-
@@ -827,10 +827,10 @@ index 9e7e44d06..d49099346 100644
 2.34.1
 
 
-From b8be7898bf49838f11c5f9e1a4687e1ff0b1367a Mon Sep 17 00:00:00 2001
+From babfcf9a60c683cba2cba63e69ba3a365fb32ffa Mon Sep 17 00:00:00 2001
 From: wenxinwang <wangwenxin21@huawei.com>
 Date: Wed, 4 Feb 2026 18:25:53 -0800
-Subject: [PATCH 2/2] [bugfix] gsa graph patch
+Subject: [PATCH 2/3] gsa graph patch
 
 ---
  vllm/v1/attention/backends/mla/flashmla.py | 2 +-
@@ -846,6 +846,35 @@ index 4d74e9d5b..c3a3d4230 100644
                  num_splits = num_splits_view
 -                topk_tile_scheduler_metadata, topk_num_splits = ucm_sparse.maybe_init_cudagraph_buffers_for_topk(n, tile_scheduler_metadata)
 +                topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens = ucm_sparse.maybe_init_cudagraph_buffers_for_topk(n, tile_scheduler_metadata, topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens)
+ 
+         return FlashMLADecodeMetadata(
+             block_table=block_table_tensor,
+-- 
+2.34.1
+
+
+From a8400a140e2e8d6c8f3e6565a57152dec2cf526b Mon Sep 17 00:00:00 2001
+From: wenxinwang <wangwenxin21@huawei.com>
+Date: Tue, 10 Mar 2026 06:30:22 -0700
+Subject: [PATCH 3/3] [bugfix] Fix CUDA full graph for DeepSeek implementation
+
+---
+ vllm/v1/attention/backends/mla/flashmla.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/vllm/v1/attention/backends/mla/flashmla.py b/vllm/v1/attention/backends/mla/flashmla.py
+index c3a3d4230..d1053ca85 100644
+--- a/vllm/v1/attention/backends/mla/flashmla.py
++++ b/vllm/v1/attention/backends/mla/flashmla.py
+@@ -110,7 +110,10 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
+                 num_splits_view.copy_(num_splits)
+                 self.cg_buf_num_splits[n:].fill_(0)  # fill the rest with 0s
+                 num_splits = num_splits_view
+-                topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens = ucm_sparse.maybe_init_cudagraph_buffers_for_topk(n, tile_scheduler_metadata, topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens)
++                if has_ucm_sparse():
++                    ucm_sparse = get_ucm_sparse()
++                    if os.getenv("VLLM_HASH_ATTENTION") == "1":
++                        topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens = ucm_sparse.maybe_init_cudagraph_buffers_for_topk(n, tile_scheduler_metadata, topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens)
  
          return FlashMLADecodeMetadata(
              block_table=block_table_tensor,

--- a/ucm/integration/vllm/patch/0.9.2/vllm-adapt.patch
+++ b/ucm/integration/vllm/patch/0.9.2/vllm-adapt.patch
@@ -1,7 +1,7 @@
 From 2703231eccf15673bd9e949ea03154cf7f52deef Mon Sep 17 00:00:00 2001
 From: wangxin <1848802892@qq.com>
 Date: Wed, 28 Jan 2026 23:22:11 -0800
-Subject: [PATCH 1/3] rerope feature for vllm0.9.2
+Subject: [PATCH 1/4] rerope feature for vllm0.9.2
 
 ---
  vllm/attention/layer.py                   | 100 ++++++++++++----
@@ -640,7 +640,7 @@ index 5a26e88db..f61a38550 100644
 From f9a8ddde6b01c6ca193e52255519c0c03b5938f9 Mon Sep 17 00:00:00 2001
 From: wenxinwang <wangwenxin21@huawei.com>
 Date: Wed, 21 Jan 2026 00:53:52 -0800
-Subject: [PATCH 2/3] update for gsaondevice + sparse + cache blend
+Subject: [PATCH 2/4] update for gsaondevice + sparse + cache blend
 
 ---
  vllm/attention/layer.py                    | 62 ++++++++++++++++
@@ -1467,7 +1467,7 @@ index 9e7e44d06..d49099346 100644
 From 1b5c2b44eb668a265d96ff46b809df877564f97a Mon Sep 17 00:00:00 2001
 From: wenxinwang <wangwenxin21@huawei.com>
 Date: Wed, 4 Feb 2026 18:29:46 -0800
-Subject: [PATCH 3/3] [bugfix] gsa graph patch
+Subject: [PATCH 3/4] [bugfix] gsa graph patch
 
 ---
  vllm/v1/attention/backends/mla/flashmla.py | 2 +-
@@ -1483,6 +1483,35 @@ index 4d74e9d5b..c3a3d4230 100644
                  num_splits = num_splits_view
 -                topk_tile_scheduler_metadata, topk_num_splits = ucm_sparse.maybe_init_cudagraph_buffers_for_topk(n, tile_scheduler_metadata)
 +                topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens = ucm_sparse.maybe_init_cudagraph_buffers_for_topk(n, tile_scheduler_metadata, topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens)
+ 
+         return FlashMLADecodeMetadata(
+             block_table=block_table_tensor,
+-- 
+2.34.1
+
+
+From 00363194ca2b9770103213dcacefdba731b14230 Mon Sep 17 00:00:00 2001
+From: wenxinwang <wangwenxin21@huawei.com>
+Date: Tue, 10 Mar 2026 06:17:23 -0700
+Subject: [PATCH 4/4] [bugfix] Fix CUDA full graph for DeepSeek implementation
+
+---
+ vllm/v1/attention/backends/mla/flashmla.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/vllm/v1/attention/backends/mla/flashmla.py b/vllm/v1/attention/backends/mla/flashmla.py
+index c3a3d4230..d1053ca85 100644
+--- a/vllm/v1/attention/backends/mla/flashmla.py
++++ b/vllm/v1/attention/backends/mla/flashmla.py
+@@ -110,7 +110,10 @@ class FlashMLAMetadataBuilder(MLACommonMetadataBuilder[FlashMLAMetadata]):
+                 num_splits_view.copy_(num_splits)
+                 self.cg_buf_num_splits[n:].fill_(0)  # fill the rest with 0s
+                 num_splits = num_splits_view
+-                topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens = ucm_sparse.maybe_init_cudagraph_buffers_for_topk(n, tile_scheduler_metadata, topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens)
++                if has_ucm_sparse():
++                    ucm_sparse = get_ucm_sparse()
++                    if os.getenv("VLLM_HASH_ATTENTION") == "1":
++                        topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens = ucm_sparse.maybe_init_cudagraph_buffers_for_topk(n, tile_scheduler_metadata, topk_tile_scheduler_metadata, topk_num_splits, topk_seq_lens)
  
          return FlashMLADecodeMetadata(
              block_table=block_table_tensor,


### PR DESCRIPTION
## Purpose
Fix CUDA full graph for DeepSeek implementation
## Modifications 
top-k metadata buffers are initialized when UCM sparse and hash attention are enabled.
Call maybe_init_cudagraph_buffers_for_topk when:
- has_ucm_sparse()
- VLLM_HASH_ATTENTION=1
## Test
