### PR TITLE
[BugFix] Fix incorrect chunk hit bitmask indexing in UCMBlendConnector

### DIFF
--- a/ucm/integration/vllm/blend_connector.py
+++ b/ucm/integration/vllm/blend_connector.py
@@ -240,21 +240,34 @@ class UCMBlendConnector(UCMDirectConnector):
         if not req_stage.is_blend_cache():
             return pc_hit_blocks, chunk_hit_blocks
 
-        # then perform chunk cache lookup
-        chunk_lookup_results = self.store.lookup(req_chunks_hashes[pc_hit_blocks:])
-        chunk_hit_blocks = sum(chunk_lookup_results)
+        # Lookup ALL chunk hashes independently in chunk-hash space.
+        # Note: prefix_block_hashes use chained hashing (each hash depends on
+        # all previous blocks), while req_chunks_hashes use independent per-chunk
+        # hashing. These are fundamentally different hash spaces, so we must not
+        # skip chunk lookups based on prefix cache hit count or merge results
+        # from the two spaces.
+        all_chunk_lookup = self.store.lookup(req_chunks_hashes)
+        chunk_hit_blocks = sum(all_chunk_lookup)
 
-        chunk_lookup_results = pc_lookup_results[:pc_hit_blocks] + chunk_lookup_results
-        # for cache blend
-        for i, chunk_meta in enumerate(req_chunks_meta):
-            chunk_meta.store_hits = chunk_lookup_results[
-                chunk_meta.start_blk_idx : chunk_meta.end_blk_idx
+        # Assign store_hits using chunk-relative offset instead of global
+        # block indices. Each chunk's store_hits must come from its own
+        # position within the chunk-hash lookup results.
+        chunk_offset = 0
+        for chunk_meta in req_chunks_meta:
+            chunk_meta.store_hits = all_chunk_lookup[
+                chunk_offset : chunk_offset + chunk_meta.chunk_blks_len
             ]
-        first_chunk_meta = req_chunks_meta[0]
-        first_chunk_meta.update_meta_partial_pc(pc_hit_blocks, self.block_size)
-        # remove total pc hit chunk
-        if first_chunk_meta.chunk_tokens_len == 0:
-            req_chunks_meta.pop(0)
+            chunk_offset += chunk_meta.chunk_blks_len
+
+        # Handle partial prefix cache overlap with the first chunk:
+        # blocks covered by prefix cache are loaded via the prefix path,
+        # so trim them from the first chunk's metadata.
+        if req_chunks_meta:
+            first_chunk_meta = req_chunks_meta[0]
+            first_chunk_meta.update_meta_partial_pc(pc_hit_blocks, self.block_size)
+            # remove chunk if entirely covered by prefix cache
+            if first_chunk_meta.chunk_tokens_len == 0:
+                req_chunks_meta.pop(0)
 
         return pc_hit_blocks, chunk_hit_blocks
 


### PR DESCRIPTION
## Purpose

Fix hash space misalignment in `UCMBlendConnector._get_req_chunk_hit` that causes incorrect `store_hits` bitmask assignment when prefix cache and chunk cache have partial overlapping hits.

**Root cause:** `prefix_block_hashes` use chained hashing (each hash depends on all previous blocks), while `req_chunks_hashes` use independent per-chunk hashing. The original code concatenated lookup results from these two fundamentally different hash spaces and then sliced by global block indices (`start_blk_idx:end_blk_idx`), causing index misalignment.

**Impact when triggered:**
- Loading blocks using wrong store keys → errors or silent data corruption
- Skipping cached blocks that should be reused → wasted computation
- Applying delta-rope to misaligned KV cache → incorrect inference output

This is likely related to #867 (incorrect token generation after prefix cache hit).

Fixes #906

## Modifications

1. **Lookup all chunk hashes independently** instead of skipping prefix-covered ones (`req_chunks_hashes[pc_hit_blocks:]` → `req_chunks_hashes`), avoiding mixed hash space results
2. **Use chunk-relative offset** for `store_hits` assignment instead of global block indices (`start_blk_idx`/`end_blk_idx`), ensuring each chunk's bitmask comes from its correct position in the chunk-hash lookup results
3. **Add safety check** for empty `req_chunks_meta` before accessing the first element

## Test

- Code review verified against downstream consumers:
  - `_generate_blend_dispatch_meta`: uses `chunk_meta.hits_chunk_blks_hash` (filtered by `store_hits`) and `chunk_meta.hits_vllm_blk_ids` — both work correctly with the fixed bitmask
  - `bind_connector_metadata`: uses `chunk_meta.position_offset` and `hits_vllm_blk_ids` — unaffected by the indexing change
  - `update_meta_partial_pc`: trims `store_hits` from the beginning — correctly applied after chunk-relative assignment
- Verified `chunk_hit_blocks` (now total chunk store hits) is used in threshold check and metrics — both benefit from the more accurate count