### PR TITLE
[wip][opt] Add parallel size check in CI

### DIFF
--- a/test/common/online_inference_utils.py
+++ b/test/common/online_inference_utils.py
@@ -88,6 +88,7 @@ class VLLMServerManager:
         additional_args: Optional[List[str]] = None,
         startup_timeout: float = 300.0,
         served_model_name: str = "",
+        pipeline_parallel_size: int = 1,
     ):
         """Initialize the VLLMServerManager.
 
@@ -105,6 +106,7 @@ class VLLMServerManager:
             additional_args: Additional arguments to pass to vllm serve
             startup_timeout: Timeout in seconds for server startup
             served_model_name: Optional model name to expose via the API (defaults to model_path)
+            pipeline_parallel_size: Pipeline parallel size (default: 1)
         """
 
         gpu_memory_utilization = float(
@@ -126,6 +128,7 @@ class VLLMServerManager:
         self.additional_args = additional_args or []
         self.startup_timeout = startup_timeout
         self.served_model_name = served_model_name
+        self.pipeline_parallel_size = pipeline_parallel_size
 
         self._process: Optional[subprocess.Popen] = None
         self._url = f"http://{host}:{port}"
@@ -163,6 +166,8 @@ class VLLMServerManager:
             str(self.max_model_len),
             "--gpu-memory-utilization",
             str(self.gpu_memory_utilization),
+            "--pipeline-parallel-size",
+            str(self.pipeline_parallel_size),
         ]
 
         # Add UCM kv-transfer-config

--- a/test/suites/E2E/test_online_inference.py
+++ b/test/suites/E2E/test_online_inference.py
@@ -45,6 +45,7 @@ class TestBasicOnlineInference:
     @pytest.mark.parametrize("ucm_connector_name", ["UcmNfsStore", "UcmPipelineStore"])
     @pytest.mark.parametrize("use_layerwise", [True, False])
     @pytest.mark.parametrize("max_num_batched_tokens", [2047])
+    @pytest.mark.parametrize("pp_size", [1, 2])
     def test_online_accuracy_hbm_ssd_mixed(
         self,
         model_name: str,
@@ -53,6 +54,7 @@ class TestBasicOnlineInference:
         ucm_connector_name: str,
         use_layerwise: bool,
         max_num_batched_tokens: int,
+        pp_size: int,
     ):
         """Test HBM + SSD mixed hit accuracy via online inference.
 
@@ -71,6 +73,12 @@ class TestBasicOnlineInference:
             max_num_batched_tokens: Maximum number of batched tokens.
         """
         # Load configuration
+        if use_layerwise is True and ucm_connector_name == "UcmNfsStore":
+            pytest.skip("Skipping: UcmNfsStore does NOT support use_layerwise=True")
+        if use_layerwise is False and pp_size > 1:
+            pytest.skip(
+                "Skipping: Pipeline parallelism does NOT support use_layerwise=False"
+            )
         config_file = get_path_relative_to_test_root("config.yaml")
         with open(config_file, "r", encoding="utf-8") as f:
             config = yaml.safe_load(f)
@@ -152,6 +160,7 @@ class TestBasicOnlineInference:
             max_model_len=12000,
             max_num_batched_tokens=max_num_batched_tokens,
             served_model_name=served_model_name,
+            pipeline_parallel_size=pp_size,
         )
 
         # Prepare messages
@@ -171,6 +180,7 @@ class TestBasicOnlineInference:
         print(f"Prompt split ratio: {prompt_split_ratio}")
         print(f"UCM connector: {ucm_connector_name}, use_layerwise: {use_layerwise}")
         print(f"Max num batched tokens: {max_num_batched_tokens}")
+        print(f"Pipeline parallel size: {pp_size}")
 
         # ===== Phase 1: Disable HBM PC, save KV cache to SSD and load (baseline) =====
         print(f"\n===== Phase 1: Save KV Cache to SSD And Load (Baseline) =====")


### PR DESCRIPTION
## Purpose
Support setting pp_size to extend CI coverage
## Modifications 
Add CI jobs for online inference tests that cover layerwise loading/saving when using pipeline parallel. This improves regression coverage for these configurations.
## Test
