### PR TITLE
[fix] log exception

### DIFF
--- a/ucm/logger.py
+++ b/ucm/logger.py
@@ -50,7 +50,6 @@ def add_log_methods(cls):
         "debug": logging.DEBUG,
         "warning": logging.WARNING,
         "error": logging.ERROR,
-        "exception": logging.ERROR,
         "critical": logging.CRITICAL,
     }
 
@@ -122,12 +121,12 @@ class Logger(logging.Logger):
     @staticmethod
     def format_exception(e):
         if isinstance(e, BaseException):
-            ei = (type(e), e, e.__traceback__)
-        else:
-            ei = sys.exc_info()
+            e = (type(e), e, e.__traceback__)
+        elif not isinstance(e, tuple):
+            e = sys.exc_info()
         sio = io.StringIO()
-        tb = ei[2]
-        traceback.print_exception(ei[0], ei[1], tb, None, sio)
+        tb = e[2]
+        traceback.print_exception(e[0], e[1], tb, None, sio)
         s = sio.getvalue()
         sio.close()
         if s[-1:] == "\n":
@@ -145,6 +144,9 @@ class Logger(logging.Logger):
     @lru_cache
     def debug_once(self, message: str, *args: Hashable, **kwargs: Hashable):
         self.log(logging.DEBUG, message, *args, **kwargs)
+
+    def exception(self, message: str, *args: Hashable, **kwargs: Hashable):
+        self.log(logging.ERROR, message, *args, **kwargs, exc_info=True)
 
 
 def init_logger(name: str = "UC") -> Logger:


### PR DESCRIPTION
## Purpose
fix bug that log.exception has no Traceback infomation

## Modifications 
create `log.exception` interface with `exc_info=True`

## Test
<img width="1291" height="567" alt="image" src="https://github.com/user-attachments/assets/7da77e10-ab1b-495f-98ca-cd898166e83e" />
