### PR TITLE
[opt]opt hma

### DIFF
--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -1062,13 +1062,14 @@ class UCMFAWAConnector(UCMDirectConnector):
             if self.wa_store is None:
                 raise RuntimeError("WA store is not initialized.")
 
-            total_keys: list[bytes] = []
+            fa_dump_keys: list[bytes] = []
+            wa_dump_keys: list[bytes] = []
             fa_ptr_rows: list[np.ndarray] = []
             wa_ptr_rows: list[np.ndarray] = []
             for request in metadata.request_meta.values():
                 if not request.dump_keys:
                     continue
-                total_keys.extend(request.dump_keys)
+                fa_dump_keys.extend(request.dump_keys)
                 fa_ptr_rows.append(
                     self._extract_fa_ptr(
                         request.dump_keys,
@@ -1077,6 +1078,7 @@ class UCMFAWAConnector(UCMDirectConnector):
                         request.dump_vllm_block_ids,
                     )
                 )
+                wa_dump_keys.extend(request.dump_keys[-1:])
                 wa_ptr_rows.append(
                     self._extract_wa_ptr(
                         request.dump_keys[-1:],
@@ -1084,7 +1086,7 @@ class UCMFAWAConnector(UCMDirectConnector):
                     )
                 )
 
-            if not total_keys:
+            if not fa_dump_keys:
                 return
 
             fa_ptrs = np.vstack(fa_ptr_rows)
@@ -1095,7 +1097,7 @@ class UCMFAWAConnector(UCMDirectConnector):
                 self._submit_dump_task(
                     "FA",
                     self.fa_store,
-                    total_keys,
+                    fa_dump_keys,
                     fa_ptrs,
                     event_handle,
                 )
@@ -1104,7 +1106,7 @@ class UCMFAWAConnector(UCMDirectConnector):
                 self._submit_dump_task(
                     "WA",
                     self.wa_store,
-                    total_keys,
+                    wa_dump_keys,
                     window_ptrs,
                     event_handle,
                 )

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -9,7 +9,6 @@ import torch
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
     KVConnectorRole,
-    KVConnectorWorkerMetadata,
 )
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -31,21 +30,11 @@ logger = init_logger(__name__)
 
 
 @dataclass(frozen=True)
-class KVCacheSegment:
-    block_id: int
-    offset: int = 0
-    length: int = 0
-
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, int):
-            return self.block_id == other and self.offset == 0
-        if not isinstance(other, KVCacheSegment):
-            return False
-        return (
-            self.block_id == other.block_id
-            and self.offset == other.offset
-            and self.length == other.length
-        )
+class KVCacheGroupMeta:
+    group_id: int
+    token_block_size: int
+    tail_blocks: int
+    tail_tokens: int
 
 
 class KVCacheGroupLayout:
@@ -60,10 +49,9 @@ class KVCacheGroupLayout:
         self.kvcaches = dict(sorted(kvcaches.items(), key=self._sort_key))
         self.base_ptrs: np.ndarray
         self.block_strides: np.ndarray
-        self.token_strides: np.ndarray
-        self.tensor_size_lists: np.ndarray
-        self.tensor_size_per_token_lists: np.ndarray
-        self.view_tensor_block_sizes: np.ndarray
+        self.tensor_token_strides: np.ndarray
+        self.tensor_sizes_per_token: np.ndarray
+        self.tensor_block_sizes: np.ndarray
         self._build_layout()
 
     @staticmethod
@@ -74,11 +62,9 @@ class KVCacheGroupLayout:
     def _build_layout(self) -> None:
         ptrs: list[int] = []
         strides: list[int] = []
-        token_strides: list[int] = []
-        tensor_sizes: list[int] = []
+        tensor_token_strides: list[int] = []
         tensor_sizes_per_token: list[int] = []
-        view_tensor_block_sizes: list[int] = []
-        view_tensors: list[torch.Tensor] = []
+        tensor_block_sizes: list[int] = []
         view_meta: list[tuple[str, tuple[int, ...], tuple[int, ...], str, int]] = []
 
         def handle_tensor(
@@ -89,24 +75,18 @@ class KVCacheGroupLayout:
             ptrs.append(t[0].data_ptr())
             strides.append(t.stride(0) * t.element_size())
             tensor_size = math.prod([t.shape[i] for i in size_dims]) * t.element_size()
-            tensor_sizes.append(tensor_size)
             token_dim = 1
-            view_tensor_block_size = int(t.shape[token_dim])
-            if view_tensor_block_size <= 0:
-                raise ValueError(
-                    f"KV cache tensor has empty block dimension: {t.shape}"
-                )
-            token_strides.append(t.stride(token_dim) * t.element_size())
-            tensor_sizes_per_token.append(tensor_size // view_tensor_block_size)
-            view_tensor_block_sizes.append(view_tensor_block_size)
-            view_tensors.append(t)
+            tensor_block_size = int(t.shape[token_dim])
+            tensor_token_strides.append(t.stride(token_dim) * t.element_size())
+            tensor_sizes_per_token.append(tensor_size // tensor_block_size)
+            tensor_block_sizes.append(tensor_block_size)
             view_meta.append(
                 (
                     layer_name,
                     tuple(t.shape),
                     tuple(t.stride()),
                     str(t.dtype),
-                    view_tensor_block_size,
+                    tensor_block_size,
                 )
             )
 
@@ -151,492 +131,87 @@ class KVCacheGroupLayout:
 
         self.base_ptrs = np.asarray(ptrs, dtype=np.uint64)
         self.block_strides = np.asarray(strides, dtype=np.uint64)
-        self.token_strides = np.asarray(token_strides, dtype=np.uint64)
-        self.tensor_size_lists = np.asarray(tensor_sizes, dtype=np.uint64)
-        self.tensor_size_per_token_lists = np.asarray(
+        self.tensor_token_strides = np.asarray(tensor_token_strides, dtype=np.uint64)
+        self.tensor_sizes_per_token = np.asarray(
             tensor_sizes_per_token, dtype=np.uint64
         )
-        self.view_tensor_block_sizes = np.asarray(
-            view_tensor_block_sizes, dtype=np.uint64
-        )
-        self.view_tensors = view_tensors
+        self.tensor_block_sizes = np.asarray(tensor_block_sizes, dtype=np.uint64)
         self.view_meta = [
             {
                 "name": name,
                 "shape": shape,
                 "stride": stride,
                 "dtype": dtype,
-                "view_tensor_block_size": view_tensor_block_size,
+                "tensor_block_size": tensor_block_size,
             }
-            for name, shape, stride, dtype, view_tensor_block_size in view_meta
+            for name, shape, stride, dtype, tensor_block_size in view_meta
         ]
         logger.info(
             f"KV cache group layout: views={len(self.kvcaches)}, "
-            f"ptrs={len(ptrs)}, tensor_block_bytes={self.tensor_block_bytes}, "
-            f"view_tensor_block_sizes={sorted(set(view_tensor_block_sizes))}"
+            f"ptrs={len(ptrs)}, "
+            f"tensor_block_sizes={sorted(set(tensor_block_sizes))}"
         )
 
-    def extract_block_addrs(self, vllm_block_ids: list[int]) -> np.ndarray:
-        vllm_block_ids_np = np.array(vllm_block_ids, np.uint64)
-        return (
-            vllm_block_ids_np[:, None] * self.block_strides[None, :]
-            + self.base_ptrs[None, :]
-        )
-
-    def _logical_to_tensor_tokens(
+    def extract_segment_addrs_batch(
         self,
-        logical_tokens: int,
-        group_tensor_block_size: int,
-        view_tensor_block_size: int,
-    ) -> int:
-        scaled = logical_tokens * view_tensor_block_size
-        if scaled % group_tensor_block_size != 0:
-            raise ValueError(
-                f"Logical segment of {logical_tokens} tokens does not align with "
-                f"view tensor block size={view_tensor_block_size} and group "
-                f"tensor block size={group_tensor_block_size}."
-            )
-        return scaled // group_tensor_block_size
-
-    def extract_segment_addrs(
-        self,
-        segments: list[KVCacheSegment],
-        group_tensor_block_size: int,
+        block_ids: np.ndarray,
+        offsets: np.ndarray,
+        group_token_block_size: int,
     ) -> np.ndarray:
-        block_ids_np = np.array([segment.block_id for segment in segments], np.uint64)
-        offsets_np = np.array(
-            [
-                [
-                    self._logical_to_tensor_tokens(
-                        segment.offset,
-                        group_tensor_block_size,
-                        int(view_tensor_block_size),
-                    )
-                    for view_tensor_block_size in self.view_tensor_block_sizes
-                ]
-                for segment in segments
-            ],
-            np.uint64,
+
+        physical_token_offsets = (
+            offsets[:, None]
+            * self.tensor_block_sizes[None, :]
+            // group_token_block_size
         )
+
         return (
-            block_ids_np[:, None] * self.block_strides[None, :]
-            + offsets_np * self.token_strides[None, :]
+            block_ids[:, None] * self.block_strides[None, :]
+            + physical_token_offsets * self.tensor_token_strides[None, :]
             + self.base_ptrs[None, :]
-        )
+        ).astype(np.uint64, copy=False)
 
     def segment_tensor_size_list(
         self,
         logical_tokens: int,
-        group_tensor_block_size: int,
+        group_token_block_size: int,
     ) -> list[int]:
-        tensor_tokens = np.array(
-            [
-                self._logical_to_tensor_tokens(
-                    logical_tokens,
-                    group_tensor_block_size,
-                    int(view_tensor_block_size),
-                )
-                for view_tensor_block_size in self.view_tensor_block_sizes
-            ],
-            np.uint64,
+
+        tensor_tokens = (
+            self.tensor_block_sizes * logical_tokens // group_token_block_size
         )
-        return (self.tensor_size_per_token_lists * tensor_tokens).tolist()
-
-    def extract_block_tensor_views(
-        self, vllm_block_ids: list[int]
-    ) -> list[torch.Tensor]:
-        tensors: list[torch.Tensor] = []
-
-        for block_id in vllm_block_ids:
-            for tensor in self.view_tensors:
-                tensors.append(tensor[block_id])
-        return tensors
-
-    def extract_segment_tensor_views(
-        self,
-        segments: list[KVCacheSegment],
-        group_tensor_block_size: int,
-    ) -> list[torch.Tensor]:
-        tensors: list[torch.Tensor] = []
-
-        for segment in segments:
-            for tensor, view_tensor_block_size in zip(
-                self.view_tensors, self.view_tensor_block_sizes
-            ):
-                tensor_offset = self._logical_to_tensor_tokens(
-                    segment.offset,
-                    group_tensor_block_size,
-                    int(view_tensor_block_size),
-                )
-                tensor_length = self._logical_to_tensor_tokens(
-                    segment.length,
-                    group_tensor_block_size,
-                    int(view_tensor_block_size),
-                )
-                tensors.append(
-                    tensor[segment.block_id].narrow(0, tensor_offset, tensor_length)
-                )
-        return tensors
-
-    @property
-    def tensor_size_list(self) -> list[int]:
-        return self.tensor_size_lists.tolist()
-
-    @property
-    def shard_size(self) -> int:
-        return int(self.tensor_size_lists.sum())
-
-    @property
-    def tensor_block_bytes(self) -> int:
-        return self.shard_size
+        return (self.tensor_sizes_per_token * tensor_tokens).tolist()
 
     @property
     def tensor_block_size(self) -> int:
-        if len(set(self.view_tensor_block_sizes.tolist())) != 1:
+        if len(set(self.tensor_block_sizes.tolist())) != 1:
             raise ValueError(
                 "KV cache group layout has mixed view tensor block sizes: "
-                f"{self.view_tensor_block_sizes.tolist()}"
+                f"{self.tensor_block_sizes.tolist()}"
             )
-        return int(self.view_tensor_block_sizes[0])
-
-
-# One canonical hash block mapped to segment spans for each vLLM KV cache group.
-KVCacheGroupRow = tuple[list[KVCacheSegment], ...]
-# Multiple canonical hash blocks, each represented as one KVCacheGroupRow.
-KVCacheGroupRows = list[KVCacheGroupRow]
-# Full HMA allocation snapshot by kv-cache group.
-KVCacheGroupAllocation = tuple[list[int], ...]
-
-
-class FAWABlockSpanLayout:
-    """Maps FAWA canonical hash blocks to per-group KV cache spans."""
-
-    ASCEND_HASH_BLOCK_SIZE = 512
-    ASCEND_REQUIRED_SPECS = frozenset(
-        {"Compress4AttentionSpec", "C4IndexerSpec", "Compress128AttentionSpec"}
-    )
-    ASCEND_TENSOR_BLOCK_SPECS = {
-        "Compress4AttentionSpec": 512,
-        "C4IndexerSpec": 4096,
-        "Compress128AttentionSpec": 16384,
-    }
-    ASCEND_MULTI_TENSOR_SPECS = {
-        # vllm-ascend _reshape_kv_cache_tensors() extends C4 indexer as
-        # [indexer_kv_cache, indexer_scale_cache]. Other DSV4 specs append one
-        # tensor each in kv-cache-group order.
-        "C4IndexerSpec": 2,
-    }
-    ASCEND_STATE_COMPRESS_RATIOS = {
-        "C4AttnKVStateSpec": 4,
-        "C4AttnScoreStateSpec": 4,
-        "C4IndexerKVStateSpec": 4,
-        "C4IndexerScoreStateSpec": 4,
-        "C128AttnKVStateSpec": 128,
-        "C128AttnScoreStateSpec": 128,
-    }
-
-    def __init__(
-        self,
-        kv_cache_config: "KVCacheConfig",
-        fa_group_ids: tuple[int, ...],
-    ) -> None:
-        self.kv_cache_config = kv_cache_config
-        self.fa_group_ids = fa_group_ids
-        self.is_ascend = self._detect_ascend_layout()
-        self.hash_block_size = self._get_hash_block_size()
-        self.group_token_block_sizes = self._get_group_token_block_sizes()
-        self.group_tensor_block_sizes = self._get_group_tensor_block_sizes()
-        self.group_layer_tensor_indices = self._get_group_layer_tensor_indices()
-
-    @staticmethod
-    def group_specs(group_spec) -> tuple[object, ...]:
-        nested_specs = getattr(group_spec.kv_cache_spec, "kv_cache_specs", None)
-        return (
-            tuple(nested_specs.values())
-            if nested_specs
-            else (group_spec.kv_cache_spec,)
-        )
-
-    @staticmethod
-    def group_layer_specs(group_spec, layer_name: str) -> tuple[object, ...]:
-        nested_specs = getattr(group_spec.kv_cache_spec, "kv_cache_specs", None)
-        if nested_specs:
-            return (nested_specs[layer_name],)
-        return (group_spec.kv_cache_spec,)
-
-    @staticmethod
-    def group_spec_items(group_spec) -> tuple[tuple[str, object], ...]:
-        nested_specs = getattr(group_spec.kv_cache_spec, "kv_cache_specs", None)
-        if nested_specs:
-            return tuple(nested_specs.items())
-        return tuple(
-            (layer_name, group_spec.kv_cache_spec)
-            for layer_name in group_spec.layer_names
-        )
-
-    @staticmethod
-    def spec_window_tokens(spec: object) -> Optional[int]:
-        window_size = getattr(spec, "sliding_window", None) or getattr(
-            spec, "attention_chunk_size", None
-        )
-        return int(window_size) if window_size is not None else None
-
-    @classmethod
-    def group_window_tokens(cls, group_spec) -> Optional[int]:
-        window_sizes = {
-            window_tokens
-            for spec in cls.group_specs(group_spec)
-            if (window_tokens := cls.spec_window_tokens(spec)) is not None
-        }
-        if not window_sizes:
-            return None
-        if len(window_sizes) != 1:
-            raise RuntimeError(
-                "FAWA KV cache group has mixed window sizes: " f"{sorted(window_sizes)}"
-            )
-        return window_sizes.pop()
-
-    @classmethod
-    def group_has_window(cls, group_spec) -> bool:
-        return cls.group_window_tokens(group_spec) is not None
-
-    @classmethod
-    def is_ascend_kv_cache_config(
-        cls, kv_cache_config: Optional["KVCacheConfig"]
-    ) -> bool:
-        if kv_cache_config is None:
-            return False
-        groups = kv_cache_config.kv_cache_groups
-        if not any(type(group).__name__.startswith("Ascend") for group in groups):
-            return False
-        spec_names = {
-            type(spec).__name__ for group in groups for spec in cls.group_specs(group)
-        }
-        return cls.ASCEND_REQUIRED_SPECS.issubset(spec_names)
-
-    @staticmethod
-    def spec_token_block_size(spec: object) -> int:
-        block_size = getattr(spec, "block_size", None)
-        if block_size is None:
-            raise RuntimeError(
-                f"FAWA KV cache spec {type(spec).__name__} has no block_size."
-            )
-        return int(block_size)
-
-    @classmethod
-    def spec_tensor_block_size(cls, spec: object) -> Optional[int]:
-        spec_name = type(spec).__name__
-        fixed_size = cls.ASCEND_TENSOR_BLOCK_SPECS.get(spec_name)
-        if fixed_size is not None:
-            return fixed_size
-        compress_ratio = int(getattr(spec, "compress_ratio", 1))
-        if compress_ratio <= 1:
-            return None
-        return cls.spec_token_block_size(spec) * compress_ratio
-
-    def _detect_ascend_layout(self) -> bool:
-        return self.is_ascend_kv_cache_config(self.kv_cache_config)
-
-    def state_compress_ratio(self, group_id: int) -> Optional[int]:
-        ratios = set()
-        group = self.kv_cache_config.kv_cache_groups[group_id]
-        for spec in self.group_specs(group):
-            spec_name = type(spec).__name__
-            ratio = getattr(spec, "compress_ratio", None)
-            if ratio is None:
-                ratio = self.ASCEND_STATE_COMPRESS_RATIOS.get(spec_name)
-            if ratio is not None and int(ratio) > 1:
-                ratios.add(int(ratio))
-        if len(ratios) > 1:
-            raise RuntimeError(
-                f"FAWA Ascend group {group_id} has mixed compress ratios: "
-                f"{sorted(ratios)}."
-            )
-        return ratios.pop() if ratios else None
-
-    def is_swa_group(self, group_id: int) -> bool:
-        group = self.kv_cache_config.kv_cache_groups[group_id]
-        return any(
-            type(spec).__name__ == "SWAAttentionSpec"
-            for spec in self.group_specs(group)
-        )
-
-    def _get_hash_block_size(self) -> int:
-        if self.is_ascend:
-            return self.ASCEND_HASH_BLOCK_SIZE
-        fa_block_sizes = {
-            self.spec_token_block_size(
-                self.kv_cache_config.kv_cache_groups[group_id].kv_cache_spec
-            )
-            for group_id in self.fa_group_ids
-        }
-        if len(fa_block_sizes) != 1:
-            raise RuntimeError(
-                "FAWA connector requires one FA token block size, got "
-                f"{sorted(fa_block_sizes)}."
-            )
-        return fa_block_sizes.pop()
-
-    def _ascend_group_token_block_size(self, group_spec) -> int:
-        # Ascend DeepSeek V4 stores selected compressed groups at a 512-token
-        # canonical segment inside larger tensor pages. Other groups keep the
-        # token block size advertised by the KV cache spec.
-        if any(
-            self.spec_tensor_block_size(spec) is not None
-            for spec in self.group_specs(group_spec)
-        ):
-            return self.hash_block_size
-        return self.spec_token_block_size(group_spec.kv_cache_spec)
-
-    def _get_group_token_block_sizes(self) -> tuple[int, ...]:
-        groups = self.kv_cache_config.kv_cache_groups
-        if self.is_ascend:
-            group_token_block_sizes = tuple(
-                self._ascend_group_token_block_size(group) for group in groups
-            )
-        else:
-            raw_group_token_block_sizes = tuple(
-                self.spec_token_block_size(group.kv_cache_spec) for group in groups
-            )
-            if not raw_group_token_block_sizes:
-                raise RuntimeError("FAWA connector found no KV cache groups.")
-            mutable_sizes = list(raw_group_token_block_sizes)
-            for group_id in self.fa_group_ids:
-                mutable_sizes[group_id] = self.hash_block_size
-            group_token_block_sizes = tuple(mutable_sizes)
-
-        for group_id, group_token_block_size in enumerate(group_token_block_sizes):
-            if group_token_block_size <= 0:
-                raise RuntimeError(
-                    f"FAWA group {group_id} block size must be positive, "
-                    f"got {group_token_block_size}."
-                )
-            if self.hash_block_size % group_token_block_size != 0:
-                raise RuntimeError(
-                    f"FAWA group {group_id} block size {group_token_block_size} "
-                    f"must divide {self.hash_block_size}."
-                )
-        return group_token_block_sizes
-
-    def _get_group_tensor_block_sizes(self) -> tuple[int, ...]:
-        tensor_block_sizes: list[int] = []
-        for group_id, group in enumerate(self.kv_cache_config.kv_cache_groups):
-            detected = {
-                tensor_block_size
-                for spec in self.group_specs(group)
-                if (tensor_block_size := self.spec_tensor_block_size(spec)) is not None
-            }
-            if len(detected) > 1:
-                raise RuntimeError(
-                    f"FAWA Ascend group {group_id} has mixed tensor "
-                    f"block sizes: {sorted(detected)}."
-                )
-            tensor_block_sizes.append(
-                detected.pop() if detected else self.group_token_block_sizes[group_id]
-            )
-        return tuple(tensor_block_sizes)
-
-    @classmethod
-    def spec_tensor_count(cls, spec: object) -> int:
-        return cls.ASCEND_MULTI_TENSOR_SPECS.get(type(spec).__name__, 1)
-
-    def _get_group_layer_tensor_indices(
-        self,
-    ) -> dict[int, dict[str, tuple[int, ...]]]:
-        if not self.is_ascend:
-            return {}
-
-        mapping: dict[int, dict[str, tuple[int, ...]]] = {}
-        next_tensor_index_by_layer: dict[str, int] = {}
-        for group_id, group in enumerate(self.kv_cache_config.kv_cache_groups):
-            group_mapping: dict[str, tuple[int, ...]] = {}
-            for layer_name in group.layer_names:
-                tensor_count = sum(
-                    self.spec_tensor_count(spec)
-                    for spec in self.group_layer_specs(group, layer_name)
-                )
-                start = next_tensor_index_by_layer.get(layer_name, 0)
-                end = start + tensor_count
-                group_mapping[layer_name] = tuple(range(start, end))
-                next_tensor_index_by_layer[layer_name] = end
-            mapping[group_id] = group_mapping
-        return mapping
-
-    def group_tensor_indices(
-        self, group_id: int, layer_name: str
-    ) -> Optional[tuple[int, ...]]:
-        if not self.is_ascend:
-            return None
-        try:
-            return self.group_layer_tensor_indices[group_id][layer_name]
-        except KeyError as exc:
-            raise RuntimeError(
-                f"FAWA Ascend layout has no tensor index mapping for "
-                f"group {group_id}, layer {layer_name}."
-            ) from exc
-
-    def block_index_to_segment(
-        self,
-        group_id: int,
-        group_block_idx: int,
-        block_id: int,
-    ) -> KVCacheSegment:
-        group_token_block_size = self.group_token_block_sizes[group_id]
-        group_tensor_block_size = self.group_tensor_block_sizes[group_id]
-        if group_tensor_block_size % group_token_block_size != 0:
-            raise RuntimeError(
-                f"FAWA group {group_id} logical block size {group_token_block_size} "
-                f"must divide tensor block size {group_tensor_block_size}."
-            )
-        token_blocks_per_tensor_block = (
-            group_tensor_block_size // group_token_block_size
-        )
-        tensor_block_idx = group_block_idx // token_blocks_per_tensor_block
-        if tensor_block_idx != block_id:
-            logger.debug(
-                f"FAWA group {group_id} logical block idx {group_block_idx} "
-                f"maps to tensor block idx {tensor_block_idx}, "
-                f"allocated id {block_id}."
-            )
-        return KVCacheSegment(
-            block_id=block_id,
-            offset=(group_block_idx % token_blocks_per_tensor_block)
-            * group_token_block_size,
-            length=group_token_block_size,
-        )
-
-    def allocation_index(self, group_id: int, group_block_idx: int) -> int:
-        return (
-            group_block_idx
-            * self.group_token_block_sizes[group_id]
-            // self.group_tensor_block_sizes[group_id]
-        )
+        return int(self.tensor_block_sizes[0])
 
 
 @dataclass
 class FAWARequestMeta:
-    # Canonical per-hash-block remote keys before _block_key() namespacing.
     ucm_block_ids: list[bytes] = field(default_factory=list)
-    # Number of 256-token hash blocks already hit in vLLM's HBM prefix cache.
     hbm_hit_block_num: int = 0
-    # Total prefix hit in hash blocks, including HBM and external UCM hits.
     total_hit_block_num: int = 0
-    # Logical request token count; persistence is capped by this, not allocation.
     num_token_ids: int = 0
-    # Number of logical tokens already accounted for by scheduler progress.
+    vllm_block_ids: tuple[list[int], ...] = field(default_factory=tuple)
     token_processed: int = 0
-    # First canonical hash block that has not yet been emitted to store.
-    store_block_cursor: int = 0
-    # canonical block idx -> per-kv-cache-group block ids needed to load/store it.
-    group_block_ids: dict[int, KVCacheGroupRow] = field(default_factory=dict)
-    # Full HMA allocation snapshot by kv-cache group, updated on alloc/chunk alloc.
-    allocated_group_block_ids: KVCacheGroupAllocation = field(default_factory=tuple)
 
 
 @dataclass
 class FAWARequestDispatchMeta:
-    load_block_ids: tuple[list[bytes], KVCacheGroupRows]
-    dump_block_ids: tuple[list[bytes], KVCacheGroupRows]
+    load_keys: list[bytes] = field(default_factory=list)
+    load_hash_start: int = 0
+    load_hash_end: int = 0
+    load_vllm_block_ids: tuple[list[int], ...] = field(default_factory=tuple)
+    dump_keys: list[bytes] = field(default_factory=list)
+    dump_hash_start: int = 0
+    dump_hash_end: int = 0
+    dump_vllm_block_ids: tuple[list[int], ...] = field(default_factory=tuple)
 
 
 @dataclass
@@ -672,30 +247,25 @@ class UCMFAWAConnector(UCMDirectConnector):
     """
 
     DEFAULT_HASH_BLOCK_SIZE = 256
+    ASCEND_DEFAULT_HASH_BLOCK_SIZE = 512
 
     def __init__(
         self,
         vllm_config: "VllmConfig",
         role: KVConnectorRole,
-        kv_cache_config: Optional["KVCacheConfig"] = None,
+        kv_cache_config: "KVCacheConfig",
     ):
         self._defer_scheduler_store = True
         super().__init__(vllm_config, role, kv_cache_config)
         self.hash_block_size = self.DEFAULT_HASH_BLOCK_SIZE
-        self.block_size = self.DEFAULT_HASH_BLOCK_SIZE
         self.group_layouts: dict[int, KVCacheGroupLayout] = {}
-        self._window_scratch_views: dict[tuple[int, int], list[torch.Tensor]] = {}
-        self.fa_group_ids, self.window_group_ids = self._partition_kv_cache_groups()
         if self._kv_cache_config is None:
             raise RuntimeError("FAWA connector requires kv_cache_config.")
-        self.block_span_layout = self._create_block_span_layout()
-        self._ascend_layout = False
-        self.hash_block_size = self._get_hash_block_size()
-        self.block_size = self.hash_block_size
-        self.group_token_block_sizes = self._get_group_token_block_sizes()
-        self.group_tensor_block_sizes = self._get_group_tensor_block_sizes()
-        self.group_tail_blocks = self._get_group_tail_blocks()
-        self.group_window_spans = self._get_group_window_spans()
+
+        self.is_ascend_layout = False
+        self.fa_group_ids, self.window_group_ids = [], []
+        self.group_metas: dict[int, KVCacheGroupMeta] = {}
+        self._init_group_metas()
         self.fa_store: Optional[UcmKVStoreBaseV1] = None
         self.wa_store: Optional[UcmKVStoreBaseV1] = None
         self.requests_meta: dict[str, FAWARequestMeta] = {}
@@ -703,14 +273,20 @@ class UCMFAWAConnector(UCMDirectConnector):
             self.store = self._create_fa_store(None)
             self.fa_store = self.store
             self.wa_store = self._create_wa_store(None)
+        group_meta_summary = tuple(
+            {
+                "group_id": meta.group_id,
+                "token_block_size": meta.token_block_size,
+                "tail_blocks": meta.tail_blocks,
+                "tail_tokens": meta.tail_tokens,
+            }
+            for _, meta in sorted(self.group_metas.items())
+        )
         logger.info(
             f"FAWA KV group config: fa_groups={self.fa_group_ids}, "
             f"window_groups={self.window_group_ids}, "
-            f"ascend_layout={self._ascend_layout}, "
-            f"token_block_sizes={self.group_token_block_sizes}, "
-            f"group_tensor_block_sizes={self.group_tensor_block_sizes}, "
-            f"tail_blocks={self.group_tail_blocks}, "
-            f"window_spans={self.group_window_spans}"
+            f"is_ascend_layout={self.is_ascend_layout}, "
+            f"group_metas={group_meta_summary}"
         )
         logger.info("Init UCM FAWA connector.")
 
@@ -720,71 +296,101 @@ class UCMFAWAConnector(UCMDirectConnector):
     ) -> bool:
         if kv_cache_config is None:
             return False
-        if cls.can_handle_ascend_kv_cache_config(kv_cache_config):
-            return False
-        fa_groups, window_groups = cls._partition_group_specs(
-            kv_cache_config.kv_cache_groups
-        )
-        return bool(fa_groups and window_groups)
+
+        kv_cache_groups = kv_cache_config.kv_cache_groups
+        spec_names = set()
+        for group_spec in kv_cache_groups:
+            nested_specs = getattr(group_spec.kv_cache_spec, "kv_cache_specs", None)
+            spec = (
+                next(iter(nested_specs.values()))
+                if nested_specs
+                else group_spec.kv_cache_spec
+            )
+            spec_names.add(type(spec).__name__)
+        # current only support for DeepSeekV4
+        DS_V4_REQUIRED_SPECS = frozenset({"SlidingWindowMLASpec"})
+        gpu_support = DS_V4_REQUIRED_SPECS.issubset(spec_names)
+        if gpu_support:
+            return True
+        return cls.can_handle_ascend_kv_cache_config(kv_cache_config)
 
     @classmethod
     def can_handle_ascend_kv_cache_config(
         cls, kv_cache_config: Optional["KVCacheConfig"]
     ) -> bool:
-        return FAWABlockSpanLayout.is_ascend_kv_cache_config(kv_cache_config)
-
-    def _create_block_span_layout(self) -> Optional[FAWABlockSpanLayout]:
-        return None
-
-    def _get_hash_block_size(self) -> int:
-        fa_block_sizes = {
-            self._spec_token_block_size(
-                self._kv_cache_config.kv_cache_groups[group_id].kv_cache_spec
+        if kv_cache_config is None:
+            return False
+        kv_cache_groups = kv_cache_config.kv_cache_groups
+        spec_names = set()
+        for group_spec in kv_cache_groups:
+            nested_specs = getattr(group_spec.kv_cache_spec, "kv_cache_specs", None)
+            spec = (
+                next(iter(nested_specs.values()))
+                if nested_specs
+                else group_spec.kv_cache_spec
             )
-            for group_id in self.fa_group_ids
-        }
-        if len(fa_block_sizes) != 1:
-            raise RuntimeError(
-                "FAWA connector requires one FA token block size, got "
-                f"{sorted(fa_block_sizes)}."
-            )
-        return fa_block_sizes.pop()
-
-    @staticmethod
-    def _spec_token_block_size(spec: object) -> int:
-        return FAWABlockSpanLayout.spec_token_block_size(spec)
-
-    def _get_group_token_block_sizes(self) -> tuple[int, ...]:
-        raw_group_token_block_sizes = tuple(
-            self._spec_token_block_size(group.kv_cache_spec)
-            for group in self._kv_cache_config.kv_cache_groups
+            spec_names.add(type(spec).__name__)
+        ASCEND_REQUIRED_SPECS = frozenset(
+            {"Compress4AttentionSpec", "C4IndexerSpec", "Compress128AttentionSpec"}
         )
-        if not raw_group_token_block_sizes:
-            raise RuntimeError("FAWA connector found no KV cache groups.")
-        mutable_sizes = list(raw_group_token_block_sizes)
-        for group_id in self.fa_group_ids:
-            mutable_sizes[group_id] = self.hash_block_size
-        group_token_block_sizes = tuple(mutable_sizes)
-        self._validate_group_token_block_sizes(group_token_block_sizes)
-        return group_token_block_sizes
+        npu_support = type(kv_cache_groups[0]).__name__.startswith(
+            "Ascend"
+        ) and ASCEND_REQUIRED_SPECS.issubset(spec_names)
+        return npu_support
 
-    def _get_group_tensor_block_sizes(self) -> tuple[int, ...]:
-        return self.group_token_block_sizes
+    def _init_group_metas(self) -> None:
+        if self.can_handle_ascend_kv_cache_config(self._kv_cache_config):
+            self.is_ascend_layout = True
+            self.hash_block_size = self.ASCEND_DEFAULT_HASH_BLOCK_SIZE
 
-    def _validate_group_token_block_sizes(
-        self, group_token_block_sizes: tuple[int, ...]
-    ) -> None:
-        for group_id, group_token_block_size in enumerate(group_token_block_sizes):
-            if group_token_block_size <= 0:
-                raise RuntimeError(
-                    f"FAWA group {group_id} block size must be positive, "
-                    f"got {group_token_block_size}."
-                )
-            if self.hash_block_size % group_token_block_size != 0:
-                raise RuntimeError(
-                    f"FAWA group {group_id} block size {group_token_block_size} "
-                    f"must divide {self.hash_block_size}."
-                )
+        groups = self._kv_cache_config.kv_cache_groups
+        self.fa_group_ids, self.window_group_ids = [], []
+        layer_compress_ratios = getattr(
+            self._vllm_config.model_config.hf_config,
+            "compress_ratios",
+            None,
+        )
+        if layer_compress_ratios is None:
+            raise "current only support DSV4"
+        for group_id, group in enumerate(groups):
+            kv_cache_spec = group.kv_cache_spec
+            # handle attention window cache
+            nested_specs = getattr(kv_cache_spec, "kv_cache_specs", None)
+            spec = next(iter(nested_specs.values())) if nested_specs else kv_cache_spec
+            window_size = getattr(spec, "sliding_window", None)
+            compress_ratio = getattr(spec, "compress_ratio", 1)
+            token_block_size = kv_cache_spec.block_size
+
+            if self.is_ascend_layout:
+                # for ascend bug, wait for ascend fix
+                token_block_size = kv_cache_spec.block_size * compress_ratio
+
+            if window_size is None:
+                # hash_block_size must be an integral multiple of token_block_size.
+                tail_tokens = self.hash_block_size
+                self.fa_group_ids.append(group_id)
+            else:
+                tensor_name = group.layer_names[0]
+                if type(spec).__name__ in ["SWAAttentionSpec"] or tensor_name.split(
+                    "."
+                )[-1] in ["swa_cache"]:
+                    # for swa cache
+                    tail_tokens = window_size
+                else:
+                    # for compressor state cache
+                    layer_index = extract_layer_index(tensor_name)
+                    tail_tokens = window_size - layer_compress_ratios[layer_index]
+
+                tail_blocks = tail_tokens // token_block_size
+                self.window_group_ids.append(group_id)
+
+            tail_blocks = max(tail_tokens // token_block_size, 1)
+            self.group_metas[group_id] = KVCacheGroupMeta(
+                group_id=group_id,
+                token_block_size=token_block_size,
+                tail_blocks=tail_blocks,
+                tail_tokens=tail_tokens,
+            )
 
     def _create_fa_store(
         self,
@@ -905,217 +511,6 @@ class UCMFAWAConnector(UCMDirectConnector):
             summary["tensor_bytes"] = sum(tensor_sizes)
         return summary
 
-    @staticmethod
-    def _partition_group_specs(
-        group_specs,
-    ) -> tuple[tuple[int, ...], tuple[int, ...]]:
-        fa_group_ids: list[int] = []
-        window_group_ids: list[int] = []
-        for group_id, group_spec in enumerate(group_specs):
-            if FAWABlockSpanLayout.group_has_window(group_spec):
-                window_group_ids.append(group_id)
-            else:
-                fa_group_ids.append(group_id)
-        return tuple(fa_group_ids), tuple(window_group_ids)
-
-    def _partition_kv_cache_groups(self) -> tuple[tuple[int, ...], tuple[int, ...]]:
-        if self._kv_cache_config is None:
-            raise RuntimeError("FAWA connector requires kv_cache_config.")
-        fa_group_ids, window_group_ids = self._partition_group_specs(
-            self._kv_cache_config.kv_cache_groups
-        )
-        if not fa_group_ids:
-            raise RuntimeError("FAWA connector found no full-attention groups.")
-        if not window_group_ids:
-            raise RuntimeError("FAWA connector found no window groups.")
-        return fa_group_ids, window_group_ids
-
-    def _get_group_tail_blocks(self) -> tuple[Optional[int], ...]:
-        tail_blocks: list[Optional[int]] = [None] * len(self.group_token_block_sizes)
-        if self._kv_cache_config is None:
-            raise RuntimeError("FAWA connector requires kv_cache_config.")
-        for group_id in self.window_group_ids:
-            group_spec = self._kv_cache_config.kv_cache_groups[group_id]
-            group_token_block_size = self.group_token_block_sizes[group_id]
-            window_tokens = FAWABlockSpanLayout.group_window_tokens(group_spec)
-            if window_tokens is None:
-                tail_blocks[group_id] = self.hash_block_size // group_token_block_size
-                continue
-            if self._is_compressor_state_group(group_id):
-                tail_blocks[group_id] = self._compressor_state_tail_blocks(
-                    group_id,
-                    window_tokens,
-                    group_token_block_size,
-                )
-                continue
-            tail_blocks[group_id] = max(
-                1, math.ceil(window_tokens / group_token_block_size)
-            )
-        return tuple(tail_blocks)
-
-    def _get_group_window_spans(self) -> tuple[tuple[int, ...], ...]:
-        spans: list[tuple[int, ...]] = []
-        for group_id, tail_blocks in enumerate(self.group_tail_blocks):
-            if tail_blocks is None:
-                spans.append((self.group_token_block_sizes[group_id],))
-            else:
-                spans.append((self.group_token_block_sizes[group_id],) * tail_blocks)
-        return tuple(spans)
-
-    @staticmethod
-    def _is_compressor_state_name(layer_name: str) -> bool:
-        return ".compressor.state_cache" in layer_name
-
-    @staticmethod
-    def _compressor_state_prefix(layer_name: str) -> str:
-        suffix = ".compressor.state_cache"
-        if layer_name.endswith(suffix):
-            return layer_name[: -len(suffix)]
-        return layer_name.split(suffix, 1)[0]
-
-    def _is_compressor_state_group(self, group_id: int) -> bool:
-        if self._kv_cache_config is None:
-            raise RuntimeError("FAWA connector requires kv_cache_config.")
-        group_spec = self._kv_cache_config.kv_cache_groups[group_id]
-        layer_names = tuple(group_spec.layer_names)
-        return bool(layer_names) and all(
-            self._is_compressor_state_name(name) for name in layer_names
-        )
-
-    def _group_compress_ratio(self, group_id: int) -> Optional[int]:
-        if self._kv_cache_config is None:
-            raise RuntimeError("FAWA connector requires kv_cache_config.")
-        group_spec = self._kv_cache_config.kv_cache_groups[group_id]
-        ratios = {
-            int(ratio)
-            for spec in FAWABlockSpanLayout.group_specs(group_spec)
-            if (ratio := getattr(spec, "compress_ratio", 1)) and int(ratio) > 1
-        }
-        if len(ratios) > 1:
-            raise RuntimeError(
-                f"FAWA KV cache group {group_id} has mixed compress ratios: "
-                f"{sorted(ratios)}"
-            )
-        if ratios:
-            return ratios.pop()
-
-        if not self._is_compressor_state_group(group_id):
-            return None
-
-        config_ratios = getattr(
-            self._vllm_config.model_config.hf_config,
-            "compress_ratios",
-            None,
-        )
-        if config_ratios:
-            for layer_name in group_spec.layer_names:
-                layer_index = extract_layer_index(layer_name)
-                if layer_index < len(config_ratios):
-                    ratio = int(config_ratios[layer_index])
-                    if ratio > 1:
-                        ratios.add(ratio)
-            if len(ratios) > 1:
-                raise RuntimeError(
-                    f"FAWA compressor state group {group_id} maps to mixed "
-                    f"model config compress ratios: {sorted(ratios)}"
-                )
-            if ratios:
-                return ratios.pop()
-
-        prefixes = tuple(
-            self._compressor_state_prefix(layer_name)
-            for layer_name in group_spec.layer_names
-        )
-        for other_group in self._kv_cache_config.kv_cache_groups:
-            for layer_name, spec in FAWABlockSpanLayout.group_spec_items(other_group):
-                ratio = getattr(spec, "compress_ratio", 1)
-                if not ratio or int(ratio) <= 1:
-                    continue
-                if any(
-                    layer_name == prefix or layer_name.startswith(prefix + ".")
-                    for prefix in prefixes
-                ):
-                    ratios.add(int(ratio))
-
-        if len(ratios) > 1:
-            raise RuntimeError(
-                f"FAWA compressor state group {group_id} maps to mixed "
-                f"compress ratios: {sorted(ratios)}"
-            )
-        return ratios.pop() if ratios else None
-
-    def _compressor_state_tail_blocks(
-        self,
-        group_id: int,
-        window_tokens: int,
-        group_token_block_size: int,
-    ) -> int:
-        compress_ratio = self._group_compress_ratio(group_id)
-        if compress_ratio is None:
-            return max(1, math.ceil(window_tokens / group_token_block_size))
-        if compress_ratio <= 0:
-            raise RuntimeError(
-                f"FAWA group {group_id} compress ratio must be positive, "
-                f"got {compress_ratio}."
-            )
-        if window_tokens <= compress_ratio:
-            return 0
-        return math.ceil((window_tokens - compress_ratio) / group_token_block_size)
-
-    def _split_kv_caches_by_vllm_groups(
-        self, kv_caches: dict[str, torch.Tensor]
-    ) -> dict[int, dict[str, torch.Tensor]]:
-        if self._kv_cache_config is None:
-            raise RuntimeError("FAWA connector requires kv_cache_config.")
-        groups: dict[int, dict[str, torch.Tensor]] = {}
-        used_names: set[str] = set()
-        for group_id, group_spec in enumerate(self._kv_cache_config.kv_cache_groups):
-            group_caches: dict[str, torch.Tensor] = {}
-            for name in group_spec.layer_names:
-                if name not in kv_caches:
-                    continue
-                kv_cache = kv_caches[name]
-                tensor_indices = (
-                    self.block_span_layout.group_tensor_indices(group_id, name)
-                    if self.block_span_layout is not None
-                    else None
-                )
-                if tensor_indices is None:
-                    group_caches[name] = kv_cache
-                else:
-                    if not isinstance(kv_cache, (list, tuple)):
-                        raise TypeError(
-                            f"FAWA Ascend KV cache {name} must be tuple/list-like, "
-                            f"got {type(kv_cache)}."
-                        )
-                    missing = [
-                        tensor_index
-                        for tensor_index in tensor_indices
-                        if tensor_index >= len(kv_cache)
-                    ]
-                    if missing:
-                        raise RuntimeError(
-                            f"FAWA Ascend KV cache {name} has {len(kv_cache)} "
-                            f"tensors, missing indices {missing} for group "
-                            f"{group_id}."
-                        )
-                    selected = tuple(
-                        kv_cache[tensor_index] for tensor_index in tensor_indices
-                    )
-                    group_caches[name] = selected[0] if len(selected) == 1 else selected
-            if group_caches:
-                groups[group_id] = group_caches
-                used_names.update(group_caches)
-
-        missing_names = set(kv_caches) - used_names
-        if missing_names:
-            raise RuntimeError(
-                "KV cache config did not include registered caches: "
-                f"{sorted(missing_names)}"
-            )
-
-        return groups
-
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         self.kv_caches = kv_caches
         self.device = create_device()
@@ -1127,20 +522,34 @@ class UCMFAWAConnector(UCMDirectConnector):
             else (None, None)
         )
 
-        grouped = self._split_kv_caches_by_vllm_groups(kv_caches)
-        for group_id, group_caches in grouped.items():
-            if not group_caches:
-                logger.warning(f"KV cache group {group_id} is empty.")
-                continue
-            layout = KVCacheGroupLayout(group_caches)
-            self.group_layouts[group_id] = layout
+        if self.is_ascend_layout:
+            # current for ascend, one layer_tensor_name per group_spec, multi tensors per layer_tensor_name
+            next_tensor_index_by_layer: dict[str, int] = {}
+            for group_id, group in enumerate(self._kv_cache_config.kv_cache_groups):
+                kv_cache_spec_name = type(group.kv_cache_spec).__name__
+                group_caches: dict[str, torch.Tensor] = {}
+                for layer_name in group.layer_names:
+                    tensor_count = 2 if kv_cache_spec_name == "C4IndexerSpec" else 1
+                    start = next_tensor_index_by_layer.get(layer_name, 0)
+                    end = start + tensor_count
+                    next_tensor_index_by_layer[layer_name] = end
+                    group_caches[layer_name] = tuple(kv_caches[layer_name][start:end])
+
+                layout = KVCacheGroupLayout(group_caches)
+                self.group_layouts[group_id] = layout
+        else:
+            for group_id, group_spec in enumerate(
+                self._kv_cache_config.kv_cache_groups
+            ):
+                group_caches: dict[str, torch.Tensor] = {}
+                for layer_name in group_spec.layer_names:
+                    group_caches[layer_name] = kv_caches[layer_name]
+                layout = KVCacheGroupLayout(group_caches)
+                self.group_layouts[group_id] = layout
 
         self.store = self._create_fa_store(self.group_layouts, store_cores)
         self.fa_store = self.store
-        self.wa_store = self._create_wa_store(
-            self.group_layouts,
-            store_cores,
-        )
+        self.wa_store = self._create_wa_store(self.group_layouts, store_cores)
 
         if worker_cores:
             try:
@@ -1148,9 +557,6 @@ class UCMFAWAConnector(UCMDirectConnector):
                 logger.info(f"[VLLM CPU Affinity] Worker bound to cores {worker_cores}")
             except Exception as e:
                 logger.warning(f"Failed to bind worker: {e}")
-
-    def _block_key(self, canonical_hash: bytes) -> bytes:
-        return self.request_hasher((b"fawa", canonical_hash))
 
     def _store_tensor_size_list(
         self,
@@ -1162,13 +568,17 @@ class UCMFAWAConnector(UCMDirectConnector):
             layout = group_layouts.get(group_id)
             if layout is None:
                 continue
-            repeat = self.group_tail_blocks[group_id]
-            if repeat is None:
-                repeat = 1
-            for segment_tokens in self.group_window_spans[group_id][:repeat]:
+            meta = self.group_metas[group_id]
+
+            if not meta.tail_tokens:
+                continue
+
+            segment_tokens = meta.tail_tokens // meta.tail_blocks
+
+            for _ in range(meta.tail_blocks):
                 segment_sizes = layout.segment_tensor_size_list(
                     segment_tokens,
-                    self.group_tensor_block_sizes[group_id],
+                    meta.token_block_size,
                 )
                 tensor_size_list.extend(segment_sizes)
         if not tensor_size_list:
@@ -1180,331 +590,23 @@ class UCMFAWAConnector(UCMDirectConnector):
             raise RuntimeError(f"Worker FAWA {group_label} layout is empty.")
         return tensor_size_list
 
-    def _select_rows(
-        self,
-        group_rows: KVCacheGroupRows,
-        group_ids: tuple[int, ...],
-    ) -> KVCacheGroupRows:
-        return [
-            tuple(list(group_row[group_id]) for group_id in group_ids)
-            for group_row in group_rows
-        ]
-
-    def _group_block_range(self, group_id: int, computed_end_token: int) -> range:
-        # The block row is determined by the logical token boundary, not by
-        # how many tensor blocks vLLM has already allocated.
-        if self.group_tail_blocks[group_id] is None:
-            canonical_block_idx = computed_end_token // self.hash_block_size - 1
-            return range(canonical_block_idx, canonical_block_idx + 1)
-
-        total_group_blocks = (
-            computed_end_token // self.group_token_block_sizes[group_id]
-        )
-        tail_blocks = self.group_tail_blocks[group_id]
-        # Some compressor-state groups need no window tail for a prefix hit.
-        if not tail_blocks:
-            return range(total_group_blocks, total_group_blocks)
-        start = max(0, total_group_blocks - tail_blocks)
-        return range(start, total_group_blocks)
-
-    def _expected_group_row_segments(self, group_id: int) -> int:
-        tail_blocks = self.group_tail_blocks[group_id]
-        return 1 if tail_blocks is None else int(tail_blocks)
-
-    def _block_index_to_segment(
-        self,
-        group_id: int,
-        group_block_idx: int,
-        block_id: int,
-        computed_end_token: Optional[int] = None,
-    ) -> KVCacheSegment:
-        if self.block_span_layout is None:
-            token_blocks_per_tensor_block = (
-                self.group_tensor_block_sizes[group_id]
-                // self.group_token_block_sizes[group_id]
-            )
-            return KVCacheSegment(
-                block_id=block_id,
-                offset=(group_block_idx % token_blocks_per_tensor_block)
-                * self.group_token_block_sizes[group_id],
-                length=self.group_token_block_sizes[group_id],
-            )
-        return self.block_span_layout.block_index_to_segment(
-            group_id,
-            group_block_idx,
-            block_id,
-        )
-
-    def _make_missing_segment(
-        self,
-        group_id: int,
-        group_block_idx: int,
-        computed_end_token: Optional[int] = None,
-    ) -> KVCacheSegment:
-        return KVCacheSegment(
-            block_id=-1,
-            offset=0,
-            length=self.group_token_block_sizes[group_id],
-        )
-
-    def _scratch_block_tensor_views(
-        self,
-        group_id: int,
-        block_pos: int,
-    ) -> list[torch.Tensor]:
-        key = (group_id, block_pos)
-        scratch_views = self._window_scratch_views.get(key)
-        if scratch_views is None:
-            layout = self.group_layouts[group_id]
-            scratch_views = [
-                torch.empty_like(tensor)
-                for tensor in layout.extract_segment_tensor_views(
-                    [
-                        KVCacheSegment(
-                            block_id=0,
-                            offset=0,
-                            length=self._window_segment_length(group_id, block_pos),
-                        )
-                    ],
-                    self.group_tensor_block_sizes[group_id],
-                )
-            ]
-            self._window_scratch_views[key] = scratch_views
-        return scratch_views
-
-    def _scratch_block_addrs(self, group_id: int, block_pos: int) -> np.ndarray:
-        return np.asarray(
-            [
-                tensor.data_ptr()
-                for tensor in self._scratch_block_tensor_views(group_id, block_pos)
-            ],
-            dtype=np.uint64,
-        )
-
-    def _window_segment_length(self, group_id: int, block_pos: int) -> int:
-        spans = self.group_window_spans[group_id]
-        if not spans:
-            return self.group_token_block_sizes[group_id]
-        return spans[min(block_pos, len(spans) - 1)]
-
-    def _extract_group_addrs(
-        self,
-        group_rows: KVCacheGroupRows,
-        group_ids: tuple[int, ...],
-        scratch_for_missing: bool = False,
-    ) -> np.ndarray:
-        rows: list[np.ndarray] = []
-        for group_row in group_rows:
-            row_parts: list[np.ndarray] = []
-            for row_group_id, selected_ids in enumerate(group_row):
-                group_id = group_ids[row_group_id]
-                layout = self.group_layouts.get(group_id)
-                if layout is None:
-                    continue
-                if not selected_ids:
-                    continue
-                for block_pos, segment in enumerate(selected_ids):
-                    if segment.block_id < 0:
-                        if not scratch_for_missing:
-                            raise ValueError(
-                                f"KV cache group {group_id} block "
-                                f"position {block_pos} needs a scratch target."
-                            )
-                        row_parts.append(self._scratch_block_addrs(group_id, block_pos))
-                    else:
-                        row_parts.append(
-                            layout.extract_segment_addrs(
-                                [segment],
-                                self.group_tensor_block_sizes[group_id],
-                            ).reshape(-1)
-                        )
-            if not row_parts:
-                raise ValueError("KV cache pointer row is empty.")
-            rows.append(np.concatenate(row_parts).astype(np.uint64, copy=False))
-        if not rows:
-            return np.empty((0, 0), dtype=np.uint64)
-        return np.vstack(rows)
-
-    def _try_select_group_block_ids(
-        self,
-        allocated_group_block_ids: KVCacheGroupAllocation,
-        computed_end_token: int,
-        allow_null_tail: bool = False,
-    ) -> Optional[KVCacheGroupRow]:
-        selected: list[list[KVCacheSegment]] = []
-        for group_id in range(len(self.group_token_block_sizes)):
-            group_indices = self._group_block_range(group_id, computed_end_token)
-            group_selected: list[KVCacheSegment] = []
-            if group_id >= len(allocated_group_block_ids):
-                if group_indices:
-                    return None
-                selected.append(group_selected)
-                continue
-
-            group_blocks = allocated_group_block_ids[group_id]
-            for group_block_idx in group_indices:
-                if self.block_span_layout is not None:
-                    tensor_block_idx = self.block_span_layout.allocation_index(
-                        group_id,
-                        group_block_idx,
-                    )
-                else:
-                    tensor_block_idx = (
-                        group_block_idx
-                        * self.group_token_block_sizes[group_id]
-                        // self.group_tensor_block_sizes[group_id]
-                    )
-                if tensor_block_idx >= len(group_blocks):
-                    return None
-                block_id = group_blocks[tensor_block_idx]
-                if block_id < 0:
-                    # A skipped WA tail before the final external-hit boundary is
-                    # loaded into scratch, because only the final WA row is used.
-                    if allow_null_tail and group_id in self.window_group_ids:
-                        group_selected.append(
-                            self._make_missing_segment(
-                                group_id,
-                                group_block_idx,
-                                computed_end_token,
-                            )
-                        )
-                        continue
-                    raise ValueError(
-                        f"KV cache group {group_id} block index "
-                        f"{group_block_idx} maps to a null HBM block for "
-                        f"computed end token {computed_end_token}."
-                    )
-                group_selected.append(
-                    self._block_index_to_segment(
-                        group_id,
-                        group_block_idx,
-                        block_id,
-                        computed_end_token,
-                    )
-                )
-            expected_segments = self._expected_group_row_segments(group_id)
-            if len(group_selected) < expected_segments:
-                padding_start_idx = group_indices.start - (
-                    expected_segments - len(group_selected)
-                )
-                group_selected = [
-                    self._make_missing_segment(
-                        group_id,
-                        padding_start_idx + pad_idx,
-                        computed_end_token,
-                    )
-                    for pad_idx in range(expected_segments - len(group_selected))
-                ] + group_selected
-            selected.append(group_selected)
-        return tuple(selected)
-
-    def _record_allocated_group_block_ids(
-        self,
-        req_meta: FAWARequestMeta,
-        group_block_ids: tuple[list[int], ...] | None,
-        replace: bool = False,
-    ) -> None:
-        if group_block_ids is None:
-            return
-        # cached.new_block_ids contains only blocks allocated in this scheduler
-        # step. Append it for chunk prefill; replace it for resumed requests.
-        new_group_block_ids = tuple(list(group) for group in group_block_ids)
-        if replace or not req_meta.allocated_group_block_ids:
-            req_meta.allocated_group_block_ids = new_group_block_ids
-        else:
-            if len(req_meta.allocated_group_block_ids) != len(new_group_block_ids):
-                raise RuntimeError(
-                    "FAWA cached allocation update has mismatched group count: "
-                    f"current={len(req_meta.allocated_group_block_ids)}, "
-                    f"new={len(new_group_block_ids)}."
-                )
-            req_meta.allocated_group_block_ids = tuple(
-                current + new
-                for current, new in zip(
-                    req_meta.allocated_group_block_ids,
-                    new_group_block_ids,
-                )
-            )
-        self._record_ready_group_block_ids(req_meta)
-
-    def _replace_allocated_blocks(
-        self,
-        req_meta: FAWARequestMeta,
-        blocks: "KVCacheBlocks",
-    ) -> None:
-        req_meta.allocated_group_block_ids = tuple(
-            [-1 if block.is_null else block.block_id for block in group_blocks]
-            for group_blocks in blocks.blocks
-        )
-        self._record_ready_group_block_ids(req_meta)
-
-    def _summarize_request_meta(self, req_meta: FAWARequestMeta) -> dict[str, object]:
-        recorded_blocks = sorted(req_meta.group_block_ids)
-        recorded_range = (
-            (recorded_blocks[0], recorded_blocks[-1] + 1) if recorded_blocks else (0, 0)
-        )
-        sample_rows = {
-            block_idx: [
-                len(group_segments)
-                for group_segments in req_meta.group_block_ids[block_idx]
-            ]
-            for block_idx in recorded_blocks[:3]
-        }
-        if len(recorded_blocks) > 3:
-            last_block_idx = recorded_blocks[-1]
-            sample_rows[last_block_idx] = [
-                len(group_segments)
-                for group_segments in req_meta.group_block_ids[last_block_idx]
-            ]
-        return {
-            "ucm_blocks": len(req_meta.ucm_block_ids),
-            "hbm_hit_blocks": req_meta.hbm_hit_block_num,
-            "total_hit_blocks": req_meta.total_hit_block_num,
-            "num_token_ids": req_meta.num_token_ids,
-            "token_processed": req_meta.token_processed,
-            "store_block_cursor": req_meta.store_block_cursor,
-            "allocated_group_lens": [
-                len(group_blocks) for group_blocks in req_meta.allocated_group_block_ids
-            ],
-            "recorded_block_count": len(recorded_blocks),
-            "recorded_block_range": recorded_range,
-            "sample_row_segment_lens": sample_rows,
-        }
-
-    def _record_ready_group_block_ids(
-        self,
-        req_meta: FAWARequestMeta,
-    ) -> None:
-        allocated_group_block_ids = req_meta.allocated_group_block_ids
-        if not allocated_group_block_ids:
-            return
-        max_full_blocks = req_meta.num_token_ids // self.hash_block_size
-        start_block = self._get_contiguous_recorded_end_block(
-            req_meta,
-            0,
-            max_full_blocks,
-        )
-        # Continue from the first unrecorded canonical block. Later chunk
-        # prefill steps may append enough group blocks to complete more rows.
-        for canonical_block_idx in range(start_block, max_full_blocks):
-            allow_null_tail = canonical_block_idx < req_meta.total_hit_block_num - 1
-            group_block_ids = self._try_select_group_block_ids(
-                allocated_group_block_ids,
-                (canonical_block_idx + 1) * self.hash_block_size,
-                allow_null_tail=allow_null_tail,
-            )
-            if group_block_ids is None:
-                break
-            req_meta.group_block_ids[canonical_block_idx] = group_block_ids
-
     def _lookup_external_hit_blocks(self, external_keys: list[bytes]) -> int:
         if self.fa_store is None:
             raise RuntimeError("FA store is not initialized.")
         if self.wa_store is None:
             raise RuntimeError("WA store is not initialized.")
         fa_hit_blocks = self.fa_store.lookup_on_prefix(external_keys) + 1
-        window_hit_blocks = self.wa_store.lookup_on_prefix(external_keys) + 1
-        return min(fa_hit_blocks, window_hit_blocks)
+        if fa_hit_blocks <= 0:
+            return 0
+
+        # WA rows represent window boundary state, so they are not required to
+        # form a prefix. Search only inside the FA-contiguous hit range and use
+        # the latest boundary that exists.
+        window_hits = self.wa_store.lookup(external_keys[:fa_hit_blocks])
+        for hit_idx in range(len(window_hits) - 1, -1, -1):
+            if window_hits[hit_idx]:
+                return hit_idx + 1
+        return 0
 
     def get_num_new_matched_tokens(
         self,
@@ -1524,10 +626,7 @@ class UCMFAWAConnector(UCMDirectConnector):
         if self.persist_token_threshold > request.num_tokens:
             return 0, False
 
-        external_keys = [
-            self._block_key(block_hash)
-            for block_hash in canonical_hashes[hbm_hit_block_num:]
-        ]
+        external_keys = canonical_hashes[hbm_hit_block_num:]
         if not external_keys:
             return 0, False
 
@@ -1552,9 +651,7 @@ class UCMFAWAConnector(UCMDirectConnector):
             total_hit_block_num=total_hit_block_num,
             num_token_ids=len(request.all_token_ids),
             token_processed=num_total_hit_tokens,
-            store_block_cursor=total_hit_block_num,
         )
-
         logger.info_once(
             f"FAWA request_id: {request.request_id}, "
             f"total_blocks_num: {len(canonical_hashes)}, "
@@ -1569,147 +666,171 @@ class UCMFAWAConnector(UCMDirectConnector):
         blocks: "KVCacheBlocks",
         num_external_tokens: int,
     ) -> None:
-        req_meta = self.requests_meta.get(request.request_id)
-        if req_meta is None:
-            return
+        pass
 
-        try:
-            self._replace_allocated_blocks(req_meta, blocks)
-            logger.info(
-                f"request {request.request_id} FAWA req_meta after "
-                f"replace_allocated_blocks: "
-                f"{self._summarize_request_meta(req_meta)}"
-            )
-        except Exception as e:
-            logger.error(
-                f"request {request.request_id} record FAWA HBM-aligned "
-                f"block ids failed. {type(e).__name__}: {e}"
-            )
-            raise
-
-    def _make_dispatch_meta(
+    def _slice_group_block_ids(
         self,
-        request_id: str,
+        group_id: int,
+        group_block_ids: list[int],
+        hash_start: int,
+        hash_end: int,
+        window_boundary_token_idx,
+        window_tail_only: bool,
+    ) -> list[int]:
+        if hash_end <= hash_start:
+            return []
+        group_meta = self.group_metas[group_id]
+        if window_tail_only:
+            if not group_meta.tail_tokens:
+                return []
+            boundary_block_idx = (
+                window_boundary_token_idx // group_meta.token_block_size
+            )
+            tail_offsets = np.arange(group_meta.tail_blocks) - (
+                group_meta.tail_blocks - 1
+            )
+            selected_idx = boundary_block_idx[:, None] + tail_offsets[None, :]
+            selected_idx = selected_idx.reshape(-1)
+
+            return np.array(group_block_ids)[selected_idx].tolist()
+        # for fa part, hash_block_size <= token_block_size, at most one block per hash block
+        selected_idx = window_boundary_token_idx // group_meta.token_block_size
+        return np.array(group_block_ids)[selected_idx].tolist()
+
+    def _generate_dispatch_meta(
+        self,
         req_meta: FAWARequestMeta,
         new_tokens: int,
-        need_load: bool,
+        new_vllm_block_ids: tuple[list[int], ...],
+        need_load: bool = True,
     ) -> FAWARequestDispatchMeta:
-        load_keys: list[bytes] = []
-        load_group_block_ids: KVCacheGroupRows = []
-        if need_load and req_meta.total_hit_block_num > req_meta.hbm_hit_block_num:
-            # External-hit loads must have a complete contiguous plan; vLLM has
-            # already treated these tokens as computed.
-            load_end_block = self._get_contiguous_recorded_end_block(
-                req_meta,
-                req_meta.hbm_hit_block_num,
-                req_meta.total_hit_block_num,
-            )
-            if load_end_block < req_meta.total_hit_block_num:
-                raise RuntimeError(
-                    f"request {request_id} FAWA load plan is missing group block "
-                    f"ids for canonical blocks "
-                    f"[{load_end_block}, {req_meta.total_hit_block_num})."
-                )
-            load_keys, load_group_block_ids = self._block_keys_and_rows(
-                req_meta,
-                range(req_meta.hbm_hit_block_num, load_end_block),
-            )
+        """
+        Request Blocks layout:
+        ----------------------------------------------------------------------------------------------------
+        | local_computed_block(HBM hit) | external_computed_block(external hit) | new_block(need to dump)  |
+        ----------------------------------------------------------------------------------------------------
+        |      hbm_hit_block_num        |                 LOAD                  |     new_blocks_num       |
+        ----------------------------------------------------------------------------------------------------
+        |                              total_hit_block_num                      |
+        ----------------------------------------------------------------------------------------------------
+        |                                         scheduled_block_num                                      |
+        """
 
-        dump_keys: list[bytes] = []
-        dump_group_block_ids: KVCacheGroupRows = []
+        if not req_meta.vllm_block_ids:
+            req_meta.vllm_block_ids = tuple([] for _ in self.group_metas)
+        if len(new_vllm_block_ids) != len(req_meta.vllm_block_ids):
+            raise RuntimeError(
+                f"FAWA dispatch metadata expected {len(req_meta.vllm_block_ids)} "
+                f"KV cache groups, got {len(new_vllm_block_ids)}."
+            )
+        for group_id, block_ids in enumerate(new_vllm_block_ids):
+            req_meta.vllm_block_ids[group_id].extend(block_ids)
+
+        all_group_block_ids = req_meta.vllm_block_ids
+        load_block_keys: list[bytes] = []
+        load_start, load_end = 0, 0
+        load_vllm_block_ids: list[list[int]] = []
+        if need_load and req_meta.total_hit_block_num > req_meta.hbm_hit_block_num:
+            load_start = req_meta.hbm_hit_block_num
+            load_end = req_meta.total_hit_block_num
+            load_block_keys = req_meta.ucm_block_ids[load_start:load_end]
+            window_boundary_token_idx = (
+                np.arange(load_start, load_end) * self.hash_block_size - 1
+            )
+            for group_id, group_block_ids in enumerate(all_group_block_ids):
+                is_window_group = group_id in self.window_group_ids
+                load_vllm_block_ids.append(
+                    self._slice_group_block_ids(
+                        group_id,
+                        group_block_ids,
+                        load_end - 1 if is_window_group else load_start,
+                        load_end,
+                        (
+                            window_boundary_token_idx[-1:]
+                            if is_window_group
+                            else window_boundary_token_idx
+                        ),
+                        window_tail_only=is_window_group,
+                    )
+                )
+
         computed_end_token = min(
             req_meta.num_token_ids,
             req_meta.token_processed + new_tokens,
         )
-        if req_meta.store_block_cursor < req_meta.num_token_ids // self.hash_block_size:
-            start_block = req_meta.store_block_cursor
-            candidate_end_block = computed_end_token // self.hash_block_size
-            # Store only full canonical blocks whose group rows are available.
-            end_block = self._get_contiguous_recorded_end_block(
-                req_meta,
-                start_block,
-                candidate_end_block,
+        dump_start = req_meta.token_processed // self.hash_block_size
+        dump_end = computed_end_token // self.hash_block_size
+        dump_block_keys: list[bytes] = []
+        dump_vllm_block_ids: list[list[int]] = []
+        if dump_end > dump_start:
+            dump_block_keys = req_meta.ucm_block_ids[dump_start:dump_end]
+            window_boundary_token_idx = (
+                np.arange(dump_start, dump_end) * self.hash_block_size - 1
             )
-            if end_block > start_block:
-                dump_keys, dump_group_block_ids = self._block_keys_and_rows(
-                    req_meta,
-                    range(start_block, end_block),
+            for group_id, group_block_ids in enumerate(all_group_block_ids):
+                dump_vllm_block_ids.append(
+                    self._slice_group_block_ids(
+                        group_id,
+                        group_block_ids,
+                        dump_start,
+                        dump_end,
+                        window_boundary_token_idx,
+                        window_tail_only=group_id in self.window_group_ids,
+                    )
                 )
-                req_meta.store_block_cursor = end_block
-            req_meta.token_processed = computed_end_token
+        req_meta.token_processed = computed_end_token
 
         return FAWARequestDispatchMeta(
-            (load_keys, load_group_block_ids),
-            (dump_keys, dump_group_block_ids),
+            load_keys=load_block_keys,
+            load_hash_start=load_start,
+            load_hash_end=load_end,
+            load_vllm_block_ids=tuple(load_vllm_block_ids),
+            dump_keys=dump_block_keys,
+            dump_hash_start=dump_start,
+            dump_hash_end=dump_end,
+            dump_vllm_block_ids=tuple(dump_vllm_block_ids),
         )
-
-    def _get_contiguous_recorded_end_block(
-        self,
-        req_meta: FAWARequestMeta,
-        start_block: int,
-        stop_block: int,
-    ) -> int:
-        end_block = start_block
-        for block_idx in range(start_block, stop_block):
-            if block_idx not in req_meta.group_block_ids:
-                break
-            end_block = block_idx + 1
-        return end_block
-
-    def _block_keys_and_rows(
-        self,
-        req_meta: FAWARequestMeta,
-        block_indices: range,
-    ) -> tuple[list[bytes], KVCacheGroupRows]:
-        indices = list(block_indices)
-        return (
-            [self._block_key(req_meta.ucm_block_ids[idx]) for idx in indices],
-            [req_meta.group_block_ids[idx] for idx in indices],
-        )
-
-    @staticmethod
-    def _scheduled_cached_new_block_ids(
-        cached,
-        index: int,
-    ) -> tuple[list[int], ...] | None:
-        if index >= len(cached.new_block_ids):
-            return None
-        return cached.new_block_ids[index]
 
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput
     ) -> KVConnectorMetadata:
         requests_dispatch_meta: dict[str, FAWARequestDispatchMeta] = {}
-
+        # for new request, we need to load and dump
         for request in scheduler_output.scheduled_new_reqs:
-            req_meta = self.requests_meta.get(request.req_id)
+            request_id, vllm_block_ids = request.req_id, request.block_ids
+            req_meta = self.requests_meta.get(request_id)
             if req_meta:
-                requests_dispatch_meta[request.req_id] = self._make_dispatch_meta(
-                    request.req_id,
+                requests_dispatch_meta[request_id] = self._generate_dispatch_meta(
                     req_meta,
-                    scheduler_output.num_scheduled_tokens[request.req_id],
-                    True,
+                    scheduler_output.num_scheduled_tokens[request_id],
+                    tuple(vllm_block_ids),
                 )
 
-        cached = scheduler_output.scheduled_cached_reqs
-        for i, request_id in enumerate(cached.req_ids):
+        scheduled_cached_reqs = scheduler_output.scheduled_cached_reqs
+        for i, request_id in enumerate(scheduled_cached_reqs.req_ids):
             req_meta = self.requests_meta.get(request_id)
-            if not req_meta:
-                continue
-            resumed = request_id in cached.resumed_req_ids
-            # Running chunk-prefill requests receive later allocations through
-            # scheduled_cached_reqs.new_block_ids, not update_state_after_alloc().
-            self._record_allocated_group_block_ids(
-                req_meta,
-                self._scheduled_cached_new_block_ids(cached, i),
-                replace=resumed,
-            )
-            requests_dispatch_meta[request_id] = self._make_dispatch_meta(
-                request_id,
-                req_meta,
-                scheduler_output.num_scheduled_tokens[request_id],
-                resumed,
-            )
+            if req_meta:
+                new_block_ids = scheduled_cached_reqs.new_block_ids[i]
+                if new_block_ids is None:
+                    new_block_ids = tuple([] for _ in self.group_metas)
+                else:
+                    new_block_ids = tuple(new_block_ids)
+                if hasattr(scheduled_cached_reqs, "resumed_from_preemption"):
+                    resumed_from_preemption = (
+                        scheduled_cached_reqs.resumed_from_preemption[i]
+                    )
+                else:
+                    resumed_from_preemption = (
+                        request_id in scheduled_cached_reqs.resumed_req_ids
+                    )
+                if resumed_from_preemption:
+                    req_meta.vllm_block_ids = tuple([] for _ in self.group_metas)
+                requests_dispatch_meta[request_id] = self._generate_dispatch_meta(
+                    req_meta,
+                    scheduler_output.num_scheduled_tokens[request_id],
+                    new_block_ids,
+                    need_load=resumed_from_preemption,
+                )
 
         for request_id in scheduler_output.finished_req_ids:
             self.requests_meta.pop(request_id, None)
@@ -1725,15 +846,11 @@ class UCMFAWAConnector(UCMDirectConnector):
     ) -> tuple[set[str] | None, set[str] | None]:
         return None, None
 
-    def build_connector_worker_meta(self) -> KVConnectorWorkerMetadata | None:
-        return None
-
     def request_finished_all_groups(
         self,
         request: "Request",
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, object] | None]:
-        self.requests_meta.pop(request.request_id, None)
         return False, None
 
     def _submit_load_task(
@@ -1762,31 +879,12 @@ class UCMFAWAConnector(UCMDirectConnector):
     ) -> None:
         try:
             load_task.store.wait(load_task.task)
-            logger.info(
-                f"request {load_task.request_id} FAWA load "
-                f"task label={load_task.label} succeeded, "
-                f"blocks={load_task.key_count}"
-            )
         except Exception as e:
             logger.error(
                 f"request {load_task.request_id} wait FAWA load "
                 f"task label={load_task.label} error. {type(e).__name__}: {e}"
             )
             self._invalid_block_ids.update(load_task.anchor_vllm_block_ids)
-
-    @staticmethod
-    def _row_anchor_vllm_block_ids(group_rows: KVCacheGroupRows) -> set[int]:
-        anchor_block_ids: set[int] = set()
-        for group_row in group_rows:
-            if not group_row:
-                continue
-            # vLLM currently handles load failures by matching block ids
-            # against the first KV-cache group. Report that anchor block id
-            # even when a non-anchor FAWA group load fails.
-            for segment in group_row[0]:
-                if segment.block_id >= 0:
-                    anchor_block_ids.add(segment.block_id)
-        return anchor_block_ids
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         """
@@ -1799,6 +897,34 @@ class UCMFAWAConnector(UCMDirectConnector):
         res = self._invalid_block_ids
         self._invalid_block_ids = set()
         return res
+
+    @staticmethod
+    def _first_group_anchor_ids(
+        candidate_vllm_ids: tuple[list[int], ...],
+    ) -> set[int]:
+        if not candidate_vllm_ids:
+            return set()
+        return {block_id for block_id in candidate_vllm_ids[0] if block_id >= 0}
+
+    def _first_group_anchor_ids_for_hash_range(
+        self,
+        candidate_vllm_ids: tuple[list[int], ...],
+        hash_start: int,
+        hash_end: int,
+        candidate_hash_start: int,
+    ) -> set[int]:
+        if not candidate_vllm_ids or hash_end <= hash_start:
+            return set()
+        first_group_ids = candidate_vllm_ids[0]
+        start = hash_start - candidate_hash_start
+        end = hash_end - candidate_hash_start
+        if start < 0 or end > len(first_group_ids):
+            raise RuntimeError(
+                f"FAWA load anchor range [{hash_start}, {hash_end}) is outside "
+                f"candidate base={candidate_hash_start}, "
+                f"candidates={len(first_group_ids)}."
+            )
+        return {block_id for block_id in first_group_ids[start:end] if block_id >= 0}
 
     def _submit_dump_task(
         self,
@@ -1819,10 +945,74 @@ class UCMFAWAConnector(UCMDirectConnector):
 
     def _wait_dump_task(self, dump_task: FAWADumpTask) -> None:
         dump_task.store.wait(dump_task.task)
-        logger.info(
-            f"FAWA dump task label={dump_task.label} succeeded, "
-            f"blocks={dump_task.key_count}"
-        )
+
+    def _extract_fa_ptr(self, store_keys, hash_start, hash_end, candidate_vllm_ids):
+        """
+        this function need to extract the data ptr, but for Ascend need to consider more
+        hash_start, hash_end is the range of the contiguous part needs to be load or dump
+        the relation of hash_start, hash_end and candidate_vllm_ids can refer _generate_dispatch_meta func
+        for each hash_block_idx, we can get the vllm block id and offset for each group's tensor
+        """
+        if not store_keys:
+            return np.empty((0, 0), dtype=np.uint64)
+        if len(store_keys) != hash_end - hash_start:
+            raise ValueError(
+                f"FA KV cache store key count {len(store_keys)} does not match "
+                f"hash range [{hash_start}, {hash_end})."
+            )
+
+        all_ptrs = []
+        for group_id in self.fa_group_ids:
+            layout = self.group_layouts.get(group_id)
+            if layout is None:
+                continue
+            meta = self.group_metas[group_id]
+            block_ids = np.asarray(candidate_vllm_ids[group_id], dtype=np.uint64)
+            token_start = np.arange(hash_start, hash_end) * self.hash_block_size
+            token_offsets = token_start % meta.token_block_size
+            group_ptrs = layout.extract_segment_addrs_batch(
+                block_ids, token_offsets, meta.token_block_size
+            )
+            all_ptrs.append(group_ptrs)
+
+        return np.concatenate(all_ptrs, axis=1)
+
+    def _extract_wa_ptr(self, store_keys, hash_start, hash_end, candidate_vllm_ids):
+        """
+        samilar as _extract_fa_ptr, but for Ascend need to consider more
+        """
+        if not store_keys:
+            return np.empty((0, 0), dtype=np.uint64)
+        if len(store_keys) != hash_end - hash_start:
+            raise ValueError(
+                f"WA KV cache store key count {len(store_keys)} does not match "
+                f"hash range [{hash_start}, {hash_end})."
+            )
+
+        all_ptrs = []
+        for group_id in self.window_group_ids:
+            layout = self.group_layouts.get(group_id)
+            if layout is None:
+                continue
+            meta = self.group_metas[group_id]
+            if not meta.tail_tokens:
+                continue
+
+            block_ids = np.asarray(candidate_vllm_ids[group_id], dtype=np.uint64)
+            if meta.tail_blocks == 1:
+                token_offsets = np.ones_like(block_ids) * (
+                    meta.token_block_size - meta.tail_tokens
+                )
+            else:
+                token_offsets = np.zeros_like(block_ids)
+
+            group_ptrs = layout.extract_segment_addrs_batch(
+                block_ids, token_offsets, meta.token_block_size
+            )
+            group_ptrs = group_ptrs.reshape(len(store_keys), -1)
+            all_ptrs.append(group_ptrs)
+
+        return np.concatenate(all_ptrs, axis=1)
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         metadata = self._get_connector_metadata()
@@ -1831,37 +1021,46 @@ class UCMFAWAConnector(UCMDirectConnector):
 
         tasks: list[FAWALoadTask] = []
         for request_id, request in metadata.request_meta.items():
-            keys, group_rows = request.load_block_ids
-            if not keys:
+            if not request.load_keys:
                 continue
+            fa_anchor_vllm_block_ids = {
+                block_id for block_id in request.load_vllm_block_ids[0] if block_id >= 0
+            }
+            wa_anchor_vllm_block_ids = set()
+            current_anchor_vllm_block_ids = fa_anchor_vllm_block_ids
             try:
                 if self.fa_store is None:
                     raise RuntimeError("FA store is not initialized.")
+                if self.wa_store is None:
+                    raise RuntimeError("WA store is not initialized.")
+
                 # FA groups are loaded for every external-hit canonical block.
-                fa_ptrs = self._extract_group_addrs(
-                    self._select_rows(group_rows, self.fa_group_ids),
-                    self.fa_group_ids,
+                fa_ptrs = self._extract_fa_ptr(
+                    request.load_keys,
+                    request.load_hash_start,
+                    request.load_hash_end,
+                    request.load_vllm_block_ids,
                 )
                 tasks.append(
                     self._submit_load_task(
                         request_id,
                         "FA",
                         self.fa_store,
-                        keys,
+                        request.load_keys,
                         fa_ptrs,
-                        self._row_anchor_vllm_block_ids(group_rows),
+                        fa_anchor_vllm_block_ids,
                     )
                 )
 
-                if self.wa_store is None:
-                    raise RuntimeError("WA store is not initialized.")
                 # WA groups only need the final matched boundary.
-                window_keys = keys[-1:]
-                window_rows = self._select_rows(group_rows[-1:], self.window_group_ids)
-                window_ptrs = self._extract_group_addrs(
-                    window_rows,
-                    self.window_group_ids,
-                    scratch_for_missing=True,
+                window_keys = request.load_keys[-1:]
+                wa_anchor_vllm_block_ids = {request.load_vllm_block_ids[0][-1]}
+                current_anchor_vllm_block_ids = wa_anchor_vllm_block_ids
+                window_ptrs = self._extract_wa_ptr(
+                    window_keys,
+                    request.load_hash_end - 1,
+                    request.load_hash_end,
+                    request.load_vllm_block_ids,
                 )
                 tasks.append(
                     self._submit_load_task(
@@ -1870,7 +1069,7 @@ class UCMFAWAConnector(UCMDirectConnector):
                         self.wa_store,
                         window_keys,
                         window_ptrs,
-                        self._row_anchor_vllm_block_ids(group_rows[-1:]),
+                        wa_anchor_vllm_block_ids,
                     )
                 )
             except Exception as e:
@@ -1878,9 +1077,7 @@ class UCMFAWAConnector(UCMDirectConnector):
                     f"request {request_id} submit FAWA load task "
                     f"error. {type(e).__name__}: {e}"
                 )
-                self._invalid_block_ids.update(
-                    self._row_anchor_vllm_block_ids(group_rows)
-                )
+                self._invalid_block_ids.update(current_anchor_vllm_block_ids)
 
         for load_task in tasks:
             self._wait_load_task(load_task)
@@ -1900,210 +1097,56 @@ class UCMFAWAConnector(UCMDirectConnector):
             if self.wa_store is None:
                 raise RuntimeError("WA store is not initialized.")
 
+            total_keys: list[bytes] = []
+            fa_ptr_rows: list[np.ndarray] = []
+            wa_ptr_rows: list[np.ndarray] = []
             for request in metadata.request_meta.values():
-                req_keys, req_group_rows = request.dump_block_ids
-                if not req_keys:
+                if not request.dump_keys:
                     continue
+                total_keys.extend(request.dump_keys)
+                fa_ptr_rows.append(
+                    self._extract_fa_ptr(
+                        request.dump_keys,
+                        request.dump_hash_start,
+                        request.dump_hash_end,
+                        request.dump_vllm_block_ids,
+                    )
+                )
+                wa_ptr_rows.append(
+                    self._extract_wa_ptr(
+                        request.dump_keys,
+                        request.dump_hash_start,
+                        request.dump_hash_end,
+                        request.dump_vllm_block_ids,
+                    )
+                )
 
-                tasks: list[FAWADumpTask] = []
-                # Dump the same canonical keys to both stores with different rows.
-                fa_ptrs = self._extract_group_addrs(
-                    self._select_rows(req_group_rows, self.fa_group_ids),
-                    self.fa_group_ids,
+            if not total_keys:
+                return
+
+            fa_ptrs = np.vstack(fa_ptr_rows)
+            window_ptrs = np.vstack(wa_ptr_rows)
+            tasks: list[FAWADumpTask] = []
+
+            tasks.append(
+                self._submit_dump_task(
+                    "FA",
+                    self.fa_store,
+                    total_keys,
+                    fa_ptrs,
+                    event_handle,
                 )
-                tasks.append(
-                    self._submit_dump_task(
-                        "FA",
-                        self.fa_store,
-                        req_keys,
-                        fa_ptrs,
-                        event_handle,
-                    )
+            )
+            tasks.append(
+                self._submit_dump_task(
+                    "WA",
+                    self.wa_store,
+                    total_keys,
+                    window_ptrs,
+                    event_handle,
                 )
-                window_ptrs = self._extract_group_addrs(
-                    self._select_rows(req_group_rows, self.window_group_ids),
-                    self.window_group_ids,
-                    scratch_for_missing=True,
-                )
-                tasks.append(
-                    self._submit_dump_task(
-                        "WA",
-                        self.wa_store,
-                        req_keys,
-                        window_ptrs,
-                        event_handle,
-                    )
-                )
-                for dump_task in tasks:
-                    self._wait_dump_task(dump_task)
+            )
+            for dump_task in tasks:
+                self._wait_dump_task(dump_task)
         except Exception as e:
             logger.error(f"dump FAWA kv cache failed. {type(e).__name__}: {e}")
-
-
-class UCMAscendFAWAConnector(UCMFAWAConnector):
-    """Ascend FAWA connector with segmented tensor KV block mapping."""
-
-    def _create_block_span_layout(self) -> Optional[FAWABlockSpanLayout]:
-        return FAWABlockSpanLayout(self._kv_cache_config, self.fa_group_ids)
-
-    def _get_hash_block_size(self) -> int:
-        if self.block_span_layout is None:
-            raise RuntimeError("Ascend FAWA connector requires block span layout.")
-        return self.block_span_layout.hash_block_size
-
-    def _get_group_token_block_sizes(self) -> tuple[int, ...]:
-        if self.block_span_layout is None:
-            raise RuntimeError("Ascend FAWA connector requires block span layout.")
-        self._ascend_layout = self.block_span_layout.is_ascend
-        group_token_block_sizes = self.block_span_layout.group_token_block_sizes
-        self._validate_group_token_block_sizes(group_token_block_sizes)
-        return group_token_block_sizes
-
-    def _get_group_tensor_block_sizes(self) -> tuple[int, ...]:
-        if self.block_span_layout is None:
-            raise RuntimeError("Ascend FAWA connector requires block span layout.")
-        return self.block_span_layout.group_tensor_block_sizes
-
-    def _ascend_window_tail_tokens(self, group_id: int) -> Optional[int]:
-        group_spec = self._kv_cache_config.kv_cache_groups[group_id]
-        window_tokens = FAWABlockSpanLayout.group_window_tokens(group_spec)
-        if window_tokens is None or self.block_span_layout.is_swa_group(group_id):
-            return window_tokens
-        compress_ratio = self.block_span_layout.state_compress_ratio(group_id)
-        if compress_ratio is None:
-            return window_tokens
-        return max(0, window_tokens - compress_ratio)
-
-    def _get_group_tail_blocks(self) -> tuple[Optional[int], ...]:
-        tail_blocks: list[Optional[int]] = [None] * len(self.group_token_block_sizes)
-        for group_id in self.window_group_ids:
-            group_token_block_size = self.group_token_block_sizes[group_id]
-            window_tail_tokens = self._ascend_window_tail_tokens(group_id)
-            if window_tail_tokens is None:
-                tail_blocks[group_id] = self.hash_block_size // group_token_block_size
-            elif window_tail_tokens == 0:
-                tail_blocks[group_id] = 0
-            elif self.block_span_layout.is_swa_group(group_id):
-                tail_blocks[group_id] = max(
-                    1,
-                    math.ceil(window_tail_tokens / group_token_block_size),
-                )
-            else:
-                tail_blocks[group_id] = math.ceil(
-                    window_tail_tokens / group_token_block_size
-                )
-        return tuple(tail_blocks)
-
-    def _get_group_window_spans(self) -> tuple[tuple[int, ...], ...]:
-        spans: list[tuple[int, ...]] = []
-        for group_id, tail_blocks in enumerate(self.group_tail_blocks):
-            if tail_blocks is None:
-                spans.append((self.group_token_block_sizes[group_id],))
-                continue
-            if tail_blocks == 0:
-                spans.append(())
-                continue
-            window_tail_tokens = self._ascend_window_tail_tokens(group_id)
-            if window_tail_tokens is None or self.block_span_layout.is_swa_group(
-                group_id
-            ):
-                spans.append((self.group_token_block_sizes[group_id],) * tail_blocks)
-                continue
-            group_token_block_size = self.group_token_block_sizes[group_id]
-            group_spans: list[int] = []
-            while window_tail_tokens > 0:
-                segment_tokens = min(group_token_block_size, window_tail_tokens)
-                group_spans.append(segment_tokens)
-                window_tail_tokens -= segment_tokens
-            spans.append(tuple(reversed(group_spans)))
-        return tuple(spans)
-
-    def _group_block_range(self, group_id: int, computed_end_token: int) -> range:
-        if (
-            self.group_tail_blocks[group_id] is None
-            or self.group_tail_blocks[group_id] == 0
-            or self.block_span_layout.is_swa_group(group_id)
-        ):
-            return super()._group_block_range(group_id, computed_end_token)
-
-        window_tail_tokens = self._ascend_window_tail_tokens(group_id)
-        if window_tail_tokens is None:
-            return super()._group_block_range(group_id, computed_end_token)
-        if window_tail_tokens == 0:
-            return range(0, 0)
-
-        group_token_block_size = self.group_token_block_sizes[group_id]
-        tail_end_token = computed_end_token
-        tail_start_token = max(0, tail_end_token - window_tail_tokens)
-        start_block = tail_start_token // group_token_block_size
-        end_block = math.ceil(tail_end_token / group_token_block_size)
-        return range(start_block, end_block)
-
-    def _block_index_to_segment(
-        self,
-        group_id: int,
-        group_block_idx: int,
-        block_id: int,
-        computed_end_token: Optional[int] = None,
-    ) -> KVCacheSegment:
-        segment = super()._block_index_to_segment(group_id, group_block_idx, block_id)
-        return self._trim_window_segment(
-            group_id,
-            group_block_idx,
-            computed_end_token,
-            segment,
-        )
-
-    def _make_missing_segment(
-        self,
-        group_id: int,
-        group_block_idx: int,
-        computed_end_token: Optional[int] = None,
-    ) -> KVCacheSegment:
-        segment = super()._make_missing_segment(group_id, group_block_idx)
-        return self._trim_window_segment(
-            group_id,
-            group_block_idx,
-            computed_end_token,
-            segment,
-        )
-
-    def _trim_window_segment(
-        self,
-        group_id: int,
-        group_block_idx: int,
-        computed_end_token: Optional[int],
-        segment: KVCacheSegment,
-    ) -> KVCacheSegment:
-        if (
-            group_id not in self.window_group_ids
-            or self.group_tail_blocks[group_id] is None
-            or self.group_tail_blocks[group_id] == 0
-            or self.block_span_layout.is_swa_group(group_id)
-        ):
-            return segment
-
-        window_tail_tokens = self._ascend_window_tail_tokens(group_id)
-        if window_tail_tokens is None:
-            return segment
-        if window_tail_tokens == 0:
-            return segment
-
-        group_token_block_size = self.group_token_block_sizes[group_id]
-        tail_end_token = (
-            computed_end_token
-            if computed_end_token is not None
-            else (group_block_idx + 1) * group_token_block_size
-        )
-        tail_start_token = max(0, tail_end_token - window_tail_tokens)
-        block_start_token = group_block_idx * group_token_block_size
-        segment_start_in_block = max(0, tail_start_token - block_start_token)
-        segment_end_in_block = min(
-            group_token_block_size, tail_end_token - block_start_token
-        )
-        length = max(0, segment_end_in_block - segment_start_in_block)
-        return KVCacheSegment(
-            block_id=segment.block_id,
-            offset=segment.offset + segment_start_in_block,
-            length=length,
-        )

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -497,8 +497,11 @@ class UCMFAWAConnector(UCMDirectConnector):
                 raise RuntimeError(f"Worker FAWA {label} store needs tensor sizes.")
             config["device_id"] = self.local_rank
             config["tensor_size_list"] = tensor_size_list
-            config["shard_size"] = int(sum(tensor_size_list))
-            config["block_size"] = int(sum(tensor_size_list))
+            # for io_direct support, shard_size & block_size should be aligned with 4KB
+            aligned_size = 4096
+            padded_size = ((sum(tensor_size_list) + aligned_size - 1) // aligned_size) * aligned_size
+            config["shard_size"] = padded_size
+            config["block_size"] = padded_size 
             # MLA stores aggregate TP shards under one logical rank group.
             config["local_rank_size"] = self.tp_size if self.is_mla else 1
             if cpu_affinity_cores:

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -499,9 +499,11 @@ class UCMFAWAConnector(UCMDirectConnector):
             config["tensor_size_list"] = tensor_size_list
             # for io_direct support, shard_size & block_size should be aligned with 4KB
             aligned_size = 4096
-            padded_size = ((sum(tensor_size_list) + aligned_size - 1) // aligned_size) * aligned_size
+            padded_size = (
+                (sum(tensor_size_list) + aligned_size - 1) // aligned_size
+            ) * aligned_size
             config["shard_size"] = padded_size
-            config["block_size"] = padded_size 
+            config["block_size"] = padded_size
             # MLA stores aggregate TP shards under one logical rank group.
             config["local_rank_size"] = self.tp_size if self.is_mla else 1
             if cpu_affinity_cores:

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -610,10 +610,11 @@ class UCMFAWAConnector(UCMDirectConnector):
         # WA rows represent window boundary state, so they are not required to
         # form a prefix. Search only inside the FA-contiguous hit range and use
         # the latest boundary that exists.
-        window_hits = self.wa_store.lookup(external_keys[:fa_hit_blocks])
-        for hit_idx in range(len(window_hits) - 1, -1, -1):
-            if window_hits[hit_idx]:
-                return hit_idx + 1
+        for hit_blocks in range(fa_hit_blocks, -1, -1):
+            # TODO: Add Posix SpaceManager::LookupOnSuffix() for sparse WA boundary lookups, where only the latest existing key is needed.
+            key = external_keys[hit_blocks - 1]
+            if self.wa_store.lookup([key])[0]:
+                return hit_blocks
         return 0
 
     def get_num_new_matched_tokens(

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -152,11 +152,11 @@ class KVCacheGroupLayout:
             f"tensor_block_sizes={sorted(set(tensor_block_sizes))}"
         )
 
-    def extract_segment_addrs_batch(
+    def extract_addrs_with_offsets(
         self,
         block_ids: np.ndarray,
-        offsets: np.ndarray,
         group_token_block_size: int,
+        offsets: np.ndarray,
     ) -> np.ndarray:
 
         physical_token_offsets = (
@@ -169,6 +169,14 @@ class KVCacheGroupLayout:
             block_ids[:, None] * self.block_strides[None, :]
             + physical_token_offsets * self.tensor_token_strides[None, :]
             + self.base_ptrs[None, :]
+        ).astype(np.uint64, copy=False)
+
+    def extract_addrs(
+        self,
+        block_ids: np.ndarray,
+    ) -> np.ndarray:
+        return (
+            block_ids[:, None] * self.block_strides[None, :] + self.base_ptrs[None, :]
         ).astype(np.uint64, copy=False)
 
     def segment_tensor_size_list(
@@ -672,30 +680,24 @@ class UCMFAWAConnector(UCMDirectConnector):
         self,
         group_id: int,
         group_block_ids: list[int],
-        hash_start: int,
-        hash_end: int,
-        window_boundary_token_idx,
-        window_tail_only: bool,
+        window_boundary_token_idx: np.ndarray,
     ) -> list[int]:
-        if hash_end <= hash_start:
-            return []
+        is_window_group = group_id in self.window_group_ids
         group_meta = self.group_metas[group_id]
-        if window_tail_only:
+        if is_window_group:
             if not group_meta.tail_tokens:
                 return []
+            # current only care the last hash block's wa cache
             boundary_block_idx = (
-                window_boundary_token_idx // group_meta.token_block_size
-            )
-            tail_offsets = np.arange(group_meta.tail_blocks) - (
-                group_meta.tail_blocks - 1
-            )
-            selected_idx = boundary_block_idx[:, None] + tail_offsets[None, :]
-            selected_idx = selected_idx.reshape(-1)
-
-            return np.array(group_block_ids)[selected_idx].tolist()
+                window_boundary_token_idx[-1] // group_meta.token_block_size
+            ) + 1
+            return group_block_ids[
+                boundary_block_idx - group_meta.tail_blocks : boundary_block_idx
+            ]
         # for fa part, hash_block_size <= token_block_size, at most one block per hash block
-        selected_idx = window_boundary_token_idx // group_meta.token_block_size
-        return np.array(group_block_ids)[selected_idx].tolist()
+        return np.array(group_block_ids)[
+            window_boundary_token_idx // group_meta.token_block_size
+        ].tolist()
 
     def _generate_dispatch_meta(
         self,
@@ -738,19 +740,11 @@ class UCMFAWAConnector(UCMDirectConnector):
                 np.arange(load_start, load_end) * self.hash_block_size - 1
             )
             for group_id, group_block_ids in enumerate(all_group_block_ids):
-                is_window_group = group_id in self.window_group_ids
                 load_vllm_block_ids.append(
                     self._slice_group_block_ids(
                         group_id,
                         group_block_ids,
-                        load_end - 1 if is_window_group else load_start,
-                        load_end,
-                        (
-                            window_boundary_token_idx[-1:]
-                            if is_window_group
-                            else window_boundary_token_idx
-                        ),
-                        window_tail_only=is_window_group,
+                        window_boundary_token_idx,
                     )
                 )
 
@@ -772,10 +766,7 @@ class UCMFAWAConnector(UCMDirectConnector):
                     self._slice_group_block_ids(
                         group_id,
                         group_block_ids,
-                        dump_start,
-                        dump_end,
                         window_boundary_token_idx,
-                        window_tail_only=group_id in self.window_group_ids,
                     )
                 )
         req_meta.token_processed = computed_end_token
@@ -947,20 +938,6 @@ class UCMFAWAConnector(UCMDirectConnector):
         dump_task.store.wait(dump_task.task)
 
     def _extract_fa_ptr(self, store_keys, hash_start, hash_end, candidate_vllm_ids):
-        """
-        this function need to extract the data ptr, but for Ascend need to consider more
-        hash_start, hash_end is the range of the contiguous part needs to be load or dump
-        the relation of hash_start, hash_end and candidate_vllm_ids can refer _generate_dispatch_meta func
-        for each hash_block_idx, we can get the vllm block id and offset for each group's tensor
-        """
-        if not store_keys:
-            return np.empty((0, 0), dtype=np.uint64)
-        if len(store_keys) != hash_end - hash_start:
-            raise ValueError(
-                f"FA KV cache store key count {len(store_keys)} does not match "
-                f"hash range [{hash_start}, {hash_end})."
-            )
-
         all_ptrs = []
         for group_id in self.fa_group_ids:
             layout = self.group_layouts.get(group_id)
@@ -968,27 +945,22 @@ class UCMFAWAConnector(UCMDirectConnector):
                 continue
             meta = self.group_metas[group_id]
             block_ids = np.asarray(candidate_vllm_ids[group_id], dtype=np.uint64)
-            token_start = np.arange(hash_start, hash_end) * self.hash_block_size
-            token_offsets = token_start % meta.token_block_size
-            group_ptrs = layout.extract_segment_addrs_batch(
-                block_ids, token_offsets, meta.token_block_size
-            )
+            # current self.hash_block_size <= meta.token_block_size
+            if self.hash_block_size == meta.token_block_size:
+                # for gpu setting
+                group_ptrs = layout.extract_addrs(block_ids)
+            else:
+                # for npu setting
+                token_start = np.arange(hash_start, hash_end) * self.hash_block_size
+                token_offsets = token_start % meta.token_block_size
+                group_ptrs = layout.extract_addrs_with_offsets(
+                    block_ids, meta.token_block_size, token_offsets
+                )
             all_ptrs.append(group_ptrs)
 
         return np.concatenate(all_ptrs, axis=1)
 
-    def _extract_wa_ptr(self, store_keys, hash_start, hash_end, candidate_vllm_ids):
-        """
-        samilar as _extract_fa_ptr, but for Ascend need to consider more
-        """
-        if not store_keys:
-            return np.empty((0, 0), dtype=np.uint64)
-        if len(store_keys) != hash_end - hash_start:
-            raise ValueError(
-                f"WA KV cache store key count {len(store_keys)} does not match "
-                f"hash range [{hash_start}, {hash_end})."
-            )
-
+    def _extract_wa_ptr(self, store_keys, vllm_ids):
         all_ptrs = []
         for group_id in self.window_group_ids:
             layout = self.group_layouts.get(group_id)
@@ -998,18 +970,19 @@ class UCMFAWAConnector(UCMDirectConnector):
             if not meta.tail_tokens:
                 continue
 
-            block_ids = np.asarray(candidate_vllm_ids[group_id], dtype=np.uint64)
-            if meta.tail_blocks == 1:
+            block_ids = np.asarray(vllm_ids[group_id], dtype=np.uint64)
+            if meta.tail_blocks == 1 and meta.token_block_size > meta.tail_tokens:
                 token_offsets = np.ones_like(block_ids) * (
                     meta.token_block_size - meta.tail_tokens
                 )
+                group_ptrs = layout.extract_addrs_with_offsets(
+                    block_ids, meta.token_block_size, token_offsets
+                )
             else:
                 token_offsets = np.zeros_like(block_ids)
+                group_ptrs = layout.extract_addrs(block_ids)
+                group_ptrs = group_ptrs.reshape(len(store_keys), -1)
 
-            group_ptrs = layout.extract_segment_addrs_batch(
-                block_ids, token_offsets, meta.token_block_size
-            )
-            group_ptrs = group_ptrs.reshape(len(store_keys), -1)
             all_ptrs.append(group_ptrs)
 
         return np.concatenate(all_ptrs, axis=1)
@@ -1023,11 +996,7 @@ class UCMFAWAConnector(UCMDirectConnector):
         for request_id, request in metadata.request_meta.items():
             if not request.load_keys:
                 continue
-            fa_anchor_vllm_block_ids = {
-                block_id for block_id in request.load_vllm_block_ids[0] if block_id >= 0
-            }
-            wa_anchor_vllm_block_ids = set()
-            current_anchor_vllm_block_ids = fa_anchor_vllm_block_ids
+            group0_vllm_block_ids = set(request.load_vllm_block_ids[0])
             try:
                 if self.fa_store is None:
                     raise RuntimeError("FA store is not initialized.")
@@ -1048,18 +1017,14 @@ class UCMFAWAConnector(UCMDirectConnector):
                         self.fa_store,
                         request.load_keys,
                         fa_ptrs,
-                        fa_anchor_vllm_block_ids,
+                        group0_vllm_block_ids,
                     )
                 )
 
                 # WA groups only need the final matched boundary.
                 window_keys = request.load_keys[-1:]
-                wa_anchor_vllm_block_ids = {request.load_vllm_block_ids[0][-1]}
-                current_anchor_vllm_block_ids = wa_anchor_vllm_block_ids
                 window_ptrs = self._extract_wa_ptr(
                     window_keys,
-                    request.load_hash_end - 1,
-                    request.load_hash_end,
                     request.load_vllm_block_ids,
                 )
                 tasks.append(
@@ -1069,7 +1034,7 @@ class UCMFAWAConnector(UCMDirectConnector):
                         self.wa_store,
                         window_keys,
                         window_ptrs,
-                        wa_anchor_vllm_block_ids,
+                        group0_vllm_block_ids,
                     )
                 )
             except Exception as e:
@@ -1077,7 +1042,7 @@ class UCMFAWAConnector(UCMDirectConnector):
                     f"request {request_id} submit FAWA load task "
                     f"error. {type(e).__name__}: {e}"
                 )
-                self._invalid_block_ids.update(current_anchor_vllm_block_ids)
+                self._invalid_block_ids.update(group0_vllm_block_ids)
 
         for load_task in tasks:
             self._wait_load_task(load_task)
@@ -1114,9 +1079,7 @@ class UCMFAWAConnector(UCMDirectConnector):
                 )
                 wa_ptr_rows.append(
                     self._extract_wa_ptr(
-                        request.dump_keys,
-                        request.dump_hash_start,
-                        request.dump_hash_end,
+                        request.dump_keys[-1:],
                         request.dump_vllm_block_ids,
                     )
                 )

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -2642,15 +2642,6 @@ class UCMConnector(KVConnectorBase_V1, SupportsHMA):
             > 1
         )
 
-        from ucm.integration.vllm.hma_connector import (
-            UCMAscendFAWAConnector,
-            UCMFAWAConnector,
-        )
-
-        use_fawa_store = UCMFAWAConnector.can_handle_kv_cache_config(
-            kv_cache_config
-        ) or UCMAscendFAWAConnector.can_handle_ascend_kv_cache_config(kv_cache_config)
-
         use_hma = (
             self._vllm_config.scheduler_config.disable_hybrid_kv_cache_manager is False
             or os.getenv("USE_MULTI_GROUPS_KV_CACHE") == "1"
@@ -2660,15 +2651,10 @@ class UCMConnector(KVConnectorBase_V1, SupportsHMA):
             kv_cache_config
         )
 
-        if use_fawa_store:
-            connector_cls = (
-                UCMAscendFAWAConnector
-                if UCMAscendFAWAConnector.can_handle_ascend_kv_cache_config(
-                    kv_cache_config
-                )
-                else UCMFAWAConnector
-            )
-            self.connector = connector_cls(vllm_config, role, kv_cache_config)
+        from ucm.integration.vllm.hma_connector import UCMFAWAConnector
+
+        if UCMFAWAConnector.can_handle_kv_cache_config(kv_cache_config):
+            self.connector = UCMFAWAConnector(vllm_config, role, kv_cache_config)
         elif use_lite:
             self.connector = UCMLiteConnector(vllm_config, role, kv_cache_config)
         elif use_ratio_rate:

--- a/ucm/store/cache/cc/cache_store.cc
+++ b/ucm/store/cache/cc/cache_store.cc
@@ -152,7 +152,7 @@ private:
         if (config.tensorSizes.empty()) { return Status::InvalidParam("invalid tensor size"); }
         if (config.shardSize == 0) { return Status::InvalidParam("invalid shard size"); }
         if (config.blockSize == 0) { return Status::InvalidParam("invalid block size"); }
-        if (std::accumulate(config.tensorSizes.begin(), config.tensorSizes.end(), size_t(0)) !=
+        if (std::accumulate(config.tensorSizes.begin(), config.tensorSizes.end(), size_t(0)) >
             config.shardSize) {
             return Status::InvalidParam("invalid shard size({})", config.shardSize);
         }


### PR DESCRIPTION
 ## Purpose

  Optimize and simplify the HMA FAWA connector implementation, reducing duplicated Ascend-specific connector logic while keeping FA/WA KV cache load and dump support in the unified FAWA path.

  ## Modifications

  - Refactored ucm/integration/vllm/hma_connector.py
      - Replaced segment-based KV cache mapping with group metadata and batched pointer extraction.
      - Added unified FA/WA pointer extraction logic for load and dump paths.
      - Simplified request metadata to record load/dump keys, hash ranges, and per-group vLLM block ids directly.
      - Batched dump submission across requests to reduce repeated FA/WA store task creation.
      - Removed the separate UCMAscendFAWAConnector and folded Ascend handling into UCMFAWAConnector.
  - Updated ucm/integration/vllm/ucm_connector.py
      - Simplified FAWA connector selection to use UCMFAWAConnector.can_handle_kv_cache_config(...).
      - Removed separate Ascend FAWA connector routing.

  ## Test
verified both on npu & gpu