### PR TITLE
feat(tools): add lightweight vLLM monitoring stack with VictoriaMetrics

### DIFF
--- a/test/monitor/README.md
+++ b/test/monitor/README.md
@@ -1,0 +1,79 @@
+```markdown
+# Quick Monitor
+
+A single-container monitoring solution based on VictoriaMetrics, serving as a lightweight alternative to Prometheus + Grafana. Uses less than 100MB memory and includes a built-in Web UI with CSV export support.
+
+## Prerequisites
+
+- Docker ≥ 20.10 with `docker compose` support
+- vLLM service started with `--enable-metrics` (or env `VLLM_ENABLE_METRICS=1`)
+- Monitoring host can reach the vLLM `/metrics` endpoint (default port 8000)
+
+## Quick Start
+
+**1. Configure Scrape Targets**
+
+```bash
+cp scrape.yml.template scrape.yml
+# Edit scrape.yml: replace 192.168.1.100:8000 with actual vLLM IP:port, update model label
+```
+
+**2. Start Services**
+
+```bash
+docker compose up -d
+```
+
+**3. Verify Collection**
+
+```bash
+curl "http://localhost:8428/api/v1/query?query=up"
+# Returns 1 = connected, 0 = check IP and --enable-metrics flag
+```
+
+## Offline Deployment
+
+For air-gapped environments without internet access:
+
+```bash
+# On a machine with internet
+docker pull victoriametrics/victoria-metrics:v1.99.0
+docker save -o vm.tar victoriametrics/victoria-metrics:v1.99.0
+
+# Transfer vm.tar to target host, then load and start
+docker load -i vm.tar
+docker compose up -d
+```
+
+## Accessing Data
+
+**VMUI Web Interface**: `http://<host>:8428/vmui`
+- Paste PromQL queries into the input box → Click **Execute** to generate charts
+- Click **Download CSV** to export raw data for Excel analysis
+
+## Data Persistence
+
+Metrics are stored in `./data` directory and can be archived for offline analysis:
+
+```bash
+# Backup
+docker compose down
+tar czf metrics-backup.tar.gz data/
+
+# Restore
+tar xzf metrics-backup.tar.gz
+docker compose up -d
+```
+
+## Stop Services
+
+```bash
+docker compose down
+```
+
+## Troubleshooting
+
+**Container keeps restarting**: Check logs with `docker logs vm-vllm`. Ensure `scrape.yml` uses actual NIC IP (not `localhost`).
+
+**No data (up=0)**: Verify vLLM metrics endpoint: `curl http://<vllm-ip>:8000/metrics`. Ensure `--enable-metrics` is enabled.
+```

--- a/test/monitor/README.md
+++ b/test/monitor/README.md
@@ -51,6 +51,17 @@ docker compose up -d
 - Paste PromQL queries into the input box → Click **Execute** to generate charts
 - Click **Download CSV** to export raw data for Excel analysis
 
+## Data Usage
+The `export_metrics.py` script is provided, which can export all data as CSV files and generate charts.
+```bash
+# Export 2 hours with 5s granularity to specific folder
+python export_metrics.py \
+    --vm-url http://141.111.33.118:8428 \
+    --duration 2h \
+    --step 5 \
+    --output ./metrics_output
+```
+
 ## Data Persistence
 
 Metrics are stored in `./data` directory and can be archived for offline analysis:

--- a/test/monitor/README_zh.md
+++ b/test/monitor/README_zh.md
@@ -47,6 +47,17 @@ docker compose up -d
 - 输入框粘贴 PromQL → Execute 生成图表
 - 点击 **Download CSV** 导出原始数据（Excel 分析）
 
+## 数据使用
+提供了`export_metrics.py`, 可导出所有数据为 CSV 文件并进行图表绘制。
+```bash
+# 导出前2小时，步长5s的所有数据并输出到metrics_output文件夹
+python export_metrics.py \
+    --vm-url http://141.111.33.118:8428 \
+    --duration 2h \
+    --step 5 \
+    --output ./metrics_output
+```
+
 ## 数据持久化
 
 数据保存在 `./data` 目录，可直接打包带走：

--- a/test/monitor/README_zh.md
+++ b/test/monitor/README_zh.md
@@ -1,0 +1,70 @@
+# Quick Monitor
+
+基于 VictoriaMetrics 的单容器监控方案，替代 Prometheus + Grafana，内存占用 < 100MB，内置 Web UI 支持 CSV 导出。
+
+## 前置条件
+
+- Docker ≥ 20.10，且 vLLM 已开启 `--enable-metrics`
+- 监控主机可访问 vLLM 的 `/metrics` 端点（默认 8000 端口）
+
+## 快速开始
+
+**1. 配置采集目标**
+
+```bash
+cp scrape.yml.template scrape.yml
+# 编辑 scrape.yml，将 192.168.1.100:8000 改为实际 vLLM IP，model 标签改为实际模型名
+```
+
+**2. 启动**
+
+```bash
+docker compose up -d
+```
+
+**3. 验证**
+
+```bash
+curl "http://localhost:8428/api/v1/query?query=up"
+# 返回 1 表示采集正常，0 表示连不上 vLLM（检查 IP 和 --enable-metrics）
+```
+
+## 离线部署
+
+```bash
+# 有网环境提前准备
+docker pull victoriametrics/victoria-metrics:v1.99.0
+docker save -o vm.tar victoriametrics/victoria-metrics:v1.99.0
+
+# 离线主机加载后启动
+docker load -i vm.tar
+docker compose up -d
+```
+
+## 查看数据
+
+**VMUI 图形界面**：`http://<host>:8428/vmui`
+- 输入框粘贴 PromQL → Execute 生成图表
+- 点击 **Download CSV** 导出原始数据（Excel 分析）
+
+## 数据持久化
+
+数据保存在 `./data` 目录，可直接打包带走：
+
+```bash
+# 备份
+docker compose down
+tar czf metrics-backup.tar.gz data/
+
+# 恢复
+tar xzf metrics-backup.tar.gz
+docker compose up -d
+```
+
+## 服务停止
+docker compose down
+
+## 故障排查
+
+**容器不断重启**：`docker logs vm-vllm`，检查 `scrape.yml` 中 IP 是否填成 `localhost`（应填实际网卡 IP）。
+**无数据（up=0）**：`curl http://<vllm-ip>:8000/metrics` 确认 vLLM 指标已开启。

--- a/test/monitor/docker-compose.yml
+++ b/test/monitor/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.2'
+
+services:
+  victoriametrics:
+    image: victoriametrics/victoria-metrics:v1.99.0
+    container_name: vm-vllm
+    hostname: vm-vllm
+    ports:
+      - "8428:8428"
+    volumes:
+      - ./data:/storage
+      - ./scrape.yml:/etc/vm/scrape.yml:ro
+    command:
+      - "--storageDataPath=/storage"
+      - "--retentionPeriod=7d"
+      - "--promscrape.config=/etc/vm/scrape.yml"
+      - "--promscrape.config.strictParse=false"
+      - "--httpListenAddr=:8428"
+      - "--search.latencyOffset=500ms"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8428/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/test/monitor/export_metrics.py
+++ b/test/monitor/export_metrics.py
@@ -1,0 +1,493 @@
+# !/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+VictoriaMetrics Metrics Exporter and Visualizer.
+
+Automatically exports all metrics from VictoriaMetrics instance and generates
+time-series visualizations. Compatible with vLLM/sglang metrics endpoints.
+
+Usage:
+    python export_metrics.py --vm-url http://localhost:8428 --duration 2h --output ./metrics_export
+"""
+
+import argparse
+import json
+import logging
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional
+from urllib.parse import urljoin
+
+import matplotlib
+import pandas as pd
+import requests
+
+matplotlib.use("Agg")  # Non-interactive backend
+import matplotlib.pyplot as plt
+from matplotlib.dates import DateFormatter
+
+# Constants
+DEFAULT_VM_URL = "http://localhost:8428"
+DEFAULT_DURATION_HOURS = 1
+DEFAULT_STEP_SECONDS = 10
+DEFAULT_TIMEOUT = 30
+MAX_RETRIES = 3
+SKIP_METRIC_PREFIXES = ("scrape_", "up", "vm_", "go_", "process_")
+
+# Setup logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(levelname)s - %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+class VMExporter:
+    """VictoriaMetrics data exporter and visualizer."""
+
+    def __init__(
+        self, vm_url: str, output_dir: Path, duration_hours: int, step_seconds: int
+    ):
+        """
+        Initialize exporter.
+
+        Args:
+            vm_url: VictoriaMetrics HTTP API endpoint
+            output_dir: Directory for output files
+            duration_hours: Time window for data export
+            step_seconds: Sampling interval in seconds
+        """
+        self.vm_url = vm_url.rstrip("/")
+        self.output_dir = Path(output_dir)
+        self.duration_hours = duration_hours
+        self.step_seconds = step_seconds
+        self.session = requests.Session()
+        self.session.headers.update({"Accept": "application/json"})
+
+        # Calculate time range
+        self.end_ts = int(datetime.now().timestamp())
+        self.start_ts = self.end_ts - (duration_hours * 3600)
+
+        # Ensure output directory exists
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+    def get_metric_names(self) -> List[str]:
+        """
+        Fetch all metric names from VM.
+
+        Returns:
+            List of metric name strings
+
+        Raises:
+            requests.RequestException: If API call fails
+        """
+        url = urljoin(self.vm_url, "/api/v1/label/__name__/values")
+
+        for attempt in range(MAX_RETRIES):
+            try:
+                resp = self.session.get(url, timeout=DEFAULT_TIMEOUT)
+                resp.raise_for_status()
+                data = resp.json()
+
+                if data.get("status") != "success":
+                    raise ValueError(f"API returned non-success status: {data}")
+
+                all_metrics = data.get("data", [])
+
+                # Filter out internal/system metrics
+                filtered = [
+                    m
+                    for m in all_metrics
+                    if not any(m.startswith(p) for p in SKIP_METRIC_PREFIXES)
+                ]
+
+                logger.info(
+                    f"Discovered {len(all_metrics)} metrics, {len(filtered)} after filtering"
+                )
+                return filtered
+
+            except requests.RequestException as e:
+                logger.warning(f"Attempt {attempt + 1}/{MAX_RETRIES} failed: {e}")
+                if attempt == MAX_RETRIES - 1:
+                    raise
+
+        return []
+
+    def query_range(self, metric: str) -> Optional[List[Dict]]:
+        """
+        Query time-series data for a specific metric.
+
+        Args:
+            metric: Metric name to query
+
+        Returns:
+            List of time-series results or None if query fails
+        """
+        url = urljoin(self.vm_url, "/api/v1/query_range")
+        params = {
+            "query": metric,
+            "start": self.start_ts,
+            "end": self.end_ts,
+            "step": f"{self.step_seconds}s",
+        }
+
+        try:
+            resp = self.session.get(url, params=params, timeout=DEFAULT_TIMEOUT)
+            resp.raise_for_status()
+            data = resp.json()
+
+            if data.get("status") != "success":
+                return None
+
+            return data.get("data", {}).get("result", [])
+
+        except (requests.RequestException, json.JSONDecodeError) as e:
+            logger.debug(f"Query failed for {metric}: {e}")
+            return None
+
+    def parse_series_to_dataframe(
+        self, metric: str, result: List[Dict]
+    ) -> Optional[pd.DataFrame]:
+        """
+        Convert VM query result to pandas DataFrame.
+
+        Args:
+            metric: Metric name
+            result: Raw API result list
+
+        Returns:
+            DataFrame with columns: timestamp, metric, value, [labels...]
+        """
+        if not result:
+            return None
+
+        rows = []
+        for series in result:
+            metric_labels = series.get("metric", {})
+            values = series.get("values", [])
+
+            for timestamp, value in values:
+                try:
+                    row = {
+                        "timestamp": datetime.fromtimestamp(timestamp),
+                        "metric": metric,
+                        "value": float(value),
+                    }
+                    # Add all labels as columns (excluding __name__ which is redundant)
+                    for label_key, label_val in metric_labels.items():
+                        if label_key != "__name__":
+                            row[label_key] = label_val
+                    rows.append(row)
+                except (ValueError, TypeError):
+                    continue
+
+        if not rows:
+            return None
+
+        return pd.DataFrame(rows)
+
+    def export_to_csv(self, metric: str, df: pd.DataFrame) -> Path:
+        """
+        Export DataFrame to CSV file.
+
+        Args:
+            metric: Metric name (used for filename)
+            df: DataFrame to export
+
+        Returns:
+            Path to exported file
+        """
+        # Sanitize filename (replace colons and special chars)
+        safe_name = metric.replace(":", "_").replace("/", "_")
+        filepath = self.output_dir / f"{safe_name}.csv"
+
+        df.to_csv(filepath, index=False, float_format="%.6f")
+        logger.info(f"Exported CSV: {filepath.name} ({len(df)} rows)")
+        return filepath
+
+    def plot_timeseries(self, metric: str, df: pd.DataFrame) -> Optional[Path]:
+        """
+        Generate time-series plot for metric.
+
+        Args:
+            metric: Metric name
+            df: DataFrame with timestamp and value columns
+
+        Returns:
+            Path to generated PNG file or None if skipped
+        """
+        # Skip if too many unique series (would clutter the plot)
+        series_count = df.groupby(
+            [c for c in df.columns if c not in ["timestamp", "value", "metric"]]
+        ).ngroups
+
+        if series_count > 20:
+            logger.debug(
+                f"Skipping plot for {metric}: too many series ({series_count})"
+            )
+            return None
+
+        try:
+            plt.figure(figsize=(12, 6))
+
+            # Group by labels to plot separate lines
+            label_cols = [
+                c for c in df.columns if c not in ["timestamp", "value", "metric"]
+            ]
+
+            if label_cols:
+                grouped = df.groupby(label_cols)
+                for group_keys, group_df in grouped:
+                    label_str = ", ".join(
+                        f"{k}={v}"
+                        for k, v in zip(label_cols, group_keys)
+                        if k != "__name__"
+                    )
+                    if len(label_str) > 50:
+                        label_str = label_str[:47] + "..."
+
+                    plt.plot(
+                        group_df["timestamp"],
+                        group_df["value"],
+                        marker="o",
+                        markersize=2,
+                        linewidth=1,
+                        label=label_str,
+                    )
+                plt.legend(loc="best", fontsize=8, framealpha=0.9)
+            else:
+                plt.plot(
+                    df["timestamp"],
+                    df["value"],
+                    marker="o",
+                    markersize=2,
+                    linewidth=1.5,
+                    color="#2E86AB",
+                )
+
+            plt.title(
+                f"{metric} (Last {self.duration_hours}h)",
+                fontsize=14,
+                fontweight="bold",
+            )
+            plt.xlabel("Time", fontsize=12)
+            plt.ylabel("Value", fontsize=12)
+            plt.grid(True, alpha=0.3, linestyle="--")
+            plt.xticks(rotation=45, ha="right")
+
+            # Format x-axis
+            ax = plt.gca()
+            ax.xaxis.set_major_formatter(DateFormatter("%H:%M"))
+
+            plt.tight_layout()
+
+            safe_name = metric.replace(":", "_").replace("/", "_")
+            filepath = self.output_dir / f"{safe_name}.png"
+            plt.savefig(filepath, dpi=150, bbox_inches="tight")
+            plt.close()
+
+            logger.info(f"Generated plot: {filepath.name}")
+            return filepath
+
+        except Exception as e:
+            logger.warning(f"Plot generation failed for {metric}: {e}")
+            plt.close()
+            return None
+
+    def generate_summary_report(self, metrics: List[str], exported_count: int):
+        """Generate markdown summary report."""
+        report_path = self.output_dir / "_summary.md"
+
+        time_range_str = f"{datetime.fromtimestamp(self.start_ts)} ~ {datetime.fromtimestamp(self.end_ts)}"
+
+        content = f"""# VM Metrics Export Report
+
+**Generated:** {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}  
+**Source:** {self.vm_url}  
+**Time Range:** {time_range_str}  
+**Total Metrics:** {len(metrics)}  
+**Successfully Exported:** {exported_count}
+
+## Metrics List
+
+| Metric | Description |
+|--------|-------------|
+{chr(10).join(f"| {m} | Auto-exported from VM |" for m in sorted(metrics))}
+
+## File Structure
+
+- `*.csv`: Raw time-series data (one file per metric)
+- `*.png`: Visualization plots (generated for metrics with < 20 series)
+- `_summary.md`: This report
+
+## Quick Analysis
+
+View CSV files with:
+```bash
+# Example: View first 10 rows of a metric
+head -n 10 {metrics[0].replace(':', '_') if metrics else 'metric_name'}.csv
+```
+
+Or import into Excel/Pandas for further analysis.
+"""
+
+        report_path.write_text(content, encoding="utf-8")
+        logger.info(f"Summary report: {report_path}")
+
+    def run(self):
+        """Execute full export workflow."""
+        logger.info(f"Starting export from {self.vm_url}")
+        logger.info(
+            f"Time range: {datetime.fromtimestamp(self.start_ts)} to {datetime.fromtimestamp(self.end_ts)}"
+        )
+
+        # Step 1: Get metric list
+        try:
+            metrics = self.get_metric_names()
+        except requests.RequestException as e:
+            logger.error(f"Failed to fetch metric list: {e}")
+            sys.exit(1)
+
+        if not metrics:
+            logger.warning("No metrics found or all filtered out")
+            sys.exit(0)
+
+        # Step 2: Export each metric
+        exported_count = 0
+        failed_metrics = []
+
+        for idx, metric in enumerate(metrics, 1):
+            logger.info(f"[{idx}/{len(metrics)}] Processing: {metric}")
+
+            # Query data
+            result = self.query_range(metric)
+            if not result:
+                failed_metrics.append(metric)
+                continue
+
+            # Convert to DataFrame
+            df = self.parse_series_to_dataframe(metric, result)
+            if df is None or df.empty:
+                logger.warning(f"No data points for {metric}")
+                continue
+
+            # Export CSV
+            self.export_to_csv(metric, df)
+
+            # Generate plot
+            self.plot_timeseries(metric, df)
+
+            exported_count += 1
+
+        # Step 3: Generate report
+        self.generate_summary_report(metrics, exported_count)
+
+        # Final status
+        logger.info("=" * 50)
+        logger.info(f"Export complete: {self.output_dir.absolute()}")
+        logger.info(f"Total metrics: {len(metrics)}")
+        logger.info(f"Successfully exported: {exported_count}")
+        logger.info(f"Failed: {len(failed_metrics)}")
+        if failed_metrics:
+            logger.debug(f"Failed metrics: {failed_metrics}")
+
+
+def parse_duration(duration_str: str) -> int:
+    """
+    Parse duration string to hours.
+    Supports: 1h, 30m, 1d
+
+    Args:
+        duration_str: Duration string
+
+    Returns:
+        Hours as integer
+
+    Raises:
+        ValueError: If format invalid
+    """
+    if not duration_str:
+        return DEFAULT_DURATION_HOURS
+
+    unit = duration_str[-1].lower()
+    try:
+        value = int(duration_str[:-1])
+    except ValueError:
+        raise ValueError(f"Invalid duration format: {duration_str}")
+
+    if unit == "h":
+        return value
+    elif unit == "m":
+        return max(1, value // 60)
+    elif unit == "d":
+        return value * 24
+    else:
+        raise ValueError(f"Unknown time unit: {unit}")
+
+
+def main():
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Export VictoriaMetrics data and generate visualizations",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Export last hour with default settings
+  python export_metrics.py --vm-url http://localhost:8428
+
+  # Export 2 hours to specific directory
+  python export_metrics.py --vm-url http://vm-host:8428 --duration 2h --output ./export
+
+  # Export with 5s sampling interval
+  python export_metrics.py --vm-url http://vm-host:8428 --step 5 --duration 30m
+        """,
+    )
+
+    parser.add_argument(
+        "--vm-url",
+        default=DEFAULT_VM_URL,
+        help=f"VictoriaMetrics HTTP API URL (default: {DEFAULT_VM_URL})",
+    )
+    parser.add_argument(
+        "--duration",
+        default=f"{DEFAULT_DURATION_HOURS}h",
+        help="Time window to export (e.g., 1h, 30m, 1d). Default: 1h",
+    )
+    parser.add_argument(
+        "--step",
+        type=int,
+        default=DEFAULT_STEP_SECONDS,
+        help=f"Sampling interval in seconds (default: {DEFAULT_STEP_SECONDS})",
+    )
+    parser.add_argument(
+        "--output",
+        default="./vm_export",
+        help="Output directory for CSV and PNG files (default: ./vm_export)",
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+
+    args = parser.parse_args()
+
+    if args.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    try:
+        duration_hours = parse_duration(args.duration)
+    except ValueError as e:
+        logger.error(str(e))
+        sys.exit(1)
+
+    exporter = VMExporter(
+        vm_url=args.vm_url,
+        output_dir=Path(args.output),
+        duration_hours=duration_hours,
+        step_seconds=args.step,
+    )
+
+    exporter.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/monitor/scrape.yml
+++ b/test/monitor/scrape.yml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 2s
+  scrape_timeout: 5s
+  external_labels:
+    monitor: 'vllm-ucm'
+
+scrape_configs:
+  - job_name: 'vllm-0'
+    static_configs:
+      - targets:
+          - '192.168.1.100:8000'
+        labels:
+          env: 'production'
+          model: 'glm-5'
+    metrics_path: /metrics

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -17,3 +17,6 @@ httpx>=0.25.0
 #uc_eval
 jieba>=0.42.1
 openpyxl>=3.1.5
+#monitor
+pandas>=1.5.0
+matplotlib>=3.6.0


### PR DESCRIPTION
feat(tools): add lightweight vLLM monitoring stack with VictoriaMetrics

- Single-container deployment (no Grafana required)
- Built-in VMUI for metrics visualization and CSV export
- Support offline/air-gapped deployment via docker save/load
- <100MB memory footprint, suitable for customer on-site testing
- Pre-configured vLLM scrape templates and common PromQL queries
<img width="745" height="534" alt="image" src="https://github.com/user-attachments/assets/79c92783-3f4b-4e68-88ba-6300a2fffe52" />
<img width="2529" height="432" alt="image" src="https://github.com/user-attachments/assets/27d83eb7-b4b1-4f8d-86a8-213f7aab412d" />
<img width="782" height="549" alt="image" src="https://github.com/user-attachments/assets/b60e79cd-7684-43d9-be69-19662588e556" />
