### PR TITLE
[Bugfix] Fix raise with string literals in UCMBlendConnector

### DIFF
--- a/ucm/integration/vllm/blend_connector.py
+++ b/ucm/integration/vllm/blend_connector.py
@@ -133,7 +133,7 @@ class UCMBlendConnector(UCMDirectConnector):
             self.enable_blend = True
             self.chunk_end_token_id = blend_config["chunk_end_token_id"]
         else:
-            raise "UCMBlendConnector init failed, please check your config"
+            raise ValueError("UCMBlendConnector init failed, please check your config")
 
         self.requests_blend_meta: dict[str, BlendRequestMeta] = {}
         self.cos_sin_cache: torch.Tensor = None
@@ -327,7 +327,7 @@ class UCMBlendConnector(UCMDirectConnector):
         post process loaded chunk kcache
         """
         if self.cos_sin_cache is None:
-            raise "Please call setup model first."
+            raise RuntimeError("Please call setup model first.")
         # triton kernl for block-wise delta rope
         block_wise_rope_forward(k_cache, vllm_ids, positions, self.cos_sin_cache)
 
@@ -336,7 +336,9 @@ class UCMBlendConnector(UCMDirectConnector):
             rotary_emb = model.model.layers[0].self_attn.rotary_emb
             self.cos_sin_cache = rotary_emb.cos_sin_cache
         except Exception:
-            raise "get cos_sin_cache from model failed!  current not implemented for this model"
+            raise RuntimeError(
+                "get cos_sin_cache from model failed! current not implemented for this model"
+            )
 
     def setup_model(self, model: "Model") -> None:
         self._register_cos_sin_cache(model)


### PR DESCRIPTION
## Purpose

Fix three `raise "string"` statements in `UCMBlendConnector` that produce `TypeError` at runtime instead of the intended error messages.

## Modifications

In Python 3, `raise "string"` does not raise an exception with that message — it raises a `TypeError: exceptions must derive from BaseException`. This means callers never see the actual diagnostic text.

| Line | Before | After |
|------|--------|-------|
| 136 | `raise "UCMBlendConnector init failed, ..."` | `raise ValueError("UCMBlendConnector init failed, ...")` |
| 330 | `raise "Please call setup model first."` | `raise RuntimeError("Please call setup model first.")` |
| 339 | `raise "get cos_sin_cache from model failed! ..."` | `raise RuntimeError("get cos_sin_cache from model failed! ...")` |

- `ValueError` for the config validation (invalid configuration input)
- `RuntimeError` for the precondition and model compatibility checks

## Test

- Verified `black --check` and `isort --check` pass on the modified file.
- No new runtime behavior — only the exception type changes from `TypeError` to the correct type with the intended message.