### PR TITLE
[opt] Optimize GSA by fusing operators

### DIFF
--- a/ucm/sparse/gsa_on_device/gsa_on_device.py
+++ b/ucm/sparse/gsa_on_device/gsa_on_device.py
@@ -564,10 +564,9 @@ class GSAOnDevice(UcmSparseBase):
     def cache_k_hash_gqa_cuda(
         self, key, attn_metadata, k_hash, forward_context, layer_name
     ):
-        k_hash_compute = self.hash_encoder.compute_hash(key).view(torch.bfloat16)
         valid_k_hash_token = attn_metadata.slot_mapping.flatten().numel()
-        reshape_and_cache_khash_triton(
-            k_hash_compute[:valid_k_hash_token],
+        self.hash_encoder.compute_hash_and_cache(
+            key[:valid_k_hash_token],
             attn_metadata.slot_mapping.flatten(),
             k_hash,
             block_size=self.block_size,
@@ -579,12 +578,10 @@ class GSAOnDevice(UcmSparseBase):
 
             k_cache = kv_cache[0][0][self.prefix_block_ids]
             k_cache = k_cache.reshape(-1, k_cache.shape[2], k_cache.shape[3])
-            prefix_k_hash_compute = self.hash_encoder.compute_hash(k_cache).view(
-                torch.bfloat16
-            )
             prefix_valid_k_hash_token = self.prefix_slot_mapping.flatten().numel()
-            reshape_and_cache_khash_triton(
-                prefix_k_hash_compute[:prefix_valid_k_hash_token],
+
+            self.hash_encoder.compute_hash_and_cache(
+                k_cache[:prefix_valid_k_hash_token],
                 self.prefix_slot_mapping.flatten(),
                 k_hash,
                 block_size=self.block_size,

--- a/ucm/sparse/gsa_on_device/hash_encoder.py
+++ b/ucm/sparse/gsa_on_device/hash_encoder.py
@@ -260,6 +260,101 @@ if hasattr(torch, "cuda") and torch.cuda.is_available():
         )
         return k_hash
 
+    @triton.jit
+    def fused_hash_and_cache_kernel(
+        x_ptr,
+        code_ptr,
+        pack_w_ptr,
+        slot_ptr,
+        k_cache_ptr,
+        T,
+        H,
+        K,
+        N_BITS,
+        N_BYTES,
+        stride_xt,
+        stride_xh,
+        stride_xk,
+        stride_codek,
+        stride_coden,
+        stride_packw,
+        stride_cb,
+        stride_cs,
+        stride_ch,
+        stride_cw,
+        block_size: tl.constexpr,
+        cache_num_slots: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_K: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+    ):
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        pid_h = tl.program_id(2)
+
+        if pid_m * BLOCK_M >= T:
+            return
+        if pid_n * BLOCK_N >= N_BITS:
+            return
+
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        offs_k = tl.arange(0, BLOCK_K)
+
+        m_mask = offs_m < T
+        n_mask = offs_n < N_BITS
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+        for _ in range(0, tl.cdiv(K, BLOCK_K)):
+            k_mask = offs_k < K
+
+            x_ptrs = (
+                x_ptr
+                + offs_m[:, None] * stride_xt
+                + pid_h * stride_xh
+                + offs_k[None, :] * stride_xk
+            )
+            x = tl.load(x_ptrs, mask=m_mask[:, None] & k_mask[None, :], other=0.0)
+
+            code_ptrs = (
+                code_ptr
+                + offs_k[:, None] * stride_codek
+                + offs_n[None, :] * stride_coden
+            )
+            code = tl.load(code_ptrs, mask=k_mask[:, None] & n_mask[None, :], other=0.0)
+
+            acc += tl.dot(x, code)
+            offs_k += BLOCK_K
+
+        bits = (acc > 0).to(tl.uint8)
+        bits_2d = tl.reshape(bits, (BLOCK_M, BLOCK_N // 8, 8))
+
+        pack_w = tl.load(pack_w_ptr + tl.arange(0, 8) * stride_packw)
+        packed = tl.sum(bits_2d * pack_w[None, None, :], axis=-1).to(tl.uint8)
+
+        offs_byte = pid_n * (BLOCK_N // 8) + tl.arange(0, BLOCK_N // 8)
+        offs_byte = offs_byte[None, :]
+
+        slot = tl.load(slot_ptr + offs_m, mask=m_mask, other=-1)
+
+        valid_slot = (slot >= 0) & (slot < cache_num_slots)
+        valid_row = m_mask & valid_slot
+        valid_byte = offs_byte < N_BYTES
+        out_mask = valid_row[:, None] & valid_byte
+        safe_slot = tl.where(valid_row, slot, tl.zeros((BLOCK_M,), dtype=tl.int64))
+
+        b = (safe_slot // block_size)[:, None]
+        s = (safe_slot % block_size)[:, None]
+
+        out_ptrs = (
+            k_cache_ptr
+            + b * stride_cb
+            + s * stride_cs
+            + pid_h * stride_ch
+            + offs_byte * stride_cw
+        )
+        tl.store(out_ptrs, packed, mask=out_mask)
+
 
 @torch.compile()
 def torch_hash_code(x, code, pack_weight):
@@ -410,6 +505,161 @@ class HashEncoder:
         packed_codes = packed_codes_flat.view(out_shape)
 
         return packed_codes
+
+    def _reinterpret_cache_as_u8(self, cache: torch.Tensor) -> torch.Tensor:
+        """
+        支持:
+        - uint8 cache: [B, BS, H, hash_numbers]
+        - bf16  cache: [B, BS, H, hash_numbers // 2]
+            内部 view 成 uint8 后变成 [B, BS, H, hash_numbers]
+        """
+        if cache.dtype == torch.uint8:
+            if cache.shape[-1] != self.hash_numbers:
+                raise ValueError(
+                    f"uint8 cache last dim mismatch: got {cache.shape[-1]}, "
+                    f"expected {self.hash_numbers}"
+                )
+            return cache
+
+        if cache.dtype == torch.bfloat16:
+            if self.hash_numbers % 2 != 0:
+                raise ValueError(
+                    f"for bfloat16 cache, hash_numbers must be even, got {self.hash_numbers}"
+                )
+            if cache.shape[-1] != self.hash_numbers // 2:
+                raise ValueError(
+                    f"bfloat16 cache last dim mismatch: got {cache.shape[-1]}, "
+                    f"expected {self.hash_numbers // 2}"
+                )
+
+            cache_u8 = cache.view(torch.uint8)
+
+            if cache_u8.shape[-1] != self.hash_numbers:
+                raise ValueError(
+                    f"reinterpret bf16->u8 failed: got last dim {cache_u8.shape[-1]}, "
+                    f"expected {self.hash_numbers}"
+                )
+            return cache_u8
+
+        raise ValueError(
+            f"unsupported k_hash_cache dtype {cache.dtype}, only uint8 / bfloat16 are supported"
+        )
+
+    def compute_hash_and_cache(
+        self,
+        x: torch.Tensor,  # [T, H, K]
+        slot_mapping: torch.Tensor,  # [T]
+        k_hash_cache: torch.Tensor,  # [B, BS, H, ?], uint8 or bf16
+        block_size: int = 128,
+        BLOCK_M: int = 64,
+        BLOCK_K: int = 16,
+        BLOCK_N: int = 32,
+        num_warps: int = 4,
+    ) -> torch.Tensor:
+        """
+        融合:
+            compute_hash(x) + cache write
+        只发起一次 Triton kernel。
+
+        支持:
+        - uint8 cache: [B, BS, H, hash_numbers]
+        - bf16  cache: [B, BS, H, hash_numbers // 2]
+            内部 reinterpret 为 uint8 后写 packed hash
+        """
+        if self.device.type != "cuda":
+            raise NotImplementedError(
+                "compute_hash_and_cache currently only supports CUDA"
+            )
+
+        if x.ndim != 3:
+            raise ValueError(f"x must be [T,H,K], got {x.shape}")
+        if slot_mapping.ndim != 1:
+            raise ValueError(f"slot_mapping must be [T], got {slot_mapping.shape}")
+        if k_hash_cache.ndim != 4:
+            raise ValueError(f"k_hash_cache must be rank-4, got {k_hash_cache.shape}")
+        if x.shape[-1] != self.input_dim:
+            raise ValueError(f"x last dim must be {self.input_dim}, got {x.shape[-1]}")
+        if x.device != self.device:
+            raise ValueError(
+                f"x device {x.device} does not match required device {self.device}"
+            )
+        if slot_mapping.device != self.device:
+            raise ValueError(
+                f"slot_mapping device {slot_mapping.device} does not match required device {self.device}"
+            )
+        if k_hash_cache.device != self.device:
+            raise ValueError(
+                f"k_hash_cache device {k_hash_cache.device} does not match required device {self.device}"
+            )
+        if BLOCK_N % 8 != 0:
+            raise ValueError(f"BLOCK_N must be multiple of 8, got {BLOCK_N}")
+
+        T, H, K = x.shape
+        B, BS, H_cache, _ = k_hash_cache.shape
+
+        if slot_mapping.shape[0] != T:
+            raise ValueError(f"slot_mapping length {slot_mapping.shape[0]} != T {T}")
+        if BS != block_size:
+            raise ValueError(f"k_hash_cache.shape[1]={BS} != block_size={block_size}")
+        if H_cache != H:
+            raise ValueError(f"k_hash_cache.shape[2]={H_cache} != H={H}")
+
+        # 关键修改：内部统一转成 uint8 view
+        k_hash_cache_u8 = self._reinterpret_cache_as_u8(k_hash_cache)
+
+        # 这里的最后一维现在一定是 packed hash bytes
+        B2, BS2, H2, W2 = k_hash_cache_u8.shape
+        if B2 != B or BS2 != BS or H2 != H:
+            raise ValueError(
+                f"reinterpret cache shape mismatch: raw={k_hash_cache.shape}, u8={k_hash_cache_u8.shape}"
+            )
+        if W2 != self.hash_numbers:
+            raise ValueError(
+                f"u8 cache last dim {W2} != hash_numbers {self.hash_numbers}"
+            )
+
+        if x.dtype != self.dtype:
+            x = x.to(self.dtype)
+
+        cache_num_slots = B * block_size
+
+        stride_xt, stride_xh, stride_xk = x.stride()
+        stride_codek, stride_coden = self.hash_weights.stride()
+        (stride_packw,) = self.bit_masks.stride()
+        stride_cb, stride_cs, stride_ch, stride_cw = k_hash_cache_u8.stride()
+
+        grid = (triton.cdiv(T, BLOCK_M), triton.cdiv(self.hash_bits, BLOCK_N), H)
+
+        fused_hash_and_cache_kernel[grid](
+            x_ptr=x,
+            code_ptr=self.hash_weights,
+            pack_w_ptr=self.bit_masks,
+            slot_ptr=slot_mapping,
+            k_cache_ptr=k_hash_cache_u8,
+            T=T,
+            H=H,
+            K=K,
+            N_BITS=self.hash_bits,
+            N_BYTES=self.hash_numbers,
+            stride_xt=stride_xt,
+            stride_xh=stride_xh,
+            stride_xk=stride_xk,
+            stride_codek=stride_codek,
+            stride_coden=stride_coden,
+            stride_packw=stride_packw,
+            stride_cb=stride_cb,
+            stride_cs=stride_cs,
+            stride_ch=stride_ch,
+            stride_cw=stride_cw,
+            block_size=block_size,
+            cache_num_slots=cache_num_slots,
+            BLOCK_M=BLOCK_M,
+            BLOCK_K=BLOCK_K,
+            BLOCK_N=BLOCK_N,
+            num_warps=num_warps,
+        )
+
+        return k_hash_cache
 
     def _unpack_hash(self, packed_codes: torch.Tensor) -> torch.Tensor:
         """

--- a/ucm/sparse/test/gsa/test_cuda_cache_and_hash.py
+++ b/ucm/sparse/test/gsa/test_cuda_cache_and_hash.py
@@ -1,0 +1,194 @@
+import pytest
+import torch
+
+from ucm.sparse.gsa_on_device.hash_encoder import (
+    HashEncoder,
+    reshape_and_cache_khash_triton,
+)
+
+torch.manual_seed(42)
+
+warmup_iters = 5
+test_iters = 20
+
+num_tokens = 1  # T
+num_heads = 8  # H
+head_dim = 128  # K (input_dim)
+hash_bits = (
+    128  # N (hash_bits) 压缩后的维度，单位是 bit，所以实际存储时需要除以 8 转换为 byte
+)
+hash_numbers = hash_bits // 8  # W (hash_numbers) 每个 token
+block_size = 128  # BS
+num_blocks = 300  # B
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+class TestCudaHashAndCacheGQA:
+    def get_input_data(self):
+        device = torch.device("cuda:0")
+        dtype = torch.bfloat16
+
+        assert (
+            num_tokens <= num_blocks * block_size
+        ), "num_tokens must be less than or equal to num_blocks * block_size for this test."
+
+        # 初始化 HashEncoder
+        encoder = HashEncoder(
+            input_dim=head_dim, hash_bits=hash_bits, dtype=dtype, device=device
+        )
+
+        # key: [T, H, K]
+        key = torch.randn((num_tokens, num_heads, head_dim), device=device, dtype=dtype)
+
+        # slot_mapping: [T], 随机映射到 cache 中的位置
+        slot_mapping = torch.randperm(num_blocks * block_size)[:num_tokens].to(
+            device, dtype=torch.int32
+        )
+        # slot_mapping = torch.arange(num_tokens).to(device, dtype=torch.int32)
+
+        # 初始化两个相同的 cache 用于对比
+        # k_hash_cache: [B, BS, H, W] 其中 W = hash_bits // 8
+        cache_fused = torch.zeros(
+            (num_blocks, block_size, num_heads, hash_numbers),
+            device=device,
+            dtype=torch.uint8,
+        )
+        cache_ref = torch.zeros_like(cache_fused)
+        return (
+            encoder,
+            key,
+            slot_mapping,
+            cache_fused,
+            cache_ref,
+            num_tokens,
+            num_heads,
+            hash_numbers,
+            block_size,
+        )
+
+    def test_cuda_hash_and_cache_gqa_accuracy(self):
+
+        (
+            encoder,
+            key,
+            slot_mapping,
+            cache_fused,
+            cache_ref,
+            num_tokens,
+            num_heads,
+            hash_numbers,
+            block_size,
+        ) = self.get_input_data()
+
+        # 融合算子
+        encoder.compute_hash_and_cache(
+            key, slot_mapping, cache_fused, block_size=block_size
+        )
+
+        # 基准计算
+        # 1. 计算 Hash Code [T, H, W]
+        k_hash_computed = encoder.compute_hash(key)
+
+        # 2. 写入 Cache
+        reshape_and_cache_khash_triton(
+            k_hash_computed.view(num_tokens, num_heads, hash_numbers),
+            slot_mapping,
+            cache_ref,
+            block_size=block_size,
+        )
+
+        # 验证融合算子的结果与分步计算的结果是否一致
+        diff = torch.abs(cache_fused.to(torch.float32) - cache_ref.to(torch.float32))
+        print(
+            f"\nBit flip rate: {diff.nonzero().shape[0]}/{diff.numel()} = {diff.nonzero().shape[0] / diff.numel():.4f}"
+        )
+        assert (
+            diff.nonzero().shape[0] / diff.numel() < 0.01
+        ), "More than 1% of the elements differ between fused and reference results."
+
+    def test_cuda_hash_and_cache_gqa_baseline(self):
+        (
+            encoder,
+            key,
+            slot_mapping,
+            cache_fused,
+            cache_ref,
+            num_tokens,
+            num_heads,
+            hash_numbers,
+            block_size,
+        ) = self.get_input_data()
+
+        # 原版：分步计算
+        # 预热
+        for _ in range(warmup_iters):
+            k_hash_computed = encoder.compute_hash(key)
+            reshape_and_cache_khash_triton(
+                k_hash_computed.view(num_tokens, num_heads, hash_numbers),
+                slot_mapping,
+                cache_ref,
+                block_size=block_size,
+            )
+        torch.cuda.synchronize()
+
+        # 性能测试
+        start_time = torch.cuda.Event(enable_timing=True)
+        end_time = torch.cuda.Event(enable_timing=True)
+        total_time = 0
+        torch.cuda.synchronize()
+        start_time.record()
+        for _ in range(test_iters):
+            k_hash_computed = encoder.compute_hash(key)
+            reshape_and_cache_khash_triton(
+                k_hash_computed.view(num_tokens, num_heads, hash_numbers),
+                slot_mapping,
+                cache_ref,
+                block_size=block_size,
+            )
+        end_time.record()
+        torch.cuda.synchronize()
+        total_time += start_time.elapsed_time(end_time)
+        avg_time_ms_ref = total_time / test_iters
+        print(f"\nAverage time per iteration (unfused): {avg_time_ms_ref:.2f} ms")
+
+    def test_cuda_hash_and_cache_gqa_performance(self):
+
+        (
+            encoder,
+            key,
+            slot_mapping,
+            cache_fused,
+            cache_ref,
+            num_tokens,
+            num_heads,
+            hash_numbers,
+            block_size,
+        ) = self.get_input_data()
+
+        # 融合算子
+        # 预热
+        for _ in range(warmup_iters):
+            encoder.compute_hash_and_cache(
+                key, slot_mapping, cache_fused, block_size=block_size
+            )
+        torch.cuda.synchronize()
+
+        # 性能测试
+        total_time = 0
+        torch.cuda.synchronize()
+        start_time = torch.cuda.Event(enable_timing=True)
+        end_time = torch.cuda.Event(enable_timing=True)
+        start_time.record()
+        for _ in range(test_iters):
+            encoder.compute_hash_and_cache(
+                key, slot_mapping, cache_fused, block_size=block_size
+            )
+        end_time.record()
+        torch.cuda.synchronize()
+        total_time += start_time.elapsed_time(end_time)
+        avg_time_ms = total_time / test_iters
+        print(f"\nAverage time per iteration (fused): {avg_time_ms:.2f} ms")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
## Purpose
Fusing 'compute_khash' and 'reshape_and_cache_khash' operators to optimize perfomance.

## Modifications 
1. Add a new fused operator and modify the original implementation with the fused one.
2. Add unit test of fused operators: `ucm\sparse\test\gsa\test_cuda_cache_and_hash.py`

## Test
<img width="606" height="224" alt="image" src="https://github.com/user-attachments/assets/75bc62bd-2508-44af-a401-f80fcebff250" />
