### PR TITLE
[fix]Add patch for finalize_kv_cache in 0.18.0rc1

### DIFF
--- a/ucm/integration/vllm/patch/v0180/vllm_ascend/pc/v1/worker/npu_model_runner.py
+++ b/ucm/integration/vllm/patch/v0180/vllm_ascend/pc/v1/worker/npu_model_runner.py
@@ -72,7 +72,9 @@ class NPUModelRunner:
             # the apply_grammar_bitmask uses torch.compile to optimize this,ascend does not support it now
             logits_dtype = logits.dtype
             logits = logits.to("cpu").float()
-            apply_grammar_bitmask(scheduler_output, grammar_output, self.input_batch, logits)
+            apply_grammar_bitmask(
+                scheduler_output, grammar_output, self.input_batch, logits
+            )
             logits = logits.to(self.device).to(logits_dtype)
 
         with record_function_or_nullcontext("sample_token"):
@@ -122,7 +124,10 @@ class NPUModelRunner:
             if self.speculative_config:
                 use_padded_batch = (
                     self.speculative_config
-                    and (self.speculative_config.use_eagle() or self.speculative_config.uses_draft_model())
+                    and (
+                        self.speculative_config.use_eagle()
+                        or self.speculative_config.uses_draft_model()
+                    )
                     and not self.speculative_config.disable_padded_drafter_batch
                 )
                 if use_padded_batch:
@@ -155,7 +160,9 @@ class NPUModelRunner:
             prompt_logprobs_dict=prompt_logprobs_dict,
             kv_connector_output=kv_connector_output,
             pooler_output=[],
-            ec_connector_output=ec_connector_output if self.supports_mm_inputs else None,
+            ec_connector_output=(
+                ec_connector_output if self.supports_mm_inputs else None
+            ),
             cudagraph_stats=cudagraph_stats,
         )
 
@@ -174,7 +181,9 @@ class NPUModelRunner:
                 torch.npu.stream(global_stream()),
             ):
                 global_stream().wait_event(self.sampling_done_event)
-                self._update_states_after_model_execute(sampler_output.sampled_token_ids, scheduler_output)
+                self._update_states_after_model_execute(
+                    sampler_output.sampled_token_ids, scheduler_output
+                )
 
         # In async scheduling + PP, broadcast sampled token ids from the
         # last PP rank so other PP ranks can receive them without going
@@ -182,7 +191,9 @@ class NPUModelRunner:
         if self.use_async_scheduling:
             pp = get_pp_group()
             if pp.world_size > 1 and pp.is_last_rank:
-                self._pp_broadcast_prev_sampled_token_ids(sampler_output.sampled_token_ids)
+                self._pp_broadcast_prev_sampled_token_ids(
+                    sampler_output.sampled_token_ids
+                )
 
         if not self.use_async_scheduling:
             return model_runner_output

--- a/ucm/integration/vllm/patch/v0180/vllm_ascend/pc/v1/worker/npu_model_runner.py
+++ b/ucm/integration/vllm/patch/v0180/vllm_ascend/pc/v1/worker/npu_model_runner.py
@@ -1,7 +1,7 @@
+import time
 from copy import copy
 from typing import TYPE_CHECKING
 
-import time
 import torch
 from vllm.distributed.parallel_state import get_pp_group
 from vllm.logger import logger
@@ -148,9 +148,9 @@ class NPUModelRunner:
             prompt_logprobs_dict=prompt_logprobs_dict,
             kv_connector_output=kv_connector_output,
             pooler_output=[],
-            ec_connector_output=ec_connector_output
-            if self.supports_mm_inputs
-            else None,
+            ec_connector_output=(
+                ec_connector_output if self.supports_mm_inputs else None
+            ),
             cudagraph_stats=cudagraph_stats,
         )
         if self.ascend_config.profiling_chunk_config.enabled and hasattr(

--- a/ucm/integration/vllm/patch/v0180/vllm_ascend/pc/v1/worker/npu_model_runner.py
+++ b/ucm/integration/vllm/patch/v0180/vllm_ascend/pc/v1/worker/npu_model_runner.py
@@ -1,4 +1,3 @@
-import time
 from copy import copy
 from typing import TYPE_CHECKING
 
@@ -27,15 +26,21 @@ class NPUModelRunner:
     @torch.inference_mode()
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
-    ) -> "ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors":
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
         kv_connector_output = self.kv_connector_output
         self.kv_connector_output = None
 
         if self.execute_model_state is None:
+            # Nothing to do (PP non-final rank case), output isn't used.
+            # receive sampled token ids from the last PP rank when using
+            # async scheduling + pipeline parallelism so downstream code
+            # (e.g., PCP input preparation) can access them.
             if self.use_async_scheduling and get_pp_group().world_size > 1:
                 self._pp_receive_prev_sampled_token_ids_to_input_batch()
             if not kv_connector_output:
                 return None  # noqa
+            # In case of PP with kv transfer, we need to pass through the
+            # kv_connector_output
             if kv_connector_output.is_empty():
                 return EMPTY_MODEL_RUNNER_OUTPUT
 
@@ -43,6 +48,7 @@ class NPUModelRunner:
             output.kv_connector_output = kv_connector_output
             return output
 
+        # Unpack ephemeral state.
         (
             scheduler_output,
             logits,
@@ -57,14 +63,16 @@ class NPUModelRunner:
             cudagraph_stats,
             batch_desc,
         ) = self.execute_model_state
+        # Clear ephemeral state.
         self.execute_model_state = None
 
+        # Apply structured output bitmasks if present.
         if grammar_output is not None:
+            # here we are different from gpu_model_runner,
+            # the apply_grammar_bitmask uses torch.compile to optimize this,ascend does not support it now
             logits_dtype = logits.dtype
             logits = logits.to("cpu").float()
-            apply_grammar_bitmask(
-                scheduler_output, grammar_output, self.input_batch, logits
-            )
+            apply_grammar_bitmask(scheduler_output, grammar_output, self.input_batch, logits)
             logits = logits.to(self.device).to(logits_dtype)
 
         with record_function_or_nullcontext("sample_token"):
@@ -76,8 +84,6 @@ class NPUModelRunner:
 
             assert self.sampling_done_event is not None
             self.sampling_done_event.record()
-
-        self.valid_sampled_token_count_gpu: torch.Tensor | None = None
 
         def propose_draft_token_ids(sampled_token_ids):
             assert spec_decode_common_attn_metadata is not None
@@ -116,15 +122,16 @@ class NPUModelRunner:
             if self.speculative_config:
                 use_padded_batch = (
                     self.speculative_config
-                    and (
-                        self.speculative_config.use_eagle()
-                        or self.speculative_config.uses_draft_model()
-                    )
+                    and (self.speculative_config.use_eagle() or self.speculative_config.uses_draft_model())
                     and not self.speculative_config.disable_padded_drafter_batch
                 )
                 if use_padded_batch:
+                    # EAGLE speculative decoding can use the GPU sampled tokens
+                    # as inputs, and does not need to wait for bookkeeping to finish.
                     propose_draft_token_ids(sampler_output.sampled_token_ids)
                 if self.speculative_config and not use_padded_batch:
+                    # ngram and other speculative decoding methods use the sampled
+                    # tokens on the CPU, so they are run after bookkeeping.
                     propose_draft_token_ids(valid_sampled_token_ids)
 
             # vLLM v0.18 defers KV connector finalization during target-model
@@ -148,18 +155,9 @@ class NPUModelRunner:
             prompt_logprobs_dict=prompt_logprobs_dict,
             kv_connector_output=kv_connector_output,
             pooler_output=[],
-            ec_connector_output=(
-                ec_connector_output if self.supports_mm_inputs else None
-            ),
+            ec_connector_output=ec_connector_output if self.supports_mm_inputs else None,
             cudagraph_stats=cudagraph_stats,
         )
-        if self.ascend_config.profiling_chunk_config.enabled and hasattr(
-            self, "_execution_start_time"
-        ):
-            self._sync_device()
-            model_runner_output.execution_time_ms = (
-                time.perf_counter() - self._execution_start_time
-            ) * 1000.0
 
         if self.dynamic_eplb:
             with record_function_or_nullcontext("EPLB update"):
@@ -176,20 +174,19 @@ class NPUModelRunner:
                 torch.npu.stream(global_stream()),
             ):
                 global_stream().wait_event(self.sampling_done_event)
-                self._update_states_after_model_execute(
-                    sampler_output.sampled_token_ids, scheduler_output
-                )
+                self._update_states_after_model_execute(sampler_output.sampled_token_ids, scheduler_output)
 
+        # In async scheduling + PP, broadcast sampled token ids from the
+        # last PP rank so other PP ranks can receive them without going
+        # through the scheduler/engine IPC path.
         if self.use_async_scheduling:
             pp = get_pp_group()
             if pp.world_size > 1 and pp.is_last_rank:
-                self._pp_broadcast_prev_sampled_token_ids(
-                    sampler_output.sampled_token_ids
-                )
+                self._pp_broadcast_prev_sampled_token_ids(sampler_output.sampled_token_ids)
 
         if not self.use_async_scheduling:
             return model_runner_output
-        async_output = AsyncGPUModelRunnerOutput(
+        return AsyncGPUModelRunnerOutput(
             model_runner_output=model_runner_output,
             sampled_token_ids=sampler_output.sampled_token_ids,
             logprobs_tensors=sampler_output.logprobs_tensors,
@@ -197,8 +194,3 @@ class NPUModelRunner:
             async_output_copy_stream=self.async_output_copy_stream,
             vocab_size=self.input_batch.vocab_size,
         )
-        self.input_batch.set_async_sampled_token_ids(
-            async_output.sampled_token_ids_cpu,
-            async_output.async_copy_ready_event,
-        )
-        return async_output

--- a/ucm/integration/vllm/patch/v0180/vllm_ascend/pc/v1/worker/npu_model_runner.py
+++ b/ucm/integration/vllm/patch/v0180/vllm_ascend/pc/v1/worker/npu_model_runner.py
@@ -1,0 +1,204 @@
+from copy import copy
+from typing import TYPE_CHECKING
+
+import time
+import torch
+from vllm.distributed.parallel_state import get_pp_group
+from vllm.logger import logger
+from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
+    RoutedExpertsCapturer,
+)
+from vllm.sequence import IntermediateTensors
+from vllm.v1.outputs import (
+    EMPTY_MODEL_RUNNER_OUTPUT,
+    AsyncModelRunnerOutput,
+    ModelRunnerOutput,
+)
+from vllm.v1.structured_output.utils import apply_grammar_bitmask
+from vllm.v1.utils import record_function_or_nullcontext
+from vllm.v1.worker.gpu_model_runner import AsyncGPUModelRunnerOutput
+from vllm_ascend.utils import global_stream
+
+if TYPE_CHECKING:
+    from vllm.v1.core.sched.output import GrammarOutput
+
+
+class NPUModelRunner:
+    @torch.inference_mode()
+    def sample_tokens(
+        self, grammar_output: "GrammarOutput | None"
+    ) -> "ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors":
+        kv_connector_output = self.kv_connector_output
+        self.kv_connector_output = None
+
+        if self.execute_model_state is None:
+            if self.use_async_scheduling and get_pp_group().world_size > 1:
+                self._pp_receive_prev_sampled_token_ids_to_input_batch()
+            if not kv_connector_output:
+                return None  # noqa
+            if kv_connector_output.is_empty():
+                return EMPTY_MODEL_RUNNER_OUTPUT
+
+            output = copy(EMPTY_MODEL_RUNNER_OUTPUT)
+            output.kv_connector_output = kv_connector_output
+            return output
+
+        (
+            scheduler_output,
+            logits,
+            spec_decode_metadata,
+            spec_decode_common_attn_metadata,
+            hidden_states,
+            sample_hidden_states,
+            aux_hidden_states,
+            attn_metadata,
+            positions,
+            ec_connector_output,
+            cudagraph_stats,
+            batch_desc,
+        ) = self.execute_model_state
+        self.execute_model_state = None
+
+        if grammar_output is not None:
+            logits_dtype = logits.dtype
+            logits = logits.to("cpu").float()
+            apply_grammar_bitmask(
+                scheduler_output, grammar_output, self.input_batch, logits
+            )
+            logits = logits.to(self.device).to(logits_dtype)
+
+        with record_function_or_nullcontext("sample_token"):
+            sampler_output = self._sample(logits, spec_decode_metadata)
+
+        if self.need_accepted_tokens:
+            if self.sampling_done_event is None:
+                self.sampling_done_event = torch.npu.Event()
+
+            assert self.sampling_done_event is not None
+            self.sampling_done_event.record()
+
+        self.valid_sampled_token_count_gpu: torch.Tensor | None = None
+
+        def propose_draft_token_ids(sampled_token_ids):
+            assert spec_decode_common_attn_metadata is not None
+            self._draft_token_ids = self.propose_draft_token_ids(
+                sampled_token_ids,
+                self.input_batch.sampling_metadata,
+                scheduler_output,
+                spec_decode_metadata,
+                spec_decode_common_attn_metadata,
+                positions,
+                scheduler_output.total_num_scheduled_tokens,
+                hidden_states,
+                aux_hidden_states,
+                sample_hidden_states,
+                batch_desc,
+            )
+            self._copy_draft_token_ids_to_cpu(scheduler_output)
+
+        (
+            logprobs_lists,
+            valid_sampled_token_ids,
+            prompt_logprobs_dict,
+            req_ids_output_copy,
+            req_id_to_index_output_copy,
+            invalid_req_indices,
+        ) = self._bookkeeping_sync(
+            scheduler_output,
+            sampler_output,
+            logits,
+            hidden_states,
+            scheduler_output.total_num_scheduled_tokens,
+            spec_decode_metadata,
+        )
+
+        with record_function_or_nullcontext("draft_token"):
+            if self.speculative_config:
+                use_padded_batch = (
+                    self.speculative_config
+                    and (
+                        self.speculative_config.use_eagle()
+                        or self.speculative_config.uses_draft_model()
+                    )
+                    and not self.speculative_config.disable_padded_drafter_batch
+                )
+                if use_padded_batch:
+                    propose_draft_token_ids(sampler_output.sampled_token_ids)
+                if self.speculative_config and not use_padded_batch:
+                    propose_draft_token_ids(valid_sampled_token_ids)
+
+            # vLLM v0.18 defers KV connector finalization during target-model
+            # forward when speculative decoding is enabled. Finalize here after
+            # draft model runs so KV pool save/put can complete.
+            if self.speculative_config is not None:
+                self.finalize_kv_connector()
+
+        if self.model_config.enable_return_routed_experts:
+            capturer = RoutedExpertsCapturer.get_instance()
+            if capturer is not None:
+                capturer.save_captured_experts(indices=self.cpu_slot_mapping)
+            else:
+                logger.warning("RoutedExpertsCapturer is not initialized.")
+
+        model_runner_output = ModelRunnerOutput(
+            req_ids=req_ids_output_copy,
+            req_id_to_index=req_id_to_index_output_copy,
+            sampled_token_ids=valid_sampled_token_ids,
+            logprobs=logprobs_lists,
+            prompt_logprobs_dict=prompt_logprobs_dict,
+            kv_connector_output=kv_connector_output,
+            pooler_output=[],
+            ec_connector_output=ec_connector_output
+            if self.supports_mm_inputs
+            else None,
+            cudagraph_stats=cudagraph_stats,
+        )
+        if self.ascend_config.profiling_chunk_config.enabled and hasattr(
+            self, "_execution_start_time"
+        ):
+            self._sync_device()
+            model_runner_output.execution_time_ms = (
+                time.perf_counter() - self._execution_start_time
+            ) * 1000.0
+
+        if self.dynamic_eplb:
+            with record_function_or_nullcontext("EPLB update"):
+                self.eplb_updator.forward_end()
+
+        if self.debugger is not None:
+            self.debugger.stop()
+            self.debugger.step()
+
+        if self.need_accepted_tokens:
+            assert self.sampling_done_event is not None
+            with (
+                record_function_or_nullcontext("async_state_update"),
+                torch.npu.stream(global_stream()),
+            ):
+                global_stream().wait_event(self.sampling_done_event)
+                self._update_states_after_model_execute(
+                    sampler_output.sampled_token_ids, scheduler_output
+                )
+
+        if self.use_async_scheduling:
+            pp = get_pp_group()
+            if pp.world_size > 1 and pp.is_last_rank:
+                self._pp_broadcast_prev_sampled_token_ids(
+                    sampler_output.sampled_token_ids
+                )
+
+        if not self.use_async_scheduling:
+            return model_runner_output
+        async_output = AsyncGPUModelRunnerOutput(
+            model_runner_output=model_runner_output,
+            sampled_token_ids=sampler_output.sampled_token_ids,
+            logprobs_tensors=sampler_output.logprobs_tensors,
+            invalid_req_indices=invalid_req_indices,
+            async_output_copy_stream=self.async_output_copy_stream,
+            vocab_size=self.input_batch.vocab_size,
+        )
+        self.input_batch.set_async_sampled_token_ids(
+            async_output.sampled_token_ids_cpu,
+            async_output.async_copy_ready_event,
+        )
+        return async_output

--- a/ucm/integration/vllm/patch/v0180/vllm_ascend/pc_ascend_patch.py
+++ b/ucm/integration/vllm/patch/v0180/vllm_ascend/pc_ascend_patch.py
@@ -1,7 +1,20 @@
-from ucm.integration.vllm.patch.utils import patch_or_inject, when_imported
+import inspect
+
+from ucm.integration.vllm.patch.utils import (
+    patch_or_inject,
+    when_imported,
+)
 from ucm.logger import init_logger
 
 logger = init_logger(__name__)
+
+
+def _npu_sample_tokens_has_spec_kv_finalize(npu_cls: type) -> bool:
+    try:
+        src = inspect.getsource(npu_cls.sample_tokens)
+    except (OSError, TypeError, AttributeError):
+        return False
+    return "vLLM v0.18 defers KV connector" in src and "finalize_kv_connector" in src
 
 
 @when_imported("vllm_ascend.attention.sfa_v1")
@@ -11,3 +24,21 @@ def patch_sfa_v1(mod):
     from ucm.integration.vllm.patch.v0180.vllm_ascend.pc.attention import sfa_v1
 
     patch_or_inject(mod.AscendSFAImpl, "forward", sfa_v1.AscendSFAImpl.forward)
+
+
+@when_imported("vllm_ascend.worker.model_runner_v1")
+def patch_worker_npu_model_runner(mod):
+    logger.debug(f"Patched {mod} called")
+
+    if _npu_sample_tokens_has_spec_kv_finalize(mod.NPUModelRunner):
+        return
+
+    from ucm.integration.vllm.patch.v0180.vllm_ascend.pc.v1.worker import (
+        npu_model_runner,
+    )
+
+    patch_or_inject(
+        mod.NPUModelRunner,
+        "sample_tokens",
+        npu_model_runner.NPUModelRunner.sample_tokens,
+    )


### PR DESCRIPTION
## Purpose
vLLM v0.18 defers KV connector finalization during target-model, forward when speculative decoding is enabled. Finalize after draft model runs so KV pool save/put can complete.
## Modifications 
Add patch for v0.18.0rc1
## Test
vllm instance can be pulled succcessfully and can receive request successfully