### PR TITLE
[Fix] Fix dump err when 0 < len(load_blocks) < fully hit

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -1116,8 +1116,18 @@ class UCMLiteConnector(UCMDirectConnector):
             external_hit_blocks = (
                 request_meta.total_hit_block_num - request_meta.hbm_hit_block_num
             )
+            need_dump_blks = request_meta.ucm_block_ids[
+                request_meta.total_hit_block_num :
+            ]
+            shard_indexs = [0] * len(need_dump_blks)
+            total_ptrs = [[0]] * len(need_dump_blks)
+            try:
+                task = self.store.dump_data(need_dump_blks, shard_indexs, total_ptrs)
+                self.store.wait(task)
+            except RuntimeError as e:
+                logger.error(f"request {request.request_id} wait dump task error. {e}")
+            self.requests_meta[request.request_id] = RequestMeta()
 
-            request_meta.total_hit_block_num = request_meta.hbm_hit_block_num
         self.total_hit_block_nums += external_hit_blocks
 
         logger.info(


### PR DESCRIPTION
## Purpose
Fix the dump failure issue that occurs when len(load_blocks) < fully_hit in the external hit scenario with **use_lite=true**.The failure is caused by len(ucm_block_ids) < len(vllm_block_ids) during wait_for_save.This discrepancy arises because, in **_generate_dispatch_meta**, the **new_tokens** parameter still includes external hits, even though req_meta.token_processed has already accounted for those tokens.

## Modifications 
- Modify func **get_num_new_matched_tokens** of UCMLiteConnector: using hbm_hit_tokens as request_meta.token_processed, as it needs to return 0 hit in external storage.
- Modify func **_generate_dispatch_meta** of UCMLiteConnector: only generating dump block infos when req_meta.token_processed + new_tokens >= total_hit_tokens

## Test
Tested with online llmperf pipeline.