### PR TITLE
[Fix] fix perf test bug

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -235,6 +235,8 @@ def setup_gpu_resource(request):
 
     marker = request.node.get_closest_marker("gpu_mem")
     if not marker:
+        # No gpu_mem marker, skip GPU resource setup
+        yield
         return
 
     mem_needed = marker.args[0]


### PR DESCRIPTION
## Purpose
now perf test will fail with error "setup_gpu_resource did not yield a value", this pr fix it

## Modifications 
add yield when a test not require gpu_mem

## Test
validated via jenkins pipeline in green field