### PR TITLE
[Build] add sparse configs

### DIFF
--- a/examples/deployments/scripts/vllm/config.properties
+++ b/examples/deployments/scripts/vllm/config.properties
@@ -74,6 +74,11 @@ speculative_decode_model=NONE
 speculative_decode_method=deepseek_mtp
 num_speculative_tokens=1
 
+# scaling configuration
+enable_rope_scaling=false
+rope_type=yarn
+factor=4.0
+original_max_position_embeddings=32768
 
 #****************************************
 #  extra vLLM Configuration for Ascend  *
@@ -90,6 +95,8 @@ export ENABLE_UCM_PATCH=1
 ucm_enable=true
 use_layerwise=false
 ucm_config_yaml_path=/vllm-workspace/unified-cache-management/examples/ucm_config_example.yaml
+export ENABLE_SPARSE=FALSE
+export VLLM_HASH_ATTENTION=0
 
 #****************************************
 #          LOG  Configuration           *

--- a/examples/deployments/scripts/vllm/run_vllm.sh
+++ b/examples/deployments/scripts/vllm/run_vllm.sh
@@ -84,6 +84,10 @@ start_server() {
         SPECULATIVE_CONFIG='{"model":"'"$speculative_decode_model"'", "num_speculative_tokens": "'"$num_speculative_tokens"'", "method":"'"$speculative_decode_method"'"}'
         CMD+=("--speculative-config" "$SPECULATIVE_CONFIG")
     fi
+    if [[ "$enable_rope_scaling" == "true" ]]; then
+        ROPE_SCALING_CONFIG='{"rope_type": "'"$rope_type"'", "factor": '"$factor"', "original_max_position_embeddings": '"$original_max_position_embeddings"'}'
+        CMD+=("--rope-scaling" "$ROPE_SCALING_CONFIG")
+    fi
 
     ADDITIONAL_CONFIG="{"
     SEP=""

--- a/examples/deployments/scripts/vllm/run_vllm_dp.sh
+++ b/examples/deployments/scripts/vllm/run_vllm_dp.sh
@@ -121,6 +121,10 @@ start_server() {
         SPECULATIVE_CONFIG='{"model":"'"$speculative_decode_model"'", "num_speculative_tokens": "'"$num_speculative_tokens"'", "method":"'"$speculative_decode_method"'"}'
         CMD+=("--speculative-config" "$SPECULATIVE_CONFIG")
     fi
+    if [[ "$enable_rope_scaling" == "true" ]]; then
+        ROPE_SCALING_CONFIG='{"rope_type": "'"$rope_type"'", "factor": '"$factor"', "original_max_position_embeddings": '"$original_max_position_embeddings"'}'
+        CMD+=("--rope-scaling" "$ROPE_SCALING_CONFIG")
+    fi
 
     ADDITIONAL_CONFIG="{"
     SEP=""

--- a/examples/ucm_config_example.yaml
+++ b/examples/ucm_config_example.yaml
@@ -19,17 +19,7 @@ enable_event_sync: false
 # metrics_config_path: "/workspace/unified-cache-management/examples/metrics/metrics_configs.yaml"
 
 # Sparse attention configuration
-# Format 1: Dictionary format (for methods like ESA, GSAOnDevice)
 # ucm_sparse_config:
-#   ESA:
-#     init_window_sz: 1
-#     local_window_sz: 2
-#     min_blocks: 4
-#     sparse_ratio: 0.3
-#     retrieval_stride: 5
-  # Or for GSA:
-  # GSA: {}
-  # Or for GSAOnDevice:
   # GSAOnDevice: {}
 
 


### PR DESCRIPTION
## Purpose
Add configurations for sparse (GsaOnDevice).

## Modifications 
- `ucm_config_example.yaml`: Only leave GsaOnDevice configs.
- `config.properties`: Add sparse needed environments and vllm configs.
- `run_vllm.sh` & `run_vllm_dp.sh`: Load `--rope-scaling` releated configs for running server.

## Test
Tested `run_vllm.sh` to run vllm server on develop environment.