### PR TITLE
[feat] Add tensor parallel size support and update GPU memory utilization for online inference tests

### DIFF
--- a/test/common/online_inference_utils.py
+++ b/test/common/online_inference_utils.py
@@ -85,7 +85,7 @@ class VLLMServerManager:
         self,
         model_path: str,
         port: int = 8000,
-        host: str = "0.0.0.0",
+        host: str = "127.0.0.1",
         ucm_config: Optional[Dict[str, Any]] = None,
         enable_prefix_caching: bool = False,
         max_model_len: int = 12000,
@@ -94,6 +94,7 @@ class VLLMServerManager:
         startup_timeout: float = 300.0,
         served_model_name: str = "",
         pipeline_parallel_size: int = 1,
+        tensor_parallel_size: int = 1,
     ):
         """Initialize the VLLMServerManager.
 
@@ -112,6 +113,7 @@ class VLLMServerManager:
             startup_timeout: Timeout in seconds for server startup
             served_model_name: Optional model name to expose via the API (defaults to model_path)
             pipeline_parallel_size: Pipeline parallel size (default: 1)
+            tensor_parallel_size: Tensor parallel size (default: 1)
         """
 
         gpu_memory_utilization = float(
@@ -134,6 +136,7 @@ class VLLMServerManager:
         self.startup_timeout = startup_timeout
         self.served_model_name = served_model_name
         self.pipeline_parallel_size = pipeline_parallel_size
+        self.tensor_parallel_size = tensor_parallel_size
 
         self._process: Optional[subprocess.Popen] = None
         self._url = f"http://{host}:{port}"
@@ -173,6 +176,8 @@ class VLLMServerManager:
             str(self.gpu_memory_utilization),
             "--pipeline-parallel-size",
             str(self.pipeline_parallel_size),
+            "--tensor-parallel-size",
+            str(self.tensor_parallel_size),
         ]
 
         # Add UCM kv-transfer-config

--- a/test/suites/E2E/test_online_inference.py
+++ b/test/suites/E2E/test_online_inference.py
@@ -22,12 +22,19 @@ import yaml
 from common.online_inference_utils import hbm_ssd_mixed_test
 from common.path_utils import get_path_relative_to_test_root, get_path_to_model
 
+os.environ["ENABLE_UCM_PATCH"] = "1"
+
+# These online E2E cases start a fresh vLLM instance with UCM enabled and a
+# relatively large max_model_len, so the previous 6 GB hint translated to an
+# unrealistically small --gpu-memory-utilization (~6%) on H20 GPUs.
+ONLINE_INFERENCE_GPU_MEM_MB = 60000
+
 
 class TestBasicOnlineInference:
     """Test basic online inference functionality."""
 
     @pytest.mark.stage(1)
-    @pytest.mark.gpu_mem(6000)
+    @pytest.mark.gpu_mem(ONLINE_INFERENCE_GPU_MEM_MB)
     @pytest.mark.feature("online_inference")
     @pytest.mark.parametrize("model_name", ["Qwen2.5-1.5B-Instruct"])
     @pytest.mark.parametrize("max_tokens", [200])
@@ -116,7 +123,7 @@ class TestBasicOnlineInference:
         )
 
     @pytest.mark.stage(1)
-    @pytest.mark.gpu_mem(6000)
+    @pytest.mark.gpu_mem(ONLINE_INFERENCE_GPU_MEM_MB)
     @pytest.mark.gpu_count(2)
     @pytest.mark.feature("online_inference")
     @pytest.mark.parametrize("model_name", ["Qwen2.5-1.5B-Instruct"])
@@ -192,6 +199,79 @@ class TestBasicOnlineInference:
             max_num_batched_tokens=max_num_batched_tokens,
             served_model_name=served_model_name,
             pipeline_parallel_size=2,
+        )
+
+        hbm_ssd_mixed_test(
+            model_name,
+            tokenizer_path,
+            max_tokens,
+            prompt_split_ratio,
+            ucm_config,
+            vllm_server_startup_args,
+        )
+
+    @pytest.mark.stage(1)
+    @pytest.mark.gpu_mem(ONLINE_INFERENCE_GPU_MEM_MB)
+    @pytest.mark.gpu_count(2)
+    @pytest.mark.feature("online_inference")
+    @pytest.mark.parametrize("model_name", ["Qwen2.5-1.5B-Instruct"])
+    @pytest.mark.parametrize("max_tokens", [200])
+    @pytest.mark.parametrize("prompt_split_ratio", [0.5])
+    @pytest.mark.parametrize("ucm_connector_name", ["UcmPipelineStore"])
+    @pytest.mark.parametrize("use_layerwise", [True])
+    @pytest.mark.parametrize("max_num_batched_tokens", [2047])
+    def test_online_accuracy_hbm_ssd_mixed_tp(
+        self,
+        model_name: str,
+        max_tokens: int,
+        prompt_split_ratio: float,
+        ucm_connector_name: str,
+        use_layerwise: bool,
+        max_num_batched_tokens: int,
+    ):
+        """Test HBM + SSD mixed hit accuracy via online inference with tensor parallel."""
+        # Load configuration
+        config_file = get_path_relative_to_test_root("config.yaml")
+        with open(config_file, "r", encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+
+        ucm_storage_dir = "/tmp/ucm_cache"
+        served_model_name = model_name
+        tokenizer_path = f"/home/models/{model_name}"
+        model_path = get_path_to_model(model_name, config)
+
+        # Build UCM config
+        ucm_config = {
+            "use_layerwise": (
+                use_layerwise if ucm_connector_name != "UcmNfsStore" else False
+            ),
+            "ucm_connectors": [
+                {
+                    "ucm_connector_name": ucm_connector_name,
+                    "ucm_connector_config": {
+                        "store_pipeline": "Cache|Posix",
+                        "storage_backends": ucm_storage_dir,
+                        "use_direct": False,
+                        "cache_buffer_capacity_gb": 32,
+                    },
+                }
+            ],
+            **(
+                {"enable_event_sync": False}
+                if ucm_connector_name == "UcmNfsStore"
+                else {}
+            ),
+        }
+
+        # Build vllm_server_startup_args with tensor parallel size
+        vllm_server_startup_args = dict(
+            model_path=model_path,
+            port=8000,
+            ucm_config=ucm_config,
+            max_model_len=12000,
+            max_num_batched_tokens=max_num_batched_tokens,
+            served_model_name=served_model_name,
+            tensor_parallel_size=2,
         )
 
         hbm_ssd_mixed_test(


### PR DESCRIPTION
## Purpose

## Modifications 

host changed from "0.0.0.0" to "127.0.0.1"
gpu_mem default set to 60000, 6000 is not enough (tests always fail on H20)
added the tensor_parallel_size parameter and a test with tensor_parallel_size parameter = 2

## Test
