### PR TITLE
[WIP] add cqe unpack

### DIFF
--- a/ucm/transport/kv/asu/CMakeLists.txt
+++ b/ucm/transport/kv/asu/CMakeLists.txt
@@ -1,3 +1,4 @@
+if(RUNTIME_ENVIRONMENT STREQUAL "ascend")
 file(GLOB ASU_TRANSPORT_SOURCES CONFIGURE_DEPENDS trans/src/*.cpp)
 add_library(asu_transport SHARED ${ASU_TRANSPORT_SOURCES})
 target_include_directories(asu_transport
@@ -43,4 +44,5 @@ if(BUILD_UNIT_TESTS)
         gtest_main gtest
     )
     gtest_discover_tests(asu.test)
+endif()
 endif()


### PR DESCRIPTION
## Purpose
Implement BufferManager for slot-based memory management with IndexPool,
and unify SQE packing/CQE unpacking into a single KvProtocol abstraction.

## Modifications
1. Add BufferManager with IndexPool-based slot allocation, supporting
   HOST (malloc), HOST_PINNED (aclrtMallocHost + aclrtHostRegister),
   and ASCEND_DEVICE (aclrtMalloc) memory types via AscendBuffer.
2. Unify Sqe/Cqe into KvProtocol base class with PackSqe/UnpackCqe
   interfaces, replacing separate SqeManager and CqeManager.
3. Add ProtocolManager to manage send_buffer and flag_buffer instances,
   with PackRequest, UnpackResponse, and GetCid interfaces.
4. Rename link_proto to link_protocol for naming consistency.
5. Remove old sqe.h/cpp files, replaced by kv_protocol.h/cpp.

## Test
BufferManagerTest (17 cases) and KvProtocolPackTest (10 cases) all passed.