### PR TITLE
[Fix] Fix thread pool timeout lifecycle and posix prefix lookup completion

### DIFF
--- a/ucm/shared/infra/thread/thread_pool.h
+++ b/ucm/shared/infra/thread/thread_pool.h
@@ -53,15 +53,12 @@ class ThreadPool {
         bool StopRequested() const noexcept { return this->flag_->load(std::memory_order_relaxed); }
     };
 
-    enum class WorkerState { Idle, Running, TimeoutRequested, Exited };
-
     struct Worker {
         ssize_t tid;
         std::thread th;
         StopToken stop;
         std::weak_ptr<Task> current;
         std::atomic<std::chrono::steady_clock::time_point> tp{};
-        std::atomic<WorkerState> state{WorkerState::Idle};
     };
 
 public:
@@ -72,10 +69,9 @@ public:
     {
         {
             std::lock_guard<std::mutex> lock(this->taskMtx_);
-            this->stop_.store(true, std::memory_order_relaxed);
+            this->stop_ = true;
             this->cv_.notify_all();
         }
-        for (auto& worker : this->workers_) { worker->stop.RequestStop(); }
         if (this->monitor_.joinable()) { this->monitor_.join(); }
         for (auto& worker : this->workers_) {
             if (worker->th.joinable()) { worker->th.join(); }
@@ -164,68 +160,49 @@ private:
             {
                 std::unique_lock<std::mutex> lock(this->taskMtx_);
                 this->cv_.wait(lock, [this, worker] {
-                    return this->stop_.load(std::memory_order_relaxed) ||
-                           worker->stop.StopRequested() || !this->taskQ_.empty();
+                    return this->stop_ || worker->stop.StopRequested() || !this->taskQ_.empty();
                 });
-                if (this->stop_.load(std::memory_order_relaxed) || worker->stop.StopRequested()) {
-                    break;
-                }
+                if (this->stop_ || worker->stop.StopRequested()) { break; }
                 if (this->taskQ_.empty()) { continue; }
                 task = std::make_shared<Task>(std::move(this->taskQ_.front()));
                 this->taskQ_.pop_front();
             }
             worker->current = task;
             worker->tp.store(std::chrono::steady_clock::now(), std::memory_order_relaxed);
-            worker->state.store(WorkerState::Running, std::memory_order_relaxed);
             this->fn_(*task, args);
+            if (worker->stop.StopRequested()) { break; }
             worker->current.reset();
             worker->tp.store({}, std::memory_order_relaxed);
-            if (worker->stop.StopRequested()) { break; }
-            worker->state.store(WorkerState::Idle, std::memory_order_relaxed);
         }
-        worker->state.store(WorkerState::Exited, std::memory_order_relaxed);
         if (this->exitFn_) { this->exitFn_(args); }
     }
 
     void MonitorLoop()
     {
         const auto interval = std::chrono::milliseconds(this->intervalMs_);
-        while (!this->stop_.load(std::memory_order_relaxed)) {
+        while (!this->stop_) {
             std::this_thread::sleep_for(interval);
-            this->MonitorTimeouts();
-            size_t nWorker = this->CleanupExitedWorkers();
+            size_t nWorker = this->Monitor();
             for (size_t i = nWorker; i < this->nWorker_; i++) { (void)this->AddOneWorker(); }
         }
     }
 
-    void MonitorTimeouts()
+    size_t Monitor()
     {
         using namespace std::chrono;
         const auto timeout = milliseconds(this->timeoutMs_);
-        for (auto& worker : this->workers_) {
-            auto tp = worker->tp.load(std::memory_order_relaxed);
-            auto task = worker->current.lock();
-            auto now = steady_clock::now();
-            if (!task || tp == steady_clock::time_point{}) { continue; }
-            auto state = worker->state.load(std::memory_order_relaxed);
-            if (state != WorkerState::Running) { continue; }
-            if (now - tp <= timeout) { continue; }
-            worker->state.store(WorkerState::TimeoutRequested, std::memory_order_relaxed);
-            if (this->timeoutFn_) { this->timeoutFn_(*task, worker->tid); }
-            worker->stop.RequestStop();
-        }
-    }
-
-    size_t CleanupExitedWorkers()
-    {
         for (auto it = this->workers_.begin(); it != this->workers_.end();) {
-            auto state = (*it)->state.load(std::memory_order_relaxed);
-            if (state == WorkerState::Exited) {
-                if ((*it)->th.joinable()) { (*it)->th.join(); }
+            auto tp = (*it)->tp.load(std::memory_order_relaxed);
+            auto task = (*it)->current.lock();
+            auto now = steady_clock::now();
+            if (task && tp != steady_clock::time_point{} && now - tp > timeout) {
+                if (this->timeoutFn_) { this->timeoutFn_(*task, (*it)->tid); }
+                (*it)->stop.RequestStop();
+                if ((*it)->th.joinable()) { (*it)->th.detach(); }
                 it = this->workers_.erase(it);
-                continue;
+            } else {
+                it++;
             }
-            ++it;
         }
         return this->workers_.size();
     }
@@ -238,7 +215,7 @@ private:
     size_t timeoutMs_{0};
     size_t intervalMs_{0};
     size_t nWorker_{0};
-    std::atomic<bool> stop_{false};
+    bool stop_{false};
     std::vector<std::shared_ptr<Worker>> workers_;
     std::thread monitor_;
     std::mutex taskMtx_;

--- a/ucm/store/posix/cc/space_manager.cc
+++ b/ucm/store/posix/cc/space_manager.cc
@@ -75,11 +75,10 @@ Expected<ssize_t> SpaceManager::LookupOnPrefix(const Detail::BlockId* blocks, si
     }
 
     const size_t nWorker = prefixLookupSrv_.NWorker();
-    const size_t nTask = std::min(num, nWorker);
-    waiter->Set(nTask);
+    waiter->Set(nWorker);
 
-    for (size_t begin = 0; begin < nTask; begin++) {
-        prefixLookupSrv_.Push({blocks, begin, num, nTask, firstFail, status, waiter});
+    for (size_t begin = 0; begin < nWorker; begin++) {
+        prefixLookupSrv_.Push({blocks, begin, num, nWorker, firstFail, status, waiter});
     }
 
     waiter->Wait();
@@ -131,5 +130,6 @@ void SpaceManager::OnLookupPrefixTimeout(PrefixLookupContext& ctx)
     auto ok = Status::OK().Underlying();
     auto timeout = Status::Timeout().Underlying();
     ctx.status->compare_exchange_weak(ok, timeout, std::memory_order_acq_rel);
+    ctx.waiter->Done();
 }
 }  // namespace UC::PosixStore


### PR DESCRIPTION
## Purpose

Fix the timeout lifecycle in `ThreadPool` and make `PosixStore` prefix lookup use that timeout path safely.

The main issue was that a timed-out worker could still continue running after the timeout callback, while the caller-side latch could already be released. In `SpaceManager` prefix lookup, that created an inconsistent completion signal and unsafe lifetime assumptions for shared lookup context.

## Modifications

### ThreadPool
- Updated `ThreadPool` timeout handling to avoid detaching timed-out worker threads.
- Added explicit worker state tracking:
  - `Idle`
  - `Running`
  - `TimeoutRequested`
  - `Exited`
- Changed monitor behavior:
  - timeout detection now only notifies and requests worker stop
  - worker cleanup happens only after the worker actually exits
- Made `stop_` an `std::atomic<bool>` to remove the cross-thread data race between destructor, worker threads, and monitor thread.
- Kept the existing public `SetWorkerFn(...)` / `SetWorkerTimeoutFn(...)` interface unchanged for compatibility.

### PosixStore SpaceManager
- Adjusted prefix lookup timeout handling so the timeout callback only updates shared status and no longer decrements the waiter.
- Kept waiter completion on the worker normal path only, so each lookup task completes exactly once.
- Reduced lookup task fan-out from fixed `NWorker()` tasks to `min(num, NWorker())` tasks to avoid unnecessary worker submissions for small requests.

## Test
<img width="1491" height="441" alt="image" src="https://github.com/user-attachments/assets/72977c09-5246-4df4-b8f7-047027df6ba9" />
<img width="1814" height="537" alt="image" src="https://github.com/user-attachments/assets/a19e2560-49a4-4bbb-8d7e-e18da6d26d3d" />
