### PR TITLE
[Feat] Add ASU SQE protocol implementations

### DIFF
--- a/ucm/transport/kv/asu/test/case/link_proto_pack_test.cc
+++ b/ucm/transport/kv/asu/test/case/link_proto_pack_test.cc
@@ -1,0 +1,203 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <cstdint>
+#include <cstring>
+#include <gtest/gtest.h>
+#include "link_proto.h"
+
+namespace UC::ASU {
+namespace {
+
+class LinkProtoPackTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(LinkProtoPackTest, NegotiateSqePackMatchesProtocol)
+{
+    NegotiateRequest req;
+    req.cap = 0;
+    req.private_len = 4;
+    req.major_version = 1;
+    req.minor_version = 0;
+    req.kato = 30;
+
+    NegotiateSqe sqe;
+    auto status = sqe.Pack(req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint8_t> expected(kMsgHeaderSize + kNegotiatePayloadSize, 0);
+
+    // Header: crc(4)=0, ver(1)=1, cmd(1)=0, pad(6)=0, len(4)=160
+    expected[4] = 1;  // ver
+    expected[5] = 0;  // cmd = Negotiate
+    std::uint32_t payload_len = kNegotiatePayloadSize;
+    std::memcpy(&expected[12], &payload_len, 4);
+
+    // Offset 16: cap[31:0] = 0
+    // Offset 20: rsv[23:0] = 0 (already zero)
+    // Offset 44: private_len[31:0]
+    std::memcpy(&expected[44], &req.private_len, 4);
+    // Offset 48: major_version
+    expected[48] = req.major_version;
+    // Offset 49: minor_version
+    expected[49] = req.minor_version;
+    // Offset 50: kato[15:0]
+    std::memcpy(&expected[50], &req.kato, 2);
+
+    ASSERT_EQ(sqe.Size(), expected.size());
+    const auto* packed = static_cast<const std::uint8_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i])
+            << "Mismatch at byte " << i << ": expected 0x" << std::hex
+            << static_cast<int>(expected[i]) << ", got 0x" << static_cast<int>(packed[i]);
+    }
+}
+
+TEST_F(LinkProtoPackTest, HandshakeSqePackMatchesProtocol)
+{
+    HandshakeRequest req;
+    for (int i = 0; i < 16; ++i) { req.gid[i] = static_cast<std::uint8_t>(0xA0 + i); }
+    req.lid = 0x1234;
+    req.mtu = 4;  // 2048 bytes
+    req.total_qp_num = 8;
+    req.sl = 1;
+    req.traffic_class = 2;
+    req.rnr_timer = 3;
+    req.rnr_retry_cnt = 7;
+    req.timeout = 14;
+    req.retry_cnt = 5;
+    req.qp_rd_atom = 6;
+    req.rsv = 0;
+    req.start_psn = 0xDEADBEEF;
+    for (int i = 0; i < 32; ++i) { req.qpn[i] = 0x1000 + i; }
+
+    HandshakeSqe sqe;
+    auto status = sqe.Pack(req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint8_t> expected(kMsgHeaderSize + kHandshakePayloadSize, 0);
+
+    // Header: crc(4)=0, ver(1)=1, cmd(1)=1, pad(6)=0, len(4)=160
+    expected[4] = 1;  // ver
+    expected[5] = 1;  // cmd = Handshake
+    std::uint32_t payload_len = kHandshakePayloadSize;
+    std::memcpy(&expected[12], &payload_len, 4);
+
+    // Offset 16: gid[15:0]
+    std::memcpy(&expected[16], req.gid, 16);
+    // Offset 32: lid[15:0]
+    std::memcpy(&expected[32], &req.lid, 2);
+    // Offset 34: mtu
+    expected[34] = req.mtu;
+    // Offset 35: total_qp_num
+    expected[35] = req.total_qp_num;
+    // Offset 36: sl
+    expected[36] = req.sl;
+    // Offset 37: traffic_class
+    expected[37] = req.traffic_class;
+    // Offset 38: rnr_timer
+    expected[38] = req.rnr_timer;
+    // Offset 39: rnr_retry_cnt
+    expected[39] = req.rnr_retry_cnt;
+    // Offset 40: timeout
+    expected[40] = req.timeout;
+    // Offset 41: retry_cnt
+    expected[41] = req.retry_cnt;
+    // Offset 42: qp_rd_atom
+    expected[42] = req.qp_rd_atom;
+    // Offset 43: rsv
+    expected[43] = req.rsv;
+    // Offset 44: start_psn[31:0]
+    std::memcpy(&expected[44], &req.start_psn, 4);
+    // Offset 48: qpn[32] (128 bytes)
+    std::memcpy(&expected[48], req.qpn, 128);
+
+    ASSERT_EQ(sqe.Size(), expected.size());
+    const auto* packed = static_cast<const std::uint8_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i])
+            << "Mismatch at byte " << i << ": expected 0x" << std::hex
+            << static_cast<int>(expected[i]) << ", got 0x" << static_cast<int>(packed[i]);
+    }
+}
+
+TEST_F(LinkProtoPackTest, HandshakeDoneSqePackMatchesProtocol)
+{
+    HandshakeDoneSqe sqe;
+    auto status = sqe.Pack();
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint8_t> expected(kMsgHeaderSize, 0);
+
+    // Header: crc(4)=0, ver(1)=1, cmd(1)=3, pad(6)=0, len(4)=0
+    expected[4] = 1;  // ver
+    expected[5] = 3;  // cmd = HandshakeDone
+    std::uint32_t payload_len = 0;
+    std::memcpy(&expected[12], &payload_len, 4);
+
+    ASSERT_EQ(sqe.Size(), expected.size());
+    const auto* packed = static_cast<const std::uint8_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i])
+            << "Mismatch at byte " << i << ": expected 0x" << std::hex
+            << static_cast<int>(expected[i]) << ", got 0x" << static_cast<int>(packed[i]);
+    }
+}
+
+TEST_F(LinkProtoPackTest, DisconnectSqePackMatchesProtocol)
+{
+    DisconnectRequest req;
+    req.local_qpn = 0x00010001;
+    req.remote_qpn = 0x00020002;
+
+    DisconnectSqe sqe;
+    auto status = sqe.Pack(req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint8_t> expected(kMsgHeaderSize + kDisconnectPayloadSize, 0);
+
+    // Header: crc(4)=0, ver(1)=1, cmd(1)=4, pad(6)=0, len(4)=8
+    expected[4] = 1;  // ver
+    expected[5] = 4;  // cmd = Disconnect
+    std::uint32_t payload_len = kDisconnectPayloadSize;
+    std::memcpy(&expected[12], &payload_len, 4);
+
+    // Offset 16: local_qpn[31:0]
+    std::memcpy(&expected[16], &req.local_qpn, 4);
+    // Offset 20: remote_qpn[31:0]
+    std::memcpy(&expected[20], &req.remote_qpn, 4);
+
+    ASSERT_EQ(sqe.Size(), expected.size());
+    const auto* packed = static_cast<const std::uint8_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i])
+            << "Mismatch at byte " << i << ": expected 0x" << std::hex
+            << static_cast<int>(expected[i]) << ", got 0x" << static_cast<int>(packed[i]);
+    }
+}
+
+}  // namespace
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/case/sqe_pack_test.cc
+++ b/ucm/transport/kv/asu/test/case/sqe_pack_test.cc
@@ -1,0 +1,411 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <cstdint>
+#include <cstring>
+#include <gtest/gtest.h>
+#include "sqe.h"
+
+namespace UC::ASU {
+namespace {
+
+class SqePackTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(SqePackTest, StoreSqePackMatchesProtocol)
+{
+    // Test values
+    constexpr std::uint32_t kCid = 0x1234;
+    constexpr std::uint32_t kKvNsId = 0x0001;
+    constexpr std::uint8_t kDtype = 0x1;   // 3 bits [15:13]
+    constexpr std::uint8_t kDspec = 0x05;  // 5 bits [12:8]
+    constexpr std::uint64_t kBufferAddr = 0x0000123456789ABCULL;
+    constexpr std::uint32_t kBufferLength = 0x00010000;  // 64KB, 512B aligned
+    constexpr std::uint32_t kMrKey = 0x76543210;
+    constexpr std::uint32_t kOffset = 0x00001000;  // 4KB, 512B aligned
+    constexpr bool kLr = true;
+    constexpr std::uint32_t kLength = 0x00000002;  // 1-based
+    const std::string kKey = "test_key_01";
+
+    // Build request
+    KvStoreRequest req;
+    req.cid = kCid;
+    req.kv_ns_id = kKvNsId;
+    req.dtype = kDtype;
+    req.dspec = kDspec;
+    req.buffer_addr = kBufferAddr;
+    req.buffer_length = kBufferLength;
+    req.mr_key = kMrKey;
+    req.offset = kOffset;
+    req.lr = kLr;
+    req.length = kLength;
+    req.key = kKey;
+
+    // Pack
+    KvStoreSqe sqe;
+    auto status = sqe.Pack(req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    // Build expected buffer according to protocol spec
+    std::vector<std::uint32_t> expected(16, 0);
+
+    // Dword 0: CID[31:16] | Fixed[15:14]=0b11 | Reserved[13:8] | Opcode[7:0]=0x01
+    expected[0] = (kCid << 16) | (0x3 << 14) | 0x01;
+
+    // Dword 1: kv_ns_id[31:0]
+    expected[1] = kKvNsId;
+
+    // Dword 2: DTYPE[15:13] | DSPEC[12:8] | Reserved[7:0]
+    expected[2] = ((kDtype & 0x7) << 13) | ((kDspec & 0x1F) << 8);
+
+    // Dword 3-5: reserved (zero)
+    expected[3] = 0;
+    expected[4] = 0;
+    expected[5] = 0;
+
+    // Dword 6-7: DPTR.buffer[63:0]
+    expected[6] = kBufferAddr & 0xFFFFFFFFULL;
+    expected[7] = (kBufferAddr >> 32) & 0xFFFFFFFFULL;
+
+    // Dword 8: DPTR.key[0]=MR_KEY[31:24] | DPTR.length[23:0]
+    expected[8] = ((kMrKey & 0xFF) << 24) | (kBufferLength & 0xFFFFFF);
+
+    // Dword 9: DPTR.Type[31:24]=0x40 | DPTR.key[3:1][23:0]
+    expected[9] = (0x40 << 24) | ((kMrKey >> 8) & 0xFFFFFF);
+
+    // Dword 10: offset[31:0]
+    expected[10] = kOffset;
+
+    // Dword 11: LR[31] | Reserved[30:24] | Length[23:0]
+    expected[11] = (kLr ? (1U << 31) : 0) | (kLength & 0xFFFFFF);
+
+    // Dword 12-15: key[bytes 15:0] - 16 bytes, low-byte aligned
+    std::size_t key_len = std::min(kKey.size(), static_cast<std::size_t>(16));
+    if (key_len > 0) { std::memcpy(&expected[12], kKey.data(), key_len); }
+
+    // Compare
+    ASSERT_EQ(sqe.Size(), expected.size() * sizeof(std::uint32_t));
+    const auto* packed = static_cast<const std::uint32_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i]) << "Mismatch at Dword " << i << ": expected 0x"
+                                          << std::hex << expected[i] << ", got 0x" << packed[i];
+    }
+}
+
+TEST_F(SqePackTest, RetrieveSqePackMatchesProtocol)
+{
+    constexpr std::uint32_t kCid = 0x5678;
+    constexpr std::uint32_t kKvNsId = 0x0002;
+    constexpr std::uint64_t kBufferAddr = 0x0000FEDCBA987654ULL;
+    constexpr std::uint32_t kBufferLength = 0x00020000;  // 128KB
+    constexpr std::uint32_t kMrKey = 0x12345678;
+    constexpr std::uint32_t kOffset = 0x00002000;  // 8KB
+    constexpr bool kLr = false;
+    constexpr std::uint32_t kLength = 0x00000003;
+    const std::string kKey = "retrieve_key";
+
+    KvRetrieveRequest req;
+    req.cid = kCid;
+    req.kv_ns_id = kKvNsId;
+    req.buffer_addr = kBufferAddr;
+    req.buffer_length = kBufferLength;
+    req.mr_key = kMrKey;
+    req.offset = kOffset;
+    req.lr = kLr;
+    req.length = kLength;
+    req.key = kKey;
+
+    KvRetrieveSqe sqe;
+    auto status = sqe.Pack(req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint32_t> expected(16, 0);
+    expected[0] = (kCid << 16) | (0x3 << 14) | 0x02;  // Opcode=0x02
+    expected[1] = kKvNsId;
+    expected[6] = kBufferAddr & 0xFFFFFFFFULL;
+    expected[7] = (kBufferAddr >> 32) & 0xFFFFFFFFULL;
+    expected[8] = ((kMrKey & 0xFF) << 24) | (kBufferLength & 0xFFFFFF);
+    expected[9] = (0x40 << 24) | ((kMrKey >> 8) & 0xFFFFFF);
+    expected[10] = kOffset;
+    expected[11] = (kLr ? (1U << 31) : 0) | (kLength & 0xFFFFFF);
+    std::memcpy(&expected[12], kKey.data(), std::min(kKey.size(), static_cast<std::size_t>(16)));
+
+    ASSERT_EQ(sqe.Size(), expected.size() * sizeof(std::uint32_t));
+    const auto* packed = static_cast<const std::uint32_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i]) << "Mismatch at Dword " << i;
+    }
+}
+
+TEST_F(SqePackTest, BatchStoreSqePackMatchesProtocol)
+{
+    constexpr std::uint32_t kCid = 0xABCD;
+    constexpr std::uint32_t kKvNsId = 0x0003;
+    constexpr std::uint8_t kDtype = 0x2;
+    constexpr std::uint8_t kDspec = 0x0A;
+    constexpr std::uint64_t kRespBufferAddr = 0x0000111122223333ULL;
+    constexpr std::uint32_t kRespMrKey = 0x99999999;
+    constexpr bool kLr = true;
+    constexpr bool kRflag = true;
+
+    KvBatchStoreEntry entry1;
+    entry1.offset = 0x1000;
+    entry1.key = "batch_key_1";
+    entry1.buffer_addr = 0x0000AAAABBBBCCCCULL;
+    entry1.mr_key = 0x11111111;
+    entry1.length = 0x2000;
+
+    KvBatchStoreEntry entry2;
+    entry2.offset = 0x2000;
+    entry2.key = "batch_key_2";
+    entry2.buffer_addr = 0x0000DDDDEEEEFFFFULL;
+    entry2.mr_key = 0x22222222;
+    entry2.length = 0x3000;
+
+    KvBatchStoreRequest req;
+    req.cid = kCid;
+    req.kv_ns_id = kKvNsId;
+    req.dtype = kDtype;
+    req.dspec = kDspec;
+    req.response_buffer_addr = kRespBufferAddr;
+    req.response_mr_key = kRespMrKey;
+    req.lr = kLr;
+    req.rflag = kRflag;
+    req.batch_number = 2;
+    req.entries = {entry1, entry2};
+
+    KvBatchStoreSqe sqe;
+    auto status = sqe.Pack(req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    // 16 base dwords + 2 entries * 9 dwords = 34 dwords
+    std::vector<std::uint32_t> expected(34, 0);
+    expected[0] = (kCid << 16) | (0x3 << 14) | (kRflag ? (1U << 13) : 0) | 0x45;
+    expected[1] = kKvNsId;
+    expected[2] = ((kDtype & 0x7) << 13) | ((kDspec & 0x1F) << 8);
+    expected[3] = kRespBufferAddr & 0xFFFFFFFFULL;
+    expected[4] = (kRespBufferAddr >> 32) & 0xFFFFFFFFULL;
+    expected[5] = kRespMrKey;
+    expected[8] = 2 * 36;      // batch_number * 36
+    expected[9] = 0x01 << 24;  // DPTR.Type=0x01
+    expected[10] = 2;          // batch_number
+    expected[11] = kLr ? (1U << 31) : 0;
+
+    // Entry 0 (base=16)
+    expected[16] = entry1.offset;
+    std::memcpy(&expected[17], entry1.key.data(),
+                std::min(entry1.key.size(), static_cast<std::size_t>(16)));
+    expected[21] = entry1.buffer_addr & 0xFFFFFFFFULL;
+    expected[22] = (entry1.buffer_addr >> 32) & 0xFFFFFFFFULL;
+    expected[23] = ((entry1.mr_key & 0xFF) << 24) | (entry1.length & 0xFFFFFF);
+    expected[24] = (0x40 << 24) | ((entry1.mr_key >> 8) & 0xFFFFFF);
+
+    // Entry 1 (base=25)
+    expected[25] = entry2.offset;
+    std::memcpy(&expected[26], entry2.key.data(),
+                std::min(entry2.key.size(), static_cast<std::size_t>(16)));
+    expected[30] = entry2.buffer_addr & 0xFFFFFFFFULL;
+    expected[31] = (entry2.buffer_addr >> 32) & 0xFFFFFFFFULL;
+    expected[32] = ((entry2.mr_key & 0xFF) << 24) | (entry2.length & 0xFFFFFF);
+    expected[33] = (0x40 << 24) | ((entry2.mr_key >> 8) & 0xFFFFFF);
+
+    ASSERT_EQ(sqe.Size(), expected.size() * sizeof(std::uint32_t));
+    const auto* packed = static_cast<const std::uint32_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i]) << "Mismatch at Dword " << i;
+    }
+}
+
+TEST_F(SqePackTest, BatchRetrieveSqePackMatchesProtocol)
+{
+    constexpr std::uint32_t kCid = 0x1111;
+    constexpr std::uint32_t kKvNsId = 0x0004;
+    constexpr std::uint64_t kRespBufferAddr = 0x0000444455556666ULL;
+    constexpr std::uint32_t kRespMrKey = 0x88888888;
+    constexpr bool kLr = false;
+    constexpr bool kRflag = false;
+
+    KvBatchRetrieveEntry entry;
+    entry.offset = 0x3000;
+    entry.key = "batch_retrieve_key";
+    entry.buffer_addr = 0x0000777788889999ULL;
+    entry.mr_key = 0x33333333;
+    entry.length = 0x4000;
+
+    KvBatchRetrieveRequest req;
+    req.cid = kCid;
+    req.kv_ns_id = kKvNsId;
+    req.response_buffer_addr = kRespBufferAddr;
+    req.response_mr_key = kRespMrKey;
+    req.lr = kLr;
+    req.rflag = kRflag;
+    req.batch_number = 1;
+    req.entries = {entry};
+
+    KvBatchRetrieveSqe sqe;
+    auto status = sqe.Pack(req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint32_t> expected(25, 0);       // 16 + 1*9
+    expected[0] = (kCid << 16) | (0x3 << 14) | 0x46;  // Opcode=0x46
+    expected[1] = kKvNsId;
+    expected[3] = kRespBufferAddr & 0xFFFFFFFFULL;
+    expected[4] = (kRespBufferAddr >> 32) & 0xFFFFFFFFULL;
+    expected[5] = kRespMrKey;
+    expected[8] = 1 * 36;
+    expected[9] = 0x01 << 24;
+    expected[10] = 1;
+    expected[16] = entry.offset;
+    std::memcpy(&expected[17], entry.key.data(),
+                std::min(entry.key.size(), static_cast<std::size_t>(16)));
+    expected[21] = entry.buffer_addr & 0xFFFFFFFFULL;
+    expected[22] = (entry.buffer_addr >> 32) & 0xFFFFFFFFULL;
+    expected[23] = ((entry.mr_key & 0xFF) << 24) | (entry.length & 0xFFFFFF);
+    expected[24] = (0x40 << 24) | ((entry.mr_key >> 8) & 0xFFFFFF);
+
+    ASSERT_EQ(sqe.Size(), expected.size() * sizeof(std::uint32_t));
+    const auto* packed = static_cast<const std::uint32_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i]) << "Mismatch at Dword " << i;
+    }
+}
+
+TEST_F(SqePackTest, DeleteSqePackMatchesProtocol)
+{
+    constexpr std::uint32_t kCid = 0x2222;
+    constexpr std::uint32_t kKvNsId = 0x0005;
+    constexpr std::uint64_t kRespBufferAddr = 0x0000AAAA0000BBBBULL;
+    constexpr std::uint32_t kRespMrKey = 0x77777777;
+    constexpr bool kRflag = true;
+
+    KvDeleteRequest req;
+    req.cid = kCid;
+    req.kv_ns_id = kKvNsId;
+    req.response_buffer_addr = kRespBufferAddr;
+    req.response_mr_key = kRespMrKey;
+    req.rflag = kRflag;
+    req.batch_number = 2;
+    req.keys = {"delete_key_1", "delete_key_2"};
+
+    KvDeleteSqe sqe;
+    auto status = sqe.Pack(req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint32_t> expected(24, 0);  // 16 + 2*4
+    expected[0] = (kCid << 16) | (0x3 << 14) | (kRflag ? (1U << 13) : 0) | 0x08;
+    expected[1] = kKvNsId;
+    expected[3] = kRespBufferAddr & 0xFFFFFFFFULL;
+    expected[4] = (kRespBufferAddr >> 32) & 0xFFFFFFFFULL;
+    expected[5] = kRespMrKey;
+    expected[8] = 2 * 16;  // batch_number * 16
+    expected[9] = 0x01 << 24;
+    expected[10] = 2;
+    std::memcpy(&expected[16], req.keys[0].data(),
+                std::min(req.keys[0].size(), static_cast<std::size_t>(16)));
+    std::memcpy(&expected[20], req.keys[1].data(),
+                std::min(req.keys[1].size(), static_cast<std::size_t>(16)));
+
+    ASSERT_EQ(sqe.Size(), expected.size() * sizeof(std::uint32_t));
+    const auto* packed = static_cast<const std::uint32_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i]) << "Mismatch at Dword " << i;
+    }
+}
+
+TEST_F(SqePackTest, ExistSqePackMatchesProtocol)
+{
+    constexpr std::uint32_t kCid = 0x3333;
+    constexpr std::uint32_t kKvNsId = 0x0006;
+    constexpr std::uint64_t kRespBufferAddr = 0x0000CCCC0000DDDDULL;
+    constexpr std::uint32_t kRespMrKey = 0x66666666;
+    constexpr bool kRflag = false;
+    constexpr bool kSc = true;
+
+    KvExistRequest req;
+    req.cid = kCid;
+    req.kv_ns_id = kKvNsId;
+    req.response_buffer_addr = kRespBufferAddr;
+    req.response_mr_key = kRespMrKey;
+    req.rflag = kRflag;
+    req.sc = kSc;
+    req.batch_number = 1;
+    req.keys = {"exist_key"};
+
+    KvExistSqe sqe;
+    auto status = sqe.Pack(req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint32_t> expected(20, 0);       // 16 + 1*4
+    expected[0] = (kCid << 16) | (0x3 << 14) | 0x0C;  // Opcode=0x0C
+    expected[1] = kKvNsId;
+    expected[3] = kRespBufferAddr & 0xFFFFFFFFULL;
+    expected[4] = (kRespBufferAddr >> 32) & 0xFFFFFFFFULL;
+    expected[5] = kRespMrKey;
+    expected[8] = 1 * 16;
+    expected[9] = 0x01 << 24;
+    expected[10] = 1 | (kSc ? (1U << 16) : 0);  // batch_number | SC
+    std::memcpy(&expected[16], req.keys[0].data(),
+                std::min(req.keys[0].size(), static_cast<std::size_t>(16)));
+
+    ASSERT_EQ(sqe.Size(), expected.size() * sizeof(std::uint32_t));
+    const auto* packed = static_cast<const std::uint32_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i]) << "Mismatch at Dword " << i;
+    }
+}
+
+TEST_F(SqePackTest, KeepAliveSqePackMatchesProtocol)
+{
+    constexpr std::uint32_t kCid = 0x4444;
+    constexpr std::uint64_t kRespBufferAddr = 0x0000EEEE0000FFFFULL;
+    constexpr std::uint32_t kRespMrKey = 0x55555555;
+    constexpr bool kRflag = true;
+
+    KvKeepAliveRequest req;
+    req.cid = kCid;
+    req.response_buffer_addr = kRespBufferAddr;
+    req.response_mr_key = kRespMrKey;
+    req.rflag = kRflag;
+
+    KvKeepAliveSqe sqe;
+    auto status = sqe.Pack(req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint32_t> expected(16, 0);
+    expected[0] = (kCid << 16) | (kRflag ? (1U << 13) : 0) | 0xF4;  // Opcode=0xF4, no Fixed bits
+    expected[3] = kRespBufferAddr & 0xFFFFFFFFULL;
+    expected[4] = (kRespBufferAddr >> 32) & 0xFFFFFFFFULL;
+    expected[5] = kRespMrKey;
+
+    ASSERT_EQ(sqe.Size(), expected.size() * sizeof(std::uint32_t));
+    const auto* packed = static_cast<const std::uint32_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i]) << "Mismatch at Dword " << i;
+    }
+}
+
+}  // namespace
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/link_proto.cpp
+++ b/ucm/transport/kv/asu/trans/src/link_proto.cpp
@@ -1,0 +1,156 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "link_proto.h"
+#include <cstring>
+
+namespace UC::ASU {
+
+Status NegotiateSqe::Pack(const NegotiateRequest& req)
+{
+    buffer.assign(kMsgHeaderSize + kNegotiatePayloadSize, 0);
+
+    MsgHeader header;
+    header.cmd = LinkProtocolCmd::Negotiate;
+    header.len = kNegotiatePayloadSize;
+    header.Pack(buffer);
+
+    // Offset 16: cap[31:0]
+    std::memcpy(&buffer[16], &req.cap, 4);
+
+    // Offset 20: rsv[23:0] (zero)
+
+    // Offset 44: private_len[31:0]
+    std::memcpy(&buffer[44], &req.private_len, 4);
+
+    // Offset 48: major_version
+    buffer[48] = req.major_version;
+
+    // Offset 49: minor_version
+    buffer[49] = req.minor_version;
+
+    // Offset 50: kato[15:0]
+    std::memcpy(&buffer[50], &req.kato, 2);
+
+    // Offset 52: reserved[123:0] (zero)
+    return Status::OK();
+}
+
+Status NegotiateSqe::Validate() const
+{
+    if (buffer.size() < kMsgHeaderSize + kNegotiatePayloadSize) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "buffer too small");
+    }
+    return Status::OK();
+}
+
+Status HandshakeSqe::Pack(const HandshakeRequest& req)
+{
+    buffer.assign(kMsgHeaderSize + kHandshakePayloadSize, 0);
+
+    MsgHeader header;
+    header.cmd = LinkProtocolCmd::Handshake;
+    header.len = kHandshakePayloadSize;
+    header.Pack(buffer);
+
+    // Offset 16: gid[15:0]
+    std::memcpy(&buffer[16], req.gid, 16);
+
+    // Offset 32: lid[15:0]
+    std::memcpy(&buffer[32], &req.lid, 2);
+
+    // Offset 34: mtu
+    buffer[34] = req.mtu;
+
+    // Offset 35: total_qp_num
+    buffer[35] = req.total_qp_num;
+
+    // Offset 36: sl
+    buffer[36] = req.sl;
+
+    // Offset 37: traffic_class
+    buffer[37] = req.traffic_class;
+
+    // Offset 38: rnr_timer
+    buffer[38] = req.rnr_timer;
+
+    // Offset 39: rnr_retry_cnt
+    buffer[39] = req.rnr_retry_cnt;
+
+    // Offset 40: timeout
+    buffer[40] = req.timeout;
+
+    // Offset 41: retry_cnt
+    buffer[41] = req.retry_cnt;
+
+    // Offset 42: qp_rd_atom
+    buffer[42] = req.qp_rd_atom;
+
+    // Offset 43: rsv
+    buffer[43] = req.rsv;
+
+    // Offset 44: start_psn[31:0]
+    std::memcpy(&buffer[44], &req.start_psn, 4);
+
+    // Offset 48: qpn[32] (128 bytes)
+    std::memcpy(&buffer[48], req.qpn, 128);
+    return Status::OK();
+}
+
+Status HandshakeSqe::Validate() const
+{
+    if (buffer.size() < kMsgHeaderSize + kHandshakePayloadSize) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "buffer too small");
+    }
+    return Status::OK();
+}
+
+Status HandshakeDoneSqe::Pack()
+{
+    buffer.assign(kMsgHeaderSize, 0);
+
+    MsgHeader header;
+    header.cmd = LinkProtocolCmd::HandshakeDone;
+    header.len = 0;
+    header.Pack(buffer);
+    return Status::OK();
+}
+
+Status DisconnectSqe::Pack(const DisconnectRequest& req)
+{
+    buffer.assign(kMsgHeaderSize + kDisconnectPayloadSize, 0);
+
+    MsgHeader header;
+    header.cmd = LinkProtocolCmd::Disconnect;
+    header.len = kDisconnectPayloadSize;
+    header.Pack(buffer);
+
+    // Offset 16: local_qpn[31:0]
+    std::memcpy(&buffer[16], &req.local_qpn, 4);
+
+    // Offset 20: remote_qpn[31:0]
+    std::memcpy(&buffer[20], &req.remote_qpn, 4);
+    return Status::OK();
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/link_proto.h
+++ b/ucm/transport/kv/asu/trans/src/link_proto.h
@@ -1,0 +1,163 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+#include "asu_transport/types.h"
+
+namespace UC::ASU {
+
+constexpr std::uint32_t kMsgHeaderSize = 16;
+constexpr std::uint32_t kMsgVersion = 1;
+
+// LinkProtocolCmd defines the message types for the KV connection protocol.
+enum class LinkProtocolCmd : std::uint8_t {
+    Negotiate = 0,
+    Handshake = 1,
+    HandshakeDone = 3,
+    Disconnect = 4
+};
+
+constexpr std::size_t kNegotiatePayloadSize = 160;  // 32 + 128
+constexpr std::size_t kHandshakePayloadSize = 160;
+constexpr std::size_t kDisconnectPayloadSize = 8;
+
+class MsgHeader {
+public:
+    std::uint32_t crc{0};
+    std::uint8_t ver{kMsgVersion};
+    LinkProtocolCmd cmd{LinkProtocolCmd::Negotiate};
+    std::uint8_t pad[6]{0};
+    std::uint32_t len{0};
+
+    void Pack(std::vector<std::uint8_t>& buffer) const
+    {
+        std::memcpy(&buffer[0], &crc, 4);
+        buffer[4] = ver;
+        buffer[5] = static_cast<std::uint8_t>(cmd);
+        std::memcpy(&buffer[12], &len, 4);
+    }
+
+    static MsgHeader Unpack(const std::uint8_t* data)
+    {
+        MsgHeader h;
+        std::memcpy(&h.crc, &data[0], 4);
+        h.ver = data[4];
+        h.cmd = static_cast<LinkProtocolCmd>(data[5]);
+        std::memcpy(&h.len, &data[12], 4);
+        return h;
+    }
+};
+
+class NegotiateRequest {
+public:
+    std::uint32_t cap{0};
+    std::uint32_t private_len{4};
+    std::uint8_t major_version{1};
+    std::uint8_t minor_version{0};
+    std::uint16_t kato{0};
+};
+
+class HandshakeRequest {
+public:
+    std::uint8_t gid[16]{0};
+    std::uint16_t lid{0};
+    std::uint8_t mtu{0};
+    std::uint8_t total_qp_num{0};
+    std::uint8_t sl{0};
+    std::uint8_t traffic_class{0};
+    std::uint8_t rnr_timer{0};
+    std::uint8_t rnr_retry_cnt{0};
+    std::uint8_t timeout{0};
+    std::uint8_t retry_cnt{0};
+    std::uint8_t qp_rd_atom{0};
+    std::uint8_t rsv{0};
+    std::uint32_t start_psn{0};
+    std::uint32_t qpn[32]{0};
+};
+
+class DisconnectRequest {
+public:
+    std::uint32_t local_qpn{0};
+    std::uint32_t remote_qpn{0};
+};
+
+class NegotiateSqe {
+public:
+    NegotiateSqe() = default;
+
+    const void* Data() const { return buffer.data(); }
+    std::size_t Size() const { return buffer.size(); }
+
+    Status Pack(const NegotiateRequest& req);
+    Status Validate() const;
+
+private:
+    std::vector<std::uint8_t> buffer;
+};
+
+class HandshakeSqe {
+public:
+    HandshakeSqe() = default;
+
+    const void* Data() const { return buffer.data(); }
+    std::size_t Size() const { return buffer.size(); }
+
+    Status Pack(const HandshakeRequest& req);
+    Status Validate() const;
+
+private:
+    std::vector<std::uint8_t> buffer;
+};
+
+class HandshakeDoneSqe {
+public:
+    HandshakeDoneSqe() = default;
+
+    const void* Data() const { return buffer.data(); }
+    std::size_t Size() const { return buffer.size(); }
+
+    Status Pack();
+
+private:
+    std::vector<std::uint8_t> buffer;
+};
+
+class DisconnectSqe {
+public:
+    DisconnectSqe() = default;
+
+    const void* Data() const { return buffer.data(); }
+    std::size_t Size() const { return buffer.size(); }
+
+    Status Pack(const DisconnectRequest& req);
+
+private:
+    std::vector<std::uint8_t> buffer;
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/sqe.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe.cpp
@@ -1,0 +1,543 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "sqe.h"
+#include <algorithm>
+#include <cstring>
+
+namespace UC::ASU {
+
+Status KvStoreSqe::Pack(const SqeRequest& req)
+{
+    auto& r = static_cast<const KvStoreRequest&>(req);
+    dwords.assign(kSqeDwordCount, 0);
+
+    // Dword 0: CID[31:16] | Fixed[15:14]=0b11 | Reserved[13:8] | Opcode[7:0]=0x01
+    dwords[0] = (r.cid << 16) | (kFixedBits << 14) | static_cast<std::uint32_t>(SqeOpcode::Store);
+
+    // Dword 1: kv_ns_id[31:0]
+    dwords[1] = r.kv_ns_id;
+
+    // Dword 2: DTYPE[15:13] | DSPEC[12:8] | Reserved[7:0]
+    dwords[2] = ((r.dtype & 0x7) << 13) | ((r.dspec & 0x1F) << 8);
+
+    // Dwords 3-5: reserved (zero)
+
+    // Dword 6-7: DPTR.buffer[63:0] - data buffer address
+    dwords[6] = r.buffer_addr & 0xFFFFFFFFULL;
+    dwords[7] = (r.buffer_addr >> 32) & 0xFFFFFFFFULL;
+
+    // Dword 8: key[0][31:24] = MR_KEY low 8 bits | length[23:0] = buffer length
+    dwords[8] = ((r.mr_key & 0xFF) << 24) | (r.buffer_length & 0xFFFFFF);
+
+    // Dword 9: Type[31:24] = 0x40 | key[3:1][23:0] = MR_KEY high 24 bits
+    dwords[9] =
+        (static_cast<std::uint32_t>(DptrType::Standard) << 24) | ((r.mr_key >> 8) & 0xFFFFFF);
+
+    // Dword 10: offset[31:0]
+    dwords[10] = r.offset;
+
+    // Dword 11: LR[31] | Reserved[30:24] | Length[23:0]
+    dwords[11] = (r.lr ? (1U << 31) : 0) | (r.length & 0xFFFFFF);
+
+    // Dwords 12-15: key[15:0] - 16 bytes key, low-byte aligned
+    std::size_t key_len = std::min(r.key.size(), static_cast<std::size_t>(16));
+    if (key_len > 0) { std::memcpy(&dwords[12], r.key.data(), key_len); }
+    return Status::OK();
+}
+
+Status KvStoreSqe::Validate() const
+{
+    if (dwords.size() < kSqeDwordCount) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "SQE not packed");
+    }
+    if (dwords[6] == 0 && dwords[7] == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "buffer_addr is zero");
+    }
+    std::uint32_t buffer_length = dwords[8] & 0xFFFFFF;
+    if (buffer_length == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "buffer_length is zero");
+    }
+    if (buffer_length % kAlignmentBytes != 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "buffer_length must be 512B aligned");
+    }
+    if (dwords[10] % kAlignmentBytes != 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "offset must be 512B aligned");
+    }
+    std::uint32_t length = dwords[11] & 0xFFFFFF;
+    if (length == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "length is 1-based, must be non-zero");
+    }
+    bool key_empty = true;
+    for (int i = 0; i < 4; ++i) {
+        if (dwords[12 + i] != 0) {
+            key_empty = false;
+            break;
+        }
+    }
+    if (key_empty) { return Status::Error(StatusCode::INVALID_ARGUMENT, "key is empty"); }
+    return Status::OK();
+}
+
+Status KvRetrieveSqe::Pack(const SqeRequest& req)
+{
+    auto& r = static_cast<const KvRetrieveRequest&>(req);
+    dwords.assign(kSqeDwordCount, 0);
+
+    // Dword 0: CID[31:16] | Fixed[15:14]=0b11 | Reserved[13:8] | Opcode[7:0]=0x02
+    dwords[0] =
+        (r.cid << 16) | (kFixedBits << 14) | static_cast<std::uint32_t>(SqeOpcode::Retrieve);
+
+    // Dword 1: kv_ns_id[31:0]
+    dwords[1] = r.kv_ns_id;
+
+    // Dword 2: Reserved[15:0]
+    // Dwords 3-5: reserved (zero)
+
+    // Dword 6-7: DPTR.buffer[63:0] - data buffer address
+    dwords[6] = r.buffer_addr & 0xFFFFFFFFULL;
+    dwords[7] = (r.buffer_addr >> 32) & 0xFFFFFFFFULL;
+
+    // Dword 8: key[0][31:24] = MR_KEY low 8 bits | length[23:0] = buffer length
+    dwords[8] = ((r.mr_key & 0xFF) << 24) | (r.buffer_length & 0xFFFFFF);
+
+    // Dword 9: Type[31:24] = 0x40 | key[3:1][23:0] = MR_KEY high 24 bits
+    dwords[9] =
+        (static_cast<std::uint32_t>(DptrType::Standard) << 24) | ((r.mr_key >> 8) & 0xFFFFFF);
+
+    // Dword 10: offset[31:0]
+    dwords[10] = r.offset;
+
+    // Dword 11: LR[31] | Reserved[30:24] | Length[23:0]
+    dwords[11] = (r.lr ? (1U << 31) : 0) | (r.length & 0xFFFFFF);
+
+    // Dwords 12-15: key[15:0] - 16 bytes key, low-byte aligned
+    std::size_t key_len = std::min(r.key.size(), static_cast<std::size_t>(16));
+    if (key_len > 0) { std::memcpy(&dwords[12], r.key.data(), key_len); }
+    return Status::OK();
+}
+
+Status KvRetrieveSqe::Validate() const
+{
+    if (dwords.size() < kSqeDwordCount) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "SQE not packed");
+    }
+    if (dwords[6] == 0 && dwords[7] == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "buffer_addr is zero");
+    }
+    std::uint32_t buffer_length = dwords[8] & 0xFFFFFF;
+    if (buffer_length == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "buffer_length is zero");
+    }
+    if (buffer_length % kAlignmentBytes != 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "buffer_length must be 512B aligned");
+    }
+    if (dwords[10] % kAlignmentBytes != 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "offset must be 512B aligned");
+    }
+    std::uint32_t length = dwords[11] & 0xFFFFFF;
+    if (length == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "length is 1-based, must be non-zero");
+    }
+    bool key_empty = true;
+    for (int i = 0; i < 4; ++i) {
+        if (dwords[12 + i] != 0) {
+            key_empty = false;
+            break;
+        }
+    }
+    if (key_empty) { return Status::Error(StatusCode::INVALID_ARGUMENT, "key is empty"); }
+    return Status::OK();
+}
+
+Status KvBatchStoreSqe::Pack(const SqeRequest& req)
+{
+    auto& r = static_cast<const KvBatchStoreRequest&>(req);
+    if (r.batch_number > r.entries.size()) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "batch_number exceeds entries.size()");
+    }
+    dwords.assign(kSqeDwordCount + r.batch_number * kBatchEntryDwordCount, 0);
+
+    // Dword 0: CID[31:16] | Fixed[15:14]=0b11 | Rflag[13] | Reserved[12:8] | Opcode[7:0]=0x45
+    dwords[0] =
+        (r.cid << 16) | (kFixedBits << 14) | static_cast<std::uint32_t>(SqeOpcode::BatchStore);
+    if (r.rflag) { dwords[0] |= (1U << 13); }
+
+    // Dword 1: kv_ns_id[31:0]
+    dwords[1] = r.kv_ns_id;
+
+    // Dword 2: DTYPE[15:13] | DSPEC[12:8]
+    dwords[2] = ((r.dtype & 0x7) << 13) | ((r.dspec & 0x1F) << 8);
+
+    // Dword 3-4: Response Buffer Address[63:0]
+    dwords[3] = r.response_buffer_addr & 0xFFFFFFFFULL;
+    dwords[4] = (r.response_buffer_addr >> 32) & 0xFFFFFFFFULL;
+
+    // Dword 5: Response Buffer MR_Key[31:0]
+    dwords[5] = r.response_mr_key;
+
+    // Dword 6-7: DPTR.buffer = 0 (fixed)
+
+    // Dword 8: DPTR.length = Batch Number * 36
+    dwords[8] = r.batch_number * kBatchEntrySizeBytes;
+
+    // Dword 9: DPTR.Type = 0x1
+    dwords[9] = static_cast<std::uint32_t>(DptrType::Batch) << 24;
+
+    // Dword 10: Batch Number
+    dwords[10] = r.batch_number;
+
+    // Dword 11: LR[31]
+    if (r.lr) { dwords[11] |= (1U << 31); }
+
+    // Dwords 12-15: reserved (zero)
+
+    // Pack batch entries
+    for (std::size_t i = 0; i < r.batch_number; ++i) { PackEntry(r.entries[i], i); }
+    return Status::OK();
+}
+
+Status KvBatchStoreSqe::Validate() const
+{
+    if (dwords.size() < kSqeDwordCount) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "SQE not packed");
+    }
+    if (dwords[3] == 0 && dwords[4] == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "response_buffer_addr is zero");
+    }
+    std::uint32_t batch_number = dwords[10] & 0xFFFF;
+    if (batch_number == 0 || batch_number > kMaxBatchNumber) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "batch_number must be in range [1, 227]");
+    }
+    std::uint32_t dptr_length = dwords[8] & 0xFFFFFF;
+    if (dptr_length != batch_number * kBatchEntrySizeBytes) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "DPTR.length must equal batch_number * 36");
+    }
+    std::size_t expected_size = kSqeDwordCount + batch_number * kBatchEntryDwordCount;
+    if (dwords.size() != expected_size) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "missing batch entries");
+    }
+    return Status::OK();
+}
+
+void KvBatchStoreSqe::PackEntry(const KvBatchStoreEntry& entry, std::size_t index)
+{
+    std::size_t base = kSqeDwordCount + index * kBatchEntryDwordCount;
+
+    // Entry Dword 0: offset
+    dwords[base + 0] = entry.offset;
+
+    // Entry Dword 1: key[15:0]
+    std::size_t key_len = std::min(entry.key.size(), static_cast<std::size_t>(16));
+    if (key_len > 0) { std::memcpy(&dwords[base + 1], entry.key.data(), key_len); }
+
+    // Entry Dword 5-6: Buffer Address[63:0]
+    dwords[base + 5] = entry.buffer_addr & 0xFFFFFFFFULL;
+    dwords[base + 6] = (entry.buffer_addr >> 32) & 0xFFFFFFFFULL;
+
+    // Entry Dword 7: MR_KEY[0][31:24] = MR_KEY low 8 bits | Length[23:0]
+    dwords[base + 7] = ((entry.mr_key & 0xFF) << 24) | (entry.length & 0xFFFFFF);
+
+    // Entry Dword 8: DPTR.Type = 0x40 | MR_KEY[3:1][23:0] = MR_KEY high 24 bits
+    dwords[base + 8] =
+        (static_cast<std::uint32_t>(DptrType::Standard) << 24) | ((entry.mr_key >> 8) & 0xFFFFFF);
+}
+
+Status KvBatchRetrieveSqe::Pack(const SqeRequest& req)
+{
+    auto& r = static_cast<const KvBatchRetrieveRequest&>(req);
+    if (r.batch_number > r.entries.size()) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "batch_number exceeds entries.size()");
+    }
+    dwords.assign(kSqeDwordCount + r.batch_number * kBatchEntryDwordCount, 0);
+
+    // Dword 0: CID[31:16] | Fixed[15:14]=0b11 | Rflag[13] | Reserved[12:8] | Opcode[7:0]=0x46
+    dwords[0] =
+        (r.cid << 16) | (kFixedBits << 14) | static_cast<std::uint32_t>(SqeOpcode::BatchRetrieve);
+    if (r.rflag) { dwords[0] |= (1U << 13); }
+
+    // Dword 1: kv_ns_id[31:0]
+    dwords[1] = r.kv_ns_id;
+
+    // Dword 2: Reserved[15:0]
+    // Dwords 3-4: Response Buffer Address[63:0]
+    dwords[3] = r.response_buffer_addr & 0xFFFFFFFFULL;
+    dwords[4] = (r.response_buffer_addr >> 32) & 0xFFFFFFFFULL;
+
+    // Dword 5: Response Buffer MR_Key[31:0]
+    dwords[5] = r.response_mr_key;
+
+    // Dword 6-7: DPTR.buffer = 0 (fixed)
+
+    // Dword 8: DPTR.length = Batch Number * 36
+    dwords[8] = r.batch_number * kBatchEntrySizeBytes;
+
+    // Dword 9: DPTR.Type = 0x1
+    dwords[9] = static_cast<std::uint32_t>(DptrType::Batch) << 24;
+
+    // Dword 10: Batch Number
+    dwords[10] = r.batch_number;
+
+    // Dword 11: LR[31]
+    if (r.lr) { dwords[11] |= (1U << 31); }
+
+    // Dwords 12-15: reserved (zero)
+
+    // Pack batch entries
+    for (std::size_t i = 0; i < r.batch_number; ++i) { PackEntry(r.entries[i], i); }
+    return Status::OK();
+}
+
+Status KvBatchRetrieveSqe::Validate() const
+{
+    if (dwords.size() < kSqeDwordCount) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "SQE not packed");
+    }
+    if (dwords[3] == 0 && dwords[4] == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "response_buffer_addr is zero");
+    }
+    std::uint32_t batch_number = dwords[10] & 0xFFFF;
+    if (batch_number == 0 || batch_number > kMaxBatchNumber) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "batch_number must be in range [1, 227]");
+    }
+    std::uint32_t dptr_length = dwords[8] & 0xFFFFFF;
+    if (dptr_length != batch_number * kBatchEntrySizeBytes) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "DPTR.length must equal batch_number * 36");
+    }
+    std::size_t expected_size = kSqeDwordCount + batch_number * kBatchEntryDwordCount;
+    if (dwords.size() != expected_size) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "missing batch entries");
+    }
+    return Status::OK();
+}
+
+void KvBatchRetrieveSqe::PackEntry(const KvBatchRetrieveEntry& entry, std::size_t index)
+{
+    std::size_t base = kSqeDwordCount + index * kBatchEntryDwordCount;
+
+    // Entry Dword 0: offset
+    dwords[base + 0] = entry.offset;
+
+    // Entry Dword 1: key[15:0]
+    std::size_t key_len = std::min(entry.key.size(), static_cast<std::size_t>(16));
+    if (key_len > 0) { std::memcpy(&dwords[base + 1], entry.key.data(), key_len); }
+
+    // Entry Dword 5-6: Buffer Address[63:0]
+    dwords[base + 5] = entry.buffer_addr & 0xFFFFFFFFULL;
+    dwords[base + 6] = (entry.buffer_addr >> 32) & 0xFFFFFFFFULL;
+
+    // Entry Dword 7: MR_KEY[0][31:24] = MR_KEY low 8 bits | Length[23:0]
+    dwords[base + 7] = ((entry.mr_key & 0xFF) << 24) | (entry.length & 0xFFFFFF);
+
+    // Entry Dword 8: DPTR.Type = 0x40 | MR_KEY[3:1][23:0] = MR_KEY high 24 bits
+    dwords[base + 8] =
+        (static_cast<std::uint32_t>(DptrType::Standard) << 24) | ((entry.mr_key >> 8) & 0xFFFFFF);
+}
+
+Status KvDeleteSqe::Pack(const SqeRequest& req)
+{
+    auto& r = static_cast<const KvDeleteRequest&>(req);
+    if (r.batch_number > r.keys.size()) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "batch_number exceeds keys.size()");
+    }
+    dwords.assign(kSqeDwordCount + r.batch_number * kDeleteEntryDwordCount, 0);
+
+    // Dword 0: CID[31:16] | Fixed[15:14]=0b11 | Rflag[13] | Reserved[12:8] | Opcode[7:0]=0x08
+    dwords[0] = (r.cid << 16) | (kFixedBits << 14) | static_cast<std::uint32_t>(SqeOpcode::Delete);
+    if (r.rflag) { dwords[0] |= (1U << 13); }
+
+    // Dword 1: kv_ns_id[31:0]
+    dwords[1] = r.kv_ns_id;
+
+    // Dword 2: Reserved[15:0]
+    // Dwords 3-4: Response Buffer Address[63:0]
+    dwords[3] = r.response_buffer_addr & 0xFFFFFFFFULL;
+    dwords[4] = (r.response_buffer_addr >> 32) & 0xFFFFFFFFULL;
+
+    // Dword 5: Response Buffer MR_Key[31:0]
+    dwords[5] = r.response_mr_key;
+
+    // Dword 6-7: DPTR.buffer = 0 (fixed)
+
+    // Dword 8: DPTR.length = Batch Number * 16
+    dwords[8] = r.batch_number * kDeleteEntrySizeBytes;
+
+    // Dword 9: DPTR.Type = 0x1
+    dwords[9] = static_cast<std::uint32_t>(DptrType::Batch) << 24;
+
+    // Dword 10: Batch Number
+    dwords[10] = r.batch_number;
+
+    // Dwords 11-15: reserved (zero)
+
+    // Pack delete entries
+    for (std::size_t i = 0; i < r.batch_number; ++i) { PackEntry(r.keys[i], i); }
+    return Status::OK();
+}
+
+Status KvDeleteSqe::Validate() const
+{
+    if (dwords.size() < kSqeDwordCount) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "SQE not packed");
+    }
+    if (dwords[3] == 0 && dwords[4] == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "response_buffer_addr is zero");
+    }
+    std::uint32_t batch_number = dwords[10] & 0xFFFF;
+    if (batch_number == 0 || batch_number > kMaxBatchNumber) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "batch_number must be in range [1, 227]");
+    }
+    std::uint32_t dptr_length = dwords[8] & 0xFFFFFF;
+    if (dptr_length != batch_number * kDeleteEntrySizeBytes) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "DPTR.length must equal batch_number * 16");
+    }
+    std::size_t expected_size = kSqeDwordCount + batch_number * kDeleteEntryDwordCount;
+    if (dwords.size() != expected_size) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "missing delete entries");
+    }
+    return Status::OK();
+}
+
+void KvDeleteSqe::PackEntry(const std::string& key, std::size_t index)
+{
+    std::size_t base = kSqeDwordCount + index * kDeleteEntryDwordCount;
+
+    std::size_t key_len = std::min(key.size(), static_cast<std::size_t>(16));
+    if (key_len > 0) { std::memcpy(&dwords[base], key.data(), key_len); }
+}
+
+Status KvExistSqe::Pack(const SqeRequest& req)
+{
+    auto& r = static_cast<const KvExistRequest&>(req);
+    if (r.batch_number > r.keys.size()) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "batch_number exceeds keys.size()");
+    }
+    dwords.assign(kSqeDwordCount + r.batch_number * kDeleteEntryDwordCount, 0);
+
+    // Dword 0: CID[31:16] | Fixed[15:14]=0b11 | Rflag[13] | Reserved[12:8] | Opcode[7:0]=0x0C
+    dwords[0] = (r.cid << 16) | (kFixedBits << 14) | static_cast<std::uint32_t>(SqeOpcode::Exist);
+    if (r.rflag) { dwords[0] |= (1U << 13); }
+
+    // Dword 1: kv_ns_id[31:0]
+    dwords[1] = r.kv_ns_id;
+
+    // Dword 2: Reserved[15:0]
+    // Dwords 3-4: Response Buffer Address[63:0]
+    dwords[3] = r.response_buffer_addr & 0xFFFFFFFFULL;
+    dwords[4] = (r.response_buffer_addr >> 32) & 0xFFFFFFFFULL;
+
+    // Dword 5: Response Buffer MR_Key[31:0]
+    dwords[5] = r.response_mr_key;
+
+    // Dword 6-7: DPTR.buffer = 0 (fixed)
+
+    // Dword 8: DPTR.length = Batch Number * 16
+    dwords[8] = r.batch_number * kDeleteEntrySizeBytes;
+
+    // Dword 9: DPTR.Type = 0x1
+    dwords[9] = static_cast<std::uint32_t>(DptrType::Batch) << 24;
+
+    // Dword 10: SC[16] | Batch Number[15:0]
+    dwords[10] = r.batch_number;
+    if (r.sc) { dwords[10] |= (1U << 16); }
+
+    // Dwords 11-15: reserved (zero)
+
+    // Pack exist entries
+    for (std::size_t i = 0; i < r.batch_number; ++i) { PackEntry(r.keys[i], i); }
+    return Status::OK();
+}
+
+Status KvExistSqe::Validate() const
+{
+    if (dwords.size() < kSqeDwordCount) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "SQE not packed");
+    }
+    if (dwords[3] == 0 && dwords[4] == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "response_buffer_addr is zero");
+    }
+    std::uint32_t batch_number = dwords[10] & 0xFFFF;
+    if (batch_number == 0 || batch_number > kMaxBatchNumber) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "batch_number must be in range [1, 227]");
+    }
+    std::uint32_t dptr_length = dwords[8] & 0xFFFFFF;
+    if (dptr_length != batch_number * kDeleteEntrySizeBytes) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "DPTR.length must equal batch_number * 16");
+    }
+    std::size_t expected_size = kSqeDwordCount + batch_number * kDeleteEntryDwordCount;
+    if (dwords.size() != expected_size) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "missing exist entries");
+    }
+    return Status::OK();
+}
+
+void KvExistSqe::PackEntry(const std::string& key, std::size_t index)
+{
+    std::size_t base = kSqeDwordCount + index * kDeleteEntryDwordCount;
+
+    std::size_t key_len = std::min(key.size(), static_cast<std::size_t>(16));
+    if (key_len > 0) { std::memcpy(&dwords[base], key.data(), key_len); }
+}
+
+Status KvKeepAliveSqe::Pack(const SqeRequest& req)
+{
+    auto& r = static_cast<const KvKeepAliveRequest&>(req);
+    dwords.assign(kSqeDwordCount, 0);
+
+    // Dword 0: CID[31:16] | Rflag[13] | Opcode[7:0]=0xF4
+    dwords[0] = (r.cid << 16) | static_cast<std::uint32_t>(SqeOpcode::KeepAlive);
+    if (r.rflag) { dwords[0] |= (1U << 13); }
+
+    // Dword 1-2: Reserved (zero)
+    // Dwords 3-4: Response Buffer Address[63:0]
+    dwords[3] = r.response_buffer_addr & 0xFFFFFFFFULL;
+    dwords[4] = (r.response_buffer_addr >> 32) & 0xFFFFFFFFULL;
+
+    // Dword 5: Response Buffer MR_Key[31:0]
+    dwords[5] = r.response_mr_key;
+
+    // Dwords 6-15: reserved (zero)
+    return Status::OK();
+}
+
+Status KvKeepAliveSqe::Validate() const
+{
+    if (dwords.size() < kSqeDwordCount) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "SQE not packed");
+    }
+    bool rflag = (dwords[0] >> 13) & 0x1;
+    if (rflag && dwords[3] == 0 && dwords[4] == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "response_buffer_addr is zero");
+    }
+    return Status::OK();
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/sqe.h
+++ b/ucm/transport/kv/asu/trans/src/sqe.h
@@ -1,0 +1,324 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "asu_transport/types.h"
+
+namespace UC::ASU {
+
+enum class SqeOpcode : std::uint8_t {
+    Store = 0x1,
+    Retrieve = 0x2,
+    BatchStore = 0x45,
+    BatchRetrieve = 0x46,
+    Delete = 0x8,
+    Exist = 0xC,
+    KeepAlive = 0xF4
+};
+
+enum class DptrType : std::uint8_t { Standard = 0x40, Batch = 0x1 };
+
+constexpr std::size_t kSqeDwordCount = 16;
+constexpr std::uint32_t kFixedBits = 0x3;
+constexpr std::uint32_t kAlignmentBytes = 512;
+constexpr std::size_t kBatchEntrySizeBytes = 36;
+constexpr std::size_t kBatchEntryDwordCount = 9;
+constexpr std::size_t kDeleteEntrySizeBytes = 16;
+constexpr std::size_t kDeleteEntryDwordCount = 4;
+constexpr std::size_t kMaxBatchNumber = 227;
+
+class SqeRequest {
+public:
+    virtual ~SqeRequest() = default;
+};
+
+class KvStoreRequest : public SqeRequest {
+public:
+    std::uint32_t cid{0};
+    std::uint32_t kv_ns_id{0};
+    std::uint8_t dtype{0};
+    std::uint8_t dspec{0};
+    std::uint64_t buffer_addr{0};
+    std::uint32_t buffer_length{0};
+    std::uint32_t mr_key{0};
+    std::uint32_t offset{0};
+    bool lr{false};
+    std::uint32_t length{0};
+    std::string key;
+};
+
+class KvRetrieveRequest : public SqeRequest {
+public:
+    std::uint32_t cid{0};
+    std::uint32_t kv_ns_id{0};
+    std::uint64_t buffer_addr{0};
+    std::uint32_t buffer_length{0};
+    std::uint32_t mr_key{0};
+    std::uint32_t offset{0};
+    bool lr{false};
+    std::uint32_t length{0};
+    std::string key;
+};
+
+class KvBatchStoreEntry {
+public:
+    std::uint32_t offset{0};
+    std::string key;
+    std::uint64_t buffer_addr{0};
+    std::uint32_t mr_key{0};
+    std::uint32_t length{0};
+};
+
+class KvBatchStoreRequest : public SqeRequest {
+public:
+    std::uint32_t cid{0};
+    std::uint32_t kv_ns_id{0};
+    std::uint8_t dtype{0};
+    std::uint8_t dspec{0};
+    std::uint64_t response_buffer_addr{0};
+    std::uint32_t response_mr_key{0};
+    bool lr{false};
+    bool rflag{false};
+    std::uint16_t batch_number{0};
+    std::vector<KvBatchStoreEntry> entries;
+};
+
+class KvBatchRetrieveEntry {
+public:
+    std::uint32_t offset{0};
+    std::string key;
+    std::uint64_t buffer_addr{0};
+    std::uint32_t mr_key{0};
+    std::uint32_t length{0};
+};
+
+class KvBatchRetrieveRequest : public SqeRequest {
+public:
+    std::uint32_t cid{0};
+    std::uint32_t kv_ns_id{0};
+    std::uint64_t response_buffer_addr{0};
+    std::uint32_t response_mr_key{0};
+    bool lr{false};
+    bool rflag{false};
+    std::uint16_t batch_number{0};
+    std::vector<KvBatchRetrieveEntry> entries;
+};
+
+class KvDeleteRequest : public SqeRequest {
+public:
+    std::uint32_t cid{0};
+    std::uint32_t kv_ns_id{0};
+    std::uint64_t response_buffer_addr{0};
+    std::uint32_t response_mr_key{0};
+    bool rflag{false};
+    std::uint16_t batch_number{0};
+    std::vector<std::string> keys;
+};
+
+class KvExistRequest : public SqeRequest {
+public:
+    std::uint32_t cid{0};
+    std::uint32_t kv_ns_id{0};
+    std::uint64_t response_buffer_addr{0};
+    std::uint32_t response_mr_key{0};
+    bool rflag{false};
+    bool sc{false};
+    std::uint16_t batch_number{0};
+    std::vector<std::string> keys;
+};
+
+class KvKeepAliveRequest : public SqeRequest {
+public:
+    std::uint32_t cid{0};
+    std::uint64_t response_buffer_addr{0};
+    std::uint32_t response_mr_key{0};
+    bool rflag{false};
+};
+
+class Sqe {
+public:
+    virtual ~Sqe() = default;
+
+    virtual std::uint32_t GetOpcode() const = 0;
+    const void* Data() const { return dwords.data(); }
+    std::size_t Size() const { return dwords.size() * sizeof(std::uint32_t); }
+
+    virtual Status Pack(const SqeRequest& req) = 0;
+    virtual Status Validate() const = 0;
+
+protected:
+    // TODO: Optimize memory allocation. Currently using vector for dynamic size,
+    // but final implementation should write directly into SendBuffer to avoid copying.
+    std::vector<std::uint32_t> dwords;
+};
+
+class SqeRegistry {
+public:
+    using Creator = std::function<std::unique_ptr<Sqe>()>;
+
+    static void Register(std::uint32_t opcode, Creator creator)
+    {
+        Creators()[opcode] = std::move(creator);
+    }
+
+    static std::unique_ptr<Sqe> Create(std::uint32_t opcode)
+    {
+        auto& creators = Creators();
+        auto it = creators.find(opcode);
+        return it != creators.end() ? it->second() : nullptr;
+    }
+
+private:
+    static std::unordered_map<std::uint32_t, Creator>& Creators()
+    {
+        static std::unordered_map<std::uint32_t, Creator> instance;
+        return instance;
+    }
+};
+
+#define REGISTER_SQE(ClassName, Opcode)                                        \
+    inline static bool _reg_##ClassName = []() {                               \
+        SqeRegistry::Register(static_cast<std::uint32_t>(Opcode),              \
+                              []() { return std::make_unique<ClassName>(); }); \
+        return true;                                                           \
+    }();
+
+class KvStoreSqe : public Sqe {
+public:
+    KvStoreSqe() = default;
+
+    std::uint32_t GetOpcode() const override
+    {
+        return static_cast<std::uint32_t>(SqeOpcode::Store);
+    }
+
+    Status Pack(const SqeRequest& req) override;
+    Status Validate() const override;
+};
+
+class KvRetrieveSqe : public Sqe {
+public:
+    KvRetrieveSqe() = default;
+
+    std::uint32_t GetOpcode() const override
+    {
+        return static_cast<std::uint32_t>(SqeOpcode::Retrieve);
+    }
+
+    Status Pack(const SqeRequest& req) override;
+    Status Validate() const override;
+};
+
+class KvBatchStoreSqe : public Sqe {
+public:
+    KvBatchStoreSqe() = default;
+
+    std::uint32_t GetOpcode() const override
+    {
+        return static_cast<std::uint32_t>(SqeOpcode::BatchStore);
+    }
+
+    Status Pack(const SqeRequest& req) override;
+    Status Validate() const override;
+
+private:
+    void PackEntry(const KvBatchStoreEntry& entry, std::size_t index);
+};
+
+class KvBatchRetrieveSqe : public Sqe {
+public:
+    KvBatchRetrieveSqe() = default;
+
+    std::uint32_t GetOpcode() const override
+    {
+        return static_cast<std::uint32_t>(SqeOpcode::BatchRetrieve);
+    }
+
+    Status Pack(const SqeRequest& req) override;
+    Status Validate() const override;
+
+private:
+    void PackEntry(const KvBatchRetrieveEntry& entry, std::size_t index);
+};
+
+class KvDeleteSqe : public Sqe {
+public:
+    KvDeleteSqe() = default;
+
+    std::uint32_t GetOpcode() const override
+    {
+        return static_cast<std::uint32_t>(SqeOpcode::Delete);
+    }
+
+    Status Pack(const SqeRequest& req) override;
+    Status Validate() const override;
+
+private:
+    void PackEntry(const std::string& key, std::size_t index);
+};
+
+class KvExistSqe : public Sqe {
+public:
+    KvExistSqe() = default;
+
+    std::uint32_t GetOpcode() const override
+    {
+        return static_cast<std::uint32_t>(SqeOpcode::Exist);
+    }
+
+    Status Pack(const SqeRequest& req) override;
+    Status Validate() const override;
+
+private:
+    void PackEntry(const std::string& key, std::size_t index);
+};
+
+class KvKeepAliveSqe : public Sqe {
+public:
+    KvKeepAliveSqe() = default;
+
+    std::uint32_t GetOpcode() const override
+    {
+        return static_cast<std::uint32_t>(SqeOpcode::KeepAlive);
+    }
+
+    Status Pack(const SqeRequest& req) override;
+    Status Validate() const override;
+};
+
+REGISTER_SQE(KvStoreSqe, SqeOpcode::Store)
+REGISTER_SQE(KvRetrieveSqe, SqeOpcode::Retrieve)
+REGISTER_SQE(KvBatchStoreSqe, SqeOpcode::BatchStore)
+REGISTER_SQE(KvBatchRetrieveSqe, SqeOpcode::BatchRetrieve)
+REGISTER_SQE(KvDeleteSqe, SqeOpcode::Delete)
+REGISTER_SQE(KvExistSqe, SqeOpcode::Exist)
+REGISTER_SQE(KvKeepAliveSqe, SqeOpcode::KeepAlive)
+
+}  // namespace UC::ASU


### PR DESCRIPTION
## Purpose
Implement ASU transport protocol packet builders for SQE commands and link establishment

## Modifications
* Add SQE classes: Store, Retrieve, BatchStore, BatchRetrieve, Delete, Exist, KeepAlive
* Add link establishment protocol: NegotiateSqe, ConnectSqe, DisconnectSqe

## Test
All 11 unit tests passed (7 SQE pack + 4 link protocol pack)