### PR TITLE
Fix #804: [Usage]: import ucm_custom_ops报错ModuleNotFoundError: No mod...

### DIFF
--- a/ucm/sparse/gsa_on_device/gsa_on_device.py
+++ b/ucm/sparse/gsa_on_device/gsa_on_device.py
@@ -6,7 +6,14 @@ import torch
 
 if hasattr(torch, "npu") and torch.npu.is_available():
     import torch_npu
-    import ucm_custom_ops
+    try:
+        import ucm_custom_ops
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError(
+            "ucm_custom_ops is not installed. "
+            "Please build and install it by running: "
+            "bash ucm/sparse/gsa_on_device/csrc/ascend/build.sh install"
+        ) from e
     from vllm_ascend.attention.attention_v1 import AscendAttentionState
 
 from vllm import _custom_ops as ops


### PR DESCRIPTION
Closes #804

## Purpose

Improve the error message when `ucm_custom_ops` is not installed, replacing the bare `ModuleNotFoundError` with an actionable message that tells users exactly how to resolve the issue.

## Modifications

- `ucm/sparse/gsa_on_device/gsa_on_device.py`: Wrapped the `import ucm_custom_ops` statement (inside the `if hasattr(torch, "npu") and torch.npu.is_available()` block) in a `try/except ModuleNotFoundError` block. When the module is missing, re-raises with a message instructing the user to build and install the custom ops via `bash ucm/sparse/gsa_on_device/csrc/ascend/build.sh install`.

## Test

Manually verified on an environment without `ucm_custom_ops` installed: the new error message `"ucm_custom_ops is not installed. Please build and install it by running: bash ucm/sparse/gsa_on_device/csrc/ascend/build.sh install"` is raised instead of the uninformative `ModuleNotFoundError: No module named 'ucm_custom_ops'`. Verified that normal execution is unaffected when `ucm_custom_ops` is present.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*