### PR TITLE
[Opt] Support generate traces

### DIFF
--- a/benchmarks/gene_trace.py
+++ b/benchmarks/gene_trace.py
@@ -1,0 +1,76 @@
+import ast
+import glob
+import gzip
+import json
+import os
+import re
+import sys
+
+match_pattern = re.compile(
+    r"timestamp:\s*(?P<timestamp>\d+\.\d+),\s*"
+    r"input_length:\s*(?P<input_length>\d+),\s*"
+    r"output_length:\s*(?P<output_length>\d+),\s*"
+    r"ucm_block_ids:\s*(?P<ucm_block_ids>\[.*?\])"
+)
+
+output_log = "./output.jsonl"
+
+
+def process_file(file_path):
+    count = 0
+    is_gz = file_path.endswith(".log.gz")
+
+    if is_gz:
+        opener = lambda: gzip.open(file_path, "rt", encoding="utf-8", errors="ignore")
+    else:
+        opener = lambda: open(file_path, "r", encoding="utf-8")
+
+    with opener() as f:
+        for line in f:
+            match = match_pattern.search(line)
+            if match:
+                clean_hash_ids = ast.literal_eval(match.group("ucm_block_ids"))
+                data = {
+                    "timestamp": float(match.group("timestamp")),
+                    "input_length": int(match.group("input_length")),
+                    "output_length": int(match.group("output_length")),
+                    "hash_ids": clean_hash_ids,
+                }
+                out_f.write(json.dumps(data, ensure_ascii=False) + "\n")
+                count += 1
+    return count
+
+
+if len(sys.argv) > 1:
+    target = sys.argv[1]
+else:
+    print("Usage: python gene_trace.py <directory_or_log_file>")
+    sys.exit(1)
+
+if os.path.exists(output_log):
+    os.remove(output_log)
+
+if os.path.isfile(target):
+    files = [target]
+elif os.path.isdir(target):
+    dir_pattern = os.path.join(target, "ucm.log*")
+    gz_pattern = os.path.join(target, "ucm_*.log.gz")
+    files = glob.glob(dir_pattern) + sorted(glob.glob(gz_pattern))
+    if not files:
+        print(f"No log files found in: {target}")
+        sys.exit(1)
+else:
+    print(f"Log files not found: {target}")
+    sys.exit(1)
+
+print(f"Processing log {len(files)} file(s)... ")
+
+with open(output_log, "a") as out_f:
+    total = 0
+    for file_path in files:
+        print(f"  -> {os.path.basename(file_path)}")
+        count = process_file(file_path)
+        total += count
+        print(f"{count} records extracted from {file_path}")
+
+print(f"Done! Total: {total} records -> {output_log}")

--- a/benchmarks/trace_replay.py
+++ b/benchmarks/trace_replay.py
@@ -9,7 +9,7 @@ import sys
 import time
 from collections import defaultdict
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Union
 
 import aiohttp
 import pandas
@@ -33,7 +33,7 @@ from vllm.benchmarks.datasets import (
     SonnetDataset,
     VisionArenaDataset,
 )
-from vllm.benchmarks.endpoint_request_func import (
+from vllm.benchmarks.lib.endpoint_request_func import (
     ASYNC_REQUEST_FUNCS,
     RequestFuncInput,
 )
@@ -78,20 +78,26 @@ class TraceReplayDataset(BenchmarkDataset):
         self.prompts_file_name = (
             f"{trace_directory_name}/{trace_file_name}_dataset.jsonl"
         )
-        self.hash_to_tokens: dict[int, list[int]] = {}
+        self.hash_to_tokens: dict[Union[int, str], list[int]] = {}
 
     def generate_prompt(
-        self, hash_ids: list[int], target_length: int, tokenizer
+        self, hash_ids: list[Union[int, str]], target_length: int, tokenizer
     ) -> str:
         DEFAULT_BLOCK_SIZE = 512
         vocab_size = tokenizer.vocab_size
 
+        def hash_str_to_num(s: str) -> int:
+            return int(s, 16) if isinstance(s, str) else s
+
+        # Convert all hash_ids to numeric
+        hash_ids_numeric = [hash_str_to_num(h) for h in hash_ids]
+
         # Use hash_ids to influence token generation
-        base_offset = hash_ids[0] if hash_ids else 0
+        base_offset = hash_ids_numeric[0] if hash_ids_numeric else 0
 
         token_ids = []
 
-        for i, value in enumerate(hash_ids):
+        for i, value in enumerate(hash_ids_numeric):
             if value in self.hash_to_tokens:
                 token_ids.extend(self.hash_to_tokens[value])
             elif (i + 1) * DEFAULT_BLOCK_SIZE <= target_length:
@@ -101,8 +107,10 @@ class TraceReplayDataset(BenchmarkDataset):
                         base_offset
                         + token_idx
                         + sum(
-                            hash_ids[
-                                token_idx % len(hash_ids) : token_idx % len(hash_ids)
+                            hash_ids_numeric[
+                                token_idx
+                                % len(hash_ids_numeric) : token_idx
+                                % len(hash_ids_numeric)
                                 + 3
                             ]
                         )
@@ -488,7 +496,7 @@ async def replay_trace_by_time(
     use_session = tuple(map(int, vllm.__version__.split(".")[:3])) >= (0, 10, 1)
     session = None
     if use_session:
-        session = vllm.aiohttp.ClientSession(
+        session = aiohttp.ClientSession(
             base_url=base_url,
             trust_env=True,
             timeout=aiohttp.ClientTimeout(total=6 * 60 * 60),
@@ -554,8 +562,9 @@ async def replay_trace_by_time(
                 request_func_input=req_input, session=session, pbar=pbar
             )
 
+    first_req_time, _ = sorted(req_groups.items())[0]
     for sec, reqs in sorted(req_groups.items()):
-        delay = sec - (time.perf_counter() - start_time)
+        delay = sec - first_req_time - (time.perf_counter() - start_time)
         delay = max(0, delay)
 
         async def send_group(r=reqs, d=delay):
@@ -598,7 +607,11 @@ async def replay_trace_by_time(
         if args.metric_percentiles
         else [50, 90]
     )
-    goodput = {k: float(v) for item in args.goodput for k, v in [item.split(":", 1)]}
+    goodput = (
+        {k: float(v) for item in args.goodput for k, v in [item.split(":", 1)]}
+        if args.goodput
+        else None
+    )
 
     benchmark_duration = time.perf_counter() - start_time
     metrics, actual_output_lens = calculate_metrics(

--- a/examples/ucm_config_example.yaml
+++ b/examples/ucm_config_example.yaml
@@ -33,3 +33,7 @@ enable_event_sync: true
 # use_layerwise: true
 # hit_ratio: 0.9
 
+# Whether to record requests' traces (optional, default: False)
+# When enable_record_traces set to true, logs per-request traces (timestamp, input_length, output_length, hash_ids)
+# Each hash_id takes 32 bytes. Enable only when needed with proper UCM_LOG_MAX_FILES and UCM_LOG_MAX_SIZE.
+enable_record_traces: false

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -10,14 +10,13 @@ from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import numpy as np
 import torch
-import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
 )
-from vllm.distributed.parallel_state import get_tp_group, get_world_group
+from vllm.distributed.parallel_state import get_world_group
 from vllm.distributed.utils import get_pp_indices
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.platforms import current_platform
@@ -244,6 +243,9 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self.launch_config = ucm_config.get_config()
         self.connector_configs = self.launch_config.get("ucm_connectors", [])
         self.enable_event_sync = self.launch_config.get("enable_event_sync", True)
+        self.enable_record_traces = self.launch_config.get(
+            "enable_record_traces", False
+        )
         assert len(self.connector_configs) > 0, "no storage connector name in config."
 
         self.chunk_size = self.block_size
@@ -409,6 +411,16 @@ class UCMDirectConnector(KVConnectorBase_V1):
         except RuntimeError as e:
             external_hit_blocks = 0
             logger.error(f"request {request.request_id} look up error. {e}")
+
+        if self.enable_record_traces and request.request_id not in self.requests_meta:
+            hex_ucm_block_ids = [id.hex() for id in ucm_block_ids]
+            logger.info_once(
+                f"timestamp: {time.perf_counter()}, "
+                f"input_length: {request.num_tokens}, "
+                f"output_length: {request.max_tokens}, "
+                f"ucm_block_ids: {hex_ucm_block_ids}"
+            )
+
         logger.info_once(
             f"request_id: {request.request_id}, "
             f"total_blocks_num: {len(ucm_block_ids)}, "
@@ -943,6 +955,16 @@ class UCMCPConnector(UCMLayerWiseConnector):
         except RuntimeError as e:
             external_hit_blocks = 0
             logger.error(f"request {request.request_id} look up error. {e}")
+
+        if self.enable_record_traces and request.request_id not in self.requests_meta:
+            hex_ucm_block_ids = [id.hex() for id in ucm_block_ids]
+            logger.info_once(
+                f"timestamp: {time.perf_counter()}, "
+                f"input_length: {request.num_tokens}, "
+                f"output_length: {request.max_tokens}, "
+                f"ucm_block_ids: {hex_ucm_block_ids}"
+            )
+
         logger.info(
             f"request_id: {request.request_id}, "
             f"total_blocks_num: {len(ucm_block_ids)}, "


### PR DESCRIPTION
## Purpose
Support generating trace.jsonl in ucm, noticing that one block would need 32 bytes in log files. For 5M log files, it only support recording about 150k blocks.
## Modifications 
Add new file **gene_trace.py** to generate trace.jsonl.
Modify **ucm_connector.py** to record trace infos.
Modify **trace_replay.py** to support replay traces when hash_ids are str.
## Test
Tested with online service. Performance compare as below:
model | tp | input len | output len | prompts | log blocks | concurrency | hit rate | ttft | tpot | e2el
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
QwQ-32B | 8 | 16000 | 100 | 50 | no | 50 | 0.5 | 6976.89 | 59.75 | 12892.46
QwQ-32B | 8 | 16000 | 100 | 50 | yes | 50 | 0.5 | 6535.24 | 59.79 | 12454.77
QwQ-32B | 8 | 2400 | 100 | 333 | no | 333 | 0.5 | 5512.79 | 65.11 | 11958.65
QwQ-32B | 8 | 2400 | 100 | 333 | yes | 333 | 0.5 | 5443.49 | 65 | 11878.84


