### PR TITLE
[Feat] Integrate Mooncake into UCM By UcmMooncakeStoreV1

### DIFF
--- a/docs/source/user-guide/prefix-cache/index.md
+++ b/docs/source/user-guide/prefix-cache/index.md
@@ -82,4 +82,5 @@ performance.
 pipeline_store
 nfs_store
 ds3fs_store
+mooncakestore
 :::

--- a/docs/source/user-guide/prefix-cache/mooncakestore.md
+++ b/docs/source/user-guide/prefix-cache/mooncakestore.md
@@ -1,0 +1,143 @@
+# Mooncake Store
+
+This document describes how to use `UcmMooncakeStoreV1` as the storage backend for UCM Prefix Cache in Ascend environments.
+
+## Overview
+
+`UcmMooncakeStoreV1` is a Mooncake-based storage backend provided by UCM for Prefix Cache scenarios. It is designed for Ascend platforms and integrated into the vLLM inference workflow through `UCMConnector`. It is responsible for prefix cache lookup, loading, and dumping, so that Prefix Cache is no longer limited to local memory within a single process or a single instance.
+
+By integrating Mooncake, UCM extends its original local caching capability with both DRAM pooling and remote storage support. As a result, in Prefix Cache scenarios, a tiered cache hierarchy can be formed:
+
+- Local DRAM on the serving node acts as the high-speed near-end cache.
+- The DRAM pool provided by Mooncake serves as a shareable intermediate cache layer.
+- Remote storage connected through UCM serves as a larger-capacity persistence layer.
+
+This three-tier design provides a better balance among capacity, shareability, and access cost, allowing Prefix Cache to be reused across a broader scope and improving overall cache-hit benefits in long-prefix scenarios.
+
+This document focuses on the capability boundaries, configuration, and basic usage flow of `UcmMooncakeStoreV1` in vLLM.
+
+## Features
+
+The current `UcmMooncakeStoreV1` implementation supports:
+
+- `lookup` / `lookup_on_prefix`: probing prefix hits by block hash
+- `load_data`: loading KV blocks from Mooncake into model KV buffers
+- `dump_data`: dumping KV blocks from model KV buffers into Mooncake
+- `wait` / `check`: handling asynchronous task completion
+- Register NPU buffers for RDMA transfer
+
+## Prerequisites
+
+`UcmMooncakeStoreV1` is intended for Ascend-based deployments and requires:
+
+- Linux
+- Ascend/NPU runtime with `torch.npu` available
+- vLLM + vLLM-Ascend + UCM integration environment
+- Mooncake runtime environment
+
+For deployment, it is recommended to use the pre-built vLLM-Ascend Docker image directly. The `vllm-ascend 0.17.0 image` already includes the Mooncake runtime dependencies required by this guide.
+
+If Mooncake needs to be installed manually, refer to the [official Ascend Store / KV Pool guide](https://docs.vllm.ai/projects/ascend/en/latest/user_guide/feature_guide/kv_pool.html) and follow its Mooncake installation instructions.
+
+## Configuration for Prefix Caching
+
+Edit or copy:
+
+`unified-cache-management/examples/ucm_config_example.yaml`
+
+### Minimal Configuration Example
+
+```yaml
+ucm_connectors:
+  - ucm_connector_name: "UcmMooncakeStoreV1"
+    ucm_connector_config:
+      protocol: "ascend"
+      local_hostname: "127.0.0.1"
+      metadata_server: "P2PHANDSHAKE"
+      master_server_address: "127.0.0.1:50088"
+      device_name: ""
+      global_segment_size: "5GB"
+      local_buffer_size: "5GB"
+      executor_workers: 4
+```
+
+### Required Parameters
+
+- `ucm_connector_name`
+  - Must be set to `UcmMooncakeStoreV1`.
+- `protocol`
+  - Must be set to `ascend`.
+- `metadata_server`
+  - Specifies the Mooncake metadata discovery mode or endpoint. In the common Ascend deployment path, use `P2PHANDSHAKE`.
+- `master_server_address`
+  - Specifies the address of the Mooncake master service, for example `127.0.0.1:50088`.
+
+### Common Optional Parameters
+
+- `local_hostname` (default: `127.0.0.1`)
+  - Local host address passed into Mooncake setup.
+- `device_name` (default: empty)
+  - Optional device identifier passed to Mooncake.
+- `global_segment_size` (default: `5GB`)
+  - Size of the global Mooncake segment. This represents the registered memory size per card.
+- `local_buffer_size` (default: `5GB`)
+  - Size of the local buffer used by the connector.
+- `executor_workers` (default: `4`)
+  - Number of worker threads used for asynchronous load and dump execution.
+
+## Run Mooncake Master
+
+Before launching vLLM, start the Mooncake master service:
+
+```bash
+mooncake_master \
+  --port 50088 \
+  --eviction_high_watermark_ratio 0.9 \
+  --eviction_ratio 0.1 \
+  --default_kv_lease_ttl 11000
+```
+
+Parameter description:
+
+- `eviction_high_watermark_ratio`
+  - Controls the watermark at which eviction is triggered.
+- `eviction_ratio`
+  - Controls the fraction of objects to evict once eviction starts.
+- `default_kv_lease_ttl`
+  - Controls the default KV lease TTL. It should be configured larger than both `ASCEND_CONNECT_TIMEOUT` and `ASCEND_TRANSFER_TIMEOUT`.
+
+## Launching Inference
+
+Use `vllm serve` with `UCMConnector`, and pass the Mooncake-backed UCM configuration file through `UCM_CONFIG_FILE`.
+
+### Recommended Launch Command
+
+```bash
+export LD_LIBRARY_PATH=/usr/local/Ascend/ascend-toolkit/latest/python/site-packages:$LD_LIBRARY_PATH
+export PYTHONHASHSEED=0
+export HCCL_INTRA_ROCE_ENABLE=1
+export HCCL_RDMA_TIMEOUT=17
+export ASCEND_CONNECT_TIMEOUT=10000
+export ASCEND_TRANSFER_TIMEOUT=10000
+
+vllm serve <your-model> \
+  --host 0.0.0.0 \
+  --port 8100 \
+  --trust-remote-code \
+  --enforce-eager \
+  --no-enable-prefix-caching \
+  --tensor-parallel-size 1 \
+  --data-parallel-size 1 \
+  --max-model-len 32768 \
+  --block-size 128 \
+  --max-num-batched-tokens 16384 \
+  --kv-transfer-config \
+  '{
+    "kv_connector": "UCMConnector",
+    "kv_role": "kv_both",
+    "kv_connector_module_path": "ucm.integration.vllm.ucm_connector",
+    "kv_connector_extra_config": {
+      "UCM_CONFIG_FILE": "/path/to/unified-cache-management/examples/ucm_config_example.yaml"
+    }
+  }'
+```

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -335,6 +335,12 @@ class UCMDirectConnector(KVConnectorBase_V1):
             config["shard_size"] = kv_cache_layout.shard_size * self.blocks_per_chunk
             config["block_size"] = kv_cache_layout.block_size * self.blocks_per_chunk
             config["local_rank_size"] = self.tp_size if self.is_mla else 1
+            register_buffer_ptrs, register_buffer_sizes = (
+                self._build_register_buffer_regions()
+            )
+            if register_buffer_ptrs:
+                config["register_buffer_ptrs"] = register_buffer_ptrs
+                config["register_buffer_sizes"] = register_buffer_sizes
             if cpu_affinity_cores:
                 config["cpu_affinity_cores"] = list(cpu_affinity_cores)
         else:
@@ -352,6 +358,28 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
         logger.info(f"create {name} with config: {config}")
         return UcmConnectorFactoryV1.create_connector(name, config, module_path)
+
+    def _build_register_buffer_regions(self) -> tuple[list[int], list[int]]:
+        ptrs: list[int] = []
+        sizes: list[int] = []
+        for kv_layer in self.kv_caches.values():
+            for tensor in self._iter_register_buffer_tensors(kv_layer):
+                ptrs.append(int(tensor.data_ptr()))
+                sizes.append(int(tensor.numel() * tensor.element_size()))
+        return ptrs, sizes
+
+    def _iter_register_buffer_tensors(
+        self, kv_layer: torch.Tensor | Tuple[torch.Tensor, ...]
+    ) -> list[torch.Tensor]:
+        if isinstance(kv_layer, torch.Tensor):
+            if kv_layer.dim() == 5:
+                return [kv_layer[0], kv_layer[1]]
+            if kv_layer.dim() == 3:
+                return [kv_layer]
+            raise ValueError(f"Unsupported kv cache tensor shape: {kv_layer.shape}")
+        if isinstance(kv_layer, tuple):
+            return list(kv_layer)
+        raise TypeError(f"Unsupported kv cache type: {type(kv_layer)}")
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         if has_ucm_sparse() and os.getenv("VLLM_HASH_ATTENTION") == "1":

--- a/ucm/store/factory_v1.py
+++ b/ucm/store/factory_v1.py
@@ -68,3 +68,8 @@ UcmConnectorFactoryV1.register_connector(
 UcmConnectorFactoryV1.register_connector(
     "UcmPipelineStore", "ucm.store.pipeline.connector", "UcmPipelineStore"
 )
+UcmConnectorFactoryV1.register_connector(
+    "UcmMooncakeStoreV1",
+    "ucm.store.mooncakestore.mooncake_connector",
+    "UcmMooncakeStoreV1",
+)

--- a/ucm/store/mooncakestore/mooncake_connector.py
+++ b/ucm/store/mooncakestore/mooncake_connector.py
@@ -1,367 +1,563 @@
-import asyncio
-import json
-import os
+from __future__ import annotations
+
+import re
 import threading
-from concurrent.futures import Future, TimeoutError
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from typing import Dict, List
 
+import numpy as np
 import torch
-from safetensors.torch import load as safetensors_load
-from safetensors.torch import save as safetensors_save
+from vllm.utils.network_utils import get_ip
 
 from ucm.logger import init_logger
-from ucm.store.ucmstore import Task, UcmKVStoreBase
-
-TIMEOUT_S_THR: int = 60 * 60
-DEFAULT_GLOBAL_SEGMENT_SIZE: int = 3355443200  # 3.125 GiB
-DEFAULT_LOCAL_BUFFER_SIZE: int = 1073741824  # 1.0 GiB
+from ucm.store.ucmstore_v1 import Task, UcmKVStoreBaseV1
 
 logger = init_logger(__name__)
 
 
-# TODO To keep it consistent with the vllm source code(vllm/distributed/kv_transfer/kv_lookup_buffer/mooncake_store.py), the source code is fully reused here. The code here will be deleted after vllm is implemented.
-@dataclass
-class MooncakeStoreConfig:
-    local_hostname: str
-    metadata_server: str
-    global_segment_size: int
-    local_buffer_size: int
-    protocol: str
-    device_name: str
-    master_server_address: str
-
-    @staticmethod
-    def load_from_dict(config: Dict = {}) -> "MooncakeStoreConfig":
-        """Load the config from dict."""
-        return MooncakeStoreConfig(
-            local_hostname=config.get("local_hostname"),
-            metadata_server=config.get("metadata_server"),
-            global_segment_size=config.get(
-                "global_segment_size", DEFAULT_GLOBAL_SEGMENT_SIZE
-            ),
-            local_buffer_size=config.get(
-                "local_buffer_size", DEFAULT_LOCAL_BUFFER_SIZE
-            ),
-            protocol=config.get("protocol", "tcp"),
-            device_name=config.get("device_name", ""),
-            master_server_address=config.get("master_server_address"),
-        )
+DEFAULT_METADATA_SERVER = "P2PHANDSHAKE"
+DEFAULT_MASTER_SERVER_ADDRESS = "127.0.0.1:50088"
+DEFAULT_PROTOCOL = "ascend"
+DEFAULT_SCHEDULER_PROTOCOL = "rpc_only"
+DEFAULT_DEVICE_NAME = ""
+DEFAULT_GLOBAL_SEGMENT_SIZE = 1073741824 * 5
+DEFAULT_LOOKUP_SHARD_INDICES = 0
+DEFAULT_MOONCAKE_V1_WORKERS = 4
 
 
 @dataclass
-class MooncakeTask(Task):
-    """A task class for Mooncake operations with a task identifier."""
+class MooncakeTaskV1(Task):
+    future: Future
+    operation: str
+    key_count: int
 
-    task_id: int = -1
 
+class _GlobalTransferEngine:
+    """Process-level singleton wrapper for ``mooncake.engine.TransferEngine``.
 
-class UcmMooncakeStore(UcmKVStoreBase):
+    Aligns with the reference implementation in
+    ``vllm_ascend/distributed/kv_transfer/utils/mooncake_transfer_engine.py``:
+    every Mooncake ``store`` in the same Python process shares ONE
+    ``TransferEngine`` (so at most one ADXL engine per process), and buffer
+    registration is de-duplicated across store instances.
     """
-    A wrapper class for MooncakeDistributedStore that implements the UcmKVStoreBase interface.
-    Provides key-value store functionality for vLLM using Mooncake as the backend.
-    """
 
-    def __init__(self, config: Dict = {}):
-        """Initialize the Mooncake store with configuration."""
+    def __init__(self) -> None:
+        self._engine = None
+        self._engine_lock = threading.Lock()
+        self._register_lock = threading.Lock()
+        self._registered_ptrs: set[int] = set()
+        self._hostname: str | None = None
+        self._metadata_server: str | None = None
+        self._protocol: str | None = None
+        self._device_name: str | None = None
+
+    def get_engine(
+        self,
+        hostname: str,
+        metadata_server: str,
+        protocol: str,
+        device_name: str,
+    ):
+        if self._engine is not None:
+            return self._engine
+        with self._engine_lock:
+            if self._engine is not None:
+                return self._engine
+            try:
+                from mooncake.engine import TransferEngine  # type: ignore
+            except ImportError as exc:
+                raise ImportError(
+                    "Please install mooncake (https://github.com/kvcache-ai/Mooncake) "
+                    "to run UcmMooncakeStoreV1."
+                ) from exc
+
+            engine = TransferEngine()
+            ret = engine.initialize(
+                hostname,
+                metadata_server,
+                protocol,
+                device_name or "",
+            )
+            if ret != 0:
+                raise RuntimeError(
+                    f"TransferEngine.initialize failed: ret={ret}, "
+                    f"hostname={hostname}, protocol={protocol}, "
+                    f"metadata_server={metadata_server}."
+                )
+            self._engine = engine
+            self._hostname = hostname
+            self._metadata_server = metadata_server
+            self._protocol = protocol
+            self._device_name = device_name or ""
+            logger.info(
+                "Mooncake global TransferEngine initialized (host=%s, protocol=%s, "
+                "rpc_port=%s).",
+                hostname,
+                protocol,
+                self.rpc_port(),
+            )
+        return self._engine
+
+    def rpc_port(self) -> int:
+        assert self._engine is not None, "TransferEngine not initialized yet."
+        return int(self._engine.get_rpc_port())
+
+    def raw_engine(self):
+        assert self._engine is not None, "TransferEngine not initialized yet."
+        return self._engine.get_engine()
+
+    def register_buffers(
+        self,
+        ptrs: list[int],
+        sizes: list[int],
+    ) -> list[int]:
+        """Register each (ptr, size) via ``transfer_engine.register_memory``.
+
+        Duplicates (same ptr already registered in this process) are skipped.
+        Returns the list of ptrs actually registered by THIS call (callers can
+        track them if they want to deregister later).
+        """
+        if self._engine is None:
+            raise RuntimeError("TransferEngine not initialized; call get_engine first.")
+        if len(ptrs) != len(sizes):
+            raise ValueError("ptrs and sizes must have equal length.")
+
+        newly_registered: list[int] = []
+        with self._register_lock:
+            for ptr, size in zip(ptrs, sizes):
+                if ptr in self._registered_ptrs:
+                    continue
+                ret = self._engine.register_memory(ptr, size)
+                if ret != 0:
+                    raise RuntimeError(
+                        "TransferEngine.register_memory failed for "
+                        f"ptr={ptr}, size={size}, ret={ret}."
+                    )
+                self._registered_ptrs.add(ptr)
+                newly_registered.append(ptr)
+        return newly_registered
+
+
+_GLOBAL_TE = _GlobalTransferEngine()
+
+
+class UcmMooncakeStoreV1(UcmKVStoreBaseV1):
+
+    def __init__(self, config: Dict[str, object]) -> None:
         super().__init__(config)
         try:
-            from mooncake.store import MooncakeDistributedStore
-        except ImportError as e:
+            from mooncake.store import MooncakeDistributedStore  # type: ignore
+        except ImportError as exc:
             raise ImportError(
                 "Please install mooncake by following the instructions at "
-                "https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/build.md "  # noqa: E501
-                "to run vLLM with MooncakeConnector."
-            ) from e
+                "https://github.com/kvcache-ai/Mooncake/blob/main/doc/en/build.md "
+                "to run UcmMooncakeStoreV1."
+            ) from exc
 
-        try:
-            self.store = MooncakeDistributedStore()
+        # The configuration determines both the runtime role (scheduler/worker)
+        # and the memory layout used later by Mooncake batch APIs.
+        is_scheduler = self._load_config(config)
+        self._validate_ascend_runtime()
 
-            mooncake_config = MooncakeStoreConfig.load_from_dict(config)
-            logger.info("Mooncake Configuration loaded from dict successfully.")
+        self.store = MooncakeDistributedStore()
+        self._shutdown = threading.Event()
+        # Load/dump calls are submitted asynchronously so that the UCM task
+        # interface can mirror the non-blocking behavior expected by callers.
+        self._executor_workers = int(
+            config.get("executor_workers", DEFAULT_MOONCAKE_V1_WORKERS)
+        )
+        self._executor = ThreadPoolExecutor(
+            max_workers=self._executor_workers,
+            initializer=self._init_worker_context,
+        )
+        self._registered_buffers: list[int] = []
+        if is_scheduler:
+            self.device_id = 0
+            logger.info(
+                f"Mooncake setup detected scheduler path: old Mooncake does not support "
+                f"{DEFAULT_SCHEDULER_PROTOCOL}, keep protocol={self.protocol} and set device to npu:{self.device_id}"
+            )
+            # Some deployments still initialize the scheduler on NPU 0 so that
+            # the underlying runtime has a valid device context before setup.
+            self._set_device_if_needed({"device_id": self.device_id})
+        global_segment_size, local_buffer_size = self._build_segment_sizes(
+            config, is_scheduler
+        )
 
-            self.store.setup(
-                mooncake_config.local_hostname,
-                mooncake_config.metadata_server,
-                mooncake_config.global_segment_size,
-                mooncake_config.local_buffer_size,
-                mooncake_config.protocol,
-                mooncake_config.device_name,
-                mooncake_config.master_server_address,
+        # Align with the vllm-ascend reference: share ONE TransferEngine per
+        # process, and pass it (plus a unique "host:port" local segment name)
+        # into store.setup().
+        transfer_engine = _GLOBAL_TE.get_engine(
+            hostname=self.local_hostname,
+            metadata_server=self.metadata_server,
+            protocol=self.protocol,
+            device_name=self.device_name,
+        )
+        self._transfer_engine = transfer_engine
+        # Mooncake store.setup expects a unique local segment identifier.
+        # Reusing "host:rpc_port" keeps it stable and easy to correlate in logs.
+        self.local_seg = f"{self.local_hostname}:{_GLOBAL_TE.rpc_port()}"
+
+        ret = self.store.setup(
+            self.local_seg,
+            self.metadata_server,
+            global_segment_size,
+            local_buffer_size,
+            self.protocol,
+            self.device_name,
+            self.master_server_address,
+            _GLOBAL_TE.raw_engine(),
+        )
+        if ret != 0:
+            raise RuntimeError(f"Initialize mooncake failed with ret={ret}.")
+        logger.info(
+            f"Mooncake setup success: role={'scheduler' if is_scheduler else 'worker'}, "
+            f"protocol={self.protocol}, local_seg={self.local_seg}, "
+            f"global_segment_size={global_segment_size}, "
+            f"local_buffer_size={local_buffer_size}"
+        )
+        self._register_buffers()
+
+    def _load_config(self, config: Dict[str, object]) -> bool:
+        self.device_id = config.get("device_id", None)
+        # Historical behavior: missing device_id implies the scheduler path,
+        # while workers are pinned to a concrete NPU id.
+        is_scheduler = self.device_id is None
+        self.protocol = str(config.get("protocol") or DEFAULT_PROTOCOL)
+
+        # Each row in tensor_size_list describes one logical KV block shard
+        # layout. Later we duplicate the row per request when building sizes.
+        self.tensor_size_list = tuple(
+            int(size) for size in config.get("tensor_size_list", ())
+        )
+        # register_buffer_ptrs/register_buffer_sizes are pre-allocated buffers
+        # owned by the runtime that Mooncake may DMA into or out of directly.
+        self.register_buffer_ptrs = tuple(
+            int(ptr) for ptr in config.get("register_buffer_ptrs", ())
+        )
+        self.register_buffer_sizes = tuple(
+            int(size) for size in config.get("register_buffer_sizes", ())
+        )
+        if len(self.register_buffer_ptrs) != len(self.register_buffer_sizes):
+            raise ValueError(
+                "register_buffer_ptrs and register_buffer_sizes must have the same length."
             )
 
-        except ValueError as e:
-            logger.error(f"Configuration loading failed: {e}")
-            raise
-        except TypeError:
-            logger.warning("Lack of configuration, please check the dict params .")
-
-        except Exception as exc:
-            logger.error(f"An error occurred while loading the configuration: {exc}")
-            raise
-
-        # Task management variables
-        self.task_id: int = 0
-        self.tasks: Dict[int, Future] = {}
-
-        # Threading and synchronization variables
-        self.loop = asyncio.new_event_loop()
-        self.lock = threading.Lock()
-        self._shutting_down = threading.Event()
-
-        # Start the event loop thread
-        self.thread = threading.Thread(target=self._run_event_loop, daemon=True)
-        self.thread.start()
-
-    def __del__(self):
-        """Release resources on garbage collection."""
-        try:
-            self.shutdown()
-        except Exception:
-            pass
-
-    def _run_event_loop(self):
-        """Run the asyncio event loop in a separate thread."""
-        asyncio.set_event_loop(self.loop)
-        self.loop.run_forever()
-
-    def create(self, block_ids: List[str]) -> List[int]:
-        """
-        create kv cache space in storafe (not implemented for Mooncake).
-
-        Args:
-            block_ids (List[str]): vLLM block hash.
-        Returns:
-            Always returns 0 as this operation is not supported by Mooncake
-        """
-        # Mooncake only has get and put interfaces, this operation is not supported
-        return [0] * len(block_ids)
-
-    def lookup(self, block_ids: List[str]) -> List[bool]:
-        """
-        Get number of blocks that can be loaded from the
-        external KV cache.
-        Mooncake integration uses hash = block_id + offset (default offset=0 if not provided).
-        Args:
-            block_ids (List[str]): vLLM block hash.
-
-        Returns:
-            hit block mask, True -> hit
-        """
-        if self._shutting_down.is_set():
-            raise RuntimeError("UcmMooncakeStore is shutting down.")
-
-        mask = [
-            True if self.store.is_exist(f"{block_key}_0") == 1 else False
-            for block_key in block_ids
-        ]
-        return mask
-
-    def prefetch(self, block_ids: List[str]) -> None:
-        """
-        prefetch kv cache to high speed cache according to block_ids (not implemented for Mooncake).
-
-        Args:
-            block_ids (List[str]): vLLM block hash.
-        """
-        # Mooncake only has get and put interfaces, this operation is not supported
-        pass
-
-    def load(
-        self, block_ids: List[str], offset: List[int], dst_tensor: List[torch.Tensor]
-    ) -> Task:
-        """
-        load kv cache to device.
-        Mooncake integration uses hash = block_id + offset (default offset=0 if not provided).
-
-        Args:
-            block_ids (List[str]): vLLM block hash.
-            offset(List[int]): tp > 1 scene
-            dst_tensor: List[torch.Tensor]: device tensor addr.
-        Returns:
-            task(Task).
-        """
-        if self._shutting_down.is_set():
-            raise RuntimeError("UcmMooncakeStore is shutting down.")
-
-        coro = self._load_impl(block_ids, offset, dst_tensor)
-        future = asyncio.run_coroutine_threadsafe(coro, self.loop)
-        with self.lock:
-            self.task_id += 1
-            self.tasks[self.task_id] = future
-            return MooncakeTask(task_id=self.task_id)
-
-    async def _load_impl(
-        self, block_ids: List[str], offset: List[int], dst_tensor: List[torch.Tensor]
-    ) -> int:
-        """Internal implementation of loading KV cache from Mooncake Store."""
-        assert len(block_ids) == len(
-            dst_tensor
-        ), "block_ids and dst_tensor have different lengths, please check!"
-        for i in range(len(block_ids)):
-            try:
-                block_hash = f"{block_ids[i]}_{offset[i]}"
-                data = self.store.get(block_hash)
-            except TypeError as err:
-                logger.error(f"Failed to get value from Mooncake Store: {err}")
-                raise TypeError("Mooncake Store Get Type Error.") from err
-
-            if data:
-                loaded_tensors = safetensors_load(data)
-                tensor_cpu = loaded_tensors["tensor"]
-                assert dst_tensor[i].shape == tensor_cpu.shape
-                assert dst_tensor[i].dtype == tensor_cpu.dtype
-                dst_tensor[i].copy_(tensor_cpu)
-            else:
-                return 1
-        return 0
-
-    def dump(
-        self, block_ids: List[str], offset: List[int], src_tensor: List[torch.Tensor]
-    ) -> Task:
-        """
-        dump kv cache to device.
-        Mooncake integration uses hash = block_id + offset (default offset=0 if not provided).
-
-        Args:
-            block_ids (List[str]): vLLM block hash.
-            offset(List[int]): tp > 1 scene
-            src_tensor: List[torch.Tensor]: device tensor addr.
-        Returns:
-            task(Task).
-        """
-        if self._shutting_down.is_set():
-            raise RuntimeError("UcmMooncakeStore is shutting down.")
-
-        coro = self._dump_impl(block_ids, offset, src_tensor)
-        future = asyncio.run_coroutine_threadsafe(coro, self.loop)
-        with self.lock:
-            self.task_id += 1
-            self.tasks[self.task_id] = future
-            return MooncakeTask(task_id=self.task_id)
-
-    async def _dump_impl(
-        self, block_ids: List[str], offset: List[int], src_tensor: List[torch.Tensor]
-    ) -> int:
-        """Internal implementation of dumping KV cache to Mooncake Store."""
-        assert len(block_ids) == len(
-            src_tensor
-        ), "block_ids and src_tensor have different lengths, please check!"
-        for i in range(len(block_ids)):
-            value_bytes = safetensors_save({"tensor": src_tensor[i]})
-            try:
-                block_hash = f"{block_ids[i]}_{offset[i]}"
-                ret = self.store.put(block_hash, value_bytes)
-                if ret != 0:
-                    return ret
-            except TypeError as err:
-                logger.error(f"Failed to put value into Mooncake Store: {err}")
-                raise TypeError("Mooncake Store Put Type Error.") from err
-        return 0
-
-    def fetch_data(
-        self,
-        block_ids: List[str],
-        offset: List[int],
-        dst_addr: List[int],
-        size: List[int],
-    ) -> Task:
-        raise NotImplementedError(
-            "Method(fetch_data) not yet implemented in this version"
+        # Allow explicit override for multi-node deployments; otherwise fall
+        # back to the IP helper used across the vLLM integration codepath.
+        configured_local = config.get("local_hostname")
+        if configured_local is not None and str(configured_local).strip():
+            self.local_hostname = str(configured_local).strip()
+        else:
+            self.local_hostname = get_ip()
+            logger.info(
+                "Mooncake local_hostname not set in config; using vllm get_ip() -> %s",
+                self.local_hostname,
+            )
+        self.metadata_server = str(
+            config.get("metadata_server") or DEFAULT_METADATA_SERVER
         )
+        self.master_server_address = str(
+            config.get("master_server_address") or DEFAULT_MASTER_SERVER_ADDRESS
+        )
+        self.device_name = str(config.get("device_name") or DEFAULT_DEVICE_NAME)
+        self.lookup_shard_indices = config.get(
+            "lookup_shard_indices", DEFAULT_LOOKUP_SHARD_INDICES
+        )
+        return is_scheduler
+
+    def _validate_ascend_runtime(self) -> None:
+        if self.protocol != "ascend":
+            raise RuntimeError(
+                f"UcmMooncakeStoreV1 only supports Ascend protocol, but got protocol='{self.protocol}'."
+            )
+        if not hasattr(torch, "npu"):
+            raise RuntimeError(
+                "UcmMooncakeStoreV1 only supports Ascend platform, but torch.npu is not available."
+            )
+
+    def _build_segment_sizes(
+        self, config: Dict[str, object], is_scheduler: bool
+    ) -> tuple[int, int]:
+        if is_scheduler:
+            # The scheduler only coordinates metadata; it does not expose a
+            # data segment of its own in the older Mooncake deployment model.
+            return 0, 0
+        global_segment_size = self._parse_size_to_bytes(
+            config.get("global_segment_size", DEFAULT_GLOBAL_SEGMENT_SIZE),
+            "global_segment_size",
+        )
+        local_buffer_size = self._parse_size_to_bytes(
+            config.get("local_buffer_size", DEFAULT_GLOBAL_SEGMENT_SIZE),
+            "local_buffer_size",
+        )
+        return global_segment_size, local_buffer_size
+
+    def _parse_size_to_bytes(self, value: object, field_name: str) -> int:
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str):
+            cleaned = value.strip().upper()
+            # Accept human-friendly strings used by config files, while keeping
+            # the parser intentionally strict to avoid silently mis-sizing
+            # Mooncake segments on typos.
+            match = re.fullmatch(r"(\d+)\s*(MB|GB)", cleaned)
+            if match:
+                number = int(match.group(1))
+                unit = match.group(2)
+                multiplier = 1024 * 1024 if unit == "MB" else 1024 * 1024 * 1024
+                return number * multiplier
+            if cleaned.isdigit():
+                return int(cleaned)
+        raise ValueError(
+            f"Invalid {field_name} value '{value}'. "
+            "Use integer bytes or strings like '512MB'/'5GB'."
+        )
+
+    def cc_store(self) -> int:
+        return 0
+
+    def lookup(self, block_ids: List[bytes]) -> List[bool]:
+        if not block_ids:
+            logger.info("Mooncake lookup skipped: empty block_ids")
+            return []
+
+        # Lookups always target shard 0 because existence is tracked per block
+        # id in this codepath; shard-aware reads/writes use _build_task_keys.
+        keys = self._build_lookup_keys(block_ids)
+        exists = self.store.batch_is_exist(keys)
+        if len(exists) != len(keys):
+            logger.error(
+                f"Mooncake lookup result size mismatch: results={len(exists)}, keys={len(keys)}"
+            )
+            raise RuntimeError(
+                f"Mooncake lookup returned {len(exists)} results for {len(keys)} keys."
+            )
+
+        hits = [int(value) == 1 for value in exists]
+        return hits
+
+    def lookup_on_prefix(self, block_ids: List[bytes]) -> int:
+        for idx, exists in enumerate(self.lookup(block_ids)):
+            if not exists:
+                return idx - 1
+        return len(block_ids) - 1
+
+    def prefetch(self, block_ids: List[bytes]) -> None:
+        del block_ids
+
+    def load(self, block_ids, shard_index, dst_tensor) -> Task:
+        # Convert tensors into raw device pointers once so the async worker can
+        # call Mooncake without depending on higher-level tensor objects.
+        addrs = self._tensor_normalize(dst_tensor)
+        return self.load_data(block_ids, shard_index, addrs)
+
+    def dump(self, block_ids, shard_index, src_tensor) -> Task:
+        addrs = self._tensor_normalize(src_tensor)
+        return self.dump_data(block_ids, shard_index, addrs)
+
+    def load_data(self, block_ids, shard_index, dst_addr) -> Task:
+        if isinstance(dst_addr, np.ndarray):
+            addrs = dst_addr
+        else:
+            addrs = np.array(dst_addr, dtype=np.uint64)
+        keys = self._build_task_keys(block_ids, shard_index)
+        # Submit work to the executor so callers can decide whether to poll via
+        # check() or block later via wait().
+        future = self._executor.submit(self._execute_load, keys, addrs)
+        return MooncakeTaskV1(future=future, operation="load_data", key_count=len(keys))
 
     def dump_data(
-        self,
-        block_ids: List[str],
-        offset: List[int],
-        src_addr: List[int],
-        size: List[int],
+        self, block_ids, shard_index, src_addr, prerequisite_handle=0
     ) -> Task:
-        raise NotImplementedError(
-            "Method(dump_data) not yet implemented in this version"
+        if isinstance(src_addr, np.ndarray):
+            addrs = src_addr
+        else:
+            addrs = np.array(src_addr, dtype=np.uint64)
+        keys = self._build_task_keys(block_ids, shard_index)
+        # prerequisite_handle is preserved for API compatibility with other
+        # stores even though the current Mooncake path only needs a sync point.
+        future = self._executor.submit(
+            self._execute_dump, keys, addrs, prerequisite_handle
+        )
+        return MooncakeTaskV1(future=future, operation="dump_data", key_count=len(keys))
+
+    def wait(self, task: Task) -> None:
+        if not isinstance(task, MooncakeTaskV1):
+            raise TypeError(f"Unsupported Mooncake task type: {type(task)}")
+        try:
+            task.future.result()
+        except Exception as exc:
+            raise RuntimeError(
+                f"Mooncake {task.operation} task failed for {task.key_count} key(s): {exc}"
+            ) from exc
+
+    def check(self, task: Task) -> bool:
+        if not isinstance(task, MooncakeTaskV1):
+            return False
+        return task.future.done()
+
+    def shutdown(self) -> None:
+        if self._shutdown.is_set():
+            return
+        self._shutdown.set()
+        # cancel_futures=True avoids wedging on queued work (Py 3.9+).
+        _kw: dict = {"wait": True}
+        import sys as _sys
+
+        if _sys.version_info >= (3, 9):
+            _kw["cancel_futures"] = True
+        self._executor.shutdown(**_kw)
+        # NOTE: Buffers are registered via the process-level shared
+        # TransferEngine (_GLOBAL_TE.register_buffers). We do NOT deregister
+        # them here because the engine is shared by sibling stores in the same
+        # process (mirrors the vllm-ascend reference behavior). The OS will
+        # release everything at process exit.
+        self._registered_buffers.clear()
+        try:
+            self.store.close()
+        except Exception as exc:
+            logger.warning(f"Mooncake store.close() raised: {exc}")
+
+    def _build_lookup_keys(self, block_ids: List[bytes]) -> List[str]:
+        keys = []
+        for block_id in block_ids:
+            block_hex = bytes(block_id).hex()
+            # Lookup uses a canonical ":0" suffix because the existence check
+            # is only probing whether the block family is present at all.
+            keys.append(f"{block_hex}:0")
+        return keys
+
+    def _build_task_keys(
+        self, block_ids: List[bytes], shard_index: List[int]
+    ) -> List[str]:
+        # Mooncake expects string keys in the form "<block_hex>:<shard>".
+        return [
+            f"{bytes(block_id).hex()}:{int(shard)}"
+            for block_id, shard in zip(block_ids, shard_index)
+        ]
+
+    def _build_sizes_matrix(self, n_rows: int) -> List[List[int]]:
+        # The C++ API receives one size row per key/buffer group.
+        return [list(self.tensor_size_list) for _ in range(n_rows)]
+
+    def _tensor_normalize(self, tensors: List[List[torch.Tensor]]) -> np.ndarray:
+        if not tensors:
+            return np.empty((0, 0), dtype=np.uint64)
+
+        # Convert nested tensor lists into a dense uint64 pointer matrix so the
+        # background worker can serialize arguments with minimal Python logic.
+        return np.asarray(
+            [[tensor.data_ptr() for tensor in row] for row in tensors],
+            dtype=np.uint64,
         )
 
-    def wait(self, task: Task) -> int:
+    def _set_device_context(self) -> None:
+        if self.protocol == "ascend" and hasattr(torch, "npu"):
+            # Worker threads do not automatically inherit the expected NPU
+            # device, so each thread pins itself once at startup.
+            torch.npu.set_device(torch.device(f"npu:{int(self.device_id)}"))
+
+    def _init_worker_context(self) -> None:
+        # Set thread-local device context once when worker starts.
+        self._set_device_context()
+
+    def _execute_load(self, keys: List[str], addrs: np.ndarray) -> None:
+        addrs_list = addrs.tolist()
+        sizes = self._build_sizes_matrix(len(addrs))
+        # Mooncake writes directly into the provided device buffers.
+        res = self.store.batch_get_into_multi_buffers(keys, addrs_list, sizes)
+        self._raise_if_batch_failed("batch_get_into_multi_buffers", keys, res)
+
+    def _execute_dump(
+        self,
+        keys: List[str],
+        addrs: np.ndarray,
+        prerequisite_handle: int,
+    ) -> None:
+        if (
+            prerequisite_handle != 0
+            and self.protocol == "ascend"
+            and hasattr(torch, "npu")
+        ):
+            # Ensure producer-side NPU work is visible before Mooncake reads the
+            # source buffers. This mirrors the conservative sync behavior in
+            # related backends when an upstream handle is present.
+            torch.npu.synchronize()
+        addrs_list = addrs.tolist()
+        sizes = self._build_sizes_matrix(len(addrs))
+        res = self.store.batch_put_from_multi_buffers(keys, addrs_list, sizes)
+        self._raise_if_batch_failed("batch_put_from_multi_buffers", keys, res)
+
+    def _raise_if_batch_failed(self, op: str, keys: List[str], res) -> None:
+        """Surface Mooncake batch errors as Python exceptions.
+
+        Historically these C++ return codes were silently ignored, so a failed
+        dump/load looked like a successful ``store.wait()`` but the destination
+        tensor was all zeros. Mirrors the error handling in the vllm-ascend
+        reference (``MooncakeBackend.put``/``.get``), but escalated to raise so
+        that ``task.future.result()`` actually fails.
         """
-        wait kv cache kv transfer task finished.
-
-        Args:
-            task (Task): transfer engine task.
-        Returns:
-            0 - success
-            others - failed.
-        """
-        # Safely retrieve the Future object
-        with self.lock:
-            future = self.tasks.pop(task.task_id, None)
-
-        if future is None:
-            logger.error(f"Invalid task ID: {task.task_id}")
-            return 1
-
+        if res is None:
+            return
         try:
-            ret = future.result(TIMEOUT_S_THR)
-            return ret
-        except TimeoutError:
-            # Cancel the task if it times out
-            future.cancel()
-            logger.error(f"Task {task.task_id} timed out after {TIMEOUT_S_THR}s")
-            return 1
-        except asyncio.CancelledError:
-            logger.error(f"Task {task.task_id} was cancelled")
-            return 1
-        except Exception as e:
-            logger.error(f"Task {task.task_id} failed: {str(e)}")
-            return 1
-
-    def commit(self, block_ids: List[str], is_success: bool = True) -> None:
-        """
-        commit kv cache, now kv cache can be reused (not implemented for Mooncake).
-
-        Args:
-            block_ids (List[str]): vLLM block hash.
-            is_success(bool): if False, we need release block
-        """
-        # Mooncake only has get and put interfaces, this operation is not supported
-        pass
-
-    def shutdown(self):
-        """Safely shutdown all components of the store."""
-        if self._shutting_down.is_set():
+            values = list(res)
+        except TypeError:
+            if isinstance(res, int) and res != 0:
+                raise RuntimeError(f"Mooncake {op} failed with ret={res}.")
             return
 
-        self._shutting_down.set()
+        failures: list[tuple[str, int]] = []
+        for key, value in zip(keys, values):
+            try:
+                code = int(value)
+            except (TypeError, ValueError):
+                continue
+            if code < 0:
+                failures.append((key, code))
+        if failures:
+            preview = ", ".join(f"{k}={c}" for k, c in failures[:3])
+            raise RuntimeError(
+                f"Mooncake {op} failed for {len(failures)}/{len(values)} key(s): "
+                f"{preview}{' ...' if len(failures) > 3 else ''}"
+            )
 
-        # Safely cancel all pending tasks (atomic operation)
-        with self.lock:
-            tasks_to_cancel = list(self.tasks.values())
-            self.tasks.clear()
+    def _set_device_if_needed(self, config: Dict[str, object]) -> None:
+        if not hasattr(torch, "npu"):
+            return
+        if self.protocol != "ascend":
+            return
 
-        for future in tasks_to_cancel:
-            if not future.done():
-                future.cancel()
+        device_id = config.get("device_id", self.device_id)
+        torch.npu.set_device(torch.device(f"npu:{int(device_id)}"))
+        logger.info(f"Set NPU device to npu:{int(device_id)} before Mooncake setup")
 
-        # Stop the event loop
-        self.loop.call_soon_threadsafe(self.loop.stop)
+    def _register_buffers(self) -> None:
+        if not self.register_buffer_ptrs:
+            return
 
-        # Wait for thread termination
-        if self.thread.is_alive():
-            self.thread.join(TIMEOUT_S_THR)
+        # De-duplicate (ptr, size) inside this store first.
+        # The global engine does another layer of de-duplication across store
+        # instances, but doing it locally keeps logs and accounting cleaner.
+        seen: set[int] = set()
+        ptrs: list[int] = []
+        sizes: list[int] = []
+        for ptr, size in zip(self.register_buffer_ptrs, self.register_buffer_sizes):
+            if ptr in seen:
+                continue
+            seen.add(ptr)
+            ptrs.append(int(ptr))
+            sizes.append(int(size))
 
-            # Force close the loop if thread didn't exit
-            if not self.loop.is_closed():
-                self.loop.close()
+        newly = _GLOBAL_TE.register_buffers(ptrs, sizes)
+        self._registered_buffers.extend(newly)
 
-        self.store.close()
-
-    def check(self, task: Task) -> int:
-        """
-        check if kv transfer task finished.
-
-        Args:
-            task (Task): transfer engine task.
-        Returns:
-            0 - finished
-            others - in process.
-        """
-        pass
+        logger.info(
+            "Mooncake registered worker buffers via shared TransferEngine: "
+            "new=%d, total_in_process_engine=%d (this store requested %d).",
+            len(newly),
+            len(_GLOBAL_TE._registered_ptrs),  # type: ignore[attr-defined]
+            len(ptrs),
+        )

--- a/ucm/store/test/e2e/mooncake_scheduler_two_workers_test.py
+++ b/ucm/store/test/e2e/mooncake_scheduler_two_workers_test.py
@@ -1,0 +1,466 @@
+# -*- coding: utf-8 -*-
+#
+# MIT License
+#
+# Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+"""Mooncake ``UcmMooncakeStoreV1`` e2e: 1 scheduler + 2 workers.
+
+Key reliability behaviors:
+
+- If **any one child fails / exits non-zero**, the parent IMMEDIATELY terminates
+  the remaining children (no 5-min barrier wait).
+- Parent installs signal (SIGINT/SIGTERM) + ``atexit`` handlers so Ctrl+C reaps
+  every child; still-alive children get ``SIGKILL``.
+- Parent is set as a process group leader (``os.setpgrp``) on Linux, so a single
+  ``kill -TERM -<PGID>`` can take everything down.
+- Child wraps ``store.shutdown()`` in a timeout-guarded thread and exits via
+  ``os._exit`` to avoid hanging in Mooncake / Ascend native teardown.
+
+Run (no pytest)::
+
+    PYTHONPATH=. python ucm/store/test/e2e/mooncake_scheduler_two_workers_test.py
+
+Env (all optional):
+
+- ``UCM_MOONCAKE_MASTER``             default 127.0.0.1:50088
+- ``UCM_MOONCAKE_METADATA``           default P2PHANDSHAKE
+- ``UCM_MOONCAKE_LOCAL_HOSTNAME``     default 127.0.0.1
+- ``UCM_MOONCAKE_GLOBAL_SEGMENT``     default 256MB
+- ``UCM_MOONCAKE_LOCAL_BUFFER``       default 256MB
+- ``UCM_MOONCAKE_TEST_BARRIER_TIMEOUT`` default 300  (seconds)
+- ``UCM_MOONCAKE_TEST_JOIN_TIMEOUT``    default 600  (seconds, per child)
+- ``UCM_MOONCAKE_TEST_SHUTDOWN_TIMEOUT`` default 60  (seconds, child-side)
+"""
+from __future__ import annotations
+
+import atexit
+import multiprocessing
+import os
+import secrets
+import signal
+import sys
+import threading
+import time
+import traceback
+from threading import BrokenBarrierError
+from typing import Any, Optional
+
+import numpy as np
+import torch
+
+from ucm.store.factory_v1 import UcmConnectorFactoryV1
+
+ROLE_SCHEDULER = 0
+ROLE_WORKER0 = 1
+ROLE_WORKER1 = 2
+ROLE_NAMES = {
+    ROLE_SCHEDULER: "scheduler",
+    ROLE_WORKER0: "worker0",
+    ROLE_WORKER1: "worker1",
+}
+_NUM_PARTIES = 3
+
+# Parent-only bookkeeping so signal handlers / atexit can reap children.
+_CHILD_PROCS: list[multiprocessing.Process] = []
+
+
+# ---------------------------------------------------------------------------
+# Configs + helpers (shared by child roles)
+# ---------------------------------------------------------------------------
+
+
+def _mooncake_base_config() -> dict[str, Any]:
+    return {
+        "protocol": "ascend",
+        "local_hostname": os.environ.get("UCM_MOONCAKE_LOCAL_HOSTNAME", "127.0.0.1"),
+        "metadata_server": os.environ.get("UCM_MOONCAKE_METADATA", "P2PHANDSHAKE"),
+        "master_server_address": os.environ.get(
+            "UCM_MOONCAKE_MASTER", "127.0.0.1:50088"
+        ),
+        "device_name": "",
+        "global_segment_size": os.environ.get("UCM_MOONCAKE_GLOBAL_SEGMENT", "256MB"),
+        "local_buffer_size": os.environ.get("UCM_MOONCAKE_LOCAL_BUFFER", "256MB"),
+        "executor_workers": 1,
+        "unique_id": os.environ.get("UCM_MOONCAKE_UNIQUE_ID", "mooncake_e2e_test"),
+    }
+
+
+def _scheduler_config(base: dict[str, Any]) -> dict[str, Any]:
+    cfg = {k: v for k, v in base.items() if k != "device_id"}
+    cfg.pop("device_id", None)
+    return cfg
+
+
+def _make_block_tensor(row_idx: int, numel: int, device_id: int) -> torch.Tensor:
+    return torch.full(
+        (numel,),
+        fill_value=float(row_idx + 1),
+        dtype=torch.bfloat16,
+        device=f"npu:{device_id}",
+    )
+
+
+def _tensor_rows_to_addr_array(tensors: list[list[torch.Tensor]]) -> np.ndarray:
+    return np.asarray(
+        [[int(t.data_ptr()) for t in row] for row in tensors],
+        dtype=np.uint64,
+    )
+
+
+def _worker_config(
+    base: dict[str, Any], device_id: int, tensors: list[list[torch.Tensor]]
+) -> dict[str, Any]:
+    ptrs: list[int] = []
+    sizes: list[int] = []
+    for row in tensors:
+        for t in row:
+            ptrs.append(int(t.data_ptr()))
+            sizes.append(int(t.numel() * t.element_size()))
+    sample = tensors[0][0]
+    tensor_size_list = (int(sample.numel() * sample.element_size()),)
+    cfg = dict(base)
+    cfg["device_id"] = device_id
+    cfg["tensor_size_list"] = tensor_size_list
+    cfg["register_buffer_ptrs"] = tuple(ptrs)
+    cfg["register_buffer_sizes"] = tuple(sizes)
+    return cfg
+
+
+# ---------------------------------------------------------------------------
+# Child side
+# ---------------------------------------------------------------------------
+
+
+def _barrier_wait(barrier: multiprocessing.Barrier, label: str) -> None:
+    timeout = float(os.environ.get("UCM_MOONCAKE_TEST_BARRIER_TIMEOUT", "300"))
+    try:
+        barrier.wait(timeout=timeout)
+    except BrokenBarrierError as exc:
+        raise RuntimeError(
+            f"barrier '{label}' broken/timeout ({timeout}s): a peer likely crashed."
+        ) from exc
+
+
+def _shutdown_store_best_effort(store: Any, role: int) -> None:
+    timeout = float(os.environ.get("UCM_MOONCAKE_TEST_SHUTDOWN_TIMEOUT", "60"))
+    done = threading.Event()
+
+    def _run() -> None:
+        try:
+            if hasattr(torch, "npu"):
+                try:
+                    torch.npu.synchronize()
+                except Exception:
+                    pass
+            store.shutdown()
+        except BaseException as exc:  # noqa: BLE001
+            print(
+                f"[{ROLE_NAMES.get(role, role)}] shutdown error: {exc}", file=sys.stderr
+            )
+        finally:
+            done.set()
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    if not done.wait(timeout=timeout):
+        print(
+            f"[{ROLE_NAMES.get(role, role)}] store.shutdown() exceeded {timeout}s; "
+            "forcing child exit.",
+            file=sys.stderr,
+        )
+
+
+def _mooncake_party(
+    role: int,
+    barrier: multiprocessing.Barrier,
+    block_ids: list[bytes],
+    tensor_numel: int,
+) -> None:
+    store = None
+    exit_code = 0
+    label = ROLE_NAMES.get(role, str(role))
+    try:
+        base = _mooncake_base_config()
+        if role == ROLE_SCHEDULER:
+            store = UcmConnectorFactoryV1.create_connector(
+                "UcmMooncakeStoreV1", _scheduler_config(base)
+            )
+        elif role == ROLE_WORKER0:
+            torch.npu.set_device(0)
+            src_tensors = [
+                [_make_block_tensor(i, tensor_numel, 0)] for i in range(len(block_ids))
+            ]
+            cfg = _worker_config(base, 0, src_tensors)
+            store = UcmConnectorFactoryV1.create_connector("UcmMooncakeStoreV1", cfg)
+        else:
+            torch.npu.set_device(1)
+            dst_tensors = [
+                [torch.zeros((tensor_numel,), dtype=torch.bfloat16, device="npu:1")]
+                for _ in block_ids
+            ]
+            cfg = _worker_config(base, 1, dst_tensors)
+            store = UcmConnectorFactoryV1.create_connector("UcmMooncakeStoreV1", cfg)
+
+        _barrier_wait(barrier, "after_setup")
+
+        if role == ROLE_WORKER0:
+            shard_indexes = [0] * len(block_ids)
+            src_addrs = _tensor_rows_to_addr_array(src_tensors)
+            task = store.dump_data(block_ids, shard_indexes, src_addrs)
+            store.wait(task)
+
+        _barrier_wait(barrier, "after_worker0_dump")
+
+        if role == ROLE_WORKER1:
+            shard_indexes = [0] * len(block_ids)
+            dst_addrs = _tensor_rows_to_addr_array(dst_tensors)
+            task = store.load_data(block_ids, shard_indexes, dst_addrs)
+            store.wait(task)
+            for i, row in enumerate(dst_tensors):
+                expected = torch.full(
+                    (tensor_numel,), float(i + 1), dtype=torch.bfloat16
+                )
+                if not torch.allclose(row[0].cpu(), expected):
+                    raise AssertionError(
+                        f"load mismatch at block row {i}: got {row[0].cpu()[:8]}, "
+                        f"expected {expected[:8]}"
+                    )
+
+        _barrier_wait(barrier, "after_worker1_load")
+
+        if role == ROLE_SCHEDULER:
+            hits = store.lookup(block_ids)
+            if not all(hits):
+                raise AssertionError(f"scheduler lookup expected all True, got {hits}")
+            prefix_idx = store.lookup_on_prefix(block_ids)
+            if prefix_idx != len(block_ids) - 1:
+                raise AssertionError(
+                    f"lookup_on_prefix expected {len(block_ids) - 1}, got {prefix_idx}"
+                )
+
+        _barrier_wait(barrier, "after_scheduler_lookup")
+        print(f"[{label}] OK", file=sys.stderr)
+    except BaseException:
+        exit_code = 1
+        print(f"[{label}] FAILED:", file=sys.stderr)
+        traceback.print_exc()
+    finally:
+        if store is not None:
+            _shutdown_store_best_effort(store, role)
+        # Bypass interpreter cleanup to guarantee the process dies promptly even
+        # if Mooncake / Ascend native state is still fussy.
+        os._exit(exit_code)
+
+
+# ---------------------------------------------------------------------------
+# Parent side: supervisor with fail-fast
+# ---------------------------------------------------------------------------
+
+
+def _kill_one(p: multiprocessing.Process, hard: bool = False) -> None:
+    if not p.is_alive():
+        return
+    if hard and sys.platform != "win32":
+        try:
+            os.kill(p.pid, signal.SIGKILL)  # type: ignore[attr-defined]
+        except (ProcessLookupError, PermissionError):
+            pass
+    else:
+        try:
+            p.terminate()
+        except Exception:
+            pass
+
+
+def _terminate_all_children(reason: Optional[str] = None) -> None:
+    if reason:
+        print(f"[mooncake_e2e] terminating children: {reason}", file=sys.stderr)
+
+    alive = [p for p in _CHILD_PROCS if p is not None and p.is_alive()]
+    for p in alive:
+        _kill_one(p, hard=False)
+    deadline = time.monotonic() + 5.0
+    for p in alive:
+        remaining = max(0.0, deadline - time.monotonic())
+        p.join(timeout=remaining)
+
+    still = [p for p in _CHILD_PROCS if p is not None and p.is_alive()]
+    for p in still:
+        _kill_one(p, hard=True)
+    for p in still:
+        p.join(timeout=3)
+
+
+def _signal_exit(signum: int, _frame: Any) -> None:
+    _terminate_all_children(f"received signal {signum}")
+    os._exit(128 + signum)
+
+
+def _install_parent_cleanup() -> None:
+    atexit.register(lambda: _terminate_all_children("parent atexit"))
+    sigs = [signal.SIGINT]
+    if sys.platform != "win32":
+        sigs.append(signal.SIGTERM)
+    for sig in sigs:
+        try:
+            signal.signal(sig, _signal_exit)
+        except (OSError, ValueError):
+            pass
+
+
+def _become_process_group_leader() -> None:
+    if sys.platform == "win32":
+        return
+    try:
+        os.setpgrp()
+    except OSError:
+        pass
+
+
+def _supervise(workers: list[multiprocessing.Process]) -> list[tuple[str, int]]:
+    """Wait for all children.
+
+    Return list of (role_name, exitcode) for failed children. If any child
+    exits with non-zero code while others are still running, terminate the rest
+    **immediately** (no barrier wait).
+    """
+    join_timeout = float(os.environ.get("UCM_MOONCAKE_TEST_JOIN_TIMEOUT", "600"))
+    poll_interval = 0.5
+    deadline = time.monotonic() + join_timeout
+
+    failed: list[tuple[str, int]] = []
+    aborted = False
+
+    while True:
+        alive_any = False
+        for p in workers:
+            if p.exitcode is None and p.is_alive():
+                alive_any = True
+                continue
+            # Process has exited -> record if failure
+            if getattr(p, "_ucm_reaped", False):
+                continue
+            p._ucm_reaped = True  # type: ignore[attr-defined]
+            role_name = p.name or "unknown"
+            if p.exitcode not in (0, None):
+                failed.append((role_name, int(p.exitcode)))
+                if not aborted:
+                    aborted = True
+                    _terminate_all_children(
+                        f"{role_name} exited with code {p.exitcode}; aborting peers"
+                    )
+
+        if not alive_any:
+            break
+
+        if time.monotonic() > deadline:
+            _terminate_all_children(f"join timeout ({join_timeout}s)")
+            # give SIGKILL a moment, then still loop to mark remaining as failed
+            deadline = time.monotonic() + 10.0  # grace period
+            for p in workers:
+                if p.exitcode is None and p.is_alive():
+                    _kill_one(p, hard=True)
+
+        time.sleep(poll_interval)
+
+    for p in workers:
+        if not getattr(p, "_ucm_reaped", False):
+            role_name = p.name or "unknown"
+            if p.exitcode not in (0, None):
+                failed.append((role_name, int(p.exitcode or -1)))
+
+    return failed
+
+
+def _run_multiprocess_e2e(block_count: int = 6, tensor_numel: int = 256) -> None:
+    ctx = multiprocessing.get_context("spawn")
+    block_ids = [secrets.token_bytes(16) for _ in range(block_count)]
+    barrier = ctx.Barrier(_NUM_PARTIES)
+
+    _CHILD_PROCS.clear()
+    workers: list[multiprocessing.Process] = []
+    for role in (ROLE_SCHEDULER, ROLE_WORKER0, ROLE_WORKER1):
+        p = ctx.Process(
+            target=_mooncake_party,
+            args=(role, barrier, block_ids, tensor_numel),
+            name=ROLE_NAMES[role],
+        )
+        workers.append(p)
+        p.start()
+    _CHILD_PROCS.extend(workers)
+
+    try:
+        failed = _supervise(workers)
+    finally:
+        _terminate_all_children("final cleanup")
+        _CHILD_PROCS.clear()
+
+    if failed:
+        details = ", ".join(f"{name}(code={code})" for name, code in failed)
+        raise RuntimeError(f"mooncake e2e failed: {details}")
+
+
+def _ascend_two_npu_available() -> bool:
+    if not hasattr(torch, "npu"):
+        return False
+    try:
+        return int(torch.npu.device_count()) >= 2
+    except Exception:
+        return False
+
+
+def run_mooncake_scheduler_two_workers_main() -> None:
+    if not hasattr(torch, "npu"):
+        print(
+            "SKIP: torch.npu not available (need Ascend environment).",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+    if not _ascend_two_npu_available():
+        print(
+            "SKIP: need at least 2 NPUs (worker0=npu:0, worker1=npu:1).",
+            file=sys.stderr,
+        )
+        sys.exit(0)
+
+    _become_process_group_leader()
+    _install_parent_cleanup()
+
+    if sys.platform != "win32":
+        pgid = os.getpgrp()
+        print(
+            f"[mooncake_e2e] parent pid={os.getpid()} pgrp={pgid} "
+            f"(group kill: kill -TERM -{pgid})",
+            file=sys.stderr,
+        )
+
+    time.sleep(0.3)
+    _run_multiprocess_e2e()
+
+
+if __name__ == "__main__":
+    multiprocessing.freeze_support()
+    try:
+        run_mooncake_scheduler_two_workers_main()
+    except BaseException:
+        _terminate_all_children("parent exception")
+        raise


### PR DESCRIPTION
## Purpose
- Integrate `UcmMooncakeStoreV1` into UCM/vLLM KV transfer flow, including lookup/load/dump/wait/check path support.
- Wire Mooncake v1 connector registration in store factory and pass runtime config from `UCMConnector`.
- Add Mooncake Prefix Cache user guide `docs/source/user-guide/prefix-cache/mooncakestore.md`.
- Update Prefix Cache docs index to include `mooncakestore`.

## Modifications 
- `ucm/store/mooncakestore/mooncake_connector.py`
  - Refactor and integrate Mooncake v1 backend logic.
  - Support async task execution and task lifecycle checks.
  - Add worker-side NPU buffer registration for RDMA transfer.
- `ucm/integration/vllm/ucm_connector.py`
  - Pass Mooncake-required runtime fields (`device_id`, tensor size metadata, optional register buffers, etc.).
- `ucm/store/factory_v1.py`
  - Register `UcmMooncakeStoreV1` for connector factory creation.
- `docs/source/user-guide/prefix-cache/mooncakestore.md`
  - Add user guide for Mooncake Store v1 usage and launch instructions.
- `docs/source/user-guide/prefix-cache/index.md`
  - Add `mooncakestore` to toctree.
 
## Test
Validated on single-machine Atlas A2 with whole-save whole-load enabled and UCM + Mooncake backend.

### QwQ-32B (TP=2)

| Sequence Length | Concurrency | Hit Rate | Baseline | Read | Improvement |
|---|---:|---:|---:|---:|---:|
| 8k | 10 | 1.0 | 10819.43 | 1238.38 | 88.55% |
| 8k | 10 | 0.8 | 10819.43 | 3270.46 | 69.77% |

### DSV2-Lite (TP=2)

| Sequence Length | Concurrency | Hit Rate | Baseline | Read | Improvement |
|---|---:|---:|---:|---:|---:|
| 8k | 10 | 1.0 | 2911.66 | 859.18 | 70.49% |
| 8k | 10 | 0.8 | 2911.66 | 1356.10 | 53.43% |