### PR TITLE
[bugfix]Fix update_graph_params

### DIFF
--- a/ucm/integration/vllm/patch/v0180/vllm_ascend/pc/attention/sfa_v1_0180.py
+++ b/ucm/integration/vllm/patch/v0180/vllm_ascend/pc/attention/sfa_v1_0180.py
@@ -21,6 +21,19 @@ from vllm_ascend.utils import get_weight_prefetch_method
 
 
 class AscendSFAImpl:
+    @staticmethod
+    def update_graph_params(
+        update_stream,
+        forward_context,
+        num_tokens,
+        vllm_config=None,
+        speculative_config=None,
+        num_dcp_pcp_tokens=None,
+        draft_attn_metadatas=None,
+    ):
+        # sfa does not need to update graph params
+        pass
+
     def forward(
         self,
         layer_name,

--- a/ucm/integration/vllm/patch/v0180/vllm_ascend/pc/attention/sfa_v1_rc1.py
+++ b/ucm/integration/vllm/patch/v0180/vllm_ascend/pc/attention/sfa_v1_rc1.py
@@ -21,6 +21,19 @@ from vllm_ascend.utils import get_weight_prefetch_method
 
 
 class AscendSFAImpl:
+    @staticmethod
+    def update_graph_params(
+        update_stream,
+        forward_context,
+        num_tokens,
+        vllm_config=None,
+        speculative_config=None,
+        num_dcp_pcp_tokens=None,
+        draft_attn_metadatas=None,
+    ):
+        # sfa does not need to update graph params
+        pass
+
     def forward(
         self,
         layer_name,

--- a/ucm/integration/vllm/patch/v0180/vllm_ascend/pc_ascend_patch.py
+++ b/ucm/integration/vllm/patch/v0180/vllm_ascend/pc_ascend_patch.py
@@ -41,14 +41,17 @@ def patch_sfa_v1(mod):
         from ucm.integration.vllm.patch.v0180.vllm_ascend.pc.attention import sfa_v1_rc1
 
         forward = sfa_v1_rc1.AscendSFAImpl.forward
+        update_graph_params = sfa_v1_rc1.AscendSFAImpl.update_graph_params
     else:
         from ucm.integration.vllm.patch.v0180.vllm_ascend.pc.attention import (
             sfa_v1_0180,
         )
 
         forward = sfa_v1_0180.AscendSFAImpl.forward
+        update_graph_params = sfa_v1_0180.AscendSFAImpl.update_graph_params
 
     patch_or_inject(mod.AscendSFAImpl, "forward", forward)
+    patch_or_inject(mod.AscendSFAImpl, "update_graph_params", update_graph_params)
 
 
 @when_imported("vllm_ascend.worker.model_runner_v1")


### PR DESCRIPTION
## Purpose
Backport the no-op AscendSFAImpl.update_graph_params from vllm-ascend main to the 0.18.0/0.18.0rc1 SFA patches.

This fixes MTP speculative decoding with FULL NPU graph, where update_full_graph_params() expects the SFA implementation to provide update_graph_params(), causing:
```text
AttributeError: type object 'AscendSFAImpl' has no attribute 'update_graph_params'
```
The issue did not reproduce with dp=2, tp=8, max-num-batched-tokens=8192, and max-num-seqs=48, but was triggered with tp=16, max-num-batched-tokens=4096, and max-num-seqs=16, likely because the latter configuration hits the FULL graph update path.
## Modifications 

## Test
