### PR TITLE
[feat]Add Cache|Fake in pipeline

### DIFF
--- a/ucm/store/pipeline/connector.py
+++ b/ucm/store/pipeline/connector.py
@@ -225,7 +225,9 @@ def _fake_pipeline_builder(
     config: Dict[str, object], pipeline: ucmpipelinestore.PipelineStore
 ):
     store_dir = Path(__file__).resolve().parent.parent
-    pipeline.Stack("Fake", str(store_dir / "fake/libfakestore.so"), config)
+    fake_config = copy.deepcopy(config)
+    fake_config["share_buffer_enable"] = True
+    pipeline.Stack("Fake", str(store_dir / "fake/libfakestore.so"), fake_config)
 
 
 def _posix_pipeline_builder(
@@ -233,6 +235,16 @@ def _posix_pipeline_builder(
 ):
     store_dir = Path(__file__).resolve().parent.parent
     pipeline.Stack("Posix", str(store_dir / "posix/libposixstore.so"), config)
+
+
+def _cache_fake_pipeline_builder(
+    config: Dict[str, object], pipeline: ucmpipelinestore.PipelineStore
+):
+    store_dir = Path(__file__).resolve().parent.parent
+    fake_config = copy.deepcopy(config)
+    fake_config["share_buffer_enable"] = True
+    pipeline.Stack("Fake", str(store_dir / "fake/libfakestore.so"), fake_config)
+    pipeline.Stack("Cache", str(store_dir / "cache/libcachestore.so"), config)
 
 
 UcmPipelineStoreBuilder.register("Cache|Ds3fs", _cache_ds3fs_pipeline_builder)
@@ -244,3 +256,4 @@ UcmPipelineStoreBuilder.register("Posix", _posix_pipeline_builder)
 UcmPipelineStoreBuilder.register(
     "Cache|Compress|Posix", _build_cache_compress_posix_pipeline
 )
+UcmPipelineStoreBuilder.register("Cache|Fake", _cache_fake_pipeline_builder)


### PR DESCRIPTION
## Purpose
`Cache|Fake` is used for dram cache only(no ssd)
`Cache|Empty` can also be used for dram cache only for MLA models 
## Modifications 
Add `Cache|Fake` in pipeline store
## Test
