### PR TITLE
[opt] Add parallel size check in CI

### DIFF
--- a/test/common/online_inference_utils.py
+++ b/test/common/online_inference_utils.py
@@ -290,3 +290,214 @@ class VLLMServerManager:
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """Context manager exit."""
         self.stop()
+
+
+def hbm_ssd_mixed_test(
+    model_name: str,
+    tokenizer_path: str,
+    max_tokens: int,
+    prompt_split_ratio: float,
+    ucm_config: Dict[str, Any],
+    vllm_server_startup_args: Dict[str, Any],
+) -> None:
+    """Test HBM + SSD mixed hit accuracy via online inference.
+
+    This function implements  2-phasekt test flow:
+    1. Phase: Start vLLM (prefix caching OFF), send full prompt twice
+       -> KV cache saved to SSD, then loaded from SSD
+    2. Phase: Start vLLM (prefix caching ON), send partial prompt (warm HBM),
+       then send full prompt (hits both HBM and SSD) -> verify accuracy
+
+    Args:
+        model_name: Name of model (used for served_model_name and model_path lookup)
+        tokenizer_path: Path to tokenizer for prompt processing
+        max_tokens: Maximum tokens to generate
+        prompt_split_ratio: Ratio to split prompt for Phase (0.5 = split in half)
+        ucm_config: UCM connector configuration
+        vllm_server_startup_args: All kwargs for VLLMServerManager initialization
+    """
+    import os
+    from typing import List
+
+    import pytest
+    import yaml
+    from common.common_inference_utils import (
+        ensure_storage_dir,
+        load_prompt_from_file,
+        split_prompt_by_tokens,
+    )
+    from common.llm_connection.LLMBase import LLMRequest
+    from common.llm_connection.openai_connector import OpenAIConn
+    from common.llm_connection.token_counter import HuggingFaceTokenizer
+    from common.path_utils import get_path_relative_to_test_root, get_path_to_model
+
+    # Load configuration
+    config_file = get_path_relative_to_test_root("config.yaml")
+    with open(config_file, "r", encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+
+    ucm_storage_dir = "/tmp/ucm_cache"
+    ensure_storage_dir(ucm_storage_dir, clear_existing=True)
+
+    served_model_name = model_name
+    model_path = get_path_to_model(model_name, config)
+
+    # Load test prompt and standard answers
+    test_prompt, standard_answers = load_prompt_from_file(
+        get_path_relative_to_test_root("suites/E2E/prompts/test_offline_inference.json")
+    )
+    if not standard_answers:
+        pytest.fail("No standard answers found in prompt.json")
+
+    print(f"Standard answers: {standard_answers}")
+
+    # Initialize tokenizer for prompt splitting
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_path, use_chat_template=True)
+
+    # Format prompt with chat template
+    system_content = "先读问题，再根据下面的文章内容回答问题，不要进行分析，不要重复问题，用简短的语句给出答案。\n\n例如：\u201c全国美国文学研究会的第十八届年会在哪所大学举办的？\u201d\n回答应该为：\u201cxx大学\u201d。\n\n"
+    try:
+        messages = [
+            {"role": "system", "content": system_content},
+            {"role": "user", "content": test_prompt},
+        ]
+        formatted_full_prompt = tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            add_special_tokens=True,
+        )
+    except Exception:
+        formatted_full_prompt = test_prompt
+
+    # Split prompt for Phase
+    prompt_first_part, _ = split_prompt_by_tokens(
+        formatted_full_prompt, tokenizer, split_ratio=prompt_split_ratio
+    )
+
+    # Prepare messages
+    phase1_messages = [
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": test_prompt},
+    ]
+    phase2_partial_messages = [
+        {"role": "system", "content": system_content},
+        {"role": "user", "content": prompt_first_part},
+    ]
+
+    print(f"\n===== Online HBM + SSD Mixed Accuracy Test =====")
+    print(f"Model: {model_path}")
+    print(f"Full prompt length: {len(test_prompt)} chars")
+    print(f"Max tokens: {max_tokens}")
+    print(f"Prompt split ratio: {prompt_split_ratio}")
+
+    # ===== Phase: Disable HBM PC, save KV cache to SSD and load (baseline) =====
+    print(f"\n===== Phase: Save KV Cache to SSD And Load (Baseline) =====")
+    print(f"Starting vLLM server with enable_prefix_caching=False")
+
+    with VLLMServerManager(
+        **vllm_server_startup_args,
+        enable_prefix_caching=False,
+    ) as server:
+        client = OpenAIConn(
+            base_url=server.url,
+            tokenizer=HuggingFaceTokenizer(tokenizer_path),
+            model=served_model_name,
+        )
+        assert client.health_check()
+
+        print(f"server models: {client.list_models()}")
+
+        # Phase.1: Send full prompt -> KV cache saved to SSD
+        phase1_1_output = client.chat(
+            LLMRequest(messages=phase1_messages, max_tokens=max_tokens, temperature=0.0)
+        ).text
+        print(f'Phase.1 output: "{phase1_1_output}"')
+
+        # Phase.2: Send same prompt again -> KV cache loaded from SSD
+        phase1_2_output = client.chat(
+            LLMRequest(messages=phase1_messages, max_tokens=max_tokens, temperature=0.0)
+        ).text
+        print(f'Phase.2 output: "{phase1_2_output}"')
+        client.close()
+
+    print("Phase vLLM server stopped.")
+
+    # ===== Phase: Enable HBM PC, test HBM + SSD mixed hit =====
+    print(f"\n===== Phase: HBM + SSD Mixed Hit Test =====")
+    print(f"Starting vLLM server with enable_prefix_caching=True")
+
+    with VLLMServerManager(
+        **vllm_server_startup_args,
+        enable_prefix_caching=True,
+    ) as server:
+        client = OpenAIConn(
+            base_url=server.url,
+            tokenizer=HuggingFaceTokenizer(tokenizer_path),
+            model=served_model_name,
+        )
+        assert client.health_check()
+
+        print(f"server models: {client.list_models()}")
+
+        # Phase.1: Send partial prompt -> warm HBM prefix cache
+        phase2_partial_output = client.chat(
+            LLMRequest(
+                messages=phase2_partial_messages,
+                max_tokens=max_tokens,
+                temperature=0.0,
+            )
+        ).text
+        print(f"[INFO] Phase.1 output (partial prompt): {phase2_partial_output}")
+
+        # Phase.2: Send full prompt -> hits HBM (prefix) + SSD (suffix)
+        phase2_full_output = client.chat(
+            LLMRequest(messages=phase1_messages, max_tokens=max_tokens, temperature=0.0)
+        ).text
+        print(f"[INFO] Phase.2 output (full prompt): {phase2_full_output}")
+        client.close()
+
+    print("Phase vLLM server stopped.")
+
+    # ===== Accuracy Test Results =====
+    print(f"\n[INFO] ===== Accuracy Test Results =====")
+
+    def normalize_text(text: str) -> str:
+        text = text.replace("\uff0c", ",")
+        text = text.replace("\u3002", ".")
+        text = text.replace("\uff01", "!")
+        text = text.replace("\uff1f", "?")
+        text = text.replace("\uff1a", ":")
+        text = text.replace("\uff1b", ";")
+        return text.strip()
+
+    def match_any_answer(output: str, answers: List[str]) -> bool:
+        for answer in answers:
+            if normalize_text(output) == normalize_text(answer):
+                return True
+        return False
+
+    # Phase accuracy check
+    phase1_correct = match_any_answer(
+        phase1_1_output, standard_answers
+    ) and match_any_answer(phase1_2_output, standard_answers)
+    if not phase1_correct:
+        print(f"\n===== Phase: SSD Load Accuracy Test (Exact Match) =====")
+        print(f"Incorrect answer in Phase.1 (SSD save) or Phase.2 (SSD load)!")
+        print(f"Phase.1 output:\n{phase1_1_output}")
+        print(f"Phase.2 output:\n{phase1_2_output}")
+        print(f"Standard answers:\n{standard_answers}")
+        pytest.fail("SSD Load Accuracy Test Failed!")
+
+    # Phase accuracy check
+    phase2_correct = match_any_answer(phase2_full_output, standard_answers)
+    if not phase2_correct:
+        print(f"\n===== Phase: HBM + SSD Mixed Accuracy Test (Exact Match) =====")
+        print(f"Incorrect answer in Phase.2 (HBM + SSD mixed)!")
+        print(f"Phase.2 output:\n{phase2_full_output}")
+        print(f"Standard answers:\n{standard_answers}")
+        pytest.fail("HBM + SSD Mixed Accuracy Test Failed!")
+
+    print("\n===== All Tests Passed! =====")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -238,28 +238,66 @@ def get_free_gpu(required_memory_mb):
 def setup_gpu_resource(request):
     import fcntl
 
-    marker = request.node.get_closest_marker("gpu_mem")
-    if not marker:
-        # No gpu_mem marker, skip GPU resource setup
+    gpu_mem_marker = request.node.get_closest_marker("gpu_mem")
+    gpu_count_marker = request.node.get_closest_marker("gpu_count")
+
+    if not gpu_mem_marker and not gpu_count_marker:
+        # No GPU markers, skip GPU resource setup
         yield
         return
 
-    mem_needed = marker.args[0]
-    gpu_id, free_in_mb, gpu_utilization, lock_file = get_free_gpu(mem_needed)
-    if gpu_id is None:
-        pytest.fail(f"No GPU with {mem_needed}MB(+30% buffer) free memory available")
+    if gpu_count_marker:
+        # Handle gpu_count marker - allocate multiple GPUs
+        gpu_count = gpu_count_marker.args[0]
+        mem_needed = gpu_mem_marker.args[0] if gpu_mem_marker else 0
+        allocated_gpus = []
+        lock_files = []
 
-    print(
-        f"Allocating GPU {gpu_id} with {free_in_mb}MB free memory, gpu utilization for test {gpu_utilization:.4%}"
-    )
-    os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
-    if gpu_utilization:
-        os.environ["E2E_TEST_GPU_MEMORY_UTILIZATION"] = str(gpu_utilization)
+        try:
+            for i in range(gpu_count):
+                gpu_id, free_in_mb, gpu_utilization, lock_file = get_free_gpu(
+                    mem_needed
+                )
+                if gpu_id is None:
+                    pytest.fail(
+                        f"Failed to {f'allocate GPU with {mem_needed}MB(+30% buffer) free memory' if mem_needed else 'allocate GPU'} {i + 1}/{gpu_count}"
+                    )
 
-    yield  # test runs here while the lock is held
+                allocated_gpus.append(gpu_id)
+                lock_files.append(lock_file)
+                print(
+                    f"Allocating GPU {gpu_id} (slot {i + 1}/{gpu_count}) with {free_in_mb}MB free memory"
+                )
 
-    fcntl.flock(lock_file, fcntl.LOCK_UN)
-    lock_file.close()
+            os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(map(str, allocated_gpus))
+            print(f"Allocated GPUs: {allocated_gpus}")
+
+            yield  # test runs here while locks are held
+
+        finally:
+            for lock_file in lock_files:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+                lock_file.close()
+    else:
+        # Handle gpu_mem marker - allocate single GPU with memory requirement
+        mem_needed = gpu_mem_marker.args[0]
+        gpu_id, free_in_mb, gpu_utilization, lock_file = get_free_gpu(mem_needed)
+        if gpu_id is None:
+            pytest.fail(
+                f"No GPU with {mem_needed}MB(+30% buffer) free memory available"
+            )
+
+        print(
+            f"Allocating GPU {gpu_id} with {free_in_mb}MB free memory, gpu utilization for test {gpu_utilization:.4%}"
+        )
+        os.environ["CUDA_VISIBLE_DEVICES"] = str(gpu_id)
+        if gpu_utilization:
+            os.environ["E2E_TEST_GPU_MEMORY_UTILIZATION"] = str(gpu_utilization)
+
+        yield  # test runs here while the lock is held
+
+        fcntl.flock(lock_file, fcntl.LOCK_UN)
+        lock_file.close()
 
 
 @pytest.fixture(scope="session")
@@ -274,7 +312,6 @@ def model_config() -> ModelConfig:
 
 
 def pytest_sessionfinish(session, exitstatus):
-
     backup_dir = config_instance.get_nested_config("database.backup") or "results/"
     backup_dir = Path(backup_dir).resolve()
 

--- a/test/pytest.ini
+++ b/test/pytest.ini
@@ -23,4 +23,5 @@ markers =
     feature:     Feature tag
     platform: Platform tag(gpu/npu)
     gpu_mem: GPU memory requirement in MB
+    gpu_count: Number of GPUs required
 # end of markers

--- a/test/suites/E2E/test_online_inference.py
+++ b/test/suites/E2E/test_online_inference.py
@@ -19,15 +19,7 @@ from typing import List
 
 import pytest
 import yaml
-from common.common_inference_utils import (
-    ensure_storage_dir,
-    load_prompt_from_file,
-    split_prompt_by_tokens,
-)
-from common.llm_connection.LLMBase import LLMRequest
-from common.llm_connection.openai_connector import OpenAIConn
-from common.llm_connection.token_counter import HuggingFaceTokenizer
-from common.online_inference_utils import VLLMServerManager
+from common.online_inference_utils import hbm_ssd_mixed_test
 from common.path_utils import get_path_relative_to_test_root, get_path_to_model
 
 os.environ["ENABLE_UCM_PATCH"] = "1"
@@ -45,7 +37,6 @@ class TestBasicOnlineInference:
     @pytest.mark.parametrize("ucm_connector_name", ["UcmNfsStore", "UcmPipelineStore"])
     @pytest.mark.parametrize("use_layerwise", [True, False])
     @pytest.mark.parametrize("max_num_batched_tokens", [2047])
-    @pytest.mark.parametrize("pp_size", [1, 2])
     def test_online_accuracy_hbm_ssd_mixed(
         self,
         model_name: str,
@@ -54,7 +45,6 @@ class TestBasicOnlineInference:
         ucm_connector_name: str,
         use_layerwise: bool,
         max_num_batched_tokens: int,
-        pp_size: int,
     ):
         """Test HBM + SSD mixed hit accuracy via online inference.
 
@@ -67,67 +57,23 @@ class TestBasicOnlineInference:
         Args:
             model_name: Name of model (used to determine tokenizer path)
             max_tokens: Maximum tokens to generate
-            prompt_split_ratio: Ratio to split prompt for Phase 2 (0.5 = split in half)
+            prompt_split_ratio: Ratio to split prompt for Phase 2 (0.5 = split in)
             ucm_connector_name: Name of UCM store.
             use_layerwise: Whether to use layerwise mode.
             max_num_batched_tokens: Maximum number of batched tokens.
         """
-        # Load configuration
         if use_layerwise is True and ucm_connector_name == "UcmNfsStore":
             pytest.skip("Skipping: UcmNfsStore does NOT support use_layerwise=True")
-        if use_layerwise is False and pp_size > 1:
-            pytest.skip(
-                "Skipping: Pipeline parallelism does NOT support use_layerwise=False"
-            )
+
+        # Load configuration
         config_file = get_path_relative_to_test_root("config.yaml")
         with open(config_file, "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
 
         ucm_storage_dir = "/tmp/ucm_cache"
-        ensure_storage_dir(ucm_storage_dir, clear_existing=True)
-
         served_model_name = model_name
         tokenizer_path = f"/home/models/{model_name}"
         model_path = get_path_to_model(model_name, config)
-
-        # Load test prompt and standard answers
-        test_prompt, standard_answers = load_prompt_from_file(
-            get_path_relative_to_test_root(
-                "suites/E2E/prompts/test_offline_inference.json"
-            )
-        )
-        if not standard_answers:
-            pytest.fail("No standard answers found in prompt.json")
-
-        print(f"Standard answers: {standard_answers}")
-
-        # Initialize tokenizer for prompt splitting
-        from transformers import AutoTokenizer
-
-        tokenizer = AutoTokenizer.from_pretrained(
-            tokenizer_path, use_chat_template=True
-        )
-
-        # Format prompt with chat template
-        system_content = "先读问题，再根据下面的文章内容回答问题，不要进行分析，不要重复问题，用简短的语句给出答案。\n\n例如：\u201c全国美国文学研究会的第十八届年会在哪所大学举办的？\u201d\n回答应该为：\u201cxx大学\u201d。\n\n"
-        try:
-            messages = [
-                {"role": "system", "content": system_content},
-                {"role": "user", "content": test_prompt},
-            ]
-            formatted_full_prompt = tokenizer.apply_chat_template(
-                messages,
-                tokenize=False,
-                add_generation_prompt=True,
-                add_special_tokens=True,
-            )
-        except Exception:
-            formatted_full_prompt = test_prompt
-
-        # Split prompt for Phase 2
-        prompt_first_part, _ = split_prompt_by_tokens(
-            formatted_full_prompt, tokenizer, split_ratio=prompt_split_ratio
-        )
 
         # Build UCM config
         ucm_config = {
@@ -152,147 +98,109 @@ class TestBasicOnlineInference:
             ),
         }
 
-        # Common VLLMServerManager kwargs
-        server_common_kwargs = dict(
+        # Build vllm_server_startup_args
+        vllm_server_startup_args = dict(
             model_path=model_path,
             port=8000,
             ucm_config=ucm_config,
             max_model_len=12000,
             max_num_batched_tokens=max_num_batched_tokens,
             served_model_name=served_model_name,
-            pipeline_parallel_size=pp_size,
         )
 
-        # Prepare messages
-        phase1_messages = [
-            {"role": "system", "content": system_content},
-            {"role": "user", "content": test_prompt},
-        ]
-        phase2_partial_messages = [
-            {"role": "system", "content": system_content},
-            {"role": "user", "content": prompt_first_part},
-        ]
+        hbm_ssd_mixed_test(
+            model_name,
+            tokenizer_path,
+            max_tokens,
+            prompt_split_ratio,
+            ucm_config,
+            vllm_server_startup_args,
+        )
 
-        print(f"\n===== Online HBM + SSD Mixed Accuracy Test =====")
-        print(f"Model: {model_path}")
-        print(f"Full prompt length: {len(test_prompt)} chars")
-        print(f"Max tokens: {max_tokens}")
-        print(f"Prompt split ratio: {prompt_split_ratio}")
-        print(f"UCM connector: {ucm_connector_name}, use_layerwise: {use_layerwise}")
-        print(f"Max num batched tokens: {max_num_batched_tokens}")
-        print(f"Pipeline parallel size: {pp_size}")
+    @pytest.mark.stage(1)
+    @pytest.mark.gpu_mem(6000)
+    @pytest.mark.gpu_count(2)
+    @pytest.mark.feature("online_inference")
+    @pytest.mark.parametrize("model_name", ["Qwen2.5-1.5B-Instruct"])
+    @pytest.mark.parametrize("max_tokens", [200])
+    @pytest.mark.parametrize("prompt_split_ratio", [0.5])
+    @pytest.mark.parametrize("ucm_connector_name", ["UcmPipelineStore"])
+    @pytest.mark.parametrize("use_layerwise", [True])
+    @pytest.mark.parametrize("max_num_batched_tokens", [2047])
+    def test_online_accuracy_hbm_ssd_mixed_pp(
+        self,
+        model_name: str,
+        max_tokens: int,
+        prompt_split_ratio: float,
+        ucm_connector_name: str,
+        use_layerwise: bool,
+        max_num_batched_tokens: int,
+    ):
+        """Test HBM + SSD mixed hit accuracy via online inference with pipeline parallel.
 
-        # ===== Phase 1: Disable HBM PC, save KV cache to SSD and load (baseline) =====
-        print(f"\n===== Phase 1: Save KV Cache to SSD And Load (Baseline) =====")
-        print(f"Starting vLLM server with enable_prefix_caching=False")
+        Mirrors test_offline_inference.py flow:
+        1. Phase 1: Start vLLM (prefix caching OFF), send full prompt twice
+           -> KV cache saved to SSD, then loaded from SSD
+        2. Phase 2: Start vLLM (prefix caching ON), send partial prompt (warm HBM),
+           then send full prompt (hits both HBM and SSD) -> verify accuracy
 
-        with VLLMServerManager(
-            **server_common_kwargs,
-            enable_prefix_caching=False,
-        ) as server:
-            client = OpenAIConn(
-                base_url=server.url,
-                tokenizer=HuggingFaceTokenizer(tokenizer_path),
-                model=served_model_name,
-            )
-            assert client.health_check()
+        Args:
+            model_name: Name of model (used to determine tokenizer path)
+            max_tokens: Maximum tokens to generate
+            prompt_split_ratio: Ratio to split prompt for Phase 2 (0.5 = split in half)
+            ucm_connector_name: Name of UCM store.
+            use_layerwise: Whether to use layerwise mode.
+            max_num_batched_tokens: Maximum number of batched tokens.
+        """
+        # Load configuration
+        config_file = get_path_relative_to_test_root("config.yaml")
+        with open(config_file, "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
 
-            print(f"server models: {client.list_models()}")
+        ucm_storage_dir = "/tmp/ucm_cache"
+        served_model_name = model_name
+        tokenizer_path = f"/home/models/{model_name}"
+        model_path = get_path_to_model(model_name, config)
 
-            # Phase 1.1: Send full prompt -> KV cache saved to SSD
-            phase1_1_output = client.chat(
-                LLMRequest(
-                    messages=phase1_messages, max_tokens=max_tokens, temperature=0.0
-                )
-            ).text
-            print(f'Phase 1.1 output: "{phase1_1_output}"')
+        # Build UCM config
+        ucm_config = {
+            "use_layerwise": (
+                use_layerwise if ucm_connector_name != "UcmNfsStore" else False
+            ),
+            "ucm_connectors": [
+                {
+                    "ucm_connector_name": ucm_connector_name,
+                    "ucm_connector_config": {
+                        "store_pipeline": "Cache|Posix",
+                        "storage_backends": ucm_storage_dir,
+                        "use_direct": False,
+                        "cache_buffer_capacity_gb": 32,
+                    },
+                }
+            ],
+            **(
+                {"enable_event_sync": False}
+                if ucm_connector_name == "UcmNfsStore"
+                else {}
+            ),
+        }
 
-            # Phase 1.2: Send same prompt again -> KV cache loaded from SSD
-            phase1_2_output = client.chat(
-                LLMRequest(
-                    messages=phase1_messages, max_tokens=max_tokens, temperature=0.0
-                )
-            ).text
-            print(f'Phase 1.2 output: "{phase1_2_output}"')
-            client.close()
+        # Build vllm_server_startup_args with pipeline parallel size
+        vllm_server_startup_args = dict(
+            model_path=model_path,
+            port=8000,
+            ucm_config=ucm_config,
+            max_model_len=12000,
+            max_num_batched_tokens=max_num_batched_tokens,
+            served_model_name=served_model_name,
+            pipeline_parallel_size=2,
+        )
 
-        print("Phase 1 vLLM server stopped.")
-
-        # ===== Phase 2: Enable HBM PC, test HBM + SSD mixed hit =====
-        print(f"\n===== Phase 2: HBM + SSD Mixed Hit Test =====")
-        print(f"Starting vLLM server with enable_prefix_caching=True")
-
-        with VLLMServerManager(
-            **server_common_kwargs,
-            enable_prefix_caching=True,
-        ) as server:
-            client = OpenAIConn(
-                base_url=server.url,
-                tokenizer=HuggingFaceTokenizer(tokenizer_path),
-                model=served_model_name,
-            )
-            assert client.health_check()
-
-            print(f"server models: {client.list_models()}")
-
-            # Phase 2.1: Send partial prompt -> warm HBM prefix cache
-            phase2_partial_output = client.chat(
-                LLMRequest(
-                    messages=phase2_partial_messages,
-                    max_tokens=max_tokens,
-                    temperature=0.0,
-                )
-            ).text
-            print(f"[INFO] Phase 2.1 output (partial prompt): {phase2_partial_output}")
-
-            # Phase 2.2: Send full prompt -> hits HBM (prefix) + SSD (suffix)
-            phase2_full_output = client.chat(
-                LLMRequest(
-                    messages=phase1_messages, max_tokens=max_tokens, temperature=0.0
-                )
-            ).text
-            print(f"[INFO] Phase 2.2 output (full prompt): {phase2_full_output}")
-            client.close()
-
-        print("Phase 2 vLLM server stopped.")
-
-        # ===== Accuracy Test Results =====
-        print(f"\n[INFO] ===== Accuracy Test Results =====")
-
-        def normalize_text(text: str) -> str:
-            text = text.replace("\uff0c", ",")
-            text = text.replace("\u3002", ".")
-            text = text.replace("\uff01", "!")
-            text = text.replace("\uff1f", "?")
-            text = text.replace("\uff1a", ":")
-            text = text.replace("\uff1b", ";")
-            return text.strip()
-
-        def match_any_answer(output: str, answers: List[str]) -> bool:
-            for answer in answers:
-                if normalize_text(output) == normalize_text(answer):
-                    return True
-            return False
-
-        # Phase 1 accuracy check
-        phase1_correct = match_any_answer(
-            phase1_1_output, standard_answers
-        ) and match_any_answer(phase1_2_output, standard_answers)
-        if not phase1_correct:
-            print(f"\n===== Phase 1: SSD Load Accuracy Test (Exact Match) =====")
-            print(f"Incorrect answer in Phase 1.1 (SSD save) or Phase 1.2 (SSD load)!")
-            print(f"Phase 1.1 output:\n{phase1_1_output}")
-            print(f"Phase 1.2 output:\n{phase1_2_output}")
-            print(f"Standard answers:\n{standard_answers}")
-            pytest.fail("SSD Load Accuracy Test Failed!")
-
-        # Phase 2 accuracy check
-        phase2_correct = match_any_answer(phase2_full_output, standard_answers)
-        if not phase2_correct:
-            print(f"\n===== Phase 2: HBM + SSD Mixed Accuracy Test (Exact Match) =====")
-            print(f"Incorrect answer in Phase 2.2 (HBM + SSD mixed)!")
-            print(f"Phase 2.2 output:\n{phase2_full_output}")
-            print(f"Standard answers:\n{standard_answers}")
-            pytest.fail("HBM + SSD Mixed Accuracy Test Failed!")
-
-        print("\n===== All Tests Passed! =====")
+        hbm_ssd_mixed_test(
+            model_name,
+            tokenizer_path,
+            max_tokens,
+            prompt_split_ratio,
+            ucm_config,
+            vllm_server_startup_args,
+        )

--- a/test/suites/E2E/test_online_inference_sparse.py
+++ b/test/suites/E2E/test_online_inference_sparse.py
@@ -22,12 +22,11 @@ import yaml
 from common.common_inference_utils import (
     ensure_storage_dir,
     load_prompt_from_file,
-    split_prompt_by_tokens,
 )
 from common.llm_connection.LLMBase import LLMRequest
 from common.llm_connection.openai_connector import OpenAIConn
 from common.llm_connection.token_counter import HuggingFaceTokenizer
-from common.online_inference_utils import VLLMServerManager
+from common.online_inference_utils import VLLMServerManager, hbm_ssd_mixed_test
 from common.path_utils import get_path_relative_to_test_root, get_path_to_model
 
 os.environ["ENABLE_UCM_PATCH"] = "1"
@@ -63,56 +62,16 @@ class TestBasicOnlineInference:
         """
         os.environ["ENABLE_SPARSE"] = "0"
         os.environ["VLLM_HASH_ATTENTION"] = "0"
+
         # Load configuration
         config_file = get_path_relative_to_test_root("config.yaml")
         with open(config_file, "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
 
         ucm_storage_dir = "/tmp/ucm_cache"
-        ensure_storage_dir(ucm_storage_dir, clear_existing=True)
-
         served_model_name = model_name
         tokenizer_path = f"/home/models/{model_name}"
         model_path = get_path_to_model(model_name, config)
-
-        # Load test prompt and standard answers
-        test_prompt, standard_answers = load_prompt_from_file(
-            get_path_relative_to_test_root(
-                "suites/E2E/prompts/test_offline_inference.json"
-            )
-        )
-        if not standard_answers:
-            pytest.fail("No standard answers found in prompt.json")
-
-        print(f"Standard answers: {standard_answers}")
-
-        # Initialize tokenizer for prompt splitting
-        from transformers import AutoTokenizer
-
-        tokenizer = AutoTokenizer.from_pretrained(
-            tokenizer_path, use_chat_template=True
-        )
-
-        # Format prompt with chat template
-        system_content = "先读问题，再根据下面的文章内容回答问题，不要进行分析，不要重复问题，用简短的语句给出答案。\n\n例如：\u201c全国美国文学研究会的第十八届年会在哪所大学举办的？\u201d\n回答应该为：\u201cxx大学\u201d。\n\n"
-        try:
-            messages = [
-                {"role": "system", "content": system_content},
-                {"role": "user", "content": test_prompt},
-            ]
-            formatted_full_prompt = tokenizer.apply_chat_template(
-                messages,
-                tokenize=False,
-                add_generation_prompt=True,
-                add_special_tokens=True,
-            )
-        except Exception:
-            formatted_full_prompt = test_prompt
-
-        # Split prompt for Phase 2
-        prompt_first_part, _ = split_prompt_by_tokens(
-            formatted_full_prompt, tokenizer, split_ratio=prompt_split_ratio
-        )
 
         # Build UCM config
         ucm_config = {
@@ -129,8 +88,8 @@ class TestBasicOnlineInference:
             ],
         }
 
-        # Common VLLMServerManager kwargs
-        server_common_kwargs = dict(
+        # Build vllm_server_server_startup_args
+        vllm_server_startup_args = dict(
             model_path=model_path,
             port=8000,
             ucm_config=ucm_config,
@@ -139,136 +98,14 @@ class TestBasicOnlineInference:
             served_model_name=served_model_name,
         )
 
-        # Prepare messages
-        phase1_messages = [
-            {"role": "system", "content": system_content},
-            {"role": "user", "content": test_prompt},
-        ]
-        phase2_partial_messages = [
-            {"role": "system", "content": system_content},
-            {"role": "user", "content": prompt_first_part},
-        ]
-
-        print(f"\n===== Online HBM + SSD Mixed Accuracy Test =====")
-        print(f"Model: {model_path}")
-        print(f"Full prompt length: {len(test_prompt)} chars")
-        print(f"Max tokens: {max_tokens}")
-        print(f"Prompt split ratio: {prompt_split_ratio}")
-
-        # ===== Phase 1: Disable HBM PC, save KV cache to SSD and load (baseline) =====
-        print(f"\n===== Phase 1: Save KV Cache to SSD And Load (Baseline) =====")
-        print(f"Starting vLLM server with enable_prefix_caching=False")
-
-        with VLLMServerManager(
-            **server_common_kwargs,
-            enable_prefix_caching=False,
-        ) as server:
-            client = OpenAIConn(
-                base_url=server.url,
-                tokenizer=HuggingFaceTokenizer(tokenizer_path),
-                model=served_model_name,
-            )
-            assert client.health_check()
-
-            print(f"server models: {client.list_models()}")
-
-            # Phase 1.1: Send full prompt -> KV cache saved to SSD
-            phase1_1_output = client.chat(
-                LLMRequest(
-                    messages=phase1_messages, max_tokens=max_tokens, temperature=0.0
-                )
-            ).text
-            print(f'Phase 1.1 output: "{phase1_1_output}"')
-
-            # Phase 1.2: Send same prompt again -> KV cache loaded from SSD
-            phase1_2_output = client.chat(
-                LLMRequest(
-                    messages=phase1_messages, max_tokens=max_tokens, temperature=0.0
-                )
-            ).text
-            print(f'Phase 1.2 output: "{phase1_2_output}"')
-            client.close()
-
-        print("Phase 1 vLLM server stopped.")
-
-        # ===== Phase 2: Enable HBM PC, test HBM + SSD mixed hit =====
-        print(f"\n===== Phase 2: HBM + SSD Mixed Hit Test =====")
-        print(f"Starting vLLM server with enable_prefix_caching=True")
-
-        with VLLMServerManager(
-            **server_common_kwargs,
-            enable_prefix_caching=True,
-        ) as server:
-            client = OpenAIConn(
-                base_url=server.url,
-                tokenizer=HuggingFaceTokenizer(tokenizer_path),
-                model=served_model_name,
-            )
-            assert client.health_check()
-
-            print(f"server models: {client.list_models()}")
-
-            # Phase 2.1: Send partial prompt -> warm HBM prefix cache
-            phase2_partial_output = client.chat(
-                LLMRequest(
-                    messages=phase2_partial_messages,
-                    max_tokens=max_tokens,
-                    temperature=0.0,
-                )
-            ).text
-            print(f"[INFO] Phase 2.1 output (partial prompt): {phase2_partial_output}")
-
-            # Phase 2.2: Send full prompt -> hits HBM (prefix) + SSD (suffix)
-            phase2_full_output = client.chat(
-                LLMRequest(
-                    messages=phase1_messages, max_tokens=max_tokens, temperature=0.0
-                )
-            ).text
-            print(f"[INFO] Phase 2.2 output (full prompt): {phase2_full_output}")
-            client.close()
-
-        print("Phase 2 vLLM server stopped.")
-
-        # ===== Accuracy Test Results =====
-        print(f"\n[INFO] ===== Accuracy Test Results =====")
-
-        def normalize_text(text: str) -> str:
-            text = text.replace("\uff0c", ",")
-            text = text.replace("\u3002", ".")
-            text = text.replace("\uff01", "!")
-            text = text.replace("\uff1f", "?")
-            text = text.replace("\uff1a", ":")
-            text = text.replace("\uff1b", ";")
-            return text.strip()
-
-        def match_any_answer(output: str, answers: List[str]) -> bool:
-            for answer in answers:
-                if normalize_text(output) == normalize_text(answer):
-                    return True
-            return False
-
-        # Phase 1 accuracy check
-        phase1_correct = match_any_answer(
-            phase1_1_output, standard_answers
-        ) and match_any_answer(phase1_2_output, standard_answers)
-        if not phase1_correct:
-            print(f"\n===== Phase 1: SSD Load Accuracy Test (Exact Match) =====")
-            print(f"Incorrect answer in Phase 1.1 (SSD save) or Phase 1.2 (SSD load)!")
-            print(f"Phase 1.1 output:\n{phase1_1_output}")
-            print(f"Phase 1.2 output:\n{phase1_2_output}")
-            print(f"Standard answers:\n{standard_answers}")
-            pytest.fail("SSD Load Accuracy Test Failed!")
-
-        # Phase 2 accuracy check
-        phase2_correct = match_any_answer(phase2_full_output, standard_answers)
-        if not phase2_correct:
-            print(f"\n===== Phase 2: HBM + SSD Mixed Accuracy Test (Exact Match) =====")
-            print(f"Incorrect answer in Phase 2.2 (HBM + SSD mixed)!")
-            print(f"Phase 2.2 output:\n{phase2_full_output}")
-            print(f"Standard answers:\n{standard_answers}")
-            pytest.fail("HBM + SSD Mixed Accuracy Test Failed!")
-
-        print("\n===== All Tests Passed! =====")
+        hbm_ssd_mixed_test(
+            model_name,
+            tokenizer_path,
+            max_tokens,
+            prompt_split_ratio,
+            ucm_config,
+            vllm_server_startup_args,
+        )
 
     @pytest.mark.skip(reason="refine this code and re-enable later")
     @pytest.mark.stage(1)


### PR DESCRIPTION
## Purpose
Support setting pp_size to extend CI coverage.
## Modifications 
Add new testcase for online inference tests that cover layerwise loading/saving when using pipeline parallel. This improves regression coverage for these configurations.

Extract the common parts of the tests into **hbm_ssd_mixed_test** in online_inference_utils.py.

Modify **setup_gpu_resource** in conftest.py to support choosing multiple devices.
## Test
<img width="833" height="429" alt="image" src="https://github.com/user-attachments/assets/87563a04-4b12-4ff4-96ad-741e18219196" />
