### PR TITLE
[Fix]TransBuffer: shared freeHead let Dump bypass the reserved limit and ring bounds

### DIFF
--- a/ucm/store/cache/cc/cache_store.cc
+++ b/ucm/store/cache/cc/cache_store.cc
@@ -201,6 +201,7 @@ private:
         UC_INFO("Set {}::RunningQueueDepth to {}.", ns, config.runningQueueDepth);
         UC_INFO("Set {}::TimeoutMs to {}.", ns, config.timeoutMs);
         UC_INFO("Set {}::StreamNumber to {}.", ns, config.streamNumber);
+        UC_INFO("Set {}::LoadExclusiveBufferNumber to {}.", ns, config.loadExclusiveBufferNumber);
     }
 };
 

--- a/ucm/store/cache/cc/trans_buffer.cc
+++ b/ucm/store/cache/cc/trans_buffer.cc
@@ -186,9 +186,10 @@ public:
     size_t FetchNode(bool allowReserved) override
     {
         const auto limit = header_.nNode - (allowReserved ? 0 : base_.reservedNumber);
-        const auto head = header_.freeHead;
-        header_.freeHead = (head + 1 == limit) ? 0 : (head + 1);
-        return head;
+        if (header_.freeHead >= limit) {
+            header_.freeHead = 0;
+        }
+        return header_.freeHead++;
     }
     void* DataAt(size_t iNode) override
     {
@@ -417,8 +418,10 @@ public:
     {
         const auto limit = header_->nNode - (allowReserved ? 0 : base_.reservedNumber);
         header_->lock.Lock();
-        const auto iNode = header_->freeHead;
-        header_->freeHead = (iNode + 1 == limit) ? 0 : (iNode + 1);
+        if (header_->freeHead >= limit) {
+            header_->freeHead = 0;
+        }
+        const auto iNode = header_->freeHead++;
         header_->lock.Unlock();
         return iNode;
     }

--- a/ucm/store/cache/cc/trans_buffer.cc
+++ b/ucm/store/cache/cc/trans_buffer.cc
@@ -186,9 +186,7 @@ public:
     size_t FetchNode(bool allowReserved) override
     {
         const auto limit = header_.nNode - (allowReserved ? 0 : base_.reservedNumber);
-        if (header_.freeHead >= limit) {
-            header_.freeHead = 0;
-        }
+        if (header_.freeHead >= limit) { header_.freeHead = 0; }
         return header_.freeHead++;
     }
     void* DataAt(size_t iNode) override
@@ -418,9 +416,7 @@ public:
     {
         const auto limit = header_->nNode - (allowReserved ? 0 : base_.reservedNumber);
         header_->lock.Lock();
-        if (header_->freeHead >= limit) {
-            header_->freeHead = 0;
-        }
+        if (header_->freeHead >= limit) { header_->freeHead = 0; }
         const auto iNode = header_->freeHead++;
         header_->lock.Unlock();
         return iNode;

--- a/ucm/store/test/case/cache/cache_trans_manager_test.cc
+++ b/ucm/store/test/case/cache/cache_trans_manager_test.cc
@@ -55,7 +55,7 @@ TEST_F(UCCacheTransManagerTest, DumpThenLoad)
     config.shardSize = tensorSize;
     config.blockSize = config.shardSize;
     config.deviceId = 0;
-    config.bufferCapacity = config.shardSize * 1024;
+    config.bufferCapacity = config.shardSize * 2049;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
     TransBuffer buffer;
@@ -111,7 +111,7 @@ TEST_F(UCCacheTransManagerTest, DumpThenLoadWithLayerWise)
     config.shardSize = shardSize;
     config.blockSize = blockSize;
     config.deviceId = 0;
-    config.bufferCapacity = shardSize * 1024;
+    config.bufferCapacity = shardSize * 2049;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
     config.timeoutMs = 10 * 60 * 1000;
@@ -179,7 +179,7 @@ TEST_F(UCCacheTransManagerTest, DumpThenLoadWithLayerAndChunk)
     config.shardSize = shardSize;
     config.blockSize = blockSize;
     config.deviceId = 0;
-    config.bufferCapacity = shardSize * 1024;
+    config.bufferCapacity = shardSize * 2049;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
     config.timeoutMs = 10 * 60 * 1000;
@@ -261,7 +261,7 @@ TEST_F(UCCacheTransManagerTest, DumpThenLoadWithVariableLengthIo)
     config.shardSize = shardSize;
     config.blockSize = blockSize;
     config.deviceId = 0;
-    config.bufferCapacity = shardSize * 1024;
+    config.bufferCapacity = shardSize * 2049;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
     TransBuffer buffer;


### PR DESCRIPTION
## Purpose
Load and Dump share `freeHead`; per-caller limit alone does not isolate reserved slots, so Dump could still take reserved indices or break ring bounds; the fix resets and advances `freeHead` consistently inside `FetchNode` for the non-reserved path.
## Modifications 
- **`LocalBufferStrategy::FetchNode(bool allowReserved)`** (`ucm/store/cache/cc/trans_buffer.cc`)
  - `limit = nNode` when `allowReserved == true`, else `limit = nNode - reservedNumber`.
  - If `freeHead >= limit`, set `freeHead = 0`.
  - Return `freeHead++` (post-increment).
- **`SharedBufferStrategy::FetchNode(bool allowReserved)`** (same file)
  - Same `limit` / reset / post-increment logic, guarded by `header_->lock`.
## Test
Set `Cache_buffer_capacity_gb` = 4
<img width="574" height="243" alt="image" src="https://github.com/user-attachments/assets/5b0eeef9-f492-4c37-939d-57df5e4981a3" />
test cases 
<img width="491" height="287" alt="image" src="https://github.com/user-attachments/assets/12bf16f3-f128-49c1-aec3-b7e3932da9da" />
vllm instance doesn't crash
