### PR TITLE
[bugfix] Fix FAWA async dump task block release

### DIFF
--- a/ucm/integration/vllm/device.py
+++ b/ucm/integration/vllm/device.py
@@ -119,7 +119,7 @@ class CudaDevice(Device):
 
     def destroy_event_handles(self):
         self.events.clear()
-    
+
     def destroy_event_handle(self, handle: int):
         self.events.pop(handle, None)
 
@@ -238,10 +238,10 @@ class NpuDevice(Device):
                 return 0
             ret = acl.rt.record_event(event, stream)
             if ret != 0:
-                handle = 0
+                acl.rt.destroy_event(event)
                 logger.error(f"acl record_event failed: {ret}")
-            else:
-                handle = int(event)
+                return 0
+            handle = int(event)
             self.events[handle] = event
             return handle
         except Exception as e:

--- a/ucm/integration/vllm/device.py
+++ b/ucm/integration/vllm/device.py
@@ -25,7 +25,7 @@ logger = init_logger(__name__)
 
 class Device(ABC):
     def __init__(self):
-        self.events = []
+        self.events = {}
 
     @abstractmethod
     def get_event_handle(self) -> int:
@@ -38,6 +38,10 @@ class Device(ABC):
 
     @abstractmethod
     def destroy_event_handles(self):
+        pass
+
+    @abstractmethod
+    def destroy_event_handle(self, handle: int):
         pass
 
     @abstractmethod
@@ -104,9 +108,7 @@ class CudaDevice(Device):
             stream = torch.cuda.current_stream()
             cuda_event.record(stream)
             handle = int(cuda_event.cuda_event)
-            if handle is None or handle == 0:
-                return 0
-            self.events.append(cuda_event)
+            self.events[handle] = cuda_event
             return handle
         except Exception as e:
             logger.error(f"get cuda event handle failed. {e}")
@@ -117,6 +119,9 @@ class CudaDevice(Device):
 
     def destroy_event_handles(self):
         self.events.clear()
+    
+    def destroy_event_handle(self, handle: int):
+        self.events.pop(handle, None)
 
     def get_cpu_affinity(self, local_rank: int) -> Optional[str]:
         """
@@ -231,14 +236,13 @@ class NpuDevice(Device):
             if ret != 0:
                 logger.error(f"acl create_event failed: {ret}")
                 return 0
-            self.events.append(event)
             ret = acl.rt.record_event(event, stream)
             if ret != 0:
+                handle = 0
                 logger.error(f"acl record_event failed: {ret}")
-                return 0
-            handle = int(event)
-            if not handle:
-                return 0
+            else:
+                handle = int(event)
+            self.events[handle] = event
             return handle
         except Exception as e:
             logger.error(f"get npu event handle failed. {e}")
@@ -250,12 +254,22 @@ class NpuDevice(Device):
     def destroy_event_handles(self):
         import acl
 
-        for event in self.events:
+        for event in self.events.values():
             try:
                 acl.rt.destroy_event(event)
             except Exception as e:
                 logger.error(f"destroy npu event failed. {e}")
         self.events.clear()
+
+    def destroy_event_handle(self, handle: int):
+        import acl
+
+        event = self.events.pop(handle, None)
+        if event is not None:
+            try:
+                acl.rt.destroy_event(event)
+            except Exception as e:
+                logger.error(f"destroy npu event failed. {e}")
 
     def _execute_command(self, cmd_list: List[str]) -> str:
         try:

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -1072,7 +1072,6 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
             raise RuntimeError(f"Unexpected FAWA metadata type: {type(metadata)}")
 
         try:
-            event_handle = self._get_dump_event_handle()
             if self.fa_store is None:
                 raise RuntimeError("FA store is not initialized.")
             if self.wa_store is None:
@@ -1140,7 +1139,8 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                             request.dump_vllm_block_ids,
                         )
                     )
-
+            
+            event_handle = self._get_dump_event_handle()
             if fa_dump_keys:
                 fa_ptrs = np.vstack(fa_ptr_rows)
                 if dump_request_ids not in self.tp_dump_tasks:
@@ -1167,6 +1167,8 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                         event_handle,
                     )
                 )
+            if self.enable_event_sync:
+                self.device.destroy_event_handles()
         except Exception as e:
             logger.error(f"dump FAWA kv cache failed. {type(e).__name__}: {e}")
 

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -241,6 +241,7 @@ class UCMFAWAConnectorMetadata(KVConnectorMetadata):
     """Connector metadata carrying FAWA dispatch plans for this step."""
 
     request_meta: dict[str, FAWARequestDispatchMeta] = field(default_factory=dict)
+    preempted_req_ids: set[str] = field(default_factory=set)
 
 
 @dataclass
@@ -838,7 +839,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
 
     def build_connector_meta(
         self, scheduler_output: SchedulerOutput
-    ) -> KVConnectorMetadata:
+    ) -> UCMFAWAConnectorMetadata:
         requests_dispatch_meta: dict[str, FAWARequestDispatchMeta] = {}
         # New requests may need both external-prefix load and new-block dump.
         for request in scheduler_output.scheduled_new_reqs:
@@ -880,7 +881,8 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         for request_id in scheduler_output.finished_req_ids:
             self.requests_meta.pop(request_id, None)
 
-        return UCMFAWAConnectorMetadata(requests_dispatch_meta)
+        preempted_req_ids = set(scheduler_output.preempted_req_ids or ())
+        return UCMFAWAConnectorMetadata(requests_dispatch_meta, preempted_req_ids)
 
     def update_connector_output(self, connector_output) -> None:
         return None
@@ -945,11 +947,6 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
             task=task,
             key_count=len(keys),
         )
-
-    def _wait_dump_task(self, dump_task: FAWADumpTask) -> None:
-        """Wait for a previously submitted FAWA dump task."""
-
-        dump_task.store.wait(dump_task.task)
 
     def _extract_fa_ptr(self, store_keys, hash_start, hash_end, candidate_vllm_ids):
         """Build store pointer rows for full-attention cache segments."""
@@ -1173,33 +1170,43 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         except Exception as e:
             logger.error(f"dump FAWA kv cache failed. {type(e).__name__}: {e}")
 
-    def handle_preemptions(self, kv_connector_metadata: KVConnectorMetadata):
-        # Worker side method
-        try:
-            for dump_tasks in self.tp_dump_tasks.values():
+    def _drain_best_effort_dump_tasks(self, finished_req_ids: set[str]) -> None:
+        """Best-effort wait for FAWA dump tasks.
+
+        Dump failures only mean the external cache may miss later. They must not
+        block vLLM from releasing HBM blocks, so failed tasks are logged and then
+        removed from tracking.
+        """
+        if not finished_req_ids:
+            return
+
+        finished_chunk_req_ids = []
+        for request_ids, dump_tasks in self.tp_dump_tasks.items():
+            if finished_req_ids.intersection(request_ids):
+                finished_chunk_req_ids.append(request_ids)
                 for dump_task in dump_tasks:
-                    self._wait_dump_task(dump_task)
-            self.tp_dump_tasks = {}
-        except Exception as e:
-            logger.error(f"Wait for dumping kv cache failed. {type(e).__name__}: {e}")
+                    try:
+                        dump_task.store.wait(dump_task.task)
+                    except Exception as e:
+                        logger.error(
+                            "Best-effort FAWA dump task failed; external cache may miss. "
+                            f"label={dump_task.label}, keys={dump_task.key_count}, "
+                            f"{type(e).__name__}: {e}"
+                        )
+
+        for request_ids in finished_chunk_req_ids:
+            self.tp_dump_tasks.pop(request_ids, None)
+
+    def handle_preemptions(self, kv_connector_metadata: UCMFAWAConnectorMetadata):
+        # Worker side method
+        self._drain_best_effort_dump_tasks(kv_connector_metadata.preempted_req_ids)
 
     def get_finished(
         self,
         finished_req_ids: set[str],
     ) -> tuple[set[str] | None, set[str] | None]:
         # Worker side method
-        try:
-            if finished_req_ids:
-                finished_chunk_req_ids = []
-                for request_ids, dump_tasks in self.tp_dump_tasks.items():
-                    if finished_req_ids.intersection(request_ids):
-                        finished_chunk_req_ids.append(request_ids)
-                        for dump_task in dump_tasks:
-                            self._wait_dump_task(dump_task)
-                for request_ids in finished_chunk_req_ids:
-                    self.tp_dump_tasks.pop(request_ids, None)
-        except Exception as e:
-            logger.error(f"Wait for dumping kv cache failed. {type(e).__name__}: {e}")
+        self._drain_best_effort_dump_tasks(finished_req_ids)
         return finished_req_ids, None
 
     def request_finished_all_groups(

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -264,6 +264,7 @@ class FAWADumpTask:
     store: UcmKVStoreBaseV1
     task: Task
     key_count: int
+    event_handle: int
 
 
 class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
@@ -299,7 +300,6 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         self.wa_store: Optional[UcmKVStoreBaseV1] = None
         self.requests_meta: dict[str, FAWARequestMeta] = {}
         self.tp_dump_tasks: dict[tuple, list[FAWADumpTask]] = {}
-        self.tp_dump_handles: dict[tuple, int] = {}
 
         if role == KVConnectorRole.SCHEDULER:
             self.store = self._create_fa_store(None)
@@ -936,7 +936,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         store: UcmKVStoreBaseV1,
         keys: list[bytes],
         ptrs: np.ndarray,
-        event_handle,
+        event_handle: int,
     ) -> FAWADumpTask:
         """Submit one store dump for FA or WA rows."""
 
@@ -947,6 +947,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
             store=store,
             task=task,
             key_count=len(keys),
+            event_handle=event_handle,
         )
 
     def _extract_fa_ptr(self, store_keys, hash_start, hash_end, candidate_vllm_ids):
@@ -1072,67 +1073,43 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         if not isinstance(metadata, UCMFAWAConnectorMetadata):
             raise RuntimeError(f"Unexpected FAWA metadata type: {type(metadata)}")
 
-        try:
-            if self.fa_store is None:
-                raise RuntimeError("FA store is not initialized.")
-            if self.wa_store is None:
-                raise RuntimeError("WA store is not initialized.")
+        if self.fa_store is None:
+            raise RuntimeError("FA store is not initialized.")
+        if self.wa_store is None:
+            raise RuntimeError("WA store is not initialized.")
 
-            fa_dump_keys: list[bytes] = []
-            wa_dump_keys: list[bytes] = []
-            fa_ptr_rows: list[np.ndarray] = []
-            wa_ptr_rows: list[np.ndarray] = []
-            dump_request_ids: tuple[str] = ()
-            if self.tp_size > 1:
-                # Split FA rows by canonical block index and balance WA rows by
-                # assigning whole request boundaries round-robin across ranks.
-                wa_dump_ring_idx = 0
-                for request_id, request in metadata.request_meta.items():
-                    if not request.dump_keys:
-                        continue
-                    dump_request_ids += (request_id,)
-                    num_keys = len(request.dump_keys)
-                    tp_block_start = num_keys * self.tp_rank // self.tp_size
-                    tp_block_end = num_keys * (self.tp_rank + 1) // self.tp_size
-                    tp_dump_keys = request.dump_keys[tp_block_start:tp_block_end]
-                    if tp_dump_keys:
-                        tp_dump_vllm_block_ids = tuple(
-                            group_block_ids[tp_block_start:tp_block_end]
-                            for group_block_ids in request.dump_vllm_block_ids
-                        )
-                        fa_dump_keys.extend(tp_dump_keys)
-                        fa_ptr_rows.append(
-                            self._extract_fa_ptr(
-                                tp_dump_keys,
-                                request.dump_hash_start + tp_block_start,
-                                request.dump_hash_start + tp_block_end,
-                                tp_dump_vllm_block_ids,
-                            )
-                        )
-                    if wa_dump_ring_idx % self.tp_size == self.tp_rank:
-                        wa_dump_keys.extend(request.dump_keys[-1:])
-                        wa_ptr_rows.append(
-                            self._extract_wa_ptr(
-                                request.dump_keys[-1:],
-                                request.dump_vllm_block_ids,
-                            )
-                        )
-                    wa_dump_ring_idx += 1
-            else:
-                for request_id, request in metadata.request_meta.items():
-                    if not request.dump_keys:
-                        continue
-                    dump_request_ids += (request_id,)
-                    fa_dump_keys.extend(request.dump_keys)
+        fa_dump_keys: list[bytes] = []
+        wa_dump_keys: list[bytes] = []
+        fa_ptr_rows: list[np.ndarray] = []
+        wa_ptr_rows: list[np.ndarray] = []
+        dump_request_ids: tuple[str] = ()
+        if self.tp_size > 1:
+            # Split FA rows by canonical block index and balance WA rows by
+            # assigning whole request boundaries round-robin across ranks.
+            wa_dump_ring_idx = 0
+            for request_id, request in metadata.request_meta.items():
+                if not request.dump_keys:
+                    continue
+                dump_request_ids += (request_id,)
+                num_keys = len(request.dump_keys)
+                tp_block_start = num_keys * self.tp_rank // self.tp_size
+                tp_block_end = num_keys * (self.tp_rank + 1) // self.tp_size
+                tp_dump_keys = request.dump_keys[tp_block_start:tp_block_end]
+                if tp_dump_keys:
+                    tp_dump_vllm_block_ids = tuple(
+                        group_block_ids[tp_block_start:tp_block_end]
+                        for group_block_ids in request.dump_vllm_block_ids
+                    )
+                    fa_dump_keys.extend(tp_dump_keys)
                     fa_ptr_rows.append(
                         self._extract_fa_ptr(
-                            request.dump_keys,
-                            request.dump_hash_start,
-                            request.dump_hash_end,
-                            request.dump_vllm_block_ids,
+                            tp_dump_keys,
+                            request.dump_hash_start + tp_block_start,
+                            request.dump_hash_start + tp_block_end,
+                            tp_dump_vllm_block_ids,
                         )
                     )
-
+                if wa_dump_ring_idx % self.tp_size == self.tp_rank:
                     wa_dump_keys.extend(request.dump_keys[-1:])
                     wa_ptr_rows.append(
                         self._extract_wa_ptr(
@@ -1140,14 +1117,36 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                             request.dump_vllm_block_ids,
                         )
                     )
-            
-            if fa_dump_keys or wa_dump_keys:
-                event_handle = self._get_dump_event_handle()
-                self.tp_dump_handles[dump_request_ids] = event_handle
-            if fa_dump_keys:
-                fa_ptrs = np.vstack(fa_ptr_rows)
-                if dump_request_ids not in self.tp_dump_tasks:
-                    self.tp_dump_tasks[dump_request_ids] = []
+                wa_dump_ring_idx += 1
+        else:
+            for request_id, request in metadata.request_meta.items():
+                if not request.dump_keys:
+                    continue
+                dump_request_ids += (request_id,)
+                fa_dump_keys.extend(request.dump_keys)
+                fa_ptr_rows.append(
+                    self._extract_fa_ptr(
+                        request.dump_keys,
+                        request.dump_hash_start,
+                        request.dump_hash_end,
+                        request.dump_vllm_block_ids,
+                    )
+                )
+
+                wa_dump_keys.extend(request.dump_keys[-1:])
+                wa_ptr_rows.append(
+                    self._extract_wa_ptr(
+                        request.dump_keys[-1:],
+                        request.dump_vllm_block_ids,
+                    )
+                )
+
+        if fa_dump_keys:
+            event_handle = self._get_dump_event_handle()
+            fa_ptrs = np.vstack(fa_ptr_rows)
+            if dump_request_ids not in self.tp_dump_tasks:
+                self.tp_dump_tasks[dump_request_ids] = []
+            try:
                 self.tp_dump_tasks[dump_request_ids].append(
                     self._submit_dump_task(
                         "FA",
@@ -1157,10 +1156,15 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                         event_handle,
                     )
                 )
-            if wa_dump_keys:
-                window_ptrs = np.vstack(wa_ptr_rows)
-                if dump_request_ids not in self.tp_dump_tasks:
-                    self.tp_dump_tasks[dump_request_ids] = []
+            except Exception as e:
+                self.device.destroy_event_handle(event_handle)
+                logger.error(f"dump FAWA kv cache failed. {type(e).__name__}: {e}")
+        if wa_dump_keys:
+            event_handle = self._get_dump_event_handle()
+            window_ptrs = np.vstack(wa_ptr_rows)
+            if dump_request_ids not in self.tp_dump_tasks:
+                self.tp_dump_tasks[dump_request_ids] = []
+            try:
                 self.tp_dump_tasks[dump_request_ids].append(
                     self._submit_dump_task(
                         "WA",
@@ -1170,8 +1174,9 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                         event_handle,
                     )
                 )
-        except Exception as e:
-            logger.error(f"dump FAWA kv cache failed. {type(e).__name__}: {e}")
+            except Exception as e:
+                self.device.destroy_event_handle(event_handle)
+                logger.error(f"dump FAWA kv cache failed. {type(e).__name__}: {e}")
 
     def _drain_best_effort_dump_tasks(self, finished_req_ids: set[str]) -> None:
         """Best-effort wait for FAWA dump tasks.
@@ -1196,12 +1201,11 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                             f"label={dump_task.label}, keys={dump_task.key_count}, "
                             f"{type(e).__name__}: {e}"
                         )
+                    finally:
+                        self.device.destroy_event_handle(dump_task.event_handle)
 
         for request_ids in finished_chunk_req_ids:
             self.tp_dump_tasks.pop(request_ids, None)
-            handle = self.tp_dump_handles.pop(request_ids, None)
-            if handle is not None:
-                self.device.destroy_event_handle(handle)
 
     def handle_preemptions(self, kv_connector_metadata: UCMFAWAConnectorMetadata):
         # Worker side method

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -1200,7 +1200,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                     self.tp_dump_tasks.pop(request_ids, None)
         except Exception as e:
             logger.error(f"Wait for dumping kv cache failed. {type(e).__name__}: {e}")
-        return None, None
+        return finished_req_ids, None
 
     def request_finished_all_groups(
         self,
@@ -1208,4 +1208,4 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, object] | None]:
         # Scheduler side method
-        return False, None
+        return True, None

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -299,6 +299,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         self.wa_store: Optional[UcmKVStoreBaseV1] = None
         self.requests_meta: dict[str, FAWARequestMeta] = {}
         self.tp_dump_tasks: dict[tuple, list[FAWADumpTask]] = {}
+        self.tp_dump_handles: dict[tuple, int] = {}
 
         if role == KVConnectorRole.SCHEDULER:
             self.store = self._create_fa_store(None)
@@ -1140,7 +1141,9 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                         )
                     )
             
-            event_handle = self._get_dump_event_handle()
+            if fa_dump_keys or wa_dump_keys:
+                event_handle = self._get_dump_event_handle()
+                self.tp_dump_handles[dump_request_ids] = event_handle
             if fa_dump_keys:
                 fa_ptrs = np.vstack(fa_ptr_rows)
                 if dump_request_ids not in self.tp_dump_tasks:
@@ -1167,8 +1170,6 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                         event_handle,
                     )
                 )
-            if self.enable_event_sync:
-                self.device.destroy_event_handles()
         except Exception as e:
             logger.error(f"dump FAWA kv cache failed. {type(e).__name__}: {e}")
 
@@ -1198,6 +1199,9 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
 
         for request_ids in finished_chunk_req_ids:
             self.tp_dump_tasks.pop(request_ids, None)
+            handle = self.tp_dump_handles.pop(request_ids, None)
+            if handle is not None:
+                self.device.destroy_event_handle(handle)
 
     def handle_preemptions(self, kv_connector_metadata: UCMFAWAConnectorMetadata):
         # Worker side method


### PR DESCRIPTION
## Purpose
Fix FAWA async dump task completion reporting so vLLM delays HMA block release until worker-side dump tasks finish.
## Modifications 
- Return finished sending request ids from `get_finished` after matching FAWA dump tasks are waited.
- Make scheduler-side `request_finished_all_groups` delay block freeing until workers report dump completion.
## Test
Not run locally.
