### PR TITLE
[feat] Ascend: add mmap-based Host memory for O_DIRECT support

### DIFF
--- a/ucm/shared/trans/CMakeLists.txt
+++ b/ucm/shared/trans/CMakeLists.txt
@@ -11,7 +11,7 @@ if(RUNTIME_ENVIRONMENT STREQUAL "simu")
     add_subdirectory(simu)
 endif()
 target_include_directories(trans PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
-target_link_libraries(trans PUBLIC infra_status)
+target_link_libraries(trans PUBLIC infra_status infra_logger)
 
 file(GLOB_RECURSE UCMTRANS_CPY_SOURCE_FILES "./cpy/*.cc")
 pybind11_add_module(ucmtrans ${UCMTRANS_CPY_SOURCE_FILES})

--- a/ucm/shared/trans/ascend/ascend_buffer.cc
+++ b/ucm/shared/trans/ascend/ascend_buffer.cc
@@ -23,8 +23,90 @@
  * */
 #include "ascend_buffer.h"
 #include <acl/acl.h>
+#include <sys/mman.h>
+#include "logger/logger.h"
 
 namespace UC::Trans {
+
+class HostHugePages : public std::enable_shared_from_this<HostHugePages> {
+    struct ConstructorKey {};
+    static constexpr auto HUGE_PAGE_SIZE = 2UL << 20;
+    static constexpr auto GIGANTIC_PAGE_SIZE = 1UL << 30;
+    static constexpr auto HUGE_PAGE_FLAG = 21 << MAP_HUGE_SHIFT;
+    static constexpr auto GIGANTIC_PAGE_FLAG = 30 << MAP_HUGE_SHIFT;
+    size_t size_;
+    void* buffer_;
+
+    static void* MMapWithTLB(size_t& size, bool useGiganticPages)
+    {
+        const auto pageSize = useGiganticPages ? GIGANTIC_PAGE_SIZE : HUGE_PAGE_SIZE;
+        const auto alignedSize = (size + pageSize - 1) / pageSize * pageSize;
+        const auto pageFlag = useGiganticPages ? GIGANTIC_PAGE_FLAG : HUGE_PAGE_FLAG;
+        const auto prot = PROT_WRITE | PROT_READ;
+        const auto flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | pageFlag;
+        void* ptr = mmap(nullptr, alignedSize, prot, flags, -1, 0);
+        if (ptr == MAP_FAILED) {
+            UC_WARN("Mmap({}) with TLB({}) return: {}.", alignedSize, pageSize, errno);
+            return ptr;
+        }
+        size = alignedSize;
+        return ptr;
+    }
+    static void* MMapWithAdvice(size_t& size)
+    {
+        const auto pageSize = HUGE_PAGE_SIZE;
+        const auto alignedSize = (size + pageSize - 1) / pageSize * pageSize;
+        const auto prot = PROT_WRITE | PROT_READ;
+        const auto flags = MAP_PRIVATE | MAP_ANONYMOUS;
+        void* ptr = mmap(nullptr, alignedSize, prot, flags, -1, 0);
+        if (ptr == MAP_FAILED) {
+            UC_WARN("Mmap({}) with advice({}) return: {}.", alignedSize, pageSize, errno);
+            return ptr;
+        }
+        madvise(ptr, alignedSize, MADV_HUGEPAGE);
+        size = alignedSize;
+        return ptr;
+    }
+
+public:
+    HostHugePages(size_t size, ConstructorKey) : size_(size), buffer_(MAP_FAILED) {}
+    static std::shared_ptr<HostHugePages> Create(size_t size)
+    {
+        return std::make_shared<HostHugePages>(size, ConstructorKey{});
+    }
+    ~HostHugePages()
+    {
+        if (buffer_ == MAP_FAILED) { return; }
+        Buffer::UnregisterHostBuffer(buffer_);
+        munlock(buffer_, size_);
+        munmap(buffer_, size_);
+    }
+    std::shared_ptr<void> Data()
+    {
+        if (buffer_ != MAP_FAILED) {
+            return std::shared_ptr<void>(buffer_, [self = shared_from_this()](auto) {});
+        }
+        const auto useGiganticPages = size_ >= GIGANTIC_PAGE_SIZE;
+        buffer_ = MMapWithTLB(size_, useGiganticPages);
+        if (buffer_ == MAP_FAILED && useGiganticPages) { buffer_ = MMapWithTLB(size_, false); }
+        if (buffer_ == MAP_FAILED) { buffer_ = MMapWithAdvice(size_); }
+        if (buffer_ == MAP_FAILED) {
+            UC_ERROR("Failed to make host buffer({}).", size_);
+            return nullptr;
+        }
+        std::memset(buffer_, 0, size_);
+        mlock(buffer_, size_);
+        auto s = Buffer::RegisterHostBuffer(buffer_, size_);
+        if (s.Failure()) {
+            UC_ERROR("Failed({}) to register buffer({}).", s, size_);
+            munlock(buffer_, size_);
+            munmap(buffer_, size_);
+            buffer_ = MAP_FAILED;
+            return nullptr;
+        }
+        return std::shared_ptr<void>(buffer_, [self = shared_from_this()](auto) {});
+    }
+};
 
 std::shared_ptr<void> Trans::AscendBuffer::MakeDeviceBuffer(size_t size)
 {
@@ -40,6 +122,15 @@ std::shared_ptr<void> Trans::AscendBuffer::MakeHostBuffer(size_t size)
     auto ret = aclrtMallocHost(&host, size);
     if (ret == ACL_SUCCESS) { return std::shared_ptr<void>(host, aclrtFreeHost); }
     return nullptr;
+}
+
+std::shared_ptr<void> Trans::AscendBuffer::MakeHostBuffer4DirectIo(size_t size)
+{
+    try {
+        return HostHugePages::Create(size)->Data();
+    } catch (...) {
+        return nullptr;
+    }
 }
 
 Status Buffer::RegisterHostBuffer(void* host, size_t size, void** pDevice)
@@ -59,4 +150,4 @@ Status Buffer::RegisterHostBuffer(void* host, size_t size, void** pDevice)
 
 void Buffer::UnregisterHostBuffer(void* host) { aclrtHostUnregister(host); }
 
-} // namespace UC::Trans
+}  // namespace UC::Trans

--- a/ucm/shared/trans/ascend/ascend_buffer.h
+++ b/ucm/shared/trans/ascend/ascend_buffer.h
@@ -32,8 +32,9 @@ class AscendBuffer : public ReservedBuffer {
 public:
     std::shared_ptr<void> MakeDeviceBuffer(size_t size) override;
     std::shared_ptr<void> MakeHostBuffer(size_t size) override;
+    std::shared_ptr<void> MakeHostBuffer4DirectIo(size_t size) override;
 };
 
-} // namespace UC::Trans
+}  // namespace UC::Trans
 
 #endif

--- a/ucm/shared/trans/buffer.h
+++ b/ucm/shared/trans/buffer.h
@@ -38,6 +38,7 @@ public:
     virtual std::shared_ptr<void> GetDeviceBuffer(size_t size) = 0;
 
     virtual std::shared_ptr<void> MakeHostBuffer(size_t size) = 0;
+    virtual std::shared_ptr<void> MakeHostBuffer4DirectIo(size_t size) = 0;
     virtual Status MakeHostBuffers(size_t size, size_t number) = 0;
     virtual std::shared_ptr<void> GetHostBuffer(size_t size) = 0;
 
@@ -45,6 +46,6 @@ public:
     static void UnregisterHostBuffer(void* host);
 };
 
-} // namespace UC::Trans
+}  // namespace UC::Trans
 
 #endif

--- a/ucm/shared/trans/detail/reserved_buffer.h
+++ b/ucm/shared/trans/detail/reserved_buffer.h
@@ -73,6 +73,11 @@ public:
         return this->MakeDeviceBuffer(size);
     }
 
+    std::shared_ptr<void> MakeHostBuffer4DirectIo(size_t size) override
+    {
+        return this->MakeHostBuffer(size);
+    }
+
     Status MakeHostBuffers(size_t size, size_t number) override
     {
         auto totalSize = size * number;
@@ -94,6 +99,6 @@ public:
     }
 };
 
-} // namespace UC::Trans
+}  // namespace UC::Trans
 
 #endif

--- a/ucm/store/cache/cc/cache_store.cc
+++ b/ucm/store/cache/cc/cache_store.cc
@@ -119,6 +119,7 @@ private:
         if (param.shardSize > 0) { param.waitingQueueDepth *= (param.blockSize / param.shardSize); }
         config.Get("share_buffer_enable", param.shareBufferEnable);
         if (!param.shareBufferEnable) { param.bufferCapacity /= 8; }
+        config.Get("io_direct", param.ioDirect);
         size_t bufferCapacityGb = 0;
         config.GetNumber("cache_buffer_capacity_gb", bufferCapacityGb);
         if (bufferCapacityGb != 0) { param.bufferCapacity = bufferCapacityGb << 30; }
@@ -185,6 +186,7 @@ private:
         }
         UC_INFO("Set {}::ShardSize to {}.", ns, config.shardSize);
         UC_INFO("Set {}::BlockSize to {}.", ns, config.blockSize);
+        UC_INFO("Set {}::IoDirect to {}.", ns, config.ioDirect);
         UC_INFO("Set {}::BufferCapacity to {}GB.", ns, config.bufferCapacity >> 30);
         UC_INFO("Set {}::ShareBufferEnable to {}.", ns, config.shareBufferEnable);
         UC_INFO("Set {}::WaitingQueueDepth to {}.", ns, config.waitingQueueDepth);

--- a/ucm/store/cache/cc/global_config.h
+++ b/ucm/store/cache/cc/global_config.h
@@ -36,6 +36,7 @@ struct Config {
     std::vector<size_t> tensorSizes{};
     size_t shardSize{0};
     size_t blockSize{0};
+    bool ioDirect{false};
     size_t bufferCapacity{256ULL << 30};
     bool shareBufferEnable{true};
     size_t waitingQueueDepth{8192};

--- a/ucm/store/cache/cc/trans_buffer.cc
+++ b/ucm/store/cache/cc/trans_buffer.cc
@@ -65,10 +65,21 @@ struct BufferMetaNode {
 };
 
 class BufferStrategy {
+protected:
+    struct BaseConfig {
+        int32_t deviceId{-1};
+        size_t nodeSize{0};
+        size_t totalSize{0};
+    };
+    BaseConfig base_;
+
 public:
+    BufferStrategy(int32_t deviceId, size_t nodeSize, size_t totalSize)
+        : base_({deviceId, nodeSize, totalSize})
+    {
+    }
     virtual ~BufferStrategy() = default;
-    virtual Status Setup(const std::string& uuid, int32_t deviceId, size_t nodeSize,
-                         size_t nNode) = 0;
+    virtual Status Setup() = 0;
     virtual void BucketLock(size_t iBucket) = 0;
     virtual bool BucketTryLock(size_t iBucket) = 0;
     virtual void BucketUnlock(size_t iBucket) = 0;
@@ -113,6 +124,7 @@ class LocalBufferStrategy : public BufferStrategy {
         void Unlock() { pthread_spin_unlock(&lock); }
     };
 
+    bool ioDirect_{false};
     BufferHeader header_;
     LocalMutex bucketLocks_[nHashTableBucket];
     std::unique_ptr<LocalLock[]> nodeLocks_;
@@ -120,9 +132,15 @@ class LocalBufferStrategy : public BufferStrategy {
     std::shared_ptr<void> data_;
 
 public:
-    Status Setup(const std::string& uuid, int32_t deviceId, size_t nodeSize,
-                 size_t totalSize) override
+    LocalBufferStrategy(int32_t deviceId, size_t nodeSize, size_t totalSize, bool ioDirect)
+        : BufferStrategy(deviceId, nodeSize, totalSize), ioDirect_(ioDirect)
     {
+    }
+    Status Setup() override
+    {
+        const auto deviceId = base_.deviceId;
+        const auto totalSize = base_.totalSize;
+        const auto nodeSize = base_.nodeSize;
         auto nNode = totalSize / nodeSize;
         try {
             nodeLocks_ = std::make_unique<LocalLock[]>(nNode);
@@ -144,7 +162,8 @@ public:
             UC_ERROR("Failed to make buffer on device({}).", deviceId);
             return Status::Error();
         }
-        data_ = buffer->MakeHostBuffer(nodeSize * nNode);
+        data_ = ioDirect_ ? buffer->MakeHostBuffer4DirectIo(nodeSize * nNode)
+                          : buffer->MakeHostBuffer(nodeSize * nNode);
         if (!data_) [[unlikely]] {
             UC_ERROR("Failed to make pinned({}) for device({}).", nodeSize * nNode, deviceId);
             return Status::OutOfMemory();
@@ -217,6 +236,7 @@ protected:
     BufferMetaNode* meta_{nullptr};
     std::byte* data_{nullptr};
     std::byte* dataOnDevice_{nullptr};
+    const std::string& uuid_;
     std::string shmName_;
     size_t nodeSize_{0};
     size_t nNode_{0};
@@ -347,15 +367,23 @@ protected:
     }
 
 public:
+    SharedBufferStrategy(const std::string& uuid, int32_t deviceId, size_t nodeSize,
+                         size_t totalSize)
+        : BufferStrategy(deviceId, nodeSize, totalSize), uuid_(uuid)
+    {
+    }
     ~SharedBufferStrategy() override
     {
         if (data_) { Trans::Buffer::UnregisterHostBuffer(data_); }
         if (addrress_) { PosixShm::MUnmap(addrress_, totalSize_); }
         PosixShm{shmName_}.ShmUnlink();
     }
-    Status Setup(const std::string& uuid, int32_t deviceId, size_t nodeSize,
-                 size_t totalSize) override
+    Status Setup() override
     {
+        const auto& uuid = uuid_;
+        const auto deviceId = base_.deviceId;
+        const auto nodeSize = base_.nodeSize;
+        const auto totalSize = base_.totalSize;
         shmName_ = ShmPrefix() + uuid;
         nodeSize_ = nodeSize;
         nNode_ = totalSize / nodeSize;
@@ -396,9 +424,10 @@ public:
 
 class SharedBufferWatcherStrategy : public SharedBufferStrategy {
 public:
-    Status Setup(const std::string& uuid, int32_t deviceId, size_t, size_t) override
+    SharedBufferWatcherStrategy(const std::string& uuid) : SharedBufferStrategy(uuid, -1, 0, 0) {}
+    Status Setup() override
     {
-        shmName_ = ShmPrefix() + uuid;
+        shmName_ = ShmPrefix() + uuid_;
         CleanUpShmFileExceptMe(shmName_);
         PosixShm shmFile{shmName_};
         auto s = shmFile.ShmOpen(PosixShm::OpenFlag::READ_WRITE);
@@ -432,17 +461,18 @@ Status TransBuffer::Setup(const Config& config)
 {
     try {
         if (!config.shareBufferEnable) {
-            strategy_ = std::make_shared<LocalBufferStrategy>();
+            strategy_ = std::make_shared<LocalBufferStrategy>(
+                config.deviceId, config.shardSize, config.bufferCapacity, config.ioDirect);
         } else if (config.deviceId >= 0) {
-            strategy_ = std::make_shared<SharedBufferStrategy>();
+            strategy_ = std::make_shared<SharedBufferStrategy>(
+                config.uniqueId, config.deviceId, config.shardSize, config.bufferCapacity);
         } else {
-            strategy_ = std::make_shared<SharedBufferWatcherStrategy>();
+            strategy_ = std::make_shared<SharedBufferWatcherStrategy>(config.uniqueId);
         }
     } catch (const std::exception& e) {
         return Status::Error(fmt::format("failed({}) to make buffer strategy", e.what()));
     }
-    return strategy_->Setup(config.uniqueId, config.deviceId, config.shardSize,
-                            config.bufferCapacity);
+    return strategy_->Setup();
 }
 
 TransBuffer::Handle TransBuffer::Get(const Detail::BlockId& blockId, size_t shardIdx)


### PR DESCRIPTION
## Purpose

`aclrtMallocHost` memory fails with `EFAULT` (error 14) when used with `O_DIRECT` I/O due to incompatible memory attributes 
with block device DMA mapping. Introduce `mmap(MAP_ANONYMOUS)`-based memory allocation as a relay transmission layer. When `O_DIRECT` is detected, the system automatically uses mmap-allocated page-aligned memory instead of `aclrtMallocHost`, then bridges data to NPU via `aclrtMemcpy`.

## Modifications 

- Add `HostHugePages` for mmap-based allocation
- Auto-detect `O_DIRECT` flag and switch memory strategy in CacheStore