### PR TITLE
[Bugfix] Rectifying the Exception in Total Throughput Calculation Results

### DIFF
--- a/test/common/llmperf/utils/token_benchmark.py
+++ b/test/common/llmperf/utils/token_benchmark.py
@@ -155,8 +155,6 @@ def get_token_throughput_latencies(
                     else:
                         metrics[common_metrics.TPOT] = 0.0
 
-                    completed_requests.append(metrics)
-
                 completed_requests.append(metrics)
 
                 incremental_time_delay += metrics.get(


### PR DESCRIPTION
## Purpose
Rectifying the Exception in Full Throughput Calculation Results

## Modifications 
Delete the repeated calculation line from the token_banchmark.py file.

## Test
All tests have passed.