### PR TITLE
[Bugfix] fix offline patch

### DIFF
--- a/examples/offline_inference_gsaondevice.py
+++ b/examples/offline_inference_gsaondevice.py
@@ -7,11 +7,6 @@ from dataclasses import asdict
 
 from transformers import AutoTokenizer
 
-# Third Party
-from vllm import LLM, SamplingParams
-from vllm.config import KVTransferConfig
-from vllm.engine.arg_utils import EngineArgs
-
 from ucm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -59,6 +54,14 @@ def setup_environment_variables():
             sys.exit(1)
 
     tokenizer = AutoTokenizer.from_pretrained(model, use_chat_template=True)
+
+
+# ENABLE_SPARSE must be set before import vllm to make sure monkey patch works
+setup_environment_variables()
+# Third Party
+from vllm import LLM, SamplingParams
+from vllm.config import KVTransferConfig
+from vllm.engine.arg_utils import EngineArgs
 
 
 @contextlib.contextmanager
@@ -124,7 +127,6 @@ def print_output(
 def main():
     module_path = "ucm.integration.vllm.ucm_connector"
     name = "UCMConnector"
-    setup_environment_variables()
 
     def get_prompt(prompt):
         messages = [

--- a/ucm/integration/vllm/patch/apply_patch.py
+++ b/ucm/integration/vllm/patch/apply_patch.py
@@ -129,9 +129,11 @@ def apply_all_patches() -> None:
         # vllm patches
         match version:
             case "0.11.0":
+                logger.info("UCM patching vllm for pc...")
                 import ucm.integration.vllm.patch.v0110.vllm.pc_patch
 
                 if ENABLE_SPARSE:
+                    logger.info("UCM patching vllm for sparse...")
                     import ucm.integration.vllm.patch.v0110.vllm.sparse_patch
             case _:
                 pass
@@ -140,9 +142,11 @@ def apply_all_patches() -> None:
         ascend_version = get_vllm_ascend_version()
         match ascend_version:
             case "0.11.0":
+                logger.info("UCM patching vllm-ascend for pc...")
                 import ucm.integration.vllm.patch.v0110.vllm_ascend.pc_ascend_patch
 
                 if ENABLE_SPARSE:
+                    logger.info("UCM patching vllm-ascend for sparse...")
                     import ucm.integration.vllm.patch.v0110.vllm_ascend.sparse_ascend_patch
             case _:
                 pass


### PR DESCRIPTION
## Purpose
Fix offline patch issue.
`apply_all_patches` is triggered when import vllm, so if we set ENABLE_SPARSE after importing vllm, it won't patch for sparse.

## Modifications
Move env setting before importing vllm in offline script.
Add more specific logs in `apply_patch.py` to show more informations when patching.

## Test
Tested on develop env.
<img width="1423" height="91" alt="image" src="https://github.com/user-attachments/assets/8f7cf03c-19c1-415c-8067-93d46b0a43ce" />

