### PR TITLE
[Bugfix] Fix the bug of connector matadata assert failure

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -783,6 +783,8 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             self._submit_request_load_tasks_for_layer(self.first_layer_id, 0, metadata)
 
     def wait_for_layer_load(self, layer_name: str) -> None:
+        if not self._connector_metadata:
+            return
         if not self.need_load:
             return
         metadata = self._get_connector_metadata()
@@ -814,7 +816,8 @@ class UCMLayerWiseConnector(UCMDirectConnector):
         attn_metadata: "AttentionMetadata",
         **kwargs,
     ) -> None:
-        # TODO support PP
+        if not self._connector_metadata:
+            return
         if self.is_mla and self.tp_rank % self.tp_size != 0:
             return
 


### PR DESCRIPTION
## Purpose
Fix the bug causing connector metadata assertion failures. In certain scenarios, the upper layer calls `save_kv_layer ` and `wait_for_layer_load ` before the metadata is bound. This triggers an assertion failure regarding the existence of connector metadata, leading to a service crash. This commit resolves the issue.

## Modifications
Added a check for `None` on `self._connector_metadata` when calling `self._get_connector_metadata()` within `save_kv_layer` and `wait_for_layer_load`. If it is None, the function returns immediately.
