### PR TITLE
[Fix] Duplicate metrics registration

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -262,7 +262,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self.metrics_config = self.launch_config.get("metrics_config_path", "")
         if self.metrics_config:
             worker_id = (
-                get_world_group().rank
+                f"{self.engine_id}_{get_world_group().rank}"
                 if role == KVConnectorRole.WORKER
                 else self.engine_id
             )

--- a/ucm/observability.py
+++ b/ucm/observability.py
@@ -36,6 +36,10 @@ from ucm.shared.metrics import ucmmetrics
 
 logger = init_logger(__name__)
 
+# Store metric mapping: metric_name -> Union[Counter, Gauge, Histogram]
+# This mapping will be used in update_stats to dynamically log metrics
+_metric_mappings: dict[str, Union[Counter, Gauge, Histogram]] = {}
+
 
 class PrometheusStatsLogger:
 
@@ -62,6 +66,9 @@ class PrometheusStatsLogger:
         Load metrics config from YAML file (config_path),
         register metrics using prometheus_client, and start a thread to get updated metrics.
         """
+        if _metric_mappings:
+            logger.warning("Metrics are already registered, skipping re-registration.")
+            return
         # Load metrics config
         self.config = self._load_config(config_path)
         self.log_interval = self.config.get("log_interval", 10)
@@ -117,16 +124,12 @@ class PrometheusStatsLogger:
                 **{k: v for k, v in cfg.items() if k in default_kwargs},
             }
 
-            self.metric_mappings[name] = metric_cls(**metric_kwargs)
+            _metric_mappings[name] = metric_cls(**metric_kwargs)
 
     def _init_metrics_from_config(self):
         """Initialize metrics based on config"""
         # Get metric name prefix from config (e.g., "ucm:")
         self.metric_prefix = self.config.get("metric_prefix", "ucm:")
-
-        # Store metric mapping: metric_name -> Union[Counter, Gauge, Histogram]
-        # This mapping will be used in update_stats to dynamically log metrics
-        self.metric_mappings: dict[str, Union[Counter, Gauge, Histogram]] = {}
 
         for metric_type in self.metric_type_config.keys():
             self._register_metrics_by_type(metric_type)
@@ -149,11 +152,11 @@ class PrometheusStatsLogger:
         and update values via the specified function (update_func).
         """
         for stat_name, value in stats.items():
-            if stat_name not in self.metric_mappings:
+            if stat_name not in _metric_mappings:
                 logger.error(f"Metric {stat_name} not found")
                 continue
 
-            metric = self.metric_mappings[stat_name]
+            metric = _metric_mappings[stat_name]
             try:
                 metric_with_labels = metric.labels(**self.labels)
                 update_func(metric_with_labels, value)


### PR DESCRIPTION
## Purpose
Fix the error register metrics twice when scheduler and worker share the same process

## Modifications 
Modify ucm/observability.py to ensure one process can only register once:  move metrics_mapping to be global variable

## Test
Start server with the following command, start server success and get metrics success 

> vllm serve /models/Qwen3-1.7B --served-model-name Qwen3-1.7B --block-size 128 --tensor-parallel-size 1 --data-parallel-size 1 --gpu-memory-utilization 0.87 --trust-remote-code --port 7850 --kv-transfer-config '{"kv_connector":"UCMConnector","kv_connector_module_path":"ucm.integration.vllm.ucm_connector","kv_role":"kv_both","kv_connector_extra_config":{"use_layerwise":"true","UCM_CONFIG_FILE":"/vllm-workspace/unified-cache-management/examples/ucm_config_example.yaml"}}'