### PR TITLE
[Fix] Update KVCacheLayout to set row counts.

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -88,8 +88,10 @@ class KVCacheLayout:
         self._build_layout(kvcaches)
 
     def _build_layout(self, kvcaches):
-        raw_ptr_rows = [[] for _ in range(self.local_num_hidden_layers)]
-        stride_rows = [[] for _ in range(self.local_num_hidden_layers)]
+
+        num_rows = len(set(self.layer_name_to_id.values()))
+        raw_ptr_rows = [[] for _ in range(num_rows)]
+        stride_rows = [[] for _ in range(num_rows)]
 
         for layer_name, kv_layer in kvcaches.items():
             ptrs = []


### PR DESCRIPTION
## Purpose

Fix the `IndexError: list index out of range` issue when running `GLM-4.7-W8A8-floatmtp`.

## Modification

Use the number of unique layer IDs, `len(set(self.layer_name_to_id.values()))`, as the row count in KV cache layout construction instead of `self.local_num_hidden_layers`.
