### PR TITLE
[Feature] Adapt prefix cache for GQA/MLA to support vLLM >= 0.14.0

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -446,11 +446,19 @@ class UCMDirectConnector(KVConnectorBase_V1):
                     new_block_ids = []
                     if scheduled_cached_reqs.new_block_ids[i] != None:
                         new_block_ids = scheduled_cached_reqs.new_block_ids[i][0]
+                    if hasattr(scheduled_cached_reqs, "resumed_from_preemption"):
+                        resumed_from_preemption = (
+                            scheduled_cached_reqs.resumed_from_preemption[i]
+                        )
+                    else:
+                        resumed_from_preemption = (
+                            request_id in scheduled_cached_reqs.resumed_req_ids
+                        )
                     requests_dispatch_meta[request_id] = self._generate_dispatch_meta(
                         req_meta,
                         scheduler_output.num_scheduled_tokens[request_id],
                         new_block_ids,
-                        scheduled_cached_reqs.resumed_from_preemption[i],
+                        resumed_from_preemption,
                     )
         else:
             for request in scheduled_cached_reqs:


### PR DESCRIPTION
## Purpose

Adapt the prefix cache connector to support vLLM >= 0.14.0.

In vLLM 0.14.0 and later, the `resumed_from_preemption` field in
`scheduled_cached_reqs` was removed and replaced with `resumed_req_ids`.
This change updates the connector logic to remain compatible with both
older and newer vLLM versions.

## Modifications

- Add compatibility handling for the scheduler output change in vLLM >= 0.14.0.
- Detect whether `resumed_from_preemption` exists.
- If the field is absent, fall back to checking `request_id` in `resumed_req_ids`.
- Keep backward compatibility with earlier vLLM versions.

## Test

- Verified prefix cache workflow with vLLM >= 0.14.0.
- Confirmed that resumed requests are correctly detected after preemption.
- Ensured no behavior change for older vLLM versions.