### PR TITLE
[fix] fix ucm patch causes unexpected log directory created

### DIFF
--- a/ucm/__init__.py
+++ b/ucm/__init__.py
@@ -21,5 +21,3 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 #
-
-from ucm.integration.vllm.patch.logger_patch import patch_logger


### PR DESCRIPTION
## Purpose

Fix ucm patch causes unexpected `log` directory created.



## Modifications 
Remove import patch from `ucm/__init__.py`. The `ucm_patch.pth` runs on every Python startup which imports `ucm.*` module. And importing `ucm` currently imports `patch_logger` which will create the `log` folder globally.

## Test
No longer create unexpected `log` directory. 
<img width="1275" height="191" alt="image" src="https://github.com/user-attachments/assets/407d8432-4c63-4671-8171-11b04c30abf8" />

Also test on online and offline inference, the logger works as usual.
<img width="1225" height="453" alt="image" src="https://github.com/user-attachments/assets/ed7430b5-99a6-4d10-8689-7f6b690ad57c" />
<img width="1469" height="490" alt="image" src="https://github.com/user-attachments/assets/bb63e3aa-15c4-4029-83ec-0795414a2ee9" />
