### PR TITLE
[Bugfix] Fix memory leak and broken metrics in UCMBlendConnector

### DIFF
--- a/ucm/integration/vllm/blend_connector.py
+++ b/ucm/integration/vllm/blend_connector.py
@@ -18,6 +18,7 @@ from ucm.integration.vllm.ucm_connector import (
     UCMDirectConnector,
 )
 from ucm.logger import init_logger
+from ucm.shared.metrics import ucmmetrics
 from ucm.sparse.blend.blockwise_rope import block_wise_rope_forward
 
 if TYPE_CHECKING:
@@ -380,8 +381,7 @@ class UCMBlendConnector(UCMDirectConnector):
             f"first chunk prefix hit: {pc_hit_blocks}, "
             f"chunks cache total hit: {chunk_hit_blocks}, "
         )
-        self.monitor.update_stats(
-            "ConnStats",
+        ucmmetrics.update_stats(
             {"interval_lookup_hit_rates": chunk_hit_blocks / max_blk_num},
         )
 
@@ -461,6 +461,7 @@ class UCMBlendConnector(UCMDirectConnector):
         # clear finished request
         for request_id in scheduler_output.finished_req_ids:
             self.requests_meta.pop(request_id, None)
+            self.requests_blend_meta.pop(request_id, None)
 
         return UCMBlendConnectorMetadata(requests_dispatch_meta)
 


### PR DESCRIPTION
## Purpose

Fix two functional bugs in `UCMBlendConnector` that affect production serving reliability.

## Modifications

### Bug 1: `requests_blend_meta` memory leak

`build_connector_meta` cleans up `self.requests_meta` for finished requests (line 466) but never cleans up `self.requests_blend_meta`. Since `get_num_new_matched_tokens` adds an entry to `requests_blend_meta` for every request (line 399), this dict grows unboundedly for the lifetime of the process.

Each `BlendRequestMeta` holds block hashes, `ChunkMetaData` objects, and stage info, so in long-running serving scenarios the memory impact is significant.

**Fix:** Add `self.requests_blend_meta.pop(request_id, None)` alongside the existing cleanup.

### Bug 2: `self.monitor` AttributeError crashes metrics path

When `self.metrics_config` is enabled, the blend connector calls `self.monitor.update_stats("ConnStats", {...})` (line 386). However, `self.monitor` is never defined — the parent class `UCMDirectConnector` uses the module-level `ucmmetrics.update_stats({...})` API instead.

This means any blend request with metrics enabled raises `AttributeError: 'UCMBlendConnector' object has no attribute 'monitor'`.

**Fix:** Replace `self.monitor.update_stats(...)` with `ucmmetrics.update_stats(...)` to match the parent class pattern.

## Test

- `black --check` and `isort --check --profile=black` pass on the modified file.
- Both fixes are mechanical corrections to match the parent class behavior.