### PR TITLE
[Fix] Not print hit rate when using 1tp

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -1096,6 +1096,7 @@ class UCMLiteConnector(UCMDirectConnector):
             ],
             "enable_record_traces": enable_record_traces,
             "persist_token_threshold": persist_token_threshold,
+            "use_lite": True,
         }
         super().__init__(vllm_config, role)
         self.total_block_nums = 0


### PR DESCRIPTION
## Purpose
Fix the bug that not print external hit rate when using 1tp
## Modifications 
Modify ucm_connector.py
## Test
Tested with online server using command like below, print external hit rate correctly.
```export ASCEND_RT_VISIBLE_DEVICES=1
vllm serve /models/Qwen3-0.6B \
--max-model-len 20000 \
--tensor-parallel-size 1 \
--gpu_memory_utilization 0.87 \
--block_size 128 \
--trust-remote-code \
--host x.x.x.x \
--port xxxx \
--no-enable-prefix-caching \
--kv-transfer-config \
'{
    "kv_connector": "UCMConnector",
    "kv_connector_module_path": "ucm.integration.vllm.ucm_connector",
    "kv_role": "kv_both",
    "kv_connector_extra_config": {"UCM_CONFIG_FILE": "/work-space/ucm_example_config.yaml"}
}'```