### PR TITLE
[CI] Remove long-running e2e tests from PR gate

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -4,4 +4,3 @@ self-hosted-runner:
     - default
     - gpu
     - npu
-    - gpu-test-in-docker

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - id: fetch_base_and_pr_branches
         env:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
@@ -48,7 +48,7 @@ jobs:
           fi
 
           ALLOWED_USERS=("dante159753" "mag1c-h" "yuanzhg078")
-          
+
           echo ".github changes detected, check if user is allowed..."
           ACTOR="${{ github.actor }}"
           echo "PR author: $ACTOR"
@@ -76,7 +76,7 @@ jobs:
   lint-and-unit-tests:
     needs: pre-check
     uses: ./.github/workflows/lint-and-test.yml
-  
+
   test-build-vllm-ascend:
     timeout-minutes: 25
     runs-on: ubuntu-24.04-arm
@@ -172,213 +172,3 @@ jobs:
           load: false
           cache-from: type=gha,scope=npu
           cache-to: type=gha,mode=max,scope=npu
-
-  test-e2e-pc-gpu:
-    timeout-minutes: 25
-    runs-on: ["gpu-test-in-docker"]
-    needs: lint-and-unit-tests
-    permissions:
-      checks: write
-      pull-requests: write
-    steps:
-    - name: Clean repo
-      run: |
-        if [ -d "${{github.workspace}}" ]; then
-          cd ${{github.workspace}}
-          rm -rf ./*
-          rm -rf .[!.]*
-        fi
-    - uses: actions/checkout@v4
-    - name: Install Docker CLI
-      run: |
-        if ! command -v docker &> /dev/null; then
-          echo "Docker CLI not found, installing..."
-          sudo apt-get update
-          sudo apt-get install -y docker.io
-        else
-          echo "Docker CLI already installed"
-        fi
-    - name: Generate Docker Image Version
-      id: version
-      run: |
-        DATE=$(date +%Y%m%d)
-        SHORT_SHA=$(echo '${{ github.sha }}' | cut -c1-7)
-        REF_NAME=$(echo '${{ github.ref_name }}' | tr '/' '-')
-        VERSION="${REF_NAME}-${DATE}-${{ github.run_number }}-${SHORT_SHA}"
-        echo "version=${VERSION}" >> $GITHUB_OUTPUT
-        echo "Docker image version: ${VERSION}"
-    - name: Build
-      run: |
-        cd ${{github.workspace}}
-        sudo -E docker build --network=host \
-          --build-arg http_proxy="${http_proxy:-}" \
-          --build-arg https_proxy="${https_proxy:-}" \
-          --build-arg no_proxy="repo.huaweicloud.com,${no_proxy:-}" \
-          --build-arg PIP_INDEX_URL=https://repo.huaweicloud.com/repository/pypi/simple \
-          -t ucm-e2etest-online-inference:${{ steps.version.outputs.version }} \
-          -f ./docker/Dockerfile.ucm-vllm-cuda-v0.17.0 ./
-    - name: Test E2E Online Inference in Docker
-      run: |
-        sudo chmod -R 777 /workspace/test_results/
-        sudo docker run --rm \
-          --gpus all \
-          --ipc=host \
-          -v /home/models:/home/models \
-          -v /home/yanzhao/pipeline_results:/workspace/test_results \
-          ucm-e2etest-online-inference:${{ steps.version.outputs.version }} \
-          -c "cd /workspace/unified-cache-management/test && pip install -r requirements.txt && python3 -m pytest -x --stage=1 --feature=online_inference --junitxml=/workspace/test_results/${{ steps.version.outputs.version }}-online-inference.xml"
-    - name: Upload pytest results
-      uses: EnricoMi/publish-unit-test-result-action/linux@v2
-      if: (!cancelled())
-      with:
-        files: |
-          /workspace/test_results/${{ steps.version.outputs.version }}-online-inference.xml
-        check_name: Online inference test results
-    - name: Cleanup Docker Image
-      if: always()
-      run: |
-        sudo docker rmi ucm-e2etest-online-inference:${{ steps.version.outputs.version }} || true
-    - name: Cleanup Test Results
-      if: always()
-      run: |
-        sudo rm -f /workspace/test_results/${{ steps.version.outputs.version }}-online-inference.xml || true
-
-  test-e2e-sparse-gpu:
-    timeout-minutes: 25
-    runs-on: ["gpu-test-in-docker"]
-    needs: lint-and-unit-tests
-    permissions:
-      checks: write
-      pull-requests: write
-    steps:
-    - name: Clean repo
-      run: |
-        if [ -d "${{github.workspace}}" ]; then
-          cd ${{github.workspace}}
-          rm -rf ./*
-          rm -rf .[!.]*
-        fi
-    - uses: actions/checkout@v4
-    - name: Install Docker CLI
-      run: |
-        if ! command -v docker &> /dev/null; then
-          echo "Docker CLI not found, installing..."
-          sudo apt-get update
-          sudo apt-get install -y docker.io
-        else
-          echo "Docker CLI already installed"
-        fi
-    - name: Generate Docker Image Version
-      id: version
-      run: |
-        DATE=$(date +%Y%m%d)
-        SHORT_SHA=$(echo '${{ github.sha }}' | cut -c1-7)
-        REF_NAME=$(echo '${{ github.ref_name }}' | tr '/' '-')
-        VERSION="${REF_NAME}-${DATE}-${{ github.run_number }}-${SHORT_SHA}"
-        echo "version=${VERSION}" >> $GITHUB_OUTPUT
-        echo "Docker image version: ${VERSION}"
-    - name: Build
-      run: |
-        cd ${{github.workspace}}
-        sudo -E docker build --network=host \
-          --build-arg http_proxy="${http_proxy:-}" \
-          --build-arg https_proxy="${https_proxy:-}" \
-          --build-arg no_proxy="repo.huaweicloud.com,${no_proxy:-}" \
-          --build-arg PIP_INDEX_URL=https://repo.huaweicloud.com/repository/pypi/simple \
-          -t ucm-e2etest-gpu-sparse:${{ steps.version.outputs.version }} \
-          -f ./docker/Dockerfile.ucm-vllm-cuda-v0.11.0 ./
-    - name: Test E2E in Docker
-      run: |
-        sudo chmod -R 777 /workspace/test_results/
-        sudo docker run --rm \
-          --gpus all \
-          --ipc=host \
-          -v /home/models:/home/models \
-          -v /home/yanzhao/pipeline_results:/workspace/test_results \
-          ucm-e2etest-gpu-sparse:${{ steps.version.outputs.version }} \
-          -c "cd /workspace/unified-cache-management/test && pip install -r requirements.txt && python3 -m pytest -x --stage=1 --feature=online_inference_sparse --junitxml=/workspace/test_results/${{ steps.version.outputs.version }}-online-inference-sparse.xml"
-    - name: Upload pytest results
-      uses: EnricoMi/publish-unit-test-result-action/linux@v2
-      if: (!cancelled())
-      with:
-        files: |
-          /workspace/test_results/${{ steps.version.outputs.version }}-online-inference-sparse.xml
-        check_name: Sparse attention test results
-    - name: Cleanup Docker Image
-      if: always()
-      run: |
-        sudo docker rmi ucm-e2etest-gpu-sparse:${{ steps.version.outputs.version }} || true
-    - name: Cleanup Test Results
-      if: always()
-      run: |
-        sudo rm -f /workspace/test_results/${{ steps.version.outputs.version }}-online-inference-sparse.xml || true
-
-  test-e2e-sparse-offline-gpu:
-    runs-on: ["gpu-test-in-docker"]
-    needs: lint-and-unit-tests
-    permissions:
-      checks: write
-      pull-requests: write
-    steps:
-    - name: Clean repo
-      run: |
-        if [ -d "${{github.workspace}}" ]; then
-          cd ${{github.workspace}}
-          rm -rf ./*
-          rm -rf .[!.]*
-        fi
-    - uses: actions/checkout@v4
-    - name: Install Docker CLI
-      run: |
-        if ! command -v docker &> /dev/null; then
-          echo "Docker CLI not found, installing..."
-          sudo apt-get update
-          sudo apt-get install -y docker.io
-        else
-          echo "Docker CLI already installed"
-        fi
-    - name: Generate Docker Image Version
-      id: version
-      run: |
-        DATE=$(date +%Y%m%d)
-        SHORT_SHA=$(echo '${{ github.sha }}' | cut -c1-7)
-        REF_NAME=$(echo '${{ github.ref_name }}' | tr '/' '-')
-        VERSION="${REF_NAME}-${DATE}-${{ github.run_number }}-${SHORT_SHA}"
-        echo "version=${VERSION}" >> $GITHUB_OUTPUT
-        echo "Docker image version: ${VERSION}"
-    - name: Build
-      run: |
-        cd ${{github.workspace}}
-        sudo -E docker build --network=host \
-          --build-arg http_proxy="${http_proxy:-}" \
-          --build-arg https_proxy="${https_proxy:-}" \
-          --build-arg no_proxy="repo.huaweicloud.com,${no_proxy:-}" \
-          --build-arg PIP_INDEX_URL=https://repo.huaweicloud.com/repository/pypi/simple \
-          -t ucm-e2etest-gpu-sparse:${{ steps.version.outputs.version }} \
-          -f ./docker/Dockerfile.ucm-vllm-cuda-v0.11.0 ./
-    - name: Test E2E in Docker
-      run: |
-        sudo chmod -R 777 /workspace/test_results/
-        sudo docker run --rm \
-          --gpus all \
-          --ipc=host \
-          -v /home/models:/home/models \
-          -v /home/yanzhao/pipeline_results:/workspace/test_results \
-          ucm-e2etest-gpu-sparse:${{ steps.version.outputs.version }} \
-          -c "cd /workspace/unified-cache-management/test && pip install -r requirements.txt && python3 -m pytest -x --stage=1 --feature=offline_inference_sparse --junitxml=/workspace/test_results/${{ steps.version.outputs.version }}-offline-inference-sparse.xml"
-    - name: Upload pytest results
-      uses: EnricoMi/publish-unit-test-result-action/linux@v2
-      if: (!cancelled())
-      with:
-        files: |
-          /workspace/test_results/${{ steps.version.outputs.version }}-offline-inference-sparse.xml
-        check_name: Sparse attention test results
-    - name: Cleanup Docker Image
-      if: always()
-      run: |
-        sudo docker rmi ucm-e2etest-gpu-sparse:${{ steps.version.outputs.version }} || true
-    - name: Cleanup Test Results
-      if: always()
-      run: |
-        sudo rm -f /workspace/test_results/${{ steps.version.outputs.version }}-offline-inference-sparse.xml || true
-


### PR DESCRIPTION
## Purpose
Remove e2e tests that run on `gpu-test-in-docker` from PR gate to reduce CI execution time and speed up the review process.
## Modifications
- Removed 3 e2e test jobs from `.github/workflows/pull-request.yml`:
  - `test-e2e-pc-gpu` - Online inference test
  - `test-e2e-sparse-gpu` - Sparse attention online inference test
  - `test-e2e-sparse-offline-gpu` - Sparse attention offline inference test
- Removed `gpu-test-in-docker` label from `.github/actionlint.yaml` self-hosted runner configuration

Total changes: 2 files modified, 215 lines deleted