### PR TITLE
[Feat] Add kv-test tool

### DIFF
--- a/docs/source/developer-guide/kv-test.md
+++ b/docs/source/developer-guide/kv-test.md
@@ -1,0 +1,536 @@
+# kv-test command line tool
+
+`kv-test` is a command line validation tool for the ASU KV client path. The
+current implementation supports local smoke testing, basic request validation,
+consistency checks, and simple benchmark metrics.
+
+The tool reads one key-value config file. It first loads the file through the
+ASU client config parser, then reads kv-test-specific options from the same
+file.
+
+## Build and environment
+
+`kv-test` is built from `ucm/transport/kv/kv-test/CMakeLists.txt` and links
+against `asu_client`.
+
+`kv-test` is included only when ASU support is enabled:
+
+```bash
+cmake -S . -B build-kv-test -DBUILD_UCM_ASU=ON
+cmake --build build-kv-test --target kv-test
+```
+
+The example environment script is:
+
+```bash
+source ucm/transport/kv/kv-test/set_kvtest_env.sh
+```
+
+Use `source` if the exported `KV_TEST_CONFIG` and `PATH` must remain visible in
+the current shell. Running the script as `./set_kvtest_env.sh` only updates the
+script process and does not update the caller's shell.
+
+The bundled example config is:
+
+```text
+ucm/transport/kv/kv-test/asu_kv_test.conf
+```
+
+The bundled example view file is:
+
+```text
+ucm/transport/kv/kv-test/asu_view.conf
+```
+
+The sample config uses relative paths such as `view.config_path`,
+`local_store.path`, and `output.path`. They are resolved against the process
+working directory, not against the config file directory. The bundled examples
+assume commands are run from the repository root.
+
+## Command format
+
+```bash
+kv-test <command> [options]
+kv-test <command> --help
+kv-test --help
+kv-test --version
+```
+
+`--configpath <path>` selects the config file for one run. If it is omitted,
+`KV_TEST_CONFIG` is used. Commands other than `--help` and `--version` fail when
+neither is set.
+
+Naming rules:
+
+- CLI commands and long options use kebab-case, for example `batch-store`,
+  `power-cycle`, `--batch-size`, and `--read-ratio`.
+- Config keys use dot-separated snake_case, for example `bench.read_ratio`,
+  `limits.batch_store_max`, and `transport.asu_ids`.
+- Compatibility spellings may exist in lower-level parsers, but kv-test help,
+  docs, examples, and generated configs should only use the canonical forms
+  above.
+
+Supported commands:
+
+| Command | Current behavior |
+| --- | --- |
+| `connect` | Initializes the ASU client and exits. |
+| `config check` | Loads config, validates fixed kv-test behavior constraints, prints selected config values, and exits. |
+| `version` | Prints `kv-test version <value>`, where the value is read from `version.ini`. |
+| `store` | Stores entries one by one. |
+| `retrieve` | Retrieves entries one by one. |
+| `delete` | Deletes all selected keys in one ASU client call. |
+| `exist` | Runs a per-key ASU query and prints existence summary. |
+| `batch-store` | Stores all selected entries in one ASU client call. |
+| `batch-retrieve` | Retrieves all selected entries in one ASU client call. |
+| `power-cycle prepare` | Same execution path as `batch-store`/store-like commands. |
+| `power-cycle verify` | Same execution path as retrieve-like commands and always performs value consistency checking. |
+| `bench` | Runs a synchronous benchmark loop for `store`, `retrieve`, `batch-store`, `batch-retrieve`, or `mix`. |
+
+## Common options
+
+Options can use either `--option value` or `--option=value`.
+
+| Option | Description |
+| --- | --- |
+| `--configpath <path>` | Config path for this run. Overrides `KV_TEST_CONFIG`. |
+| `--help`, `-h` | Prints general or command-specific help. |
+| `--version` | Prints tool version. Does not accept positional arguments. |
+| `--check` | Enables consistency checking where supported. |
+| `--timeout <ms>` | Overrides `default_wait_timeout_ms` for this run. |
+| `--output <path>` | Overrides `output.path`. |
+
+## Key selection
+
+At most one key selector can be used in a command:
+
+| Selector | Description |
+| --- | --- |
+| `--key <key>` | Selects one key. |
+| `--keys <k1,k2,...>` | Selects comma-separated keys. Empty items are rejected. |
+| `--keys-file <path>` | Reads comma-separated and/or newline-separated keys from a file. Empty items are rejected. |
+| `--count <n>` | Generates `n` keys as `<kv.key_prefix><index>`, starting at index `0`. |
+| `--prefix <p> --key-start <n> --key-end <n>` | Generates keys in the closed interval `[key-start, key-end]` as `<prefix><index>`. |
+
+`--prefix`, `--key-start`, and `--key-end` must be provided together.
+`--key-start` must be less than or equal to `--key-end`.
+
+When count-based generation is used, `kv.key_prefix` is required. For commands
+that need values, `kv.value_size` is also required.
+
+## Data generation
+
+For normal commands, values are generated deterministically from:
+
+- key
+- seed
+- value size
+
+`delete` and `exist` are key-only commands and do not generate value buffers.
+
+The generator uses a FNV-1a-style seed mix and SplitMix64 byte generation.
+Consistency digests are CRC64-ECMA hex strings.
+
+For `bench`, data generation is separate:
+
+- key prefix defaults to `bench-key-` when `kv.key_prefix` is empty
+- value bytes are filled from `(index + byteIndex + seed) & 0xFF`
+- key count is at least `concurrency * entries_per_operation * 16`
+
+## Config file
+
+The config file format is `key=value`. Empty lines and lines beginning with
+`#` are ignored. The current implementation does not use YAML.
+
+Example:
+
+```ini
+client_id=kv-test-client-0
+default_wait_timeout_ms=5000
+
+asu.client.mode=local
+local_store.path=./kv-test-local-store
+# To exercise AsuClient + AsuTransportImpl with a local mock backend:
+# asu.client.mode=fake_backend
+# fake_backend.path=./kv-test-fake-backend-store
+# fake_backend.latency_ms=1
+
+view.config_path=./ucm/transport/kv/kv-test/asu_view.conf
+hash_table.type=RING_HASH
+ring_hash.virtual_node_count=128
+
+transport.asu_ids=1
+asu_info.1=protocol=TCP,local.comm_id=127.0.0.1,port=19001,local.phy_device_id=0
+
+kv.key_prefix=kv-test-key-
+kv.seed=20260530
+kv.value_size=4096
+kv.count=16
+
+limits.batch_store_max=110
+limits.batch_retrieve_max=110
+limits.delete_max=254
+limits.exist_max=256
+limits.memory_max_bytes=4294967296
+
+bench.io_size=4096
+bench.concurrency=1
+bench.duration_sec=10
+bench.warmup_sec=1
+bench.read_ratio=50
+bench.write_ratio=50
+bench.batch_size=16
+
+output.path=./kv-test-output
+output.realtime_file_max_bytes=104857600
+```
+
+### ASU client fields
+
+These fields are parsed by the ASU client config parser:
+
+| Field | Description |
+| --- | --- |
+| `client_id` | Client identifier. |
+| `view_service_addrs` | View service addresses. |
+| `view.config_path` | File used by the default `ConfigFileViewServer`. |
+| `default_wait_timeout_ms` | Default wait timeout in milliseconds. |
+| `transport.asu_ids` | ASU ids. |
+| `asu_info.<id>` | Endpoint config for one ASU. |
+| `hash_table.type` | Router hash table type. |
+| `ring_hash.virtual_node_count` | Ring hash virtual node count. |
+| `maglev.table_size` | Maglev table size. |
+| `contiguous_block_affinity.*` | Contiguous block affinity options. |
+| `batch_topk_affinity.*` | Batch top-k affinity options. |
+
+### kv-test-only fields
+
+These fields are parsed by `kv-test` itself:
+
+| Field | Description |
+| --- | --- |
+| `asu.client.mode` | Set to `local` to use the file-backed local ASU transport. Set to `fake_backend` to use normal `AsuClient` and `AsuTransportImpl` paths with kv-test's mock backend. Any other value uses the default ASU client transport factory. |
+| `local_store.path` | Local transport storage root. Defaults to `./kv-test-local-store` if local mode is enabled and this field is empty. |
+| `fake_backend.path` | fake_backend storage root. If empty, fake_backend reuses `local_store.path`; if both are empty, it uses `./kv-test-fake-backend-store`. |
+| `fake_backend.latency_ms` | Mock backend completion delay in milliseconds. Default is `1`. |
+| `kv.key_prefix` | Prefix for count-based key generation. |
+| `kv.seed` | Seed for deterministic value generation. |
+| `kv.value_size` | Value size for normal commands. |
+| `kv.count` | Default count for count-based generation. |
+| `limits.batch_store_max` | Maximum accepted `batch-store` batch size. Default `110`. |
+| `limits.batch_retrieve_max` | Maximum accepted `batch-retrieve` batch size. Default `110`. |
+| `limits.delete_max` | Client-side sub-batch limit used after Client routes a delete request to transports. kv-test does not split the user-selected key set before calling Client. |
+| `limits.exist_max` | Client-side sub-batch limit used after Client routes an exist/query request to transports. kv-test does not split the user-selected key set before calling Client. |
+| `limits.memory_max_bytes` | Maximum generated value payload bytes held by kv-test before a command starts. Default is 4 GiB. |
+| `bench.io_size` | Bench value size. |
+| `bench.concurrency` | Number of benchmark operations launched concurrently in one wave. |
+| `bench.duration_sec` | Measured benchmark duration. Must be greater than zero. |
+| `bench.warmup_sec` | Warmup duration. |
+| `bench.read_ratio` | Read ratio used by `bench mix`. |
+| `bench.write_ratio` | Write ratio used by `bench mix`. |
+| `bench.batch_size` | Entries per batch operation. |
+| `output.path` | Base output directory. Empty value uses `.`. |
+| `output.realtime_file_max_bytes` | Maximum realtime CSV size before rolling. Default is 100 MiB. |
+| `connection.timeout_ms` | Also overrides ASU client default wait timeout. |
+
+## Local mode
+
+`asu.client.mode=local` creates a file-backed local ASU transport. It is useful
+for early kv-test self-checks without connecting to a real ViewServer, Hcomm,
+network, or ASU hardware.
+
+Local mode still creates `AsuClient`, but injects kv-test's in-process
+`LocalAsuTransport` factory instead of using the developed `AsuTransportImpl`.
+It is intended for developing and debugging kv-test command parsing, config
+loading, data generation, buffer allocation, consistency checks, report output,
+and basic store/retrieve/delete/exist behavior with a local file-backed
+transport.
+
+Local mode still requires each ASU to have at least one endpoint in `asu_info`.
+The endpoint's `local.comm_id` and `port` are validated so local tests catch
+missing address config in the same place as real transport setup.
+
+In the bundled local config, `protocol=TCP` is a convenient placeholder for ASU
+config parsing and validation. It does not imply that local mode performs real
+TCP IO. For real ASU/Hcomm testing, switch away from local mode and replace
+`protocol`, `local.comm_id`, `port`, and `local.phy_device_id` with the target
+hardware setup.
+
+The local transport stores each key under:
+
+```text
+<local_store.path>/asu-<asuId>/<hex-encoded-key>.bin
+```
+
+The directory persists across separate `kv-test` commands. Delete removes the
+corresponding file. Exist checks whether the file exists.
+
+Because this mode replaces the ASU transport implementation, it can exercise
+`AsuClient` routing and aggregation at a high level, but it does not validate
+`AsuTransportImpl` request building, send-buffer submission, polling, or
+CQE/result-buffer parsing paths.
+
+## fake_backend mode
+
+`asu.client.mode=fake_backend` is for the current `AsuClient` +
+`AsuTransportImpl` software integration stage. kv-test creates the normal
+`AsuClient` path and uses the developed `AsuTransportImpl`, but replaces the
+missing backend send/completion side with a local mock backend.
+
+Use this mode to validate:
+
+- `AsuClient` routing and per-ASU subtask splitting
+- `AsuClient` task aggregation, `Wait`, and result merging
+- `AsuTransportImpl` async submit paths for store, retrieve, delete, and query
+- SQE packing into send buffers
+- flag buffer/CQE polling
+- CQE status handling and result-buffer parsing
+- current register/bind bookkeeping paths
+
+Mocked or not covered in this mode:
+
+- real device or network `Send`
+- real ASU backend execution
+- real CQE writeback by device
+- real memory registration, `rkey`, and `lkey` semantics
+- real connection failure, drain, and recovery behavior
+
+The fake backend stores each key under:
+
+```text
+<fake_backend.path>/asu-<kv_ns_id>/<fnv64-key-hash>.bin
+```
+
+If `fake_backend.path` is empty, fake backend reuses `local_store.path`. If both
+are empty, it uses:
+
+```text
+./kv-test-fake-backend-store
+```
+
+During this temporary integration stage, fake backend maps each
+`TransportConfig.asuId` into `TransportConfig.attrs["kv_ns_id"]` before
+`Transport::Init`. The packed SQE carries `kv_ns_id`, so the mock backend can
+recover a per-ASU namespace from the send buffer without changing the Transport
+`Send` interface. This is a kv-test-only temporary semantic mapping, not a
+long-term protocol statement that KVNS_ID is ASU ID.
+
+Mode differences:
+
+| Item | local | fake_backend |
+| --- | --- | --- |
+| Main development stage | kv-test self-check | `AsuClient` + `AsuTransportImpl` software integration |
+| Uses normal `AsuClient` routing | Yes | Yes |
+| Uses developed `AsuTransportImpl` submit/poll/CQE code | No | Yes |
+| Backend | kv-test `LocalAsuTransport` | kv-test `MockSend` + local CQE completion |
+| Filesystem store layout | `<root>/asu-<asuId>/<hex-key>.bin` | `<root>/asu-<kv_ns_id>/<fnv64-key-hash>.bin` |
+| Validates real device communication | No | No |
+
+## Command behavior
+
+### connect
+
+```bash
+kv-test connect --configpath ./ucm/transport/kv/kv-test/asu_kv_test.conf
+```
+
+The tool loads config, creates the ASU client, initializes it, opens the output
+directory, writes a summary, shuts the client down, and exits.
+
+### config check
+
+```bash
+kv-test config check --configpath ./ucm/transport/kv/kv-test/asu_kv_test.conf
+```
+
+The command validates config loading and fixed kv-test behavior constraints. It
+does not initialize the ASU client and does not open the result writer.
+
+### store and batch-store
+
+```bash
+kv-test store --key key1 --check
+kv-test store --keys key1,key2,key3
+kv-test store --count 16
+kv-test store --prefix user- --key-start 100 --key-end 199
+kv-test batch-store --count 16 --batch-size 16 --check
+```
+
+`store` submits one ASU `StoreAsync` call per entry. `batch-store` submits all
+selected entries in one ASU `StoreAsync` call.
+
+With `--check`, the tool retrieves the same entries and compares the returned
+bytes with generated expected values.
+
+### retrieve and batch-retrieve
+
+```bash
+kv-test retrieve --key key1 --check
+kv-test retrieve --keys key1,key2,key3 --check
+kv-test batch-retrieve --count 16 --batch-size 16 --check
+```
+
+`retrieve` submits one ASU `LoadAsync` call per entry. `batch-retrieve` submits
+all selected entries in one ASU `LoadAsync` call.
+
+With `--check`, retrieved bytes are compared with generated expected values.
+
+### delete
+
+```bash
+kv-test delete --key key1 --check
+kv-test delete --keys key1,key2,key3
+```
+
+The command submits one ASU `DeleteAsync` call containing all selected keys.
+Any DHT routing or per-transport sub-batch splitting is handled inside Client.
+With `--check`, the tool runs an exist query and expects all selected keys to be
+missing.
+
+### exist
+
+```bash
+kv-test exist --key key1
+kv-test exist --keys key1,key2,key3
+```
+
+The command runs ASU `Query` in `PER_KEY` mode with all selected keys. Any DHT
+routing or per-transport sub-batch splitting is handled inside Client.
+Single-key output includes the key and either `exists` or `missing`; multi-key
+output prints total, existing, and missing counts.
+
+### power-cycle prepare and verify
+
+```bash
+kv-test power-cycle prepare --count 16 --value-size 4096
+kv-test power-cycle verify --count 16 --value-size 4096
+```
+
+`power-cycle prepare` uses the same store-like path as `batch-store` and writes
+`power-cycle-metadata.conf` under `output.path` or `.`. The metadata records
+key prefix, seed, value size, and count.
+
+`power-cycle verify` uses the retrieve-like path, reads the same metadata file,
+checks that the current generation settings match it, and always performs
+consistency checking even when `--check` is omitted.
+
+### bench
+
+```bash
+kv-test bench store --duration 10 --concurrency 1 --io-size 4096
+kv-test bench retrieve --duration 10 --concurrency 1 --io-size 4096
+kv-test bench --op batch-store --batch-size 16 --duration 10 --concurrency 1
+kv-test bench --op batch-retrieve --batch-size 16 --duration 10 --concurrency 1
+kv-test bench mix --read-ratio 70 --write-ratio 30 --duration 10 --concurrency 1
+```
+
+Bench operation can be provided as `kv-test bench <op>` or through `--op` /
+`--bench-op`.
+
+Requirements:
+
+- `bench.op` must be set by config, positional op, `--op`, or `--bench-op`.
+- `bench.concurrency` must be greater than zero.
+- `bench.duration_sec` must be greater than zero.
+- `bench.io_size` must be greater than zero.
+- `read_ratio` and `write_ratio` must each be in `0..100`.
+- For `mix`, at least one of `read_ratio` or `write_ratio` must be greater than
+  zero.
+- For `mix`, `read_ratio + write_ratio` must equal `100`.
+
+The benchmark runner launches one asynchronous task per operation in a wave.
+Each wave contains up to `concurrency` operations.
+
+## Output
+
+For commands other than `config check`, the result writer creates:
+
+```text
+<output.path or .>/
+  index.html
+  run-YYYYMMDD-HHMMSS/
+    summary.txt
+    summary.json
+    report.html
+```
+
+Benchmark runs also create these files when samples are written:
+
+```text
+bench-realtime-0.csv
+latency.csv
+```
+
+Runs with consistency failures create:
+
+```text
+consistency_errors.jsonl
+```
+
+Realtime CSV files roll when the next sample would exceed
+`output.realtime_file_max_bytes`.
+
+`report.html` is a self-contained HTML report for one run. It contains request
+metadata, status, benchmark cards, an inline SVG bandwidth curve, latency
+tables, consistency summary, and artifact links.
+
+`index.html` is regenerated after each run and lists all `run-*` reports under
+the same `output.path`.
+
+For a Linux VM, one simple way to view the reports from a browser is:
+
+```bash
+cd ./kv-test-output
+python3 -m http.server 8080 --bind 0.0.0.0
+```
+
+If the VM uses NAT networking, configure host-to-guest port forwarding for TCP
+port `8080`, then open the forwarded host URL in the browser.
+
+The terminal prints:
+
+```text
+kv-test: succeeded
+command=<command>
+config=<config path>
+```
+
+Failures print:
+
+```text
+kv-test: failed: <message> (exit_code=<code>)
+```
+
+Additional terminal summaries are printed for `exist`, enabled consistency
+checks, and `bench`.
+
+## Exit codes
+
+The kv-test layer uses these explicit codes:
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success. |
+| `1` | Invalid argument or config/result-writer error. |
+| `4` | Consistency check failed. |
+
+ASU client failures are converted to `100 + static_cast<int>(UC::ASU::StatusCode)`
+so they do not overlap the kv-test layer's exit codes.
+
+## Examples
+
+```bash
+export KV_TEST_CONFIG=./ucm/transport/kv/kv-test/asu_kv_test.conf
+
+kv-test config check
+kv-test connect
+kv-test store --key hello --check
+kv-test retrieve --key hello --check
+kv-test exist --key hello
+kv-test delete --key hello --check
+
+kv-test store --prefix user- --key-start 100 --key-end 199 --check
+kv-test retrieve --keys-file ./keys.txt --check
+
+kv-test bench batch-store --batch-size 16 --duration 10 --concurrency 1
+```

--- a/docs/source/developer-guide/kv-test.md
+++ b/docs/source/developer-guide/kv-test.md
@@ -16,8 +16,14 @@ against `asu_client`.
 `kv-test` is included only when ASU support is enabled:
 
 ```bash
-cmake -S . -B build-kv-test -DBUILD_UCM_ASU=ON
+cmake -S . -B build-kv-test -DBUILD_UCM_ASU=ON -DBUILD_UCM_STORE=OFF -DBUILD_UNIT_TESTS=OFF -DRUNTIME_ENVIRONMENT=ascend
 cmake --build build-kv-test --target kv-test
+```
+
+The same build can be started from any working directory with:
+
+```bash
+bash ucm/transport/kv/kv-test/build.sh
 ```
 
 The example environment script is:
@@ -325,6 +331,31 @@ Mode differences:
 | Backend | kv-test `LocalAsuTransport` | kv-test `MockSend` + local CQE completion |
 | Filesystem store layout | `<root>/asu-<asuId>/<hex-key>.bin` | `<root>/asu-<kv_ns_id>/<fnv64-key-hash>.bin` |
 | Validates real device communication | No | No |
+
+fake_backend smoke scripts live under:
+
+```text
+ucm/transport/kv/kv-test/scripts/
+```
+
+They can be run after `kv-test` is built and discoverable in `PATH`, or by
+setting `KV_TEST_BIN` to the executable path:
+
+```bash
+export KV_TEST_BIN=./build-kv-test/ucm/transport/kv/kv-test/kv-test
+bash ucm/transport/kv/kv-test/scripts/test_fake_backend_single_asu.sh
+bash ucm/transport/kv/kv-test/scripts/test_fake_backend_multi_asu.sh
+bash ucm/transport/kv/kv-test/scripts/test_fake_backend_protocol_results.sh
+```
+
+Each script keeps its generated config, command logs, fake store, trace files,
+and kv-test reports under:
+
+```text
+./kv-test-output/fake-backend-scripts/run-<timestamp>-<pid>/
+```
+
+Set `KV_TEST_SCRIPT_LOG_DIR` to place these artifacts elsewhere.
 
 ## Command behavior
 

--- a/ucm/transport/kv/CMakeLists.txt
+++ b/ucm/transport/kv/CMakeLists.txt
@@ -2,4 +2,5 @@ add_subdirectory(common)
 
 if(BUILD_UCM_ASU)
     add_subdirectory(asu)
+    add_subdirectory(kv-test)
 endif()

--- a/ucm/transport/kv/kv-test/CMakeLists.txt
+++ b/ucm/transport/kv/kv-test/CMakeLists.txt
@@ -1,0 +1,28 @@
+add_executable(kv-test
+    src/arg_parser.cpp
+    src/asu_client_runner.cpp
+    src/bench_runner.cpp
+    src/buffer_allocator.cpp
+    src/consistency_checker.cpp
+    src/fake_backend.cpp
+    src/hcomm_config_adapter.cpp
+    src/key_value_generator.cpp
+    src/kv_test_app.cpp
+    src/kv_test_config_loader.cpp
+    src/local_asu_transport.cpp
+    src/kv_test_main.cpp
+    src/result_writer.cpp
+)
+
+target_include_directories(kv-test
+    PRIVATE
+        include
+        ../asu/client/include
+        ../asu/trans/include
+        ../asu/trans/src
+)
+
+target_link_libraries(kv-test
+    PRIVATE
+        asu_client
+)

--- a/ucm/transport/kv/kv-test/asu_kv_test.conf
+++ b/ucm/transport/kv/kv-test/asu_kv_test.conf
@@ -8,7 +8,7 @@ default_wait_timeout_ms=5000
 # kv-test local mode uses a file-system backed ASU transport. It does not
 # connect to a real ViewServer, network, Hcomm, or ASU device, but the ASU
 # client still needs view and endpoint fields below to build its router.
-asu.client.mode=local
+asu.client.mode=fake_backend
 
 # Relative paths in this file are resolved against the process working
 # directory. The examples below assume kv-test is run from the repository root.
@@ -44,10 +44,6 @@ kv.value_size=4096
 kv.count=16
 
 # Operation limits used by kv-test validation.
-limits.batch_store_max=110
-limits.batch_retrieve_max=110
-limits.delete_max=254
-limits.exist_max=256
 limits.memory_max_bytes=4294967296
 
 # Bench defaults. CLI flags can override these.

--- a/ucm/transport/kv/kv-test/asu_kv_test.conf
+++ b/ucm/transport/kv/kv-test/asu_kv_test.conf
@@ -1,0 +1,64 @@
+# Example kv-test + ASU client config.
+# Format: key=value. Lines starting with # are ignored.
+
+# ASU client identity and wait behavior.
+client_id=kv-test-client-0
+default_wait_timeout_ms=5000
+
+# kv-test local mode uses a file-system backed ASU transport. It does not
+# connect to a real ViewServer, network, Hcomm, or ASU device, but the ASU
+# client still needs view and endpoint fields below to build its router.
+asu.client.mode=local
+
+# Relative paths in this file are resolved against the process working
+# directory. The examples below assume kv-test is run from the repository root.
+local_store.path=./kv-test-local-store
+
+# The ASU view is loaded from a key-value file. Later refreshes re-read this
+# file; changing the file is the external trigger for view changes.
+view.config_path=./ucm/transport/kv/kv-test/asu_view.conf
+
+# Route all keys to a single ASU for local smoke testing.
+hash_table.type=RING_HASH
+ring_hash.virtual_node_count=128
+transport.asu_ids=1
+
+# ASU endpoint list. Endpoint format:
+# protocol=<UB|ROCE|TCP>,local.comm_id=<ip-or-comm-id>,port=<port>,local.phy_device_id=<device>
+#
+# In local mode, protocol=TCP is a convenient placeholder for parser and
+# validation compatibility; it does not imply real TCP IO.
+# For real ASU/Hcomm testing, replace protocol/local.comm_id/port/device with
+# the target setup and use the non-local ASU client mode.
+#
+# To exercise AsuClient + AsuTransport with a local mock Send/CQE backend, set:
+# asu.client.mode=fake_backend
+# fake_backend.path=./kv-test-fake-backend-store
+# fake_backend.latency_ms=1
+asu_info.1=protocol=TCP,local.comm_id=127.0.0.1,port=19001,local.phy_device_id=0
+
+# kv-test data generation defaults.
+kv.key_prefix=kv-test-key-
+kv.seed=20260530
+kv.value_size=4096
+kv.count=16
+
+# Operation limits used by kv-test validation.
+limits.batch_store_max=110
+limits.batch_retrieve_max=110
+limits.delete_max=254
+limits.exist_max=256
+limits.memory_max_bytes=4294967296
+
+# Bench defaults. CLI flags can override these.
+bench.io_size=4096
+bench.concurrency=1
+bench.duration_sec=10
+bench.warmup_sec=1
+bench.read_ratio=50
+bench.write_ratio=50
+bench.batch_size=16
+
+# ResultWriter output directory.
+output.path=./kv-test-output
+output.realtime_file_max_bytes=104857600

--- a/ucm/transport/kv/kv-test/asu_view.conf
+++ b/ucm/transport/kv/kv-test/asu_view.conf
@@ -3,5 +3,7 @@
 
 viewEpoch=1
 viewId=1
-asuIds=1
+asuIds=1,2,3
 asu_info.1=protocol=TCP,local.comm_id=127.0.0.1,port=19001,local.phy_device_id=0
+asu_info.2=protocol=TCP,local.comm_id=127.0.0.1,port=19002,local.phy_device_id=0
+asu_info.3=protocol=TCP,local.comm_id=127.0.0.1,port=19003,local.phy_device_id=0

--- a/ucm/transport/kv/kv-test/asu_view.conf
+++ b/ucm/transport/kv/kv-test/asu_view.conf
@@ -1,0 +1,7 @@
+# Example ASU view config for kv-test local mode.
+# Format: key=value. Refresh reads this file again; this module does not modify it.
+
+viewEpoch=1
+viewId=1
+asuIds=1
+asu_info.1=protocol=TCP,local.comm_id=127.0.0.1,port=19001,local.phy_device_id=0

--- a/ucm/transport/kv/kv-test/include/kv_test/arg_parser.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/arg_parser.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "kv_test/kv_test_types.h"
+
+namespace UC::KVTest {
+
+class ArgParser {
+public:
+    Status Parse(int argc, char** argv, CommandOptions& options) const;
+};
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/include/kv_test/asu_client_runner.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/asu_client_runner.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <memory>
+#include "kv_test/kv_test_types.h"
+
+namespace UC::KVTest {
+
+class AsuClientRunner {
+public:
+    explicit AsuClientRunner(std::unique_ptr<UC::ASU::AsuClient> client);
+    ~AsuClientRunner();
+
+    Status Init(const KvTestConfig& config);
+    Status Shutdown();
+
+    Status RegisterBuffers(BufferSet& buffers);
+    Status UnregisterBuffers(const BufferSet& buffers);
+
+    // SINGLE_ENTRY_PER_CALL maps single Store/Retrieve to one AsuClient call per entry.
+    // ALL_ENTRIES_IN_ONE_CALL maps batch commands to one AsuClient call with all entries.
+    Status Store(const BufferSet& buffers, SubmitMode submitMode, std::uint64_t timeoutMs,
+                 CommandResult& result);
+    Status Retrieve(const BufferSet& buffers, SubmitMode submitMode, std::uint64_t timeoutMs,
+                    CommandResult& result);
+    Status Delete(const std::vector<UC::ASU::CacheKey>& keys, std::uint64_t timeoutMs,
+                  CommandResult& result);
+    Status Exist(const std::vector<UC::ASU::CacheKey>& keys, std::uint64_t timeoutMs,
+                 CommandResult& result);
+
+private:
+    std::unique_ptr<UC::ASU::AsuClient> client_;
+};
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/include/kv_test/bench_runner.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/bench_runner.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "kv_test/asu_client_runner.h"
+#include "kv_test/kv_test_types.h"
+
+namespace UC::KVTest {
+
+class BenchRunner {
+public:
+    Status Run(const CommandOptions& options, const KvTestConfig& config,
+               AsuClientRunner& clientRunner, CommandResult& result) const;
+};
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/include/kv_test/buffer_allocator.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/buffer_allocator.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "kv_test/kv_test_types.h"
+
+namespace UC::KVTest {
+
+class BufferAllocator {
+public:
+    Status BuildStoreBuffers(const GeneratedData& data, BufferSet& buffers) const;
+    Status BuildRetrieveBuffers(const GeneratedData& data, BufferSet& buffers) const;
+};
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/include/kv_test/consistency_checker.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/consistency_checker.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "kv_test/kv_test_types.h"
+
+namespace UC::KVTest {
+
+class ConsistencyChecker {
+public:
+    Status CheckStoreResult(const GeneratedData& expected, const BufferSet& retrieved,
+                            const CommandResult& result, ConsistencySummary& summary) const;
+    Status CheckRetrieveResult(const GeneratedData& expected, const BufferSet& retrieved,
+                               const CommandResult& result, ConsistencySummary& summary) const;
+    Status CheckDeleteResult(const std::vector<UC::ASU::CacheKey>& keys,
+                             const CommandResult& deleteResult, const CommandResult& existResult,
+                             ConsistencySummary& summary) const;
+    Status CheckExistResult(const std::vector<UC::ASU::CacheKey>& keys, const CommandResult& result,
+                            bool expectedExists, ConsistencySummary& summary) const;
+};
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/include/kv_test/fake_backend.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/fake_backend.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "kv_test/kv_test_types.h"
+
+namespace UC::KVTest {
+
+bool IsFakeBackendMode(const KvTestConfig& config);
+void MaybePrepareFakeBackend(KvTestConfig& config);
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/include/kv_test/fake_backend.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/fake_backend.h
@@ -4,6 +4,19 @@
 
 namespace UC::KVTest {
 
+class FakeBackendAclRuntime {
+public:
+    FakeBackendAclRuntime() = default;
+    ~FakeBackendAclRuntime();
+
+    Status MaybeSetUp(const KvTestConfig& config);
+    void TearDown();
+
+private:
+    bool initialized_{false};
+    bool deviceSet_{false};
+};
+
 bool IsFakeBackendMode(const KvTestConfig& config);
 void MaybePrepareFakeBackend(KvTestConfig& config);
 

--- a/ucm/transport/kv/kv-test/include/kv_test/hcomm_config_adapter.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/hcomm_config_adapter.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "kv_test/kv_test_types.h"
+
+namespace UC::KVTest {
+
+class HcommConfigAdapter {
+public:
+    // Maps UC::ASU::Protocol to the Hcomm protocol selected in questions.md.
+    // TODO: Confirm UBOE and TCP->PCIE mapping with the final Hcomm header.
+    Status ResolveProtocol(UC::ASU::Protocol protocol, const KvTestConfig& config,
+                           HcommProtocol& hcommProtocol) const;
+
+    // Hcomm local role is fixed to server; socket and port are read from ASU config.
+    Status ValidateChannelSource(const KvTestConfig& config) const;
+};
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/include/kv_test/key_value_generator.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/key_value_generator.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "kv_test/kv_test_types.h"
+
+namespace UC::KVTest {
+
+class KeyValueGenerator {
+public:
+    // Generates deterministic value bytes from key, seed, and value-size.
+    Status Generate(const CommandOptions& options, const KvTestConfig& config,
+                    GeneratedData& data) const;
+    // Uses CRC64 by default; digest is for consistency logs and result files.
+    Status Digest(const std::vector<std::uint8_t>& value, std::string& digest) const;
+};
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/include/kv_test/kv_test_app.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/kv_test_app.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "kv_test/arg_parser.h"
+#include "kv_test/asu_client_runner.h"
+#include "kv_test/bench_runner.h"
+#include "kv_test/buffer_allocator.h"
+#include "kv_test/consistency_checker.h"
+#include "kv_test/hcomm_config_adapter.h"
+#include "kv_test/key_value_generator.h"
+#include "kv_test/kv_test_config_loader.h"
+#include "kv_test/result_writer.h"
+
+namespace UC::KVTest {
+
+class KvTestApp {
+public:
+    KvTestApp();
+
+    int Run(int argc, char** argv);
+
+private:
+    Status RunCommand(const CommandOptions& options, const KvTestConfig& config,
+                      AsuClientRunner& clientRunner, CommandResult& result);
+    Status RunStoreLikeCommand(const CommandOptions& options, const KvTestConfig& config,
+                               AsuClientRunner& clientRunner, CommandResult& result);
+    Status RunRetrieveLikeCommand(const CommandOptions& options, const KvTestConfig& config,
+                                  AsuClientRunner& clientRunner, CommandResult& result);
+    Status RunDeleteCommand(const CommandOptions& options, const KvTestConfig& config,
+                            AsuClientRunner& clientRunner, CommandResult& result);
+    Status RunExistCommand(const CommandOptions& options, const KvTestConfig& config,
+                           AsuClientRunner& clientRunner, CommandResult& result);
+
+    ArgParser argParser_;
+    BenchRunner benchRunner_;
+    BufferAllocator bufferAllocator_;
+    ConsistencyChecker consistencyChecker_;
+    HcommConfigAdapter hcommConfigAdapter_;
+    KeyValueGenerator generator_;
+    KvTestConfigLoader configLoader_;
+    ResultWriter resultWriter_;
+};
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/include/kv_test/kv_test_config_loader.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/kv_test_config_loader.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "kv_test/kv_test_types.h"
+
+namespace UC::KVTest {
+
+class KvTestConfigLoader {
+public:
+    Status ResolveConfigPath(const std::string& configPath, std::string& resolvedPath) const;
+
+    // Loads the existing AsuClientConfig key-value format and derives kv-test fields.
+    Status Load(const std::string& configPath, KvTestConfig& config) const;
+    Status MergeCommandOptions(const CommandOptions& options, KvTestConfig& config) const;
+};
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/include/kv_test/kv_test_types.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/kv_test_types.h
@@ -121,6 +121,7 @@ struct CommandOptions {
     bool singleKeyRequested{false};
     bool keyStartSet{false};
     bool keyEndSet{false};
+    bool progress{false};
     std::string outputPath;
 };
 

--- a/ucm/transport/kv/kv-test/include/kv_test/kv_test_types.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/kv_test_types.h
@@ -1,0 +1,258 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+#include "asu_client/asu_client.h"
+
+namespace UC::KVTest {
+
+constexpr std::uint64_t kDefaultMemoryMaxBytes = 4ULL * 1024ULL * 1024ULL * 1024ULL;
+
+enum class CommandType {
+    CONNECT = 0,
+    CONFIG_CHECK,
+    STORE,
+    RETRIEVE,
+    DELETE,
+    EXIST,
+    BATCH_STORE,
+    BATCH_RETRIEVE,
+    POWER_CYCLE_PREPARE,
+    POWER_CYCLE_VERIFY,
+    BENCH,
+    VERSION,
+    UNKNOWN,
+};
+
+enum class BenchOpType {
+    STORE = 0,
+    RETRIEVE,
+    BATCH_STORE,
+    BATCH_RETRIEVE,
+    MIX,
+    UNKNOWN,
+};
+
+enum class ConfigFormat {
+    ASU_CLIENT_KEY_VALUE = 0,
+};
+
+enum class HcommApiBoundary {
+    C_API = 0,
+};
+
+enum class WireProtocol {
+    SQE = 0,
+};
+
+enum class ValuePlacement {
+    ASU_MANAGED = 0,
+};
+
+enum class DigestAlgorithm {
+    CRC64 = 0,
+};
+
+enum class SubmitMode {
+    SINGLE_ENTRY_PER_CALL = 0,
+    ALL_ENTRIES_IN_ONE_CALL,
+};
+
+enum class RetrieveMissingKeyPolicy {
+    PARTIAL_FAILED = 0,
+};
+
+enum class TransportLinkPolicy {
+    SHARED_DATA_LINK = 0,
+};
+
+enum class HcommLocalRole {
+    SERVER = 0,
+};
+
+enum class HcommProtocol {
+    UBOE = 0,
+    ROCE,
+    PCIE,
+};
+
+enum class HcommChannelConfigSource {
+    ASU_CONFIG = 0,
+};
+
+struct Status {
+    int code{0};
+    std::string message;
+
+    bool Ok() const noexcept { return code == 0; }
+
+    static Status Success() { return {}; }
+    static Status Error(int errorCode, std::string errorMessage)
+    {
+        return Status{errorCode, std::move(errorMessage)};
+    }
+};
+
+struct CommandOptions {
+    CommandType command{CommandType::UNKNOWN};
+    BenchOpType benchOp{BenchOpType::UNKNOWN};
+    std::string configPath;
+    std::vector<std::string> keys;
+    std::string keysFile;
+    std::string keyPrefix;
+    std::uint64_t count{0};
+    std::uint64_t keyStart{0};
+    std::uint64_t keyEnd{0};
+    std::uint64_t seed{0};
+    std::uint64_t valueSize{0};
+    std::uint32_t batchSize{0};
+    std::uint32_t concurrency{0};
+    std::uint64_t durationSec{0};
+    std::uint64_t warmupSec{0};
+    std::uint32_t readRatio{0};
+    std::uint32_t writeRatio{0};
+    std::uint64_t timeoutMs{0};
+    bool check{false};
+    bool helpRequested{false};
+    bool versionRequested{false};
+    bool singleKeyRequested{false};
+    bool keyStartSet{false};
+    bool keyEndSet{false};
+    std::string outputPath;
+};
+
+struct BatchLimits {
+    std::uint32_t batchStoreMax{110};
+    std::uint32_t batchRetrieveMax{110};
+    std::uint32_t deleteMax{254};
+    std::uint32_t existMax{256};
+};
+
+struct BenchConfig {
+    BenchOpType op{BenchOpType::UNKNOWN};
+    std::uint64_t ioSize{0};
+    std::uint32_t concurrency{0};
+    std::uint64_t durationSec{0};
+    std::uint64_t warmupSec{0};
+    std::uint32_t readRatio{0};
+    std::uint32_t writeRatio{0};
+    std::uint32_t batchSize{0};
+};
+
+struct OutputConfig {
+    std::string path;
+    std::uint64_t realtimeFileMaxBytes{0};
+};
+
+struct FakeBackendConfig {
+    std::string storePath;
+    std::uint64_t latencyMs{1};
+};
+
+struct ToolBehaviorConfig {
+    ConfigFormat configFormat{ConfigFormat::ASU_CLIENT_KEY_VALUE};
+    HcommApiBoundary hcommApiBoundary{HcommApiBoundary::C_API};
+    WireProtocol wireProtocol{WireProtocol::SQE};
+    ValuePlacement valuePlacement{ValuePlacement::ASU_MANAGED};
+    DigestAlgorithm digestAlgorithm{DigestAlgorithm::CRC64};
+    RetrieveMissingKeyPolicy retrieveMissingKeyPolicy{RetrieveMissingKeyPolicy::PARTIAL_FAILED};
+    TransportLinkPolicy transportLinkPolicy{TransportLinkPolicy::SHARED_DATA_LINK};
+    HcommLocalRole hcommLocalRole{HcommLocalRole::SERVER};
+    HcommChannelConfigSource hcommChannelConfigSource{HcommChannelConfigSource::ASU_CONFIG};
+};
+
+struct HcommProtocolMapping {
+    // TODO: Verify UBOE and TCP->PCIE names against the final Hcomm public enum.
+    HcommProtocol ub{HcommProtocol::UBOE};
+    HcommProtocol roce{HcommProtocol::ROCE};
+    HcommProtocol tcp{HcommProtocol::PCIE};
+};
+
+struct KvTestConfig {
+    UC::ASU::AsuClientConfig asuClientConfig;
+    ToolBehaviorConfig behavior;
+    HcommProtocolMapping hcommProtocolMapping;
+    BatchLimits limits;
+    BenchConfig bench;
+    OutputConfig output;
+    FakeBackendConfig fakeBackend;
+    std::string asuClientMode;
+    std::string localStorePath;
+    std::string keyPrefix;
+    std::uint64_t seed{0};
+    std::uint64_t valueSize{0};
+    std::uint64_t count{0};
+    std::uint64_t memoryMaxBytes{kDefaultMemoryMaxBytes};
+};
+
+struct GeneratedData {
+    std::vector<UC::ASU::CacheKey> keys;
+    std::vector<std::vector<std::uint8_t>> values;
+};
+
+struct BufferSet {
+    std::vector<std::vector<std::uint8_t>> ownedBuffers;
+    std::vector<UC::ASU::MemoryRegion> regions;
+    std::vector<UC::ASU::KVBuffer> entries;
+    std::vector<UC::ASU::RegisterResult> registerResults;
+};
+
+struct BenchLatencyStats {
+    double avgUs{0.0};
+    double minUs{0.0};
+    double maxUs{0.0};
+    double p99_9Us{0.0};
+    double p99_99Us{0.0};
+    double p99_999Us{0.0};
+};
+
+struct BenchRealtimeSample {
+    std::uint64_t timestampSec{0};
+    BenchOpType op{BenchOpType::UNKNOWN};
+    double bandwidthBytesPerSec{0.0};
+    double iops{0.0};
+    double avgLatencyUs{0.0};
+    std::uint64_t errorCount{0};
+};
+
+struct BenchMetrics {
+    BenchOpType op{BenchOpType::UNKNOWN};
+    std::uint64_t valueSize{0};
+    std::uint32_t batchSize{0};
+    std::uint32_t concurrency{0};
+    std::uint64_t warmupSec{0};
+    std::uint64_t durationSec{0};
+    std::uint64_t completedOperations{0};
+    std::uint64_t completedEntries{0};
+    std::uint64_t completedBytes{0};
+    std::uint64_t errorCount{0};
+    double elapsedSec{0.0};
+    double avgBandwidthBytesPerSec{0.0};
+    double avgIops{0.0};
+    double avgBatchIops{0.0};
+    BenchLatencyStats latency;
+    std::vector<BenchRealtimeSample> realtimeSamples;
+};
+
+struct ConsistencySummary {
+    bool enabled{false};
+    std::uint64_t checked{0};
+    std::uint64_t passed{0};
+    std::uint64_t failed{0};
+    std::string key;
+    std::string expected;
+    std::string actual;
+};
+
+struct CommandResult {
+    Status status;
+    UC::ASU::TaskResult taskResult;
+    UC::ASU::QueryResult queryResult;
+    BenchMetrics benchMetrics;
+    ConsistencySummary consistency;
+};
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/include/kv_test/local_asu_transport.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/local_asu_transport.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+#include "asu_client/asu_client.h"
+
+namespace UC::KVTest {
+
+UC::ASU::TransportFactory CreateLocalAsuTransportFactory(std::string storeRoot);
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/include/kv_test/result_writer.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/result_writer.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include "kv_test/kv_test_types.h"
+
+namespace UC::KVTest {
+
+class ResultWriter {
+public:
+    Status Open(const OutputConfig& config);
+    Status WriteSummary(const CommandOptions& options, const CommandResult& result);
+    Status WriteRealtimeSample(const std::string& csvLine);
+    Status WriteLatencySample(const std::string& csvLine);
+    Status WriteConsistencyError(const std::string& line);
+    Status Close();
+
+private:
+    Status WriteHtmlReport(const CommandOptions& options, const CommandResult& result);
+    Status WriteReportIndex();
+    Status OpenRealtimeFile();
+    Status OpenLatencyFile();
+    Status OpenConsistencyErrorFile();
+    Status RollRealtimeFileIfNeeded(std::uint64_t incomingBytes);
+
+    std::string baseOutputDir_;
+    std::string outputDir_;
+    std::uint64_t realtimeFileMaxBytes_{0};
+    std::uint32_t realtimeFileIndex_{0};
+    std::uint64_t realtimeFileBytes_{0};
+    std::ofstream realtimeFile_;
+    std::ofstream latencyFile_;
+    std::ofstream consistencyErrorFile_;
+};
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/scripts/fake_backend_common.sh
+++ b/ucm/transport/kv/kv-test/scripts/fake_backend_common.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+KV_TEST_DIR=$(cd "${SCRIPT_DIR}/.." && pwd)
+PROJECT_ROOT=$(cd "${KV_TEST_DIR}/../../../.." && pwd)
+ANSI_GREEN=$'\033[32m'
+ANSI_RED=$'\033[31m'
+ANSI_RESET=$'\033[0m'
+
+print_success() {
+    echo "${ANSI_GREEN}$*${ANSI_RESET}"
+}
+
+print_error() {
+    echo "${ANSI_RED}$*${ANSI_RESET}" >&2
+}
+
+find_kv_test_bin() {
+    if [[ -n "${KV_TEST_BIN:-}" ]]; then
+        printf '%s\n' "${KV_TEST_BIN}"
+        return
+    fi
+
+    if command -v kv-test >/dev/null 2>&1; then
+        command -v kv-test
+        return
+    fi
+
+    if command -v kv-test.exe >/dev/null 2>&1; then
+        command -v kv-test.exe
+        return
+    fi
+
+    local candidate
+    for candidate in \
+        "${PROJECT_ROOT}/kv-test" \
+        "${PROJECT_ROOT}/kv-test.exe" \
+        "${PROJECT_ROOT}/build-kv-test/ucm/transport/kv/kv-test/kv-test" \
+        "${PROJECT_ROOT}/build-kv-test/ucm/transport/kv/kv-test/kv-test.exe" \
+        "${PROJECT_ROOT}/build/ucm/transport/kv/kv-test/kv-test" \
+        "${PROJECT_ROOT}/build/ucm/transport/kv/kv-test/kv-test.exe"; do
+        if [[ -x "${candidate}" ]]; then
+            printf '%s\n' "${candidate}"
+            return
+        fi
+    done
+
+    echo "kv-test binary not found. Set KV_TEST_BIN or add kv-test to PATH." >&2
+    return 1
+}
+
+make_temp_dir() {
+    local base_dir="${KV_TEST_SCRIPT_LOG_DIR:-${PROJECT_ROOT}/kv-test-output/fake-backend-scripts}"
+    local run_id
+    run_id=$(date +"%Y%m%d-%H%M%S")
+    local dir="${base_dir}/run-${run_id}-$$"
+    mkdir -p "${dir}"
+    printf '%s\n' "${dir}"
+}
+
+write_fake_backend_config() {
+    local config_path=$1
+    local store_path=$2
+    local output_path=$3
+    local asu_ids=$4
+    local view_path="${config_path}.view"
+
+    {
+        echo "viewEpoch=1"
+        echo "viewId=1"
+        echo "asuIds=${asu_ids}"
+        local id
+        IFS=',' read -ra ids <<< "${asu_ids}"
+        for id in "${ids[@]}"; do
+            echo "asu_info.${id}=protocol=TCP,local.comm_id=127.0.0.1,port=$((19000 + id)),local.phy_device_id=0"
+        done
+    } > "${view_path}"
+
+    {
+        echo "client_id=kv-test-fake-backend-script"
+        echo "default_wait_timeout_ms=5000"
+        echo
+        echo "asu.client.mode=fake_backend"
+        echo "fake_backend.path=${store_path}"
+        echo "fake_backend.latency_ms=1"
+        echo "local_store.path=${store_path}"
+        echo
+        echo "view.config_path=${view_path}"
+        echo "hash_table.type=RING_HASH"
+        echo "ring_hash.virtual_node_count=128"
+        echo "transport.asuIds=${asu_ids}"
+        IFS=',' read -ra ids <<< "${asu_ids}"
+        for id in "${ids[@]}"; do
+            echo "asu_info.${id}=protocol=TCP,local.comm_id=127.0.0.1,port=$((19000 + id)),local.phy_device_id=0"
+        done
+        echo
+        echo "kv.key_prefix=kv-test-fake-key-"
+        echo "kv.seed=20260530"
+        echo "kv.value_size=4096"
+        echo "kv.count=16"
+        echo
+        echo "limits.batch_store_max=110"
+        echo "limits.batch_retrieve_max=110"
+        echo "limits.delete_max=254"
+        echo "limits.exist_max=256"
+        echo "limits.memory_max_bytes=4294967296"
+        echo
+        echo "bench.io_size=4096"
+        echo "bench.concurrency=1"
+        echo "bench.duration_sec=1"
+        echo "bench.warmup_sec=0"
+        echo "bench.read_ratio=50"
+        echo "bench.write_ratio=50"
+        echo "bench.batch_size=16"
+        echo
+        echo "output.path=${output_path}"
+        echo "output.realtime_file_max_bytes=104857600"
+    } > "${config_path}"
+}
+
+run_success() {
+    local log_file=$1
+    shift
+    local timeout_sec="${KV_TEST_COMMAND_TIMEOUT_SEC:-30}"
+
+    echo "+ $*"
+    set +e
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "${timeout_sec}" "$@" 2>&1 | tee "${log_file}"
+    else
+        "$@" 2>&1 | tee "${log_file}"
+    fi
+    local exit_code=${PIPESTATUS[0]}
+    set -e
+    if [[ ${exit_code} -ne 0 ]]; then
+        print_error "command failed with exit code ${exit_code}: $*"
+        return "${exit_code}"
+    fi
+}
+
+run_failure() {
+    local log_file=$1
+    shift
+    local timeout_sec="${KV_TEST_COMMAND_TIMEOUT_SEC:-30}"
+
+    echo "+ $*"
+    set +e
+    if command -v timeout >/dev/null 2>&1; then
+        timeout "${timeout_sec}" "$@" 2>&1 | tee "${log_file}"
+    else
+        "$@" 2>&1 | tee "${log_file}"
+    fi
+    local exit_code=${PIPESTATUS[0]}
+    set -e
+    if [[ ${exit_code} -eq 124 ]]; then
+        print_error "command timed out after ${timeout_sec}s: $*"
+        return 1
+    fi
+    if [[ ${exit_code} -eq 0 ]]; then
+        print_error "expected command to fail, but it succeeded: $*"
+        return 1
+    fi
+}
+
+assert_contains() {
+    local file=$1
+    local pattern=$2
+
+    if ! grep -Fq "${pattern}" "${file}"; then
+        print_error "missing expected pattern '${pattern}' in ${file}"
+        return 1
+    fi
+}
+
+assert_dir_has_bins() {
+    local dir=$1
+
+    if [[ ! -d "${dir}" ]]; then
+        print_error "missing directory: ${dir}"
+        return 1
+    fi
+
+    if ! find "${dir}" -maxdepth 1 -type f -name '*.bin' | grep -q .; then
+        print_error "directory has no .bin files: ${dir}"
+        return 1
+    fi
+}

--- a/ucm/transport/kv/kv-test/scripts/test_fake_backend_multi_asu.sh
+++ b/ucm/transport/kv/kv-test/scripts/test_fake_backend_multi_asu.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/fake_backend_common.sh"
+
+KV_TEST=$(find_kv_test_bin)
+WORK_DIR=$(make_temp_dir)
+echo "script artifacts: ${WORK_DIR}"
+
+CONFIG="${WORK_DIR}/kv-test.conf"
+STORE="${WORK_DIR}/store"
+OUTPUT="${WORK_DIR}/output"
+LOG="${WORK_DIR}/command.log"
+
+write_fake_backend_config "${CONFIG}" "${STORE}" "${OUTPUT}" "1,2"
+
+run_success "${LOG}" "${KV_TEST}" store --configpath "${CONFIG}" --prefix fb-multi- --key-start 0 --key-end 63 --check
+run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --prefix fb-multi- --key-start 0 --key-end 63
+assert_contains "${LOG}" "total=64"
+assert_contains "${LOG}" "exists=64"
+assert_contains "${LOG}" "missing=0"
+
+assert_dir_has_bins "${STORE}/asu-1"
+assert_dir_has_bins "${STORE}/asu-2"
+
+print_success "fake_backend multi ASU store namespace passed"

--- a/ucm/transport/kv/kv-test/scripts/test_fake_backend_protocol_results.sh
+++ b/ucm/transport/kv/kv-test/scripts/test_fake_backend_protocol_results.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/fake_backend_common.sh"
+
+KV_TEST=$(find_kv_test_bin)
+WORK_DIR=$(make_temp_dir)
+echo "script artifacts: ${WORK_DIR}"
+
+CONFIG="${WORK_DIR}/kv-test.conf"
+STORE="${WORK_DIR}/store"
+OUTPUT="${WORK_DIR}/output"
+LOG="${WORK_DIR}/command.log"
+TRACE="${WORK_DIR}/fake-backend.trace"
+
+write_fake_backend_config "${CONFIG}" "${STORE}" "${OUTPUT}" "1"
+export KV_TEST_FAKE_BACKEND_TRACE="${TRACE}"
+
+run_success "${LOG}" "${KV_TEST}" store --configpath "${CONFIG}" --key proto-existing
+
+>"${TRACE}"
+run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --key proto-existing
+assert_contains "${LOG}" "result=exists"
+assert_contains "${TRACE}" "opcode=Exist"
+assert_contains "${TRACE}" "status=0x000"
+assert_contains "${TRACE}" "result_buffer=0"
+
+>"${TRACE}"
+run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --keys proto-existing,proto-missing
+assert_contains "${LOG}" "total=2"
+assert_contains "${LOG}" "exists=1"
+assert_contains "${LOG}" "missing=1"
+assert_contains "${TRACE}" "opcode=Exist"
+assert_contains "${TRACE}" "status=0x732"
+assert_contains "${TRACE}" "result_buffer=1"
+
+>"${TRACE}"
+run_failure "${LOG}" "${KV_TEST}" batch-retrieve --configpath "${CONFIG}" --keys proto-existing,proto-missing --batch-size 2
+assert_contains "${TRACE}" "opcode=BatchRetrieve"
+assert_contains "${TRACE}" "status=0x732"
+assert_contains "${TRACE}" "result_buffer=1"
+
+>"${TRACE}"
+run_success "${LOG}" "${KV_TEST}" delete --configpath "${CONFIG}" --keys proto-existing,proto-missing
+assert_contains "${TRACE}" "opcode=Delete"
+assert_contains "${TRACE}" "status=0x000"
+assert_contains "${TRACE}" "result_buffer=0"
+
+print_success "fake_backend protocol result handling passed"

--- a/ucm/transport/kv/kv-test/scripts/test_fake_backend_single_asu.sh
+++ b/ucm/transport/kv/kv-test/scripts/test_fake_backend_single_asu.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/fake_backend_common.sh"
+
+KV_TEST=$(find_kv_test_bin)
+WORK_DIR=$(make_temp_dir)
+echo "script artifacts: ${WORK_DIR}"
+
+CONFIG="${WORK_DIR}/kv-test.conf"
+STORE="${WORK_DIR}/store"
+OUTPUT="${WORK_DIR}/output"
+LOG="${WORK_DIR}/command.log"
+
+write_fake_backend_config "${CONFIG}" "${STORE}" "${OUTPUT}" "1"
+
+run_success "${LOG}" "${KV_TEST}" store --configpath "${CONFIG}" --key fb-single --check
+run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --key fb-single
+assert_contains "${LOG}" "result=exists"
+
+run_success "${LOG}" "${KV_TEST}" retrieve --configpath "${CONFIG}" --key fb-single --check
+run_success "${LOG}" "${KV_TEST}" delete --configpath "${CONFIG}" --key fb-single --check
+
+run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --key fb-single
+assert_contains "${LOG}" "result=missing"
+
+print_success "fake_backend single ASU flow passed"

--- a/ucm/transport/kv/kv-test/set_kvtest_env.sh
+++ b/ucm/transport/kv/kv-test/set_kvtest_env.sh
@@ -2,5 +2,8 @@ SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_ROOT=$(cd "${SCRIPT_DIR}/../../../.." && pwd)
 BUILD_DIR="${BUILD_DIR:-${PROJECT_ROOT}/build-kv-test}"
 
-export KV_TEST_CONFIG="${SCRIPT_DIR}/asu_kv_test.conf"
-export PATH="${PATH}:${BUILD_DIR}/ucm/transport/kv/kv-test"
+export KV_TEST_CONFIG="${SCRIPT_DIR}/asu_kv_test.conf"  # 配置文件路径
+export PATH="${PATH}:${BUILD_DIR}/ucm/transport/kv/kv-test"  # 可执行文件路径
+# export UC_LOGGER_LEVEL=debug
+# export ASU_TRACE=1  # SubBatch切分检查工具
+# export KV_TEST_FAKE_BACKEND_TRACE=/path/of/unified-cache-management/fb.trace

--- a/ucm/transport/kv/kv-test/set_kvtest_env.sh
+++ b/ucm/transport/kv/kv-test/set_kvtest_env.sh
@@ -1,0 +1,6 @@
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "${SCRIPT_DIR}/../../../.." && pwd)
+BUILD_DIR="${BUILD_DIR:-${PROJECT_ROOT}/build-kv-test}"
+
+export KV_TEST_CONFIG="${SCRIPT_DIR}/asu_kv_test.conf"
+export PATH="${PATH}:${BUILD_DIR}/ucm/transport/kv/kv-test"

--- a/ucm/transport/kv/kv-test/src/arg_parser.cpp
+++ b/ucm/transport/kv/kv-test/src/arg_parser.cpp
@@ -1,0 +1,356 @@
+﻿#include "kv_test/arg_parser.h"
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
+#include <sstream>
+#include <unordered_map>
+
+namespace UC::KVTest {
+
+namespace {
+
+constexpr int kExitSuccess = 0;
+constexpr int kExitInvalidArgument = 1;
+
+bool IsOption(const std::string& argument)
+{
+    return argument.rfind("--", 0) == 0 || argument == "-h";
+}
+
+std::vector<std::string> SplitCommaList(const std::string& value)
+{
+    std::vector<std::string> items;
+    std::string item;
+    std::stringstream stream(value);
+    while (std::getline(stream, item, ',')) { items.push_back(item); }
+    return items;
+}
+
+Status ParseUint64(const std::string& option, const std::string& value, std::uint64_t& output)
+{
+    if (value.empty() || value[0] == '-') {
+        return Status::Error(kExitInvalidArgument, option + " expects a non-negative integer");
+    }
+
+    char* end = nullptr;
+    errno = 0;
+    unsigned long long parsed = std::strtoull(value.c_str(), &end, 10);
+    if (errno == ERANGE || end == value.c_str() || *end != '\0') {
+        return Status::Error(kExitInvalidArgument, option + " expects a non-negative integer");
+    }
+
+    output = static_cast<std::uint64_t>(parsed);
+    return Status::Success();
+}
+
+Status ParseUint32(const std::string& option, const std::string& value, std::uint32_t& output)
+{
+    std::uint64_t parsed = 0;
+    auto status = ParseUint64(option, value, parsed);
+    if (!status.Ok()) { return status; }
+    if (parsed > std::numeric_limits<std::uint32_t>::max()) {
+        return Status::Error(kExitInvalidArgument, option + " is too large");
+    }
+
+    output = static_cast<std::uint32_t>(parsed);
+    return Status::Success();
+}
+
+CommandType ParseCommand(const std::string& command)
+{
+    static const std::unordered_map<std::string, CommandType> kCommands = {
+        {"connect",        CommandType::CONNECT       },
+        {"version",        CommandType::VERSION       },
+        {"store",          CommandType::STORE         },
+        {"retrieve",       CommandType::RETRIEVE      },
+        {"delete",         CommandType::DELETE        },
+        {"exist",          CommandType::EXIST         },
+        {"batch-store",    CommandType::BATCH_STORE   },
+        {"batch-retrieve", CommandType::BATCH_RETRIEVE},
+        {"bench",          CommandType::BENCH         },
+    };
+
+    auto iter = kCommands.find(command);
+    return iter == kCommands.end() ? CommandType::UNKNOWN : iter->second;
+}
+
+BenchOpType ParseBenchOp(const std::string& operation)
+{
+    static const std::unordered_map<std::string, BenchOpType> kBenchOps = {
+        {"store",          BenchOpType::STORE         },
+        {"retrieve",       BenchOpType::RETRIEVE      },
+        {"batch-store",    BenchOpType::BATCH_STORE   },
+        {"batch-retrieve", BenchOpType::BATCH_RETRIEVE},
+        {"mix",            BenchOpType::MIX           },
+    };
+
+    auto iter = kBenchOps.find(operation);
+    return iter == kBenchOps.end() ? BenchOpType::UNKNOWN : iter->second;
+}
+
+Status SetCommand(const std::vector<std::string>& positionals, CommandOptions& options)
+{
+    if (positionals.empty()) {
+        return Status::Error(kExitInvalidArgument, "missing kv-test command");
+    }
+
+    if (positionals[0] == "config") {
+        if (positionals.size() != 2) {
+            return Status::Error(kExitInvalidArgument, "config expects check subcommand");
+        }
+        if (positionals[1] == "check") {
+            options.command = CommandType::CONFIG_CHECK;
+            return Status::Success();
+        }
+        return Status::Error(kExitInvalidArgument, "unknown config subcommand: " + positionals[1]);
+    }
+
+    if (positionals[0] == "power-cycle") {
+        if (positionals.size() != 2) {
+            return Status::Error(kExitInvalidArgument,
+                                 "power-cycle expects prepare or verify subcommand");
+        }
+        if (positionals[1] == "prepare") {
+            options.command = CommandType::POWER_CYCLE_PREPARE;
+            return Status::Success();
+        }
+        if (positionals[1] == "verify") {
+            options.command = CommandType::POWER_CYCLE_VERIFY;
+            return Status::Success();
+        }
+        return Status::Error(kExitInvalidArgument,
+                             "unknown power-cycle subcommand: " + positionals[1]);
+    }
+
+    options.command = ParseCommand(positionals[0]);
+    if (options.command == CommandType::UNKNOWN) {
+        return Status::Error(kExitInvalidArgument, "unknown kv-test command: " + positionals[0]);
+    }
+
+    if (options.command == CommandType::BENCH && positionals.size() == 2) {
+        const auto positionalBenchOp = ParseBenchOp(positionals[1]);
+        if (positionalBenchOp == BenchOpType::UNKNOWN) {
+            return Status::Error(kExitInvalidArgument,
+                                 "unknown bench operation: " + positionals[1]);
+        }
+        if (options.benchOp != BenchOpType::UNKNOWN && options.benchOp != positionalBenchOp) {
+            return Status::Error(kExitInvalidArgument, "bench operation conflicts with --bench-op");
+        }
+        options.benchOp = positionalBenchOp;
+        return Status::Success();
+    }
+
+    if (positionals.size() != 1) {
+        return Status::Error(kExitInvalidArgument,
+                             "unexpected positional argument: " + positionals[1]);
+    }
+
+    return Status::Success();
+}
+
+}  // namespace
+
+Status ArgParser::Parse(int argc, char** argv, CommandOptions& options) const
+{
+    options = CommandOptions{};
+    std::vector<std::string> positionals;
+    bool hasKey = false;
+    bool hasKeys = false;
+    bool hasKeysFile = false;
+    bool hasCount = false;
+
+    for (int index = 1; index < argc; ++index) {
+        std::string argument = argv[index];
+        if (!IsOption(argument)) {
+            positionals.push_back(argument);
+            continue;
+        }
+
+        std::string option = argument;
+        std::string value;
+        bool hasInlineValue = false;
+        const auto equalPos = argument.find('=');
+        if (equalPos != std::string::npos) {
+            option = argument.substr(0, equalPos);
+            value = argument.substr(equalPos + 1);
+            hasInlineValue = true;
+        }
+
+        auto requireValue = [&]() -> Status {
+            if (hasInlineValue) {
+                if (value.empty()) {
+                    return Status::Error(kExitInvalidArgument, option + " expects a value");
+                }
+                return Status::Success();
+            }
+            if (index + 1 >= argc || IsOption(argv[index + 1])) {
+                return Status::Error(kExitInvalidArgument, option + " expects a value");
+            }
+            value = argv[++index];
+            return Status::Success();
+        };
+
+        if (option == "--help" || option == "-h") {
+            if (hasInlineValue) {
+                return Status::Error(kExitInvalidArgument, option + " does not take a value");
+            }
+            options.helpRequested = true;
+        } else if (option == "--version") {
+            if (hasInlineValue) {
+                return Status::Error(kExitInvalidArgument, "--version does not take a value");
+            }
+            options.versionRequested = true;
+            options.command = CommandType::VERSION;
+        } else if (option == "--check") {
+            if (hasInlineValue) {
+                return Status::Error(kExitInvalidArgument, "--check does not take a value");
+            }
+            options.check = true;
+        } else if (option == "--configpath") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            options.configPath = value;
+        } else if (option == "--key") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            hasKey = true;
+            options.singleKeyRequested = true;
+            options.keys.push_back(value);
+        } else if (option == "--keys") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            hasKeys = true;
+            auto keys = SplitCommaList(value);
+            for (const auto& key : keys) {
+                if (key.empty()) {
+                    return Status::Error(kExitInvalidArgument, "--keys contains an empty key");
+                }
+                options.keys.push_back(key);
+            }
+        } else if (option == "--keys-file") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            hasKeysFile = true;
+            options.keysFile = value;
+        } else if (option == "--prefix") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            options.keyPrefix = value;
+        } else if (option == "--key-start") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            options.keyStartSet = true;
+            status = ParseUint64(option, value, options.keyStart);
+            if (!status.Ok()) { return status; }
+        } else if (option == "--key-end") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            options.keyEndSet = true;
+            status = ParseUint64(option, value, options.keyEnd);
+            if (!status.Ok()) { return status; }
+        } else if (option == "--count") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            hasCount = true;
+            status = ParseUint64(option, value, options.count);
+            if (!status.Ok()) { return status; }
+        } else if (option == "--seed") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            status = ParseUint64(option, value, options.seed);
+            if (!status.Ok()) { return status; }
+        } else if (option == "--value-size" || option == "--io-size") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            status = ParseUint64(option, value, options.valueSize);
+            if (!status.Ok()) { return status; }
+        } else if (option == "--batch-size") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            status = ParseUint32(option, value, options.batchSize);
+            if (!status.Ok()) { return status; }
+        } else if (option == "--timeout") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            status = ParseUint64(option, value, options.timeoutMs);
+            if (!status.Ok()) { return status; }
+        } else if (option == "--output") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            options.outputPath = value;
+        } else if (option == "--bench-op" || option == "--op") {
+            // TODO(#12): Align bench CLI parameter names with the final kv-test CLI spec.
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            options.benchOp = ParseBenchOp(value);
+            if (options.benchOp == BenchOpType::UNKNOWN) {
+                return Status::Error(kExitInvalidArgument, "unknown bench operation: " + value);
+            }
+        } else if (option == "--concurrency") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            status = ParseUint32(option, value, options.concurrency);
+            if (!status.Ok()) { return status; }
+        } else if (option == "--duration") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            status = ParseUint64(option, value, options.durationSec);
+            if (!status.Ok()) { return status; }
+        } else if (option == "--warmup") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            status = ParseUint64(option, value, options.warmupSec);
+            if (!status.Ok()) { return status; }
+        } else if (option == "--read-ratio") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            status = ParseUint32(option, value, options.readRatio);
+            if (!status.Ok()) { return status; }
+        } else if (option == "--write-ratio") {
+            auto status = requireValue();
+            if (!status.Ok()) { return status; }
+            status = ParseUint32(option, value, options.writeRatio);
+            if (!status.Ok()) { return status; }
+        } else {
+            return Status::Error(kExitInvalidArgument, "unknown option: " + option);
+        }
+    }
+
+    if (options.versionRequested) {
+        if (!positionals.empty()) {
+            return Status::Error(kExitInvalidArgument,
+                                 "--version does not take positional arguments");
+        }
+        return Status::Success();
+    }
+    if (options.helpRequested && positionals.empty()) { return Status::Success(); }
+
+    const bool hasRangePart =
+        !options.keyPrefix.empty() || options.keyStartSet || options.keyEndSet;
+    if (hasRangePart && (options.keyPrefix.empty() || !options.keyStartSet || !options.keyEndSet)) {
+        return Status::Error(kExitInvalidArgument,
+                             "--prefix, --key-start, and --key-end must be specified together");
+    }
+    if (options.keyStartSet && options.keyEndSet && options.keyStart > options.keyEnd) {
+        return Status::Error(kExitInvalidArgument,
+                             "--key-start must be less than or equal to "
+                             "--key-end");
+    }
+
+    const int keySelectorCount = (hasKey ? 1 : 0) + (hasKeys ? 1 : 0) + (hasKeysFile ? 1 : 0) +
+                                 (hasCount ? 1 : 0) + (hasRangePart ? 1 : 0);
+    if (keySelectorCount > 1) {
+        return Status::Error(kExitInvalidArgument,
+                             "--key, --keys, --keys-file, --count, and prefix range are mutually "
+                             "exclusive");
+    }
+
+    auto status = SetCommand(positionals, options);
+    if (!status.Ok()) { return status; }
+
+    if (options.helpRequested) { return Status::Success(); }
+
+    return Status::Success();
+}
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/src/arg_parser.cpp
+++ b/ucm/transport/kv/kv-test/src/arg_parser.cpp
@@ -206,6 +206,11 @@ Status ArgParser::Parse(int argc, char** argv, CommandOptions& options) const
                 return Status::Error(kExitInvalidArgument, "--check does not take a value");
             }
             options.check = true;
+        } else if (option == "--progress") {
+            if (hasInlineValue) {
+                return Status::Error(kExitInvalidArgument, "--progress does not take a value");
+            }
+            options.progress = true;
         } else if (option == "--configpath") {
             auto status = requireValue();
             if (!status.Ok()) { return status; }

--- a/ucm/transport/kv/kv-test/src/asu_client_runner.cpp
+++ b/ucm/transport/kv/kv-test/src/asu_client_runner.cpp
@@ -1,0 +1,258 @@
+﻿#include "kv_test/asu_client_runner.h"
+#include <algorithm>
+#include "asu_client/asu_client.h"
+
+namespace UC::KVTest {
+
+namespace {
+
+constexpr int kExitInvalidArgument = 1;
+constexpr int kExitAsuStatusBase = 100;
+
+Status ToKvTestStatus(const UC::ASU::Status& status, const std::string& operation)
+{
+    if (status.ok()) { return Status::Success(); }
+    return Status::Error(kExitAsuStatusBase + static_cast<int>(status.code),
+                         operation + " failed: " + status.message);
+}
+
+UC::ASU::TaskResult BuildEmptyTaskResult()
+{
+    UC::ASU::TaskResult result;
+    result.status = UC::ASU::Status::OK();
+    return result;
+}
+
+UC::ASU::TaskResult BuildFailedTaskResult(const UC::ASU::Status& status, std::size_t entryCount)
+{
+    UC::ASU::TaskResult result;
+    result.status = status;
+    result.entryStatus.assign(entryCount, status);
+    return result;
+}
+
+Status FinalizeTaskResult(CommandResult& result)
+{
+    result.status = ToKvTestStatus(result.taskResult.status, "asu task");
+    return result.status;
+}
+
+Status FinalizeQueryResult(CommandResult& result)
+{
+    result.status = Status::Success();
+    return result.status;
+}
+
+using EntrySubmitMethod = UC::ASU::Status (UC::ASU::AsuClient::*)(
+    const std::vector<UC::ASU::KVBuffer>&, UC::ASU::TaskId&);
+
+Status SubmitAndWaitEntries(UC::ASU::AsuClient& client,
+                            const std::vector<UC::ASU::KVBuffer>& entries,
+                            EntrySubmitMethod submitMethod, std::uint64_t timeoutMs,
+                            const std::string& operation, CommandResult& result)
+{
+    UC::ASU::TaskId taskId{UC::ASU::kInvalidTaskId};
+    auto status = (client.*submitMethod)(entries, taskId);
+    if (!status.ok()) {
+        result.taskResult = BuildFailedTaskResult(status, entries.size());
+        return FinalizeTaskResult(result);
+    }
+
+    status = client.Wait(taskId, timeoutMs, result.taskResult);
+    if (!status.ok()) {
+        if (result.taskResult.status.ok()) { result.taskResult.status = status; }
+        result.status = ToKvTestStatus(status, operation);
+        return result.status;
+    }
+
+    return FinalizeTaskResult(result);
+}
+
+Status SubmitAndWaitKeys(UC::ASU::AsuClient& client, const std::vector<UC::ASU::CacheKey>& keys,
+                         std::uint64_t timeoutMs, CommandResult& result)
+{
+    UC::ASU::TaskId taskId{UC::ASU::kInvalidTaskId};
+    auto status = client.DeleteAsync(keys, taskId);
+    if (!status.ok()) {
+        result.taskResult = BuildFailedTaskResult(status, keys.size());
+        return FinalizeTaskResult(result);
+    }
+
+    status = client.Wait(taskId, timeoutMs, result.taskResult);
+    if (!status.ok()) {
+        if (result.taskResult.status.ok()) { result.taskResult.status = status; }
+        result.status = ToKvTestStatus(status, "delete");
+        return result.status;
+    }
+
+    return FinalizeTaskResult(result);
+}
+
+Status SubmitEntriesOneByOne(UC::ASU::AsuClient& client,
+                             const std::vector<UC::ASU::KVBuffer>& entries,
+                             EntrySubmitMethod submitMethod, std::uint64_t timeoutMs,
+                             const std::string& operation, CommandResult& result)
+{
+    result.taskResult = BuildEmptyTaskResult();
+    result.taskResult.entryStatus.reserve(entries.size());
+
+    UC::ASU::Status firstFailure = UC::ASU::Status::OK();
+    for (const auto& entry : entries) {
+        std::vector<UC::ASU::KVBuffer> singleEntry{entry};
+        CommandResult singleResult;
+        auto status = SubmitAndWaitEntries(client, singleEntry, submitMethod, timeoutMs, operation,
+                                           singleResult);
+        if (singleResult.taskResult.entryStatus.empty()) {
+            result.taskResult.entryStatus.push_back(singleResult.taskResult.status);
+        } else {
+            result.taskResult.entryStatus.push_back(singleResult.taskResult.entryStatus.front());
+        }
+
+        if (!status.Ok() && firstFailure.ok()) {
+            firstFailure = singleResult.taskResult.status.ok()
+                               ? UC::ASU::Status::Error(
+                                     static_cast<UC::ASU::StatusCode>(status.code), status.message)
+                               : singleResult.taskResult.status;
+        }
+    }
+
+    if (!firstFailure.ok()) {
+        result.taskResult.status = UC::ASU::Status::Error(
+            UC::ASU::StatusCode::PARTIAL_FAILED, operation + " failed for one or more entries");
+        return FinalizeTaskResult(result);
+    }
+
+    return FinalizeTaskResult(result);
+}
+
+}  // namespace
+
+AsuClientRunner::AsuClientRunner(std::unique_ptr<UC::ASU::AsuClient> client)
+    : client_(std::move(client))
+{
+}
+
+AsuClientRunner::~AsuClientRunner() = default;
+
+Status AsuClientRunner::Init(const KvTestConfig& config)
+{
+    if (client_ == nullptr) { return Status::Error(kExitInvalidArgument, "asu client is null"); }
+
+    auto status = client_->Init(config.asuClientConfig);
+    return ToKvTestStatus(status, "asu client init");
+}
+
+Status AsuClientRunner::Shutdown()
+{
+    if (client_ == nullptr) { return Status::Success(); }
+
+    auto status = client_->Shutdown();
+    return ToKvTestStatus(status, "asu client shutdown");
+}
+
+Status AsuClientRunner::RegisterBuffers(BufferSet& buffers)
+{
+    if (client_ == nullptr) { return Status::Error(kExitInvalidArgument, "asu client is null"); }
+    if (buffers.regions.size() != buffers.entries.size()) {
+        return Status::Error(kExitInvalidArgument,
+                             "buffer region count does not match entry count");
+    }
+
+    buffers.registerResults.clear();
+    auto status = client_->RegisterRegions(buffers.regions, buffers.registerResults);
+    if (!status.ok()) { return ToKvTestStatus(status, "register buffers"); }
+    if (buffers.registerResults.size() != buffers.regions.size()) {
+        return Status::Error(kExitInvalidArgument,
+                             "register buffer result count does not match region count");
+    }
+
+    for (std::size_t index = 0; index < buffers.registerResults.size(); ++index) {
+        const auto& result = buffers.registerResults[index];
+        if (!result.status.ok()) { return ToKvTestStatus(result.status, "register buffer entry"); }
+        buffers.entries[index].buffer.handle = result.handle;
+    }
+
+    return Status::Success();
+}
+
+Status AsuClientRunner::UnregisterBuffers(const BufferSet& buffers)
+{
+    if (client_ == nullptr) { return Status::Success(); }
+
+    std::vector<UC::ASU::MRHandle> handles;
+    handles.reserve(buffers.registerResults.size());
+    for (const auto& result : buffers.registerResults) {
+        if (result.handle != UC::ASU::kInvalidMRHandle) { handles.push_back(result.handle); }
+    }
+    if (handles.empty()) { return Status::Success(); }
+
+    auto status = client_->UnregisterRegions(handles);
+    return ToKvTestStatus(status, "unregister buffers");
+}
+
+Status AsuClientRunner::Store(const BufferSet& buffers, SubmitMode submitMode,
+                              std::uint64_t timeoutMs, CommandResult& result)
+{
+    if (client_ == nullptr) { return Status::Error(kExitInvalidArgument, "asu client is null"); }
+    if (buffers.entries.empty()) {
+        result.taskResult = BuildEmptyTaskResult();
+        return FinalizeTaskResult(result);
+    }
+
+    if (submitMode == SubmitMode::SINGLE_ENTRY_PER_CALL) {
+        return SubmitEntriesOneByOne(*client_, buffers.entries, &UC::ASU::AsuClient::StoreAsync,
+                                     timeoutMs, "store", result);
+    }
+
+    return SubmitAndWaitEntries(*client_, buffers.entries, &UC::ASU::AsuClient::StoreAsync,
+                                timeoutMs, "store", result);
+}
+
+Status AsuClientRunner::Retrieve(const BufferSet& buffers, SubmitMode submitMode,
+                                 std::uint64_t timeoutMs, CommandResult& result)
+{
+    if (client_ == nullptr) { return Status::Error(kExitInvalidArgument, "asu client is null"); }
+    if (buffers.entries.empty()) {
+        result.taskResult = BuildEmptyTaskResult();
+        return FinalizeTaskResult(result);
+    }
+
+    if (submitMode == SubmitMode::SINGLE_ENTRY_PER_CALL) {
+        return SubmitEntriesOneByOne(*client_, buffers.entries, &UC::ASU::AsuClient::LoadAsync,
+                                     timeoutMs, "retrieve", result);
+    }
+
+    return SubmitAndWaitEntries(*client_, buffers.entries, &UC::ASU::AsuClient::LoadAsync,
+                                timeoutMs, "retrieve", result);
+}
+
+Status AsuClientRunner::Delete(const std::vector<UC::ASU::CacheKey>& keys, std::uint64_t timeoutMs,
+                               CommandResult& result)
+{
+    if (client_ == nullptr) { return Status::Error(kExitInvalidArgument, "asu client is null"); }
+    if (keys.empty()) {
+        result.taskResult = BuildEmptyTaskResult();
+        return FinalizeTaskResult(result);
+    }
+
+    return SubmitAndWaitKeys(*client_, keys, timeoutMs, result);
+}
+
+Status AsuClientRunner::Exist(const std::vector<UC::ASU::CacheKey>& keys, std::uint64_t timeoutMs,
+                              CommandResult& result)
+{
+    if (client_ == nullptr) { return Status::Error(kExitInvalidArgument, "asu client is null"); }
+
+    UC::ASU::QueryOptions options;
+    options.mode = UC::ASU::QueryMode::PER_KEY;
+    options.timeoutMs = timeoutMs;
+    auto status = client_->Query(keys, options, result.queryResult);
+    if (!status.ok()) {
+        result.status = ToKvTestStatus(status, "exist");
+        return result.status;
+    }
+
+    return FinalizeQueryResult(result);
+}
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/src/bench_runner.cpp
+++ b/ucm/transport/kv/kv-test/src/bench_runner.cpp
@@ -1,0 +1,381 @@
+﻿#include "kv_test/bench_runner.h"
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <future>
+#include <limits>
+#include <numeric>
+#include "kv_test/buffer_allocator.h"
+
+namespace UC::KVTest {
+
+namespace {
+
+constexpr int kExitInvalidArgument = 1;
+
+UC::ASU::MemoryRegion MakeHostRegion(std::vector<std::uint8_t>& buffer)
+{
+    UC::ASU::MemoryRegion region;
+    region.memoryType = UC::ASU::MemoryType::HOST;
+    region.addr = buffer.empty() ? 0 : reinterpret_cast<std::uint64_t>(buffer.data());
+    region.size = buffer.size();
+    region.deviceId = -1;
+    region.numaNode = -1;
+    return region;
+}
+
+UC::ASU::KVBuffer MakeKvBuffer(const UC::ASU::CacheKey& key, const UC::ASU::MemoryRegion& region)
+{
+    UC::ASU::Buffer buffer;
+    buffer.region = region;
+    buffer.handle = UC::ASU::kInvalidMRHandle;
+    return UC::ASU::KVBuffer{key, buffer};
+}
+
+UC::ASU::TaskResult BuildEmptyTaskResult()
+{
+    UC::ASU::TaskResult result;
+    result.status = UC::ASU::Status::OK();
+    return result;
+}
+
+struct OperationOutcome {
+    Status status;
+    double latencyUs{0.0};
+    std::size_t entryCount{0};
+    std::uint64_t bytes{0};
+};
+
+std::uint64_t BenchEntryCount(const BenchConfig& bench, BenchOpType op)
+{
+    if (op == BenchOpType::BATCH_STORE || op == BenchOpType::BATCH_RETRIEVE ||
+        op == BenchOpType::MIX) {
+        return std::max<std::uint32_t>(bench.batchSize, 1);
+    }
+    return 1;
+}
+
+double PercentileUs(const std::vector<double>& sortedLatenciesUs, double percentile)
+{
+    if (sortedLatenciesUs.empty()) { return 0.0; }
+    const double rank =
+        std::ceil((percentile / 100.0) * static_cast<double>(sortedLatenciesUs.size()));
+    const auto index = static_cast<std::size_t>(
+        std::min<double>(std::max<double>(rank, 1.0), sortedLatenciesUs.size()) - 1.0);
+    return sortedLatenciesUs[index];
+}
+
+BenchLatencyStats BuildLatencyStats(const std::vector<double>& latenciesUs)
+{
+    BenchLatencyStats stats;
+    if (latenciesUs.empty()) { return stats; }
+
+    auto sortedLatenciesUs = latenciesUs;
+    std::sort(sortedLatenciesUs.begin(), sortedLatenciesUs.end());
+    stats.minUs = sortedLatenciesUs.front();
+    stats.maxUs = sortedLatenciesUs.back();
+    stats.avgUs = std::accumulate(sortedLatenciesUs.begin(), sortedLatenciesUs.end(), 0.0) /
+                  static_cast<double>(sortedLatenciesUs.size());
+    stats.p99_9Us = PercentileUs(sortedLatenciesUs, 99.9);
+    stats.p99_99Us = PercentileUs(sortedLatenciesUs, 99.99);
+    stats.p99_999Us = PercentileUs(sortedLatenciesUs, 99.999);
+    return stats;
+}
+
+Status CheckBenchMemoryLimit(std::uint64_t keyCount, std::uint64_t ioSize,
+                             std::uint64_t memoryMaxBytes)
+{
+    if (memoryMaxBytes == 0) {
+        return Status::Error(kExitInvalidArgument,
+                             "limits.memory_max_bytes must be greater than zero");
+    }
+    if (keyCount == 0 || ioSize == 0) { return Status::Success(); }
+    if (keyCount > std::numeric_limits<std::uint64_t>::max() / ioSize) {
+        return Status::Error(kExitInvalidArgument, "bench generated value bytes overflow uint64");
+    }
+
+    const auto requiredBytes = keyCount * ioSize;
+    if (requiredBytes > memoryMaxBytes) {
+        return Status::Error(
+            kExitInvalidArgument,
+            "bench generated value bytes exceed limits.memory_max_bytes: required=" +
+                std::to_string(requiredBytes) + ", limit=" + std::to_string(memoryMaxBytes));
+    }
+    return Status::Success();
+}
+
+Status BuildBenchData(const KvTestConfig& config, std::uint64_t keyCount, GeneratedData& data)
+{
+    if (config.bench.ioSize == 0) {
+        return Status::Error(kExitInvalidArgument, "bench io_size must be greater than zero");
+    }
+    if (keyCount > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+        return Status::Error(kExitInvalidArgument, "bench key count exceeds addressable memory");
+    }
+    if (config.bench.ioSize > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+        return Status::Error(kExitInvalidArgument, "bench io_size exceeds addressable memory");
+    }
+
+    auto status = CheckBenchMemoryLimit(keyCount, config.bench.ioSize, config.memoryMaxBytes);
+    if (!status.Ok()) { return status; }
+
+    const std::string keyPrefix = config.keyPrefix.empty() ? "bench-key-" : config.keyPrefix;
+    data = GeneratedData{};
+    data.keys.reserve(static_cast<std::size_t>(keyCount));
+    data.values.reserve(static_cast<std::size_t>(keyCount));
+    for (std::uint64_t index = 0; index < keyCount; ++index) {
+        data.keys.emplace_back(keyPrefix + std::to_string(index));
+        auto& value = data.values.emplace_back(config.bench.ioSize);
+        for (std::uint64_t byteIndex = 0; byteIndex < config.bench.ioSize; ++byteIndex) {
+            value[byteIndex] = static_cast<std::uint8_t>((index + byteIndex + config.seed) & 0xFF);
+        }
+    }
+    return Status::Success();
+}
+
+BufferSet SliceBuffers(const BufferSet& source, std::size_t begin, std::size_t count)
+{
+    BufferSet slice;
+    const auto end = std::min(begin + count, source.entries.size());
+    slice.ownedBuffers.reserve(end - begin);
+    slice.regions.reserve(end - begin);
+    slice.entries.reserve(end - begin);
+
+    for (auto index = begin; index < end; ++index) {
+        slice.ownedBuffers.emplace_back(source.ownedBuffers[index]);
+    }
+    for (std::size_t index = 0; index < slice.ownedBuffers.size(); ++index) {
+        auto region = MakeHostRegion(slice.ownedBuffers[index]);
+        slice.regions.emplace_back(region);
+        slice.entries.emplace_back(MakeKvBuffer(source.entries[begin + index].key, region));
+    }
+    return slice;
+}
+
+bool IsBenchReadOperation(BenchOpType op, std::uint64_t operationIndex, const BenchConfig& bench)
+{
+    if (op == BenchOpType::RETRIEVE || op == BenchOpType::BATCH_RETRIEVE) { return true; }
+    if (op == BenchOpType::STORE || op == BenchOpType::BATCH_STORE) { return false; }
+
+    const auto ratioTotal = bench.readRatio + bench.writeRatio;
+    if (ratioTotal == 0) { return true; }
+    return operationIndex % ratioTotal < bench.readRatio;
+}
+
+Status ExecuteBenchOperation(BenchOpType requestedOp, const BenchConfig& bench,
+                             AsuClientRunner& clientRunner, const BufferSet& storeBuffers,
+                             const BufferSet& retrieveBuffers, std::size_t begin,
+                             std::size_t entryCount, std::uint64_t operationIndex,
+                             std::uint64_t timeoutMs, CommandResult& operationResult)
+{
+    const bool isRead = IsBenchReadOperation(requestedOp, operationIndex, bench);
+    const auto submitMode =
+        entryCount > 1 ? SubmitMode::ALL_ENTRIES_IN_ONE_CALL : SubmitMode::SINGLE_ENTRY_PER_CALL;
+    auto buffers = SliceBuffers(isRead ? retrieveBuffers : storeBuffers, begin, entryCount);
+
+    auto status = clientRunner.RegisterBuffers(buffers);
+    if (!status.Ok()) { return status; }
+
+    status = isRead ? clientRunner.Retrieve(buffers, submitMode, timeoutMs, operationResult)
+                    : clientRunner.Store(buffers, submitMode, timeoutMs, operationResult);
+    auto unregisterStatus = clientRunner.UnregisterBuffers(buffers);
+    if (status.Ok() && !unregisterStatus.Ok()) { status = unregisterStatus; }
+    return status;
+}
+
+using EntrySubmitMethod = UC::ASU::Status (UC::ASU::AsuClient::*)(
+    const std::vector<UC::ASU::KVBuffer>&, UC::ASU::TaskId&);
+
+}  // namespace
+
+Status BenchRunner::Run(const CommandOptions&, const KvTestConfig& config,
+                        AsuClientRunner& clientRunner, CommandResult& result) const
+{
+    const auto& bench = config.bench;
+    if (bench.op == BenchOpType::UNKNOWN) {
+        return Status::Error(kExitInvalidArgument, "bench op is required");
+    }
+    if (bench.concurrency == 0) {
+        return Status::Error(kExitInvalidArgument, "bench concurrency must be greater than zero");
+    }
+    if (bench.durationSec == 0) {
+        return Status::Error(kExitInvalidArgument, "bench duration must be greater than zero");
+    }
+    if (bench.op == BenchOpType::MIX && bench.readRatio + bench.writeRatio == 0) {
+        return Status::Error(kExitInvalidArgument,
+                             "bench mix requires read_ratio or write_ratio greater than zero");
+    }
+    if (bench.readRatio > 100 || bench.writeRatio > 100) {
+        return Status::Error(kExitInvalidArgument,
+                             "bench read_ratio and write_ratio must be in range 0..100");
+    }
+    if (bench.op == BenchOpType::MIX && bench.readRatio + bench.writeRatio != 100) {
+        return Status::Error(kExitInvalidArgument,
+                             "bench mix read_ratio and write_ratio must sum to 100");
+    }
+
+    const auto entryCountPerOperation = BenchEntryCount(bench, bench.op);
+    const auto keyCount = std::max<std::uint64_t>(
+        config.count, std::max<std::uint64_t>(bench.concurrency * entryCountPerOperation * 16,
+                                              entryCountPerOperation));
+
+    GeneratedData data;
+    auto status = BuildBenchData(config, keyCount, data);
+    if (!status.Ok()) { return status; }
+
+    BufferAllocator allocator;
+    BufferSet storeBuffers;
+    status = allocator.BuildStoreBuffers(data, storeBuffers);
+    if (!status.Ok()) { return status; }
+
+    BufferSet retrieveBuffers;
+    status = allocator.BuildRetrieveBuffers(data, retrieveBuffers);
+    if (!status.Ok()) { return status; }
+
+    using Clock = std::chrono::steady_clock;
+    std::vector<double> measuredLatenciesUs;
+    std::uint64_t operationIndex = 0;
+    result = CommandResult{};
+    result.benchMetrics.op = bench.op;
+    result.benchMetrics.valueSize = bench.ioSize;
+    result.benchMetrics.batchSize = static_cast<std::uint32_t>(entryCountPerOperation);
+    result.benchMetrics.concurrency = bench.concurrency;
+    result.benchMetrics.warmupSec = bench.warmupSec;
+    result.benchMetrics.durationSec = bench.durationSec;
+
+    auto runPhase = [&](std::uint64_t durationSec, bool collectStats) -> Status {
+        const auto phaseStart = Clock::now();
+        const auto phaseEnd = phaseStart + std::chrono::seconds(durationSec);
+        std::uint64_t windowOperationCount = 0;
+        std::uint64_t windowEntryCount = 0;
+        std::uint64_t windowBytes = 0;
+        std::uint64_t windowErrors = 0;
+        double windowLatencyUs = 0.0;
+        std::uint64_t currentSecond = 1;
+
+        while (Clock::now() < phaseEnd) {
+            std::vector<std::future<OperationOutcome>> futures;
+            futures.reserve(bench.concurrency);
+            for (std::uint32_t inFlight = 0;
+                 inFlight < bench.concurrency && Clock::now() < phaseEnd; ++inFlight) {
+                const auto begin =
+                    static_cast<std::size_t>((operationIndex * entryCountPerOperation) % keyCount);
+                const auto available = keyCount - begin;
+                const auto currentEntryCount = static_cast<std::size_t>(
+                    std::min<std::uint64_t>(entryCountPerOperation, available));
+                const auto currentOperationIndex = operationIndex++;
+
+                futures.emplace_back(std::async(
+                    std::launch::async,
+                    [&, begin, currentEntryCount, currentOperationIndex]() -> OperationOutcome {
+                        CommandResult operationResult;
+                        const auto operationStart = Clock::now();
+                        auto opStatus = ExecuteBenchOperation(
+                            bench.op, bench, clientRunner, storeBuffers, retrieveBuffers, begin,
+                            currentEntryCount, currentOperationIndex,
+                            config.asuClientConfig.defaultWaitTimeoutMs, operationResult);
+                        const auto operationEnd = Clock::now();
+                        OperationOutcome outcome;
+                        outcome.status = opStatus;
+                        outcome.latencyUs =
+                            std::chrono::duration<double, std::micro>(operationEnd - operationStart)
+                                .count();
+                        outcome.entryCount = currentEntryCount;
+                        outcome.bytes = currentEntryCount * bench.ioSize;
+                        return outcome;
+                    }));
+            }
+
+            for (auto& future : futures) {
+                auto outcome = future.get();
+                if (!outcome.status.Ok()) {
+                    ++result.benchMetrics.errorCount;
+                    if (collectStats) { ++windowErrors; }
+                    result.status = outcome.status;
+                    return outcome.status;
+                }
+
+                if (!collectStats) { continue; }
+
+                measuredLatenciesUs.push_back(outcome.latencyUs);
+                ++result.benchMetrics.completedOperations;
+                result.benchMetrics.completedEntries += outcome.entryCount;
+                result.benchMetrics.completedBytes += outcome.bytes;
+                ++windowOperationCount;
+                windowEntryCount += outcome.entryCount;
+                windowBytes += outcome.bytes;
+                windowLatencyUs += outcome.latencyUs;
+
+                const auto operationEnd = Clock::now();
+                const auto elapsedSec =
+                    std::chrono::duration_cast<std::chrono::seconds>(operationEnd - phaseStart)
+                        .count() +
+                    1;
+                if (static_cast<std::uint64_t>(elapsedSec) != currentSecond) {
+                    BenchRealtimeSample sample;
+                    sample.timestampSec = currentSecond;
+                    sample.op = bench.op;
+                    sample.bandwidthBytesPerSec = static_cast<double>(windowBytes);
+                    sample.iops = static_cast<double>(windowEntryCount);
+                    sample.avgLatencyUs =
+                        windowOperationCount == 0
+                            ? 0.0
+                            : windowLatencyUs / static_cast<double>(windowOperationCount);
+                    sample.errorCount = windowErrors;
+                    result.benchMetrics.realtimeSamples.emplace_back(sample);
+
+                    currentSecond = static_cast<std::uint64_t>(elapsedSec);
+                    windowOperationCount = 0;
+                    windowEntryCount = 0;
+                    windowBytes = 0;
+                    windowErrors = 0;
+                    windowLatencyUs = 0.0;
+                }
+            }
+        }
+
+        if (collectStats && (windowOperationCount != 0 || windowErrors != 0)) {
+            BenchRealtimeSample sample;
+            sample.timestampSec = currentSecond;
+            sample.op = bench.op;
+            sample.bandwidthBytesPerSec = static_cast<double>(windowBytes);
+            sample.iops = static_cast<double>(windowEntryCount);
+            sample.avgLatencyUs = windowOperationCount == 0
+                                      ? 0.0
+                                      : windowLatencyUs / static_cast<double>(windowOperationCount);
+            sample.errorCount = windowErrors;
+            result.benchMetrics.realtimeSamples.emplace_back(sample);
+        }
+
+        return Status::Success();
+    };
+
+    if (bench.warmupSec != 0) {
+        status = runPhase(bench.warmupSec, false);
+        if (!status.Ok()) { return status; }
+    }
+
+    const auto measureStart = Clock::now();
+    status = runPhase(bench.durationSec, true);
+    const auto measureEnd = Clock::now();
+    if (!status.Ok()) { return status; }
+
+    result.benchMetrics.elapsedSec =
+        std::chrono::duration<double>(measureEnd - measureStart).count();
+    if (result.benchMetrics.elapsedSec > 0.0) {
+        result.benchMetrics.avgBandwidthBytesPerSec =
+            static_cast<double>(result.benchMetrics.completedBytes) /
+            result.benchMetrics.elapsedSec;
+        result.benchMetrics.avgIops = static_cast<double>(result.benchMetrics.completedEntries) /
+                                      result.benchMetrics.elapsedSec;
+        result.benchMetrics.avgBatchIops =
+            static_cast<double>(result.benchMetrics.completedOperations) /
+            result.benchMetrics.elapsedSec;
+    }
+    result.benchMetrics.latency = BuildLatencyStats(measuredLatenciesUs);
+    result.taskResult = BuildEmptyTaskResult();
+    result.status = Status::Success();
+    return result.status;
+}
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/src/bench_runner.cpp
+++ b/ucm/transport/kv/kv-test/src/bench_runner.cpp
@@ -3,15 +3,21 @@
 #include <chrono>
 #include <cmath>
 #include <future>
+#include <iomanip>
+#include <iostream>
 #include <limits>
 #include <numeric>
-#include "kv_test/buffer_allocator.h"
+#include <sstream>
 
 namespace UC::KVTest {
 
 namespace {
 
 constexpr int kExitInvalidArgument = 1;
+
+struct BenchBufferSlot {
+    BufferSet buffers;
+};
 
 UC::ASU::MemoryRegion MakeHostRegion(std::vector<std::uint8_t>& buffer)
 {
@@ -45,6 +51,8 @@ struct OperationOutcome {
     std::size_t entryCount{0};
     std::uint64_t bytes{0};
 };
+
+using BenchBufferPool = std::vector<BenchBufferSlot>;
 
 std::uint64_t BenchEntryCount(const BenchConfig& bench, BenchOpType op)
 {
@@ -82,74 +90,91 @@ BenchLatencyStats BuildLatencyStats(const std::vector<double>& latenciesUs)
     return stats;
 }
 
-Status CheckBenchMemoryLimit(std::uint64_t keyCount, std::uint64_t ioSize,
+std::string FormatMiBPerSec(double bytesPerSec)
+{
+    std::ostringstream stream;
+    stream << std::fixed << std::setprecision(2) << (bytesPerSec / (1024.0 * 1024.0));
+    return stream.str();
+}
+
+std::string FormatUs(double latencyUs)
+{
+    std::ostringstream stream;
+    stream << std::fixed << std::setprecision(1) << latencyUs;
+    return stream.str();
+}
+
+void PrintProgressSample(const BenchRealtimeSample& sample, std::uint64_t operationsPerSec)
+{
+    std::cout << '[' << sample.timestampSec << "s] ops=" << operationsPerSec
+              << " entries/s=" << static_cast<std::uint64_t>(sample.iops)
+              << " bw=" << FormatMiBPerSec(sample.bandwidthBytesPerSec)
+              << "MiB/s avg=" << FormatUs(sample.avgLatencyUs) << "us"
+              << " err=" << sample.errorCount << '\n';
+}
+
+Status CheckBenchMemoryLimit(std::uint64_t entryCount, std::uint64_t ioSize,
                              std::uint64_t memoryMaxBytes)
 {
     if (memoryMaxBytes == 0) {
         return Status::Error(kExitInvalidArgument,
                              "limits.memory_max_bytes must be greater than zero");
     }
-    if (keyCount == 0 || ioSize == 0) { return Status::Success(); }
-    if (keyCount > std::numeric_limits<std::uint64_t>::max() / ioSize) {
-        return Status::Error(kExitInvalidArgument, "bench generated value bytes overflow uint64");
+    if (entryCount == 0 || ioSize == 0) { return Status::Success(); }
+    if (entryCount > std::numeric_limits<std::uint64_t>::max() / ioSize) {
+        return Status::Error(kExitInvalidArgument, "bench buffer pool bytes overflow uint64");
     }
 
-    const auto requiredBytes = keyCount * ioSize;
+    const auto requiredBytes = entryCount * ioSize;
     if (requiredBytes > memoryMaxBytes) {
-        return Status::Error(
-            kExitInvalidArgument,
-            "bench generated value bytes exceed limits.memory_max_bytes: required=" +
-                std::to_string(requiredBytes) + ", limit=" + std::to_string(memoryMaxBytes));
+        return Status::Error(kExitInvalidArgument,
+                             "bench buffer pool bytes exceed limits.memory_max_bytes: required=" +
+                                 std::to_string(requiredBytes) +
+                                 ", limit=" + std::to_string(memoryMaxBytes));
     }
     return Status::Success();
 }
 
-Status BuildBenchData(const KvTestConfig& config, std::uint64_t keyCount, GeneratedData& data)
+Status ValidateBenchBufferConfig(const BenchConfig& bench, std::uint64_t poolEntryCount,
+                                 std::uint64_t memoryMaxBytes)
 {
-    if (config.bench.ioSize == 0) {
+    if (bench.ioSize == 0) {
         return Status::Error(kExitInvalidArgument, "bench io_size must be greater than zero");
     }
-    if (keyCount > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
-        return Status::Error(kExitInvalidArgument, "bench key count exceeds addressable memory");
+    if (poolEntryCount > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+        return Status::Error(kExitInvalidArgument,
+                             "bench buffer pool entry count exceeds addressable memory");
     }
-    if (config.bench.ioSize > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+    if (bench.ioSize > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
         return Status::Error(kExitInvalidArgument, "bench io_size exceeds addressable memory");
     }
 
-    auto status = CheckBenchMemoryLimit(keyCount, config.bench.ioSize, config.memoryMaxBytes);
-    if (!status.Ok()) { return status; }
-
-    const std::string keyPrefix = config.keyPrefix.empty() ? "bench-key-" : config.keyPrefix;
-    data = GeneratedData{};
-    data.keys.reserve(static_cast<std::size_t>(keyCount));
-    data.values.reserve(static_cast<std::size_t>(keyCount));
-    for (std::uint64_t index = 0; index < keyCount; ++index) {
-        data.keys.emplace_back(keyPrefix + std::to_string(index));
-        auto& value = data.values.emplace_back(config.bench.ioSize);
-        for (std::uint64_t byteIndex = 0; byteIndex < config.bench.ioSize; ++byteIndex) {
-            value[byteIndex] = static_cast<std::uint8_t>((index + byteIndex + config.seed) & 0xFF);
-        }
-    }
-    return Status::Success();
+    return CheckBenchMemoryLimit(poolEntryCount, bench.ioSize, memoryMaxBytes);
 }
 
-BufferSet SliceBuffers(const BufferSet& source, std::size_t begin, std::size_t count)
+void FillStoreValue(std::vector<std::uint8_t>& value, std::uint64_t valueIndex, std::uint64_t seed)
 {
-    BufferSet slice;
-    const auto end = std::min(begin + count, source.entries.size());
-    slice.ownedBuffers.reserve(end - begin);
-    slice.regions.reserve(end - begin);
-    slice.entries.reserve(end - begin);
+    for (std::size_t byteIndex = 0; byteIndex < value.size(); ++byteIndex) {
+        value[byteIndex] = static_cast<std::uint8_t>((valueIndex + byteIndex + seed) & 0xFF);
+    }
+}
 
-    for (auto index = begin; index < end; ++index) {
-        slice.ownedBuffers.emplace_back(source.ownedBuffers[index]);
+BenchBufferPool BuildBenchBufferPool(const BenchConfig& bench, std::uint64_t entryCountPerOperation,
+                                     std::uint64_t seed)
+{
+    BenchBufferPool pool;
+    pool.resize(bench.concurrency);
+
+    for (std::size_t slotIndex = 0; slotIndex < pool.size(); ++slotIndex) {
+        auto& slot = pool[slotIndex];
+        auto& buffers = slot.buffers;
+        buffers.ownedBuffers.reserve(static_cast<std::size_t>(entryCountPerOperation));
+        for (std::uint64_t index = 0; index < entryCountPerOperation; ++index) {
+            auto& value = buffers.ownedBuffers.emplace_back(static_cast<std::size_t>(bench.ioSize));
+            FillStoreValue(value, slotIndex * entryCountPerOperation + index, seed);
+        }
     }
-    for (std::size_t index = 0; index < slice.ownedBuffers.size(); ++index) {
-        auto region = MakeHostRegion(slice.ownedBuffers[index]);
-        slice.regions.emplace_back(region);
-        slice.entries.emplace_back(MakeKvBuffer(source.entries[begin + index].key, region));
-    }
-    return slice;
+    return pool;
 }
 
 bool IsBenchReadOperation(BenchOpType op, std::uint64_t operationIndex, const BenchConfig& bench)
@@ -162,16 +187,36 @@ bool IsBenchReadOperation(BenchOpType op, std::uint64_t operationIndex, const Be
     return operationIndex % ratioTotal < bench.readRatio;
 }
 
+void PrepareBenchBuffers(BenchBufferSlot& slot, std::uint64_t begin, std::size_t entryCount,
+                         const std::string& keyPrefix)
+{
+    auto& buffers = slot.buffers;
+    buffers.regions.clear();
+    buffers.entries.clear();
+    buffers.registerResults.clear();
+    buffers.regions.reserve(entryCount);
+    buffers.entries.reserve(entryCount);
+
+    for (std::size_t index = 0; index < entryCount; ++index) {
+        const auto keyIndex = begin + index;
+        auto& value = buffers.ownedBuffers[index];
+        auto region = MakeHostRegion(value);
+        buffers.regions.emplace_back(region);
+        buffers.entries.emplace_back(MakeKvBuffer(keyPrefix + std::to_string(keyIndex), region));
+    }
+}
+
 Status ExecuteBenchOperation(BenchOpType requestedOp, const BenchConfig& bench,
-                             AsuClientRunner& clientRunner, const BufferSet& storeBuffers,
-                             const BufferSet& retrieveBuffers, std::size_t begin,
-                             std::size_t entryCount, std::uint64_t operationIndex,
+                             AsuClientRunner& clientRunner, BenchBufferSlot& slot,
+                             std::uint64_t begin, std::size_t entryCount,
+                             std::uint64_t operationIndex, const std::string& keyPrefix,
                              std::uint64_t timeoutMs, CommandResult& operationResult)
 {
     const bool isRead = IsBenchReadOperation(requestedOp, operationIndex, bench);
     const auto submitMode =
         entryCount > 1 ? SubmitMode::ALL_ENTRIES_IN_ONE_CALL : SubmitMode::SINGLE_ENTRY_PER_CALL;
-    auto buffers = SliceBuffers(isRead ? retrieveBuffers : storeBuffers, begin, entryCount);
+    PrepareBenchBuffers(slot, begin, entryCount, keyPrefix);
+    auto& buffers = slot.buffers;
 
     auto status = clientRunner.RegisterBuffers(buffers);
     if (!status.Ok()) { return status; }
@@ -188,7 +233,7 @@ using EntrySubmitMethod = UC::ASU::Status (UC::ASU::AsuClient::*)(
 
 }  // namespace
 
-Status BenchRunner::Run(const CommandOptions&, const KvTestConfig& config,
+Status BenchRunner::Run(const CommandOptions& options, const KvTestConfig& config,
                         AsuClientRunner& clientRunner, CommandResult& result) const
 {
     const auto& bench = config.bench;
@@ -215,22 +260,16 @@ Status BenchRunner::Run(const CommandOptions&, const KvTestConfig& config,
     }
 
     const auto entryCountPerOperation = BenchEntryCount(bench, bench.op);
+    const auto poolEntryCount = entryCountPerOperation * bench.concurrency;
     const auto keyCount = std::max<std::uint64_t>(
         config.count, std::max<std::uint64_t>(bench.concurrency * entryCountPerOperation * 16,
                                               entryCountPerOperation));
 
-    GeneratedData data;
-    auto status = BuildBenchData(config, keyCount, data);
+    auto status = ValidateBenchBufferConfig(bench, poolEntryCount, config.memoryMaxBytes);
     if (!status.Ok()) { return status; }
 
-    BufferAllocator allocator;
-    BufferSet storeBuffers;
-    status = allocator.BuildStoreBuffers(data, storeBuffers);
-    if (!status.Ok()) { return status; }
-
-    BufferSet retrieveBuffers;
-    status = allocator.BuildRetrieveBuffers(data, retrieveBuffers);
-    if (!status.Ok()) { return status; }
+    const std::string keyPrefix = config.keyPrefix.empty() ? "bench-key-" : config.keyPrefix;
+    auto bufferPool = BuildBenchBufferPool(bench, entryCountPerOperation, config.seed);
 
     using Clock = std::chrono::steady_clock;
     std::vector<double> measuredLatenciesUs;
@@ -253,6 +292,20 @@ Status BenchRunner::Run(const CommandOptions&, const KvTestConfig& config,
         double windowLatencyUs = 0.0;
         std::uint64_t currentSecond = 1;
 
+        auto emitProgressSample = [&](std::uint64_t operationsPerSec) {
+            BenchRealtimeSample sample;
+            sample.timestampSec = currentSecond;
+            sample.op = bench.op;
+            sample.bandwidthBytesPerSec = static_cast<double>(windowBytes);
+            sample.iops = static_cast<double>(windowEntryCount);
+            sample.avgLatencyUs = windowOperationCount == 0
+                                      ? 0.0
+                                      : windowLatencyUs / static_cast<double>(windowOperationCount);
+            sample.errorCount = windowErrors;
+            result.benchMetrics.realtimeSamples.emplace_back(sample);
+            if (options.progress) { PrintProgressSample(sample, operationsPerSec); }
+        };
+
         while (Clock::now() < phaseEnd) {
             std::vector<std::future<OperationOutcome>> futures;
             futures.reserve(bench.concurrency);
@@ -264,15 +317,17 @@ Status BenchRunner::Run(const CommandOptions&, const KvTestConfig& config,
                 const auto currentEntryCount = static_cast<std::size_t>(
                     std::min<std::uint64_t>(entryCountPerOperation, available));
                 const auto currentOperationIndex = operationIndex++;
+                auto* bufferSlot = &bufferPool[inFlight];
 
                 futures.emplace_back(std::async(
                     std::launch::async,
-                    [&, begin, currentEntryCount, currentOperationIndex]() -> OperationOutcome {
+                    [&, begin, currentEntryCount, currentOperationIndex,
+                     bufferSlot]() -> OperationOutcome {
                         CommandResult operationResult;
                         const auto operationStart = Clock::now();
                         auto opStatus = ExecuteBenchOperation(
-                            bench.op, bench, clientRunner, storeBuffers, retrieveBuffers, begin,
-                            currentEntryCount, currentOperationIndex,
+                            bench.op, bench, clientRunner, *bufferSlot, begin, currentEntryCount,
+                            currentOperationIndex, keyPrefix,
                             config.asuClientConfig.defaultWaitTimeoutMs, operationResult);
                         const auto operationEnd = Clock::now();
                         OperationOutcome outcome;
@@ -312,17 +367,7 @@ Status BenchRunner::Run(const CommandOptions&, const KvTestConfig& config,
                         .count() +
                     1;
                 if (static_cast<std::uint64_t>(elapsedSec) != currentSecond) {
-                    BenchRealtimeSample sample;
-                    sample.timestampSec = currentSecond;
-                    sample.op = bench.op;
-                    sample.bandwidthBytesPerSec = static_cast<double>(windowBytes);
-                    sample.iops = static_cast<double>(windowEntryCount);
-                    sample.avgLatencyUs =
-                        windowOperationCount == 0
-                            ? 0.0
-                            : windowLatencyUs / static_cast<double>(windowOperationCount);
-                    sample.errorCount = windowErrors;
-                    result.benchMetrics.realtimeSamples.emplace_back(sample);
+                    emitProgressSample(windowOperationCount);
 
                     currentSecond = static_cast<std::uint64_t>(elapsedSec);
                     windowOperationCount = 0;
@@ -335,16 +380,7 @@ Status BenchRunner::Run(const CommandOptions&, const KvTestConfig& config,
         }
 
         if (collectStats && (windowOperationCount != 0 || windowErrors != 0)) {
-            BenchRealtimeSample sample;
-            sample.timestampSec = currentSecond;
-            sample.op = bench.op;
-            sample.bandwidthBytesPerSec = static_cast<double>(windowBytes);
-            sample.iops = static_cast<double>(windowEntryCount);
-            sample.avgLatencyUs = windowOperationCount == 0
-                                      ? 0.0
-                                      : windowLatencyUs / static_cast<double>(windowOperationCount);
-            sample.errorCount = windowErrors;
-            result.benchMetrics.realtimeSamples.emplace_back(sample);
+            emitProgressSample(windowOperationCount);
         }
 
         return Status::Success();

--- a/ucm/transport/kv/kv-test/src/buffer_allocator.cpp
+++ b/ucm/transport/kv/kv-test/src/buffer_allocator.cpp
@@ -1,0 +1,85 @@
+﻿#include "kv_test/buffer_allocator.h"
+
+namespace UC::KVTest {
+
+namespace {
+
+constexpr int kExitInvalidArgument = 1;
+
+constexpr std::uint8_t kRetrieveBufferInitialValue = 0xA5;
+
+UC::ASU::MemoryRegion MakeHostRegion(std::vector<std::uint8_t>& buffer)
+{
+    UC::ASU::MemoryRegion region;
+    region.memoryType = UC::ASU::MemoryType::HOST;
+    region.addr = buffer.empty() ? 0 : reinterpret_cast<std::uint64_t>(buffer.data());
+    region.size = buffer.size();
+    region.deviceId = -1;
+    region.numaNode = -1;
+    return region;
+}
+
+UC::ASU::KVBuffer MakeKvBuffer(const UC::ASU::CacheKey& key, const UC::ASU::MemoryRegion& region)
+{
+    UC::ASU::Buffer buffer;
+    buffer.region = region;
+    buffer.handle = UC::ASU::kInvalidMRHandle;
+    return UC::ASU::KVBuffer{key, buffer};
+}
+
+Status ValidateGeneratedData(const GeneratedData& data, const std::string& operation)
+{
+    if (data.keys.size() != data.values.size()) {
+        return Status::Error(kExitInvalidArgument,
+                             operation + " generated key/value count mismatch");
+    }
+    return Status::Success();
+}
+
+}  // namespace
+
+Status BufferAllocator::BuildStoreBuffers(const GeneratedData& data, BufferSet& buffers) const
+{
+    auto status = ValidateGeneratedData(data, "store");
+    if (!status.Ok()) { return status; }
+
+    buffers = BufferSet{};
+    buffers.ownedBuffers.reserve(data.values.size());
+    buffers.regions.reserve(data.values.size());
+    buffers.entries.reserve(data.values.size());
+
+    for (const auto& value : data.values) { buffers.ownedBuffers.emplace_back(value); }
+
+    for (std::size_t index = 0; index < data.keys.size(); ++index) {
+        auto region = MakeHostRegion(buffers.ownedBuffers[index]);
+        buffers.regions.emplace_back(region);
+        buffers.entries.emplace_back(MakeKvBuffer(data.keys[index], region));
+    }
+
+    return Status::Success();
+}
+
+Status BufferAllocator::BuildRetrieveBuffers(const GeneratedData& data, BufferSet& buffers) const
+{
+    auto status = ValidateGeneratedData(data, "retrieve");
+    if (!status.Ok()) { return status; }
+
+    buffers = BufferSet{};
+    buffers.ownedBuffers.reserve(data.values.size());
+    buffers.regions.reserve(data.values.size());
+    buffers.entries.reserve(data.values.size());
+
+    for (const auto& value : data.values) {
+        buffers.ownedBuffers.emplace_back(value.size(), kRetrieveBufferInitialValue);
+    }
+
+    for (std::size_t index = 0; index < data.keys.size(); ++index) {
+        auto region = MakeHostRegion(buffers.ownedBuffers[index]);
+        buffers.regions.emplace_back(region);
+        buffers.entries.emplace_back(MakeKvBuffer(data.keys[index], region));
+    }
+
+    return Status::Success();
+}
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/src/consistency_checker.cpp
+++ b/ucm/transport/kv/kv-test/src/consistency_checker.cpp
@@ -1,0 +1,239 @@
+﻿#include "kv_test/consistency_checker.h"
+#include "kv_test/key_value_generator.h"
+
+namespace UC::KVTest {
+
+namespace {
+
+constexpr int kExitInvalidArgument = 1;
+constexpr int kExitConsistencyFailed = 4;
+
+Status ValidateGeneratedData(const GeneratedData& data, const std::string& operation)
+{
+    if (data.keys.size() != data.values.size()) {
+        return Status::Error(kExitInvalidArgument,
+                             operation + " generated key/value count mismatch");
+    }
+    return Status::Success();
+}
+
+std::string AsuStatusCodeToString(UC::ASU::StatusCode code)
+{
+    switch (code) {
+        case UC::ASU::StatusCode::OK: return "OK";
+        case UC::ASU::StatusCode::INVALID_ARGUMENT: return "INVALID_ARGUMENT";
+        case UC::ASU::StatusCode::NOT_INITIALIZED: return "NOT_INITIALIZED";
+        case UC::ASU::StatusCode::TIMEOUT: return "TIMEOUT";
+        case UC::ASU::StatusCode::NOT_FOUND: return "NOT_FOUND";
+        case UC::ASU::StatusCode::PARTIAL_FAILED: return "PARTIAL_FAILED";
+        case UC::ASU::StatusCode::CONNECTION_ERROR: return "CONNECTION_ERROR";
+        case UC::ASU::StatusCode::IO_ERROR: return "IO_ERROR";
+        case UC::ASU::StatusCode::BUFFER_NOT_REGISTERED: return "BUFFER_NOT_REGISTERED";
+        case UC::ASU::StatusCode::BUFFER_NOT_SUPPORTED: return "BUFFER_NOT_SUPPORTED";
+        case UC::ASU::StatusCode::TASK_NOT_FOUND: return "TASK_NOT_FOUND";
+        case UC::ASU::StatusCode::RESOURCE_BUSY: return "RESOURCE_BUSY";
+        case UC::ASU::StatusCode::UNSUPPORTED: return "UNSUPPORTED";
+        case UC::ASU::StatusCode::IN_PROGRESS: return "IN_PROGRESS";
+        case UC::ASU::StatusCode::INTERNAL_ERROR: return "INTERNAL_ERROR";
+        case UC::ASU::StatusCode::CANCELED: return "CANCELED";
+        default: return "UNKNOWN";
+    }
+}
+
+Status ConsistencyError(const std::string& operation, const UC::ASU::CacheKey& key,
+                        const std::string& reason)
+{
+    return Status::Error(
+        kExitConsistencyFailed,
+        "consistency check failed: operation=" + operation + " key=" + key + " reason=" + reason);
+}
+
+Status ValidateTaskForConsistency(const CommandResult& result, const std::string& operation,
+                                  std::size_t expectedCount)
+{
+    if (!result.status.Ok()) { return result.status; }
+    if (!result.taskResult.status.ok()) {
+        return Status::Error(kExitConsistencyFailed,
+                             "consistency check failed: operation=" + operation + " task_status=" +
+                                 AsuStatusCodeToString(result.taskResult.status.code) +
+                                 " message=" + result.taskResult.status.message);
+    }
+    if (!result.taskResult.entryStatus.empty() &&
+        result.taskResult.entryStatus.size() != expectedCount) {
+        return Status::Error(
+            kExitConsistencyFailed,
+            "consistency check failed: operation=" + operation +
+                " entry_status_count=" + std::to_string(result.taskResult.entryStatus.size()) +
+                " expected=" + std::to_string(expectedCount));
+    }
+    for (std::size_t index = 0; index < result.taskResult.entryStatus.size(); ++index) {
+        const auto& entryStatus = result.taskResult.entryStatus[index];
+        if (!entryStatus.ok()) {
+            return Status::Error(kExitConsistencyFailed,
+                                 "consistency check failed: operation=" + operation +
+                                     " entry_index=" + std::to_string(index) +
+                                     " entry_status=" + AsuStatusCodeToString(entryStatus.code) +
+                                     " message=" + entryStatus.message);
+        }
+    }
+    return Status::Success();
+}
+
+Status ValidateExpectedBuffers(const GeneratedData& expected, const BufferSet& retrieved,
+                               const std::string& operation)
+{
+    auto status = ValidateGeneratedData(expected, operation);
+    if (!status.Ok()) { return status; }
+    if (retrieved.ownedBuffers.size() != expected.values.size()) {
+        return Status::Error(kExitInvalidArgument, operation + " retrieve buffer count mismatch");
+    }
+    return Status::Success();
+}
+
+Status DigestValue(const std::vector<std::uint8_t>& value, std::string& digest)
+{
+    KeyValueGenerator generator;
+    return generator.Digest(value, digest);
+}
+
+void SetValueComparison(ConsistencySummary& summary, const UC::ASU::CacheKey& key,
+                        const std::string& expectedDigest, const std::string& actualDigest)
+{
+    summary.key = key;
+    summary.expected = "digest=" + expectedDigest;
+    summary.actual = "digest=" + actualDigest;
+}
+
+void SetExistComparison(ConsistencySummary& summary, const UC::ASU::CacheKey& key,
+                        bool expectedExists, bool actualExists)
+{
+    summary.key = key;
+    summary.expected = expectedExists ? "exists=true" : "exists=false";
+    summary.actual = actualExists ? "exists=true" : "exists=false";
+}
+
+Status CheckRetrievedValues(const GeneratedData& expected, const BufferSet& retrieved,
+                            const std::string& operation, ConsistencySummary& summary)
+{
+    auto status = ValidateExpectedBuffers(expected, retrieved, operation);
+    if (!status.Ok()) { return status; }
+
+    summary.enabled = true;
+    summary.checked = expected.values.size();
+    for (std::size_t index = 0; index < expected.values.size(); ++index) {
+        const auto& expectedValue = expected.values[index];
+        const auto& actualValue = retrieved.ownedBuffers[index];
+
+        std::string expectedDigest;
+        std::string actualDigest;
+        status = DigestValue(expectedValue, expectedDigest);
+        if (!status.Ok()) { return status; }
+        status = DigestValue(actualValue, actualDigest);
+        if (!status.Ok()) { return status; }
+        SetValueComparison(summary, expected.keys[index], expectedDigest, actualDigest);
+
+        if (actualValue == expectedValue) {
+            ++summary.passed;
+            continue;
+        }
+
+        summary.failed = summary.checked - summary.passed;
+        return ConsistencyError(operation, expected.keys[index],
+                                "value mismatch expected_digest=" + expectedDigest +
+                                    " actual_digest=" + actualDigest +
+                                    " expected_size=" + std::to_string(expectedValue.size()) +
+                                    " actual_size=" + std::to_string(actualValue.size()));
+    }
+
+    summary.failed = 0;
+    return Status::Success();
+}
+
+Status ValidateQueryResultForConsistency(const std::vector<UC::ASU::CacheKey>& keys,
+                                         const CommandResult& result, const std::string& operation)
+{
+    if (!result.status.Ok()) { return result.status; }
+    if (result.queryResult.exists.size() != keys.size()) {
+        return Status::Error(kExitConsistencyFailed,
+                             "consistency check failed: operation=" + operation + " exists_count=" +
+                                 std::to_string(result.queryResult.exists.size()) +
+                                 " expected=" + std::to_string(keys.size()));
+    }
+    return Status::Success();
+}
+
+}  // namespace
+
+Status ConsistencyChecker::CheckStoreResult(const GeneratedData& expected,
+                                            const BufferSet& retrieved, const CommandResult& result,
+                                            ConsistencySummary& summary) const
+{
+    auto status = ValidateTaskForConsistency(result, "store", expected.keys.size());
+    if (!status.Ok()) { return status; }
+    return CheckRetrievedValues(expected, retrieved, "store", summary);
+}
+
+Status ConsistencyChecker::CheckRetrieveResult(const GeneratedData& expected,
+                                               const BufferSet& retrieved,
+                                               const CommandResult& result,
+                                               ConsistencySummary& summary) const
+{
+    auto status = ValidateTaskForConsistency(result, "retrieve", expected.keys.size());
+    if (!status.Ok()) { return status; }
+    return CheckRetrievedValues(expected, retrieved, "retrieve", summary);
+}
+
+Status ConsistencyChecker::CheckDeleteResult(const std::vector<UC::ASU::CacheKey>& keys,
+                                             const CommandResult& deleteResult,
+                                             const CommandResult& existResult,
+                                             ConsistencySummary& summary) const
+{
+    auto status = ValidateTaskForConsistency(deleteResult, "delete", keys.size());
+    if (!status.Ok()) { return status; }
+
+    status = ValidateQueryResultForConsistency(keys, existResult, "delete-exist");
+    if (!status.Ok()) { return status; }
+
+    summary.enabled = true;
+    summary.checked = keys.size();
+    for (std::size_t index = 0; index < keys.size(); ++index) {
+        const bool actualExists = existResult.queryResult.exists[index] != 0;
+        SetExistComparison(summary, keys[index], false, actualExists);
+        if (actualExists) {
+            summary.failed = summary.checked - summary.passed;
+            return ConsistencyError("delete", keys[index],
+                                    "expected_exists=false actual_exists=true");
+        }
+        ++summary.passed;
+    }
+    summary.failed = 0;
+    return Status::Success();
+}
+
+Status ConsistencyChecker::CheckExistResult(const std::vector<UC::ASU::CacheKey>& keys,
+                                            const CommandResult& result, bool expectedExists,
+                                            ConsistencySummary& summary) const
+{
+    auto status = ValidateQueryResultForConsistency(keys, result, "exist");
+    if (!status.Ok()) { return status; }
+
+    const std::uint8_t expectedValue = expectedExists ? 1 : 0;
+    summary.enabled = true;
+    summary.checked = keys.size();
+    for (std::size_t index = 0; index < keys.size(); ++index) {
+        const bool actualExists = result.queryResult.exists[index] != 0;
+        SetExistComparison(summary, keys[index], expectedExists, actualExists);
+        if (actualExists != expectedExists) {
+            summary.failed = summary.checked - summary.passed;
+            return ConsistencyError(
+                "exist", keys[index],
+                "expected_exists=" + std::to_string(expectedValue) +
+                    " actual_exists=" + std::to_string(result.queryResult.exists[index]));
+        }
+        ++summary.passed;
+    }
+    summary.failed = 0;
+    return Status::Success();
+}
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/src/fake_backend.cpp
+++ b/ucm/transport/kv/kv-test/src/fake_backend.cpp
@@ -1,0 +1,429 @@
+#include "kv_test/fake_backend.h"
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <mutex>
+#include <sstream>
+#include <thread>
+#include "buffer_manager.h"
+#include "connection_manager.h"
+#include "kv_protocol.h"
+
+namespace UC::KVTest {
+namespace {
+
+constexpr std::uint16_t kCqeSuccess = 0x000;
+constexpr std::uint16_t kCqeCheckResultBuffer = 0x732;
+constexpr std::uint8_t kBatchEntryOk = 0x0;
+constexpr std::uint8_t kBatchEntryKeyNotFound = 0x3;
+constexpr std::uint8_t kDeleteEntryOk = 0x0;
+constexpr std::uint8_t kDeleteEntryFailed = 0x1;
+constexpr std::uint8_t kExistEntryNotExist = 0x0;
+constexpr std::uint8_t kExistEntryExist = 0x1;
+
+std::mutex g_fakeBackendMu;
+FakeBackendConfig g_fakeBackendConfig;
+bool g_fakeBackendEnabled = false;
+
+std::string NormalizeMode(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
+std::filesystem::path StoreRoot(const FakeBackendConfig& config)
+{
+    if (!config.storePath.empty()) { return config.storePath; }
+    return "./kv-test-fake-backend-store";
+}
+
+std::uint64_t ReadU64(std::uint32_t low, std::uint32_t high)
+{
+    return static_cast<std::uint64_t>(low) | (static_cast<std::uint64_t>(high) << 32);
+}
+
+std::uint32_t RequestCid(const std::uint32_t* request) { return request[0] >> 16; }
+
+UC::ASU::AsuId RequestAsuId(const std::uint32_t* request)
+{
+    // kv-test fake backend temporarily reuses kv_ns_id as the ASU store namespace.
+    return request[1];
+}
+
+UC::ASU::KvOpcode RequestOpcode(const std::uint32_t* request)
+{
+    return static_cast<UC::ASU::KvOpcode>(request[0] & 0xFF);
+}
+
+std::string ReadKey(const std::uint32_t* data)
+{
+    char key[17] = {};
+    std::memcpy(key, data, 16);
+    const auto keyLen = std::find(key, key + 16, '\0') - key;
+    return std::string(key, static_cast<std::size_t>(keyLen));
+}
+
+std::string KeyFileName(const std::string& key)
+{
+    std::uint64_t hash = 1469598103934665603ULL;
+    for (unsigned char ch : key) {
+        hash ^= ch;
+        hash *= 1099511628211ULL;
+    }
+
+    std::ostringstream stream;
+    stream << std::hex << std::setw(16) << std::setfill('0') << hash << ".bin";
+    return stream.str();
+}
+
+std::filesystem::path AsuRoot(const FakeBackendConfig& config, UC::ASU::AsuId asuId)
+{
+    return StoreRoot(config) / ("asu-" + std::to_string(asuId));
+}
+
+std::filesystem::path KeyPath(const FakeBackendConfig& config, UC::ASU::AsuId asuId,
+                              const std::string& key)
+{
+    return AsuRoot(config, asuId) / KeyFileName(key);
+}
+
+bool StoreBytes(const FakeBackendConfig& config, UC::ASU::AsuId asuId, const std::string& key,
+                std::uint64_t addr, std::uint32_t length)
+{
+    std::filesystem::create_directories(AsuRoot(config, asuId));
+    std::ofstream output(KeyPath(config, asuId, key), std::ios::binary | std::ios::trunc);
+    if (!output) { return false; }
+    output.write(reinterpret_cast<const char*>(addr), length);
+    return output.good();
+}
+
+bool LoadBytes(const FakeBackendConfig& config, UC::ASU::AsuId asuId, const std::string& key,
+               std::uint64_t addr, std::uint32_t length)
+{
+    std::ifstream input(KeyPath(config, asuId, key), std::ios::binary);
+    if (!input) { return false; }
+    input.read(reinterpret_cast<char*>(addr), length);
+    const auto readCount = input.gcount();
+    if (readCount < static_cast<std::streamsize>(length)) {
+        std::memset(reinterpret_cast<char*>(addr) + readCount, 0,
+                    length - static_cast<std::uint32_t>(readCount));
+    }
+    return true;
+}
+
+bool DeleteKey(const FakeBackendConfig& config, UC::ASU::AsuId asuId, const std::string& key)
+{
+    std::error_code errorCode;
+    std::filesystem::remove(KeyPath(config, asuId, key), errorCode);
+    return !errorCode;
+}
+
+bool ExistsKey(const FakeBackendConfig& config, UC::ASU::AsuId asuId, const std::string& key)
+{
+    std::error_code errorCode;
+    return std::filesystem::exists(KeyPath(config, asuId, key), errorCode);
+}
+
+void PackCqeHeader(std::uint32_t* flagBuffer, std::uint16_t cid, std::uint16_t status)
+{
+    flagBuffer[0] = 0;
+    flagBuffer[1] = 0;
+    flagBuffer[2] = 0;
+    flagBuffer[3] = static_cast<std::uint32_t>(cid) | (static_cast<std::uint32_t>(status) << 17);
+}
+
+void PackResultBuffer4Bit(std::uint32_t* resultData, const std::vector<std::uint8_t>& results)
+{
+    const auto dwordCount = (results.size() + 7) / 8;
+    std::fill(resultData, resultData + dwordCount, 0);
+    for (std::size_t index = 0; index < results.size(); ++index) {
+        resultData[index / 8] |= static_cast<std::uint32_t>(results[index] & 0xF)
+                                 << ((index % 8) * 4);
+    }
+}
+
+void PackResultBuffer1Bit(std::uint32_t* resultData, const std::vector<std::uint8_t>& results)
+{
+    const auto dwordCount = (results.size() + 31) / 32;
+    std::fill(resultData, resultData + dwordCount, 0);
+    for (std::size_t index = 0; index < results.size(); ++index) {
+        resultData[index / 32] |= static_cast<std::uint32_t>(results[index] & 0x1) << (index % 32);
+    }
+}
+
+struct BatchEntry {
+    std::string key;
+    std::uint64_t bufferAddr{0};
+    std::uint32_t length{0};
+};
+
+std::vector<BatchEntry> ReadBatchEntries(const std::uint32_t* request, std::uint16_t batchNumber)
+{
+    std::vector<BatchEntry> entries;
+    entries.reserve(batchNumber);
+    for (std::uint16_t index = 0; index < batchNumber; ++index) {
+        const auto* entry =
+            request + UC::ASU::kSqeDwordCount + index * UC::ASU::kBatchEntryDwordCount;
+        BatchEntry parsed;
+        parsed.key = ReadKey(entry + 1);
+        parsed.bufferAddr = ReadU64(entry[5], entry[6]);
+        parsed.length = entry[7] & 0xFFFFFF;
+        entries.emplace_back(std::move(parsed));
+    }
+    return entries;
+}
+
+std::vector<std::string> ReadKeyEntries(const std::uint32_t* request, std::uint16_t batchNumber)
+{
+    std::vector<std::string> keys;
+    keys.reserve(batchNumber);
+    for (std::uint16_t index = 0; index < batchNumber; ++index) {
+        const auto* entry =
+            request + UC::ASU::kSqeDwordCount + index * UC::ASU::kKeyEntryDwordCount;
+        keys.emplace_back(ReadKey(entry));
+    }
+    return keys;
+}
+
+UC::ASU::Status CompleteBatchStore(const FakeBackendConfig& config, UC::ASU::AsuId asuId,
+                                   const std::uint32_t* request)
+{
+    const auto cid = static_cast<std::uint16_t>(RequestCid(request));
+    const auto responseBufferAddr = ReadU64(request[3], request[4]);
+    const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
+    auto* flagBuffer = reinterpret_cast<std::uint32_t*>(responseBufferAddr);
+    std::vector<std::uint8_t> results(batchNumber, kBatchEntryOk);
+
+    const auto entries = ReadBatchEntries(request, batchNumber);
+    for (std::size_t index = 0; index < entries.size(); ++index) {
+        const auto& entry = entries[index];
+        if (!StoreBytes(config, asuId, entry.key, entry.bufferAddr, entry.length)) {
+            results[index] = kBatchEntryKeyNotFound;
+        }
+    }
+
+    const auto allOk = std::all_of(results.begin(), results.end(),
+                                   [](std::uint8_t result) { return result == kBatchEntryOk; });
+    PackCqeHeader(flagBuffer, cid, allOk ? kCqeSuccess : kCqeCheckResultBuffer);
+    if (!allOk) { PackResultBuffer4Bit(flagBuffer + UC::ASU::kCqeDwordCount, results); }
+    return UC::ASU::Status::OK();
+}
+
+UC::ASU::Status CompleteBatchRetrieve(const FakeBackendConfig& config, UC::ASU::AsuId asuId,
+                                      const std::uint32_t* request)
+{
+    const auto cid = static_cast<std::uint16_t>(RequestCid(request));
+    const auto responseBufferAddr = ReadU64(request[3], request[4]);
+    const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
+    auto* flagBuffer = reinterpret_cast<std::uint32_t*>(responseBufferAddr);
+    std::vector<std::uint8_t> results(batchNumber, kBatchEntryOk);
+
+    const auto entries = ReadBatchEntries(request, batchNumber);
+    for (std::size_t index = 0; index < entries.size(); ++index) {
+        const auto& entry = entries[index];
+        if (!LoadBytes(config, asuId, entry.key, entry.bufferAddr, entry.length)) {
+            results[index] = kBatchEntryKeyNotFound;
+        }
+    }
+
+    const auto allOk = std::all_of(results.begin(), results.end(),
+                                   [](std::uint8_t result) { return result == kBatchEntryOk; });
+    PackCqeHeader(flagBuffer, cid, allOk ? kCqeSuccess : kCqeCheckResultBuffer);
+    if (!allOk) { PackResultBuffer4Bit(flagBuffer + UC::ASU::kCqeDwordCount, results); }
+    return UC::ASU::Status::OK();
+}
+
+UC::ASU::Status CompleteDelete(const FakeBackendConfig& config, UC::ASU::AsuId asuId,
+                               const std::uint32_t* request)
+{
+    const auto cid = static_cast<std::uint16_t>(RequestCid(request));
+    const auto responseBufferAddr = ReadU64(request[3], request[4]);
+    const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
+    auto* flagBuffer = reinterpret_cast<std::uint32_t*>(responseBufferAddr);
+    std::vector<std::uint8_t> results(batchNumber, kDeleteEntryOk);
+
+    const auto keys = ReadKeyEntries(request, batchNumber);
+    for (std::size_t index = 0; index < keys.size(); ++index) {
+        if (!DeleteKey(config, asuId, keys[index])) { results[index] = kDeleteEntryFailed; }
+    }
+
+    const auto allOk = std::all_of(results.begin(), results.end(),
+                                   [](std::uint8_t result) { return result == kDeleteEntryOk; });
+    PackCqeHeader(flagBuffer, cid, allOk ? kCqeSuccess : kCqeCheckResultBuffer);
+    if (!allOk) { PackResultBuffer1Bit(flagBuffer + UC::ASU::kCqeDwordCount, results); }
+    return UC::ASU::Status::OK();
+}
+
+UC::ASU::Status CompleteExist(const FakeBackendConfig& config, UC::ASU::AsuId asuId,
+                              const std::uint32_t* request)
+{
+    const auto cid = static_cast<std::uint16_t>(RequestCid(request));
+    const auto responseBufferAddr = ReadU64(request[3], request[4]);
+    const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
+    auto* flagBuffer = reinterpret_cast<std::uint32_t*>(responseBufferAddr);
+    std::vector<std::uint8_t> results(batchNumber, kExistEntryNotExist);
+    std::uint16_t existingKeyNumber = 0;
+
+    const auto keys = ReadKeyEntries(request, batchNumber);
+    for (std::size_t index = 0; index < keys.size(); ++index) {
+        if (!ExistsKey(config, asuId, keys[index])) { continue; }
+        results[index] = kExistEntryExist;
+        ++existingKeyNumber;
+    }
+
+    const auto allExist = std::all_of(results.begin(), results.end(), [](std::uint8_t result) {
+        return result == kExistEntryExist;
+    });
+    PackCqeHeader(flagBuffer, cid, allExist ? kCqeSuccess : kCqeCheckResultBuffer);
+    flagBuffer[0] = existingKeyNumber;
+    if (!allExist) { PackResultBuffer1Bit(flagBuffer + UC::ASU::kCqeDwordCount, results); }
+    return UC::ASU::Status::OK();
+}
+
+UC::ASU::Status CompleteFakeBackendRequest(FakeBackendConfig config,
+                                           const UC::ASU::ScatterGatherEntry& sendSge)
+{
+    if (config.latencyMs > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(config.latencyMs));
+    }
+
+    const auto* request = reinterpret_cast<const std::uint32_t*>(sendSge.addr);
+    const auto asuId = RequestAsuId(request);
+    switch (RequestOpcode(request)) {
+        case UC::ASU::KvOpcode::BatchStore: return CompleteBatchStore(config, asuId, request);
+        case UC::ASU::KvOpcode::BatchRetrieve: return CompleteBatchRetrieve(config, asuId, request);
+        case UC::ASU::KvOpcode::Delete: return CompleteDelete(config, asuId, request);
+        case UC::ASU::KvOpcode::Exist: return CompleteExist(config, asuId, request);
+        case UC::ASU::KvOpcode::KeepAlive: {
+            auto* flagBuffer = reinterpret_cast<std::uint32_t*>(ReadU64(request[3], request[4]));
+            PackCqeHeader(flagBuffer, static_cast<std::uint16_t>(RequestCid(request)), kCqeSuccess);
+            return UC::ASU::Status::OK();
+        }
+        default:
+            return UC::ASU::Status::Error(UC::ASU::StatusCode::UNSUPPORTED,
+                                          "fake backend only supports batch ASU operations");
+    }
+}
+
+FakeBackendConfig GetFakeBackendConfig(bool& enabled)
+{
+    std::lock_guard<std::mutex> lock(g_fakeBackendMu);
+    enabled = g_fakeBackendEnabled;
+    return g_fakeBackendConfig;
+}
+
+void SetFakeBackendConfig(FakeBackendConfig config)
+{
+    std::lock_guard<std::mutex> lock(g_fakeBackendMu);
+    g_fakeBackendConfig = std::move(config);
+    g_fakeBackendEnabled = true;
+}
+
+void DisableFakeBackend()
+{
+    std::lock_guard<std::mutex> lock(g_fakeBackendMu);
+    g_fakeBackendConfig = FakeBackendConfig{};
+    g_fakeBackendEnabled = false;
+}
+
+void PatchTransportConfig(UC::ASU::TransportConfig& config)
+{
+    config.attrs.try_emplace("kernel_count", "1");
+    config.attrs.try_emplace("quiet_count", "1");
+    // kv-test fake backend has no direct TransportConfig context in Send, so this temporary
+    // test-only mapping lets the mock recover the ASU store namespace from the packed SQE.
+    config.attrs["kv_ns_id"] = std::to_string(config.asuId);
+    config.attrs.try_emplace("dtype", "0");
+    config.attrs.try_emplace("dspec", "0");
+    config.attrs.try_emplace("lr", "false");
+    config.attrs["sc"] = "true";
+    if (config.endpoints.empty()) {
+        UC::ASU::AsuEndpoint endpoint;
+        endpoint.ip = "fake_backend";
+        endpoint.port = 19001;
+        endpoint.protocol = UC::ASU::Protocol::TCP;
+        config.endpoints.emplace_back(std::move(endpoint));
+    }
+}
+
+}  // namespace
+
+bool IsFakeBackendMode(const KvTestConfig& config)
+{
+    const auto mode = NormalizeMode(config.asuClientMode);
+    return mode == "fake_backend" || mode == "fakebackend";
+}
+
+void MaybePrepareFakeBackend(KvTestConfig& config)
+{
+    if (!IsFakeBackendMode(config)) {
+        DisableFakeBackend();
+        return;
+    }
+
+    if (config.fakeBackend.storePath.empty()) {
+        config.fakeBackend.storePath =
+            config.localStorePath.empty() ? "./kv-test-fake-backend-store" : config.localStorePath;
+    }
+    SetFakeBackendConfig(config.fakeBackend);
+
+    config.asuClientConfig.attrs.try_emplace("hash_table.type", "RING_HASH");
+    config.asuClientConfig.attrs.try_emplace("ring_hash.virtual_node_count", "128");
+    if (config.asuClientConfig.transportConfigs.empty()) {
+        UC::ASU::TransportConfig transportConfig;
+        transportConfig.asuId = 1;
+        config.asuClientConfig.transportConfigs.emplace_back(std::move(transportConfig));
+    }
+    for (auto& transportConfig : config.asuClientConfig.transportConfigs) {
+        PatchTransportConfig(transportConfig);
+    }
+}
+
+}  // namespace UC::KVTest
+
+namespace UC::ASU {
+
+std::vector<Status> MockSend(const std::vector<SendIoBatch>& ioBatches, std::uint32_t kernelCount,
+                             std::uint32_t quietCount)
+{
+    (void)kernelCount;
+    (void)quietCount;
+
+    bool enabled = false;
+    const auto config = UC::KVTest::GetFakeBackendConfig(enabled);
+    if (!enabled) {
+        return std::vector<Status>(
+            ioBatches.size(),
+            Status::Error(StatusCode::UNSUPPORTED, "kv-test fake backend Send is not enabled"));
+    }
+
+    std::vector<Status> statuses;
+    statuses.reserve(ioBatches.size());
+    for (const auto& ioBatch : ioBatches) {
+        if (ioBatch.sendSge == nullptr || ioBatch.sendSge->addr == 0) {
+            statuses.emplace_back(
+                Status::Error(StatusCode::INVALID_ARGUMENT, "fake backend send SGE is empty"));
+            continue;
+        }
+
+        const auto sendSge = *ioBatch.sendSge;
+        std::thread([config, sendSge] {
+            (void)UC::KVTest::CompleteFakeBackendRequest(config, sendSge);
+        }).detach();
+        statuses.emplace_back(Status::OK());
+    }
+    return statuses;
+}
+
+std::vector<Status> Send(const std::vector<SendIoBatch>& ioBatches, std::uint32_t kernelCount,
+                         std::uint32_t quietCount)
+{
+    return MockSend(ioBatches, kernelCount, quietCount);
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/kv-test/src/fake_backend.cpp
+++ b/ucm/transport/kv/kv-test/src/fake_backend.cpp
@@ -1,7 +1,9 @@
 #include "kv_test/fake_backend.h"
+#include <acl/acl.h>
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <cstdlib>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -24,8 +26,11 @@ constexpr std::uint8_t kDeleteEntryOk = 0x0;
 constexpr std::uint8_t kDeleteEntryFailed = 0x1;
 constexpr std::uint8_t kExistEntryNotExist = 0x0;
 constexpr std::uint8_t kExistEntryExist = 0x1;
+constexpr int kExitInvalidArgument = 1;
+constexpr int kFakeBackendAclDeviceId = 0;
 
 std::mutex g_fakeBackendMu;
+std::mutex g_traceMu;
 FakeBackendConfig g_fakeBackendConfig;
 bool g_fakeBackendEnabled = false;
 
@@ -58,6 +63,35 @@ UC::ASU::AsuId RequestAsuId(const std::uint32_t* request)
 UC::ASU::KvOpcode RequestOpcode(const std::uint32_t* request)
 {
     return static_cast<UC::ASU::KvOpcode>(request[0] & 0xFF);
+}
+
+const char* OpcodeName(UC::ASU::KvOpcode opcode)
+{
+    switch (opcode) {
+        case UC::ASU::KvOpcode::BatchStore: return "BatchStore";
+        case UC::ASU::KvOpcode::BatchRetrieve: return "BatchRetrieve";
+        case UC::ASU::KvOpcode::Delete: return "Delete";
+        case UC::ASU::KvOpcode::Exist: return "Exist";
+        case UC::ASU::KvOpcode::KeepAlive: return "KeepAlive";
+        default: return "Unknown";
+    }
+}
+
+void TraceCompletion(UC::ASU::KvOpcode opcode, UC::ASU::AsuId asuId, std::uint16_t cid,
+                     std::uint16_t status, bool resultBuffer, std::uint16_t batchNumber,
+                     std::uint16_t existingKeyNumber = 0)
+{
+    const auto* tracePath = std::getenv("KV_TEST_FAKE_BACKEND_TRACE");
+    if (tracePath == nullptr || tracePath[0] == '\0') { return; }
+
+    std::lock_guard<std::mutex> lock(g_traceMu);
+    std::ofstream trace(tracePath, std::ios::app);
+    if (!trace) { return; }
+
+    trace << "opcode=" << OpcodeName(opcode) << " asu_id=" << asuId << " cid=" << cid
+          << " status=0x" << std::hex << std::setw(3) << std::setfill('0') << status << std::dec
+          << " result_buffer=" << (resultBuffer ? 1 : 0) << " batch_number=" << batchNumber
+          << " existing_key_number=" << existingKeyNumber << '\n';
 }
 
 std::string ReadKey(const std::uint32_t* data)
@@ -120,6 +154,7 @@ bool DeleteKey(const FakeBackendConfig& config, UC::ASU::AsuId asuId, const std:
 {
     std::error_code errorCode;
     std::filesystem::remove(KeyPath(config, asuId, key), errorCode);
+    // Delete result buffer uses 0 for success. A missing key is still a successful delete.
     return !errorCode;
 }
 
@@ -209,8 +244,10 @@ UC::ASU::Status CompleteBatchStore(const FakeBackendConfig& config, UC::ASU::Asu
 
     const auto allOk = std::all_of(results.begin(), results.end(),
                                    [](std::uint8_t result) { return result == kBatchEntryOk; });
-    PackCqeHeader(flagBuffer, cid, allOk ? kCqeSuccess : kCqeCheckResultBuffer);
+    const auto cqeStatus = allOk ? kCqeSuccess : kCqeCheckResultBuffer;
+    PackCqeHeader(flagBuffer, cid, cqeStatus);
     if (!allOk) { PackResultBuffer4Bit(flagBuffer + UC::ASU::kCqeDwordCount, results); }
+    TraceCompletion(UC::ASU::KvOpcode::BatchStore, asuId, cid, cqeStatus, !allOk, batchNumber);
     return UC::ASU::Status::OK();
 }
 
@@ -233,8 +270,10 @@ UC::ASU::Status CompleteBatchRetrieve(const FakeBackendConfig& config, UC::ASU::
 
     const auto allOk = std::all_of(results.begin(), results.end(),
                                    [](std::uint8_t result) { return result == kBatchEntryOk; });
-    PackCqeHeader(flagBuffer, cid, allOk ? kCqeSuccess : kCqeCheckResultBuffer);
+    const auto cqeStatus = allOk ? kCqeSuccess : kCqeCheckResultBuffer;
+    PackCqeHeader(flagBuffer, cid, cqeStatus);
     if (!allOk) { PackResultBuffer4Bit(flagBuffer + UC::ASU::kCqeDwordCount, results); }
+    TraceCompletion(UC::ASU::KvOpcode::BatchRetrieve, asuId, cid, cqeStatus, !allOk, batchNumber);
     return UC::ASU::Status::OK();
 }
 
@@ -254,8 +293,10 @@ UC::ASU::Status CompleteDelete(const FakeBackendConfig& config, UC::ASU::AsuId a
 
     const auto allOk = std::all_of(results.begin(), results.end(),
                                    [](std::uint8_t result) { return result == kDeleteEntryOk; });
-    PackCqeHeader(flagBuffer, cid, allOk ? kCqeSuccess : kCqeCheckResultBuffer);
+    const auto cqeStatus = allOk ? kCqeSuccess : kCqeCheckResultBuffer;
+    PackCqeHeader(flagBuffer, cid, cqeStatus);
     if (!allOk) { PackResultBuffer1Bit(flagBuffer + UC::ASU::kCqeDwordCount, results); }
+    TraceCompletion(UC::ASU::KvOpcode::Delete, asuId, cid, cqeStatus, !allOk, batchNumber);
     return UC::ASU::Status::OK();
 }
 
@@ -279,9 +320,12 @@ UC::ASU::Status CompleteExist(const FakeBackendConfig& config, UC::ASU::AsuId as
     const auto allExist = std::all_of(results.begin(), results.end(), [](std::uint8_t result) {
         return result == kExistEntryExist;
     });
-    PackCqeHeader(flagBuffer, cid, allExist ? kCqeSuccess : kCqeCheckResultBuffer);
+    const auto cqeStatus = allExist ? kCqeSuccess : kCqeCheckResultBuffer;
+    PackCqeHeader(flagBuffer, cid, cqeStatus);
     flagBuffer[0] = existingKeyNumber;
     if (!allExist) { PackResultBuffer1Bit(flagBuffer + UC::ASU::kCqeDwordCount, results); }
+    TraceCompletion(UC::ASU::KvOpcode::Exist, asuId, cid, cqeStatus, !allExist, batchNumber,
+                    existingKeyNumber);
     return UC::ASU::Status::OK();
 }
 
@@ -302,6 +346,8 @@ UC::ASU::Status CompleteFakeBackendRequest(FakeBackendConfig config,
         case UC::ASU::KvOpcode::KeepAlive: {
             auto* flagBuffer = reinterpret_cast<std::uint32_t*>(ReadU64(request[3], request[4]));
             PackCqeHeader(flagBuffer, static_cast<std::uint16_t>(RequestCid(request)), kCqeSuccess);
+            TraceCompletion(UC::ASU::KvOpcode::KeepAlive, asuId,
+                            static_cast<std::uint16_t>(RequestCid(request)), kCqeSuccess, false, 0);
             return UC::ASU::Status::OK();
         }
         default:
@@ -352,6 +398,44 @@ void PatchTransportConfig(UC::ASU::TransportConfig& config)
 }
 
 }  // namespace
+
+FakeBackendAclRuntime::~FakeBackendAclRuntime() { TearDown(); }
+
+Status FakeBackendAclRuntime::MaybeSetUp(const KvTestConfig& config)
+{
+    if (!IsFakeBackendMode(config)) { return Status::Success(); }
+
+    auto ret = aclInit(nullptr);
+    if (ret != ACL_SUCCESS) {
+        return Status::Error(kExitInvalidArgument,
+                             "fake_backend aclInit failed: " + std::to_string(ret));
+    }
+    initialized_ = true;
+
+    // kv-test fake_backend is a temporary standalone test path. Use device 0 until the
+    // ASU client/transport runtime contract is formalized.
+    ret = aclrtSetDevice(kFakeBackendAclDeviceId);
+    if (ret != ACL_SUCCESS) {
+        return Status::Error(kExitInvalidArgument,
+                             "fake_backend aclrtSetDevice failed: device_id=" +
+                                 std::to_string(kFakeBackendAclDeviceId) +
+                                 " ret=" + std::to_string(ret));
+    }
+    deviceSet_ = true;
+    return Status::Success();
+}
+
+void FakeBackendAclRuntime::TearDown()
+{
+    if (deviceSet_) {
+        (void)aclrtResetDevice(kFakeBackendAclDeviceId);
+        deviceSet_ = false;
+    }
+    if (initialized_) {
+        (void)aclFinalize();
+        initialized_ = false;
+    }
+}
 
 bool IsFakeBackendMode(const KvTestConfig& config)
 {
@@ -411,11 +495,10 @@ std::vector<Status> MockSend(const std::vector<SendIoBatch>& ioBatches, std::uin
             continue;
         }
 
-        const auto sendSge = *ioBatch.sendSge;
-        std::thread([config, sendSge] {
-            (void)UC::KVTest::CompleteFakeBackendRequest(config, sendSge);
-        }).detach();
-        statuses.emplace_back(Status::OK());
+        // kv-test fake backend temporarily completes the CQE before Send returns. The production
+        // path still observes completion through Transport polling, while the mock avoids detached
+        // threads racing with sub-batch buffer lifetime in multi sub-batch tests.
+        statuses.emplace_back(UC::KVTest::CompleteFakeBackendRequest(config, *ioBatch.sendSge));
     }
     return statuses;
 }

--- a/ucm/transport/kv/kv-test/src/hcomm_config_adapter.cpp
+++ b/ucm/transport/kv/kv-test/src/hcomm_config_adapter.cpp
@@ -1,0 +1,82 @@
+﻿#include "kv_test/hcomm_config_adapter.h"
+
+namespace UC::KVTest {
+
+namespace {
+
+constexpr int kExitInvalidArgument = 1;
+
+}  // namespace
+
+Status HcommConfigAdapter::ResolveProtocol(UC::ASU::Protocol protocol, const KvTestConfig& config,
+                                           HcommProtocol& hcommProtocol) const
+{
+    switch (protocol) {
+        case UC::ASU::Protocol::UB:
+            hcommProtocol = config.hcommProtocolMapping.ub;
+            return Status::Success();
+        case UC::ASU::Protocol::ROCE:
+            hcommProtocol = config.hcommProtocolMapping.roce;
+            return Status::Success();
+        case UC::ASU::Protocol::TCP:
+            // TODO(#6): Confirm whether ASU TCP should map to Hcomm COMM_PROTOCOL_PCIE.
+            hcommProtocol = config.hcommProtocolMapping.tcp;
+            return Status::Success();
+        default: return Status::Error(kExitInvalidArgument, "unsupported ASU protocol for Hcomm");
+    }
+}
+
+Status HcommConfigAdapter::ValidateChannelSource(const KvTestConfig& config) const
+{
+    if (config.behavior.hcommLocalRole != HcommLocalRole::SERVER) {
+        return Status::Error(kExitInvalidArgument, "kv-test Hcomm local role must be server");
+    }
+    if (config.behavior.hcommChannelConfigSource != HcommChannelConfigSource::ASU_CONFIG) {
+        return Status::Error(kExitInvalidArgument,
+                             "kv-test Hcomm channel config source must be ASU config");
+    }
+    if (config.behavior.hcommApiBoundary != HcommApiBoundary::C_API) {
+        return Status::Error(kExitInvalidArgument, "kv-test Hcomm API boundary must be C API");
+    }
+    if (config.behavior.wireProtocol != WireProtocol::SQE) {
+        return Status::Error(kExitInvalidArgument, "kv-test wire protocol must be SQE");
+    }
+    if (config.behavior.transportLinkPolicy != TransportLinkPolicy::SHARED_DATA_LINK) {
+        return Status::Error(kExitInvalidArgument,
+                             "kv-test transport link policy must use shared data link");
+    }
+    if (config.asuClientConfig.transportConfigs.empty()) {
+        return Status::Error(kExitInvalidArgument,
+                             "ASU transport config is required for Hcomm channel source");
+    }
+
+    for (const auto& transportConfig : config.asuClientConfig.transportConfigs) {
+        if (transportConfig.endpoints.empty()) {
+            return Status::Error(kExitInvalidArgument,
+                                 "ASU transport endpoint is required for Hcomm channel source, "
+                                 "asuId=" +
+                                     std::to_string(transportConfig.asuId));
+        }
+        for (const auto& endpoint : transportConfig.endpoints) {
+            if (endpoint.ip.empty()) {
+                return Status::Error(kExitInvalidArgument,
+                                     "ASU endpoint local socket/comm_id is required for Hcomm, "
+                                     "asuId=" +
+                                         std::to_string(transportConfig.asuId));
+            }
+            if (endpoint.port == 0) {
+                return Status::Error(kExitInvalidArgument,
+                                     "ASU endpoint port is required for Hcomm, asuId=" +
+                                         std::to_string(transportConfig.asuId));
+            }
+
+            HcommProtocol hcommProtocol{HcommProtocol::ROCE};
+            auto status = ResolveProtocol(endpoint.protocol, config, hcommProtocol);
+            if (!status.Ok()) { return status; }
+        }
+    }
+
+    return Status::Success();
+}
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/src/key_value_generator.cpp
+++ b/ucm/transport/kv/kv-test/src/key_value_generator.cpp
@@ -1,0 +1,219 @@
+﻿#include "kv_test/key_value_generator.h"
+#include <algorithm>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+
+namespace UC::KVTest {
+
+namespace {
+
+constexpr int kExitInvalidArgument = 1;
+
+constexpr std::uint64_t kFnvOffsetBasis64 = 14695981039346656037ULL;
+constexpr std::uint64_t kFnvPrime64 = 1099511628211ULL;
+constexpr std::uint64_t kSplitMixIncrement = 0x9E3779B97F4A7C15ULL;
+constexpr std::uint64_t kCrc64EcmaPolynomial = 0x42F0E1EBA9EA3693ULL;
+
+std::uint64_t HashByte(std::uint64_t hash, std::uint8_t value)
+{
+    hash ^= value;
+    hash *= kFnvPrime64;
+    return hash;
+}
+
+std::uint64_t HashUint64(std::uint64_t hash, std::uint64_t value)
+{
+    for (std::uint32_t index = 0; index < 8; ++index) {
+        hash = HashByte(hash, static_cast<std::uint8_t>((value >> (index * 8)) & 0xFFU));
+    }
+    return hash;
+}
+
+std::uint64_t HashString(std::uint64_t hash, const std::string& value)
+{
+    for (const char byte : value) { hash = HashByte(hash, static_cast<std::uint8_t>(byte)); }
+    return hash;
+}
+
+std::uint64_t SplitMix64Next(std::uint64_t& state)
+{
+    state += kSplitMixIncrement;
+    std::uint64_t value = state;
+    value = (value ^ (value >> 30)) * 0xBF58476D1CE4E5B9ULL;
+    value = (value ^ (value >> 27)) * 0x94D049BB133111EBULL;
+    return value ^ (value >> 31);
+}
+
+std::vector<std::uint8_t> GenerateValueBytes(const UC::ASU::CacheKey& key, std::uint64_t seed,
+                                             std::uint64_t valueSize)
+{
+    std::vector<std::uint8_t> value(static_cast<std::size_t>(valueSize));
+    std::uint64_t state = HashString(HashUint64(kFnvOffsetBasis64, seed), key);
+    for (std::size_t offset = 0; offset < value.size();) {
+        const std::uint64_t random = SplitMix64Next(state);
+        for (std::uint32_t byteIndex = 0; byteIndex < 8 && offset < value.size();
+             ++byteIndex, ++offset) {
+            value[offset] = static_cast<std::uint8_t>((random >> (byteIndex * 8)) & 0xFFU);
+        }
+    }
+    return value;
+}
+
+std::string Trim(const std::string& value)
+{
+    const auto begin = value.find_first_not_of(" \t\r\n");
+    if (begin == std::string::npos) { return ""; }
+    const auto end = value.find_last_not_of(" \t\r\n");
+    return value.substr(begin, end - begin + 1);
+}
+
+Status AddCommaSeparatedKeys(const std::string& value, const std::string& source,
+                             std::vector<UC::ASU::CacheKey>& keys)
+{
+    std::string normalized = value;
+    std::replace(normalized.begin(), normalized.end(), '\n', ',');
+    std::replace(normalized.begin(), normalized.end(), '\r', ',');
+
+    std::string item;
+    std::stringstream stream(normalized);
+    while (std::getline(stream, item, ',')) {
+        item = Trim(item);
+        if (item.empty()) {
+            return Status::Error(kExitInvalidArgument, source + " contains an empty key");
+        }
+        keys.push_back(item);
+    }
+
+    return Status::Success();
+}
+
+Status LoadKeysFile(const std::string& keysFile, std::vector<UC::ASU::CacheKey>& keys)
+{
+    std::ifstream input{keysFile};
+    if (!input.is_open()) {
+        return Status::Error(kExitInvalidArgument, "failed to open keys file: " + keysFile);
+    }
+
+    std::ostringstream content;
+    content << input.rdbuf();
+    auto status = AddCommaSeparatedKeys(content.str(), "--keys-file", keys);
+    if (!status.Ok()) { return status; }
+    if (keys.empty()) {
+        return Status::Error(kExitInvalidArgument, "--keys-file does not contain any keys");
+    }
+    return Status::Success();
+}
+
+Status GenerateRangeKeys(const CommandOptions& options, std::vector<UC::ASU::CacheKey>& keys)
+{
+    if (!options.keyStartSet && !options.keyEndSet) { return Status::Success(); }
+
+    const auto rangeSpan = options.keyEnd - options.keyStart;
+    const auto maxCount = static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max());
+    if (rangeSpan >= maxCount) {
+        return Status::Error(kExitInvalidArgument, "key range exceeds addressable memory");
+    }
+    const auto rangeCount = rangeSpan + 1;
+
+    keys.reserve(static_cast<std::size_t>(rangeCount));
+    for (std::uint64_t index = options.keyStart; index <= options.keyEnd; ++index) {
+        keys.push_back(options.keyPrefix + std::to_string(index));
+        if (index == std::numeric_limits<std::uint64_t>::max()) { break; }
+    }
+    return Status::Success();
+}
+
+Status CheckValueMemoryLimit(std::uint64_t count, std::uint64_t valueSize,
+                             std::uint64_t memoryMaxBytes)
+{
+    if (memoryMaxBytes == 0) {
+        return Status::Error(kExitInvalidArgument,
+                             "limits.memory_max_bytes must be greater than zero");
+    }
+    if (count == 0 || valueSize == 0) { return Status::Success(); }
+    if (count > std::numeric_limits<std::uint64_t>::max() / valueSize) {
+        return Status::Error(kExitInvalidArgument, "generated value bytes overflow uint64");
+    }
+
+    const auto requiredBytes = count * valueSize;
+    if (requiredBytes > memoryMaxBytes) {
+        return Status::Error(kExitInvalidArgument,
+                             "generated value bytes exceed limits.memory_max_bytes: required=" +
+                                 std::to_string(requiredBytes) +
+                                 ", limit=" + std::to_string(memoryMaxBytes));
+    }
+    return Status::Success();
+}
+
+}  // namespace
+
+Status KeyValueGenerator::Generate(const CommandOptions& options, const KvTestConfig& config,
+                                   GeneratedData& data) const
+{
+    const std::uint64_t count = options.count == 0 ? config.count : options.count;
+    const std::uint64_t seed = options.seed == 0 ? config.seed : options.seed;
+    const std::uint64_t valueSize = options.valueSize == 0 ? config.valueSize : options.valueSize;
+
+    if (valueSize > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+        return Status::Error(kExitInvalidArgument, "value-size exceeds addressable memory");
+    }
+
+    data.keys.clear();
+    data.values.clear();
+
+    if (!options.keys.empty()) {
+        data.keys.reserve(options.keys.size());
+        for (const auto& key : options.keys) {
+            if (key.empty()) { return Status::Error(kExitInvalidArgument, "key cannot be empty"); }
+            data.keys.push_back(key);
+        }
+    } else if (!options.keysFile.empty()) {
+        auto status = LoadKeysFile(options.keysFile, data.keys);
+        if (!status.Ok()) { return status; }
+    } else if (options.keyStartSet || options.keyEndSet) {
+        auto status = GenerateRangeKeys(options, data.keys);
+        if (!status.Ok()) { return status; }
+    } else {
+        if (count > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max())) {
+            return Status::Error(kExitInvalidArgument, "count exceeds addressable memory");
+        }
+        data.keys.reserve(static_cast<std::size_t>(count));
+        for (std::uint64_t index = 0; index < count; ++index) {
+            data.keys.push_back(config.keyPrefix + std::to_string(index));
+        }
+    }
+
+    if (options.command == CommandType::DELETE || options.command == CommandType::EXIST) {
+        return Status::Success();
+    }
+
+    auto status = CheckValueMemoryLimit(static_cast<std::uint64_t>(data.keys.size()), valueSize,
+                                        config.memoryMaxBytes);
+    if (!status.Ok()) { return status; }
+
+    data.values.reserve(data.keys.size());
+    for (const auto& key : data.keys) {
+        data.values.push_back(GenerateValueBytes(key, seed, valueSize));
+    }
+    return Status::Success();
+}
+
+Status KeyValueGenerator::Digest(const std::vector<std::uint8_t>& value, std::string& digest) const
+{
+    std::uint64_t crc = 0;
+    for (const std::uint8_t byte : value) {
+        crc ^= static_cast<std::uint64_t>(byte) << 56;
+        for (std::uint32_t bit = 0; bit < 8; ++bit) {
+            crc = (crc & 0x8000000000000000ULL) != 0 ? (crc << 1) ^ kCrc64EcmaPolynomial : crc << 1;
+        }
+    }
+
+    std::ostringstream output;
+    output << std::hex << std::nouppercase << std::setfill('0') << std::setw(16) << crc;
+    digest = output.str();
+    return Status::Success();
+}
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/src/kv_test_app.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_app.cpp
@@ -1,0 +1,595 @@
+﻿#include "kv_test/kv_test_app.h"
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <unordered_map>
+#include "asu_client/asu_client.h"
+#include "kv_test/fake_backend.h"
+#include "kv_test/local_asu_transport.h"
+
+namespace UC::KVTest {
+
+namespace {
+
+constexpr int kExitSuccess = 0;
+constexpr int kExitInvalidArgument = 1;
+
+int ToExitCode(const Status& status) { return status.Ok() ? kExitSuccess : status.code; }
+
+std::filesystem::path PowerCycleMetadataPath(const KvTestConfig& config)
+{
+    const auto baseDir = config.output.path.empty() ? std::filesystem::path(".")
+                                                    : std::filesystem::path(config.output.path);
+    return baseDir / "power-cycle-metadata.conf";
+}
+
+std::uint64_t EffectiveSeed(const CommandOptions& options, const KvTestConfig& config)
+{
+    return options.seed == 0 ? config.seed : options.seed;
+}
+
+std::uint64_t EffectiveValueSize(const CommandOptions& options, const KvTestConfig& config)
+{
+    return options.valueSize == 0 ? config.valueSize : options.valueSize;
+}
+
+std::uint64_t EffectiveCount(const CommandOptions& options, const KvTestConfig& config)
+{
+    return options.count == 0 ? config.count : options.count;
+}
+
+std::string EffectiveKeyPrefix(const CommandOptions& options, const KvTestConfig& config)
+{
+    return options.keyPrefix.empty() ? config.keyPrefix : options.keyPrefix;
+}
+
+Status WritePowerCycleMetadata(const CommandOptions& options, const KvTestConfig& config)
+{
+    std::error_code errorCode;
+    auto metadataPath = PowerCycleMetadataPath(config);
+    std::filesystem::create_directories(metadataPath.parent_path(), errorCode);
+    if (errorCode) {
+        return Status::Error(
+            kExitInvalidArgument,
+            "failed to create power-cycle metadata directory: " + errorCode.message());
+    }
+
+    std::ofstream file{metadataPath};
+    if (!file.is_open()) {
+        return Status::Error(kExitInvalidArgument,
+                             "failed to open power-cycle metadata: " + metadataPath.string());
+    }
+
+    file << "key_prefix=" << EffectiveKeyPrefix(options, config) << '\n'
+         << "seed=" << EffectiveSeed(options, config) << '\n'
+         << "value_size=" << EffectiveValueSize(options, config) << '\n'
+         << "count=" << EffectiveCount(options, config) << '\n';
+    if (!file.good()) {
+        return Status::Error(kExitInvalidArgument,
+                             "failed to write power-cycle metadata: " + metadataPath.string());
+    }
+    return Status::Success();
+}
+
+bool ReadMetadataValue(const std::string& line, const std::string& key, std::string& value)
+{
+    const auto prefix = key + "=";
+    if (line.rfind(prefix, 0) != 0) { return false; }
+    value = line.substr(prefix.size());
+    return true;
+}
+
+Status ValidatePowerCycleMetadata(const CommandOptions& options, const KvTestConfig& config)
+{
+    const auto metadataPath = PowerCycleMetadataPath(config);
+    std::ifstream file{metadataPath};
+    if (!file.is_open()) {
+        return Status::Error(kExitInvalidArgument,
+                             "failed to open power-cycle metadata: " + metadataPath.string());
+    }
+
+    std::unordered_map<std::string, std::string> values;
+    std::string line;
+    while (std::getline(file, line)) {
+        for (const auto& key : {"key_prefix", "seed", "value_size", "count"}) {
+            std::string value;
+            if (ReadMetadataValue(line, key, value)) { values[key] = value; }
+        }
+    }
+
+    const std::unordered_map<std::string, std::string> expected = {
+        {"key_prefix", EffectiveKeyPrefix(options,                config) },
+        {"seed",       std::to_string(EffectiveSeed(options,      config))},
+        {"value_size", std::to_string(EffectiveValueSize(options, config))},
+        {"count",      std::to_string(EffectiveCount(options,     config))},
+    };
+    for (const auto& item : expected) {
+        auto iter = values.find(item.first);
+        if (iter == values.end() || iter->second != item.second) {
+            return Status::Error(kExitInvalidArgument,
+                                 "power-cycle metadata mismatch for " + item.first);
+        }
+    }
+    return Status::Success();
+}
+
+std::string CommandTypeName(CommandType command)
+{
+    switch (command) {
+        case CommandType::CONNECT: return "connect";
+        case CommandType::CONFIG_CHECK: return "config check";
+        case CommandType::STORE: return "store";
+        case CommandType::RETRIEVE: return "retrieve";
+        case CommandType::DELETE: return "delete";
+        case CommandType::EXIST: return "exist";
+        case CommandType::BATCH_STORE: return "batch-store";
+        case CommandType::BATCH_RETRIEVE: return "batch-retrieve";
+        case CommandType::POWER_CYCLE_PREPARE: return "power-cycle prepare";
+        case CommandType::POWER_CYCLE_VERIFY: return "power-cycle verify";
+        case CommandType::BENCH: return "bench";
+        case CommandType::VERSION: return "version";
+        case CommandType::UNKNOWN:
+        default: return "unknown";
+    }
+}
+
+std::string BenchOpTypeName(BenchOpType op)
+{
+    switch (op) {
+        case BenchOpType::STORE: return "store";
+        case BenchOpType::RETRIEVE: return "retrieve";
+        case BenchOpType::BATCH_STORE: return "batch-store";
+        case BenchOpType::BATCH_RETRIEVE: return "batch-retrieve";
+        case BenchOpType::MIX: return "mix";
+        case BenchOpType::UNKNOWN:
+        default: return "unknown";
+    }
+}
+
+void PrintGeneralHelp()
+{
+    std::cout
+        << "Usage:\n"
+        << "  kv-test <command> [options]\n"
+        << "  kv-test <command> --help\n"
+        << "  kv-test --help\n\n"
+        << "Config:\n"
+        << "  --configpath <path>      Override config file path for this run.\n"
+        << "  KV_TEST_CONFIG=<path>    Default config file path when --configpath is omitted.\n\n"
+        << "Commands:\n"
+        << "  connect\n"
+        << "  config check\n"
+        << "  version\n"
+        << "  store | retrieve | delete | exist\n"
+        << "  batch-store | batch-retrieve\n"
+        << "  power-cycle prepare | power-cycle verify\n"
+        << "  bench [store|retrieve|batch-store|batch-retrieve|mix]\n\n"
+        << "Common options:\n"
+        << "  --key <key>              Use one key.\n"
+        << "  --keys <k1,k2,...>       Use a comma-separated key list.\n"
+        << "  --keys-file <path>       Read comma-separated keys from a file.\n"
+        << "  --count <n>              Generate n keys from kv.key_prefix.\n"
+        << "  --prefix <p> --key-start <n> --key-end <n>\n"
+        << "                           Generate keys in the closed interval [start, end].\n"
+        << "  --seed <n>               Override kv.seed.\n"
+        << "  --value-size <bytes>     Override kv.value_size.\n"
+        << "  --batch-size <n>         Override bench.batch_size.\n"
+        << "  --timeout <ms>           Override default wait timeout.\n"
+        << "  --check                  Run consistency check when supported.\n"
+        << "  --output <path>          Override output.path.\n"
+        << "\n"
+        << "Bench options:\n"
+        << "  --op <op>, --bench-op <op>, --io-size <bytes>, --concurrency <n>,\n"
+        << "  --duration <sec>, --warmup <sec>, --read-ratio <n>, --write-ratio <n>\n\n"
+        << "Examples:\n"
+        << "  export KV_TEST_CONFIG=/abs/path/to/asu_kv_test.conf\n"
+        << "  kv-test connect\n"
+        << "  kv-test store --key hello --check\n"
+        << "  kv-test retrieve --keys hello,world --check\n"
+        << "  kv-test delete --keys-file ./keys.txt\n"
+        << "  kv-test exist --prefix user- --key-start 100 --key-end 199\n";
+}
+
+void PrintCommandHelp(CommandType command)
+{
+    switch (command) {
+        case CommandType::CONNECT:
+            std::cout << "Usage: kv-test connect [--configpath <path>] [--timeout <ms>]\n";
+            break;
+        case CommandType::CONFIG_CHECK:
+            std::cout << "Usage: kv-test config check [--configpath <path>]\n";
+            break;
+        case CommandType::VERSION:
+            std::cout << "Usage: kv-test version\n       kv-test --version\n";
+            break;
+        case CommandType::STORE:
+            std::cout << "Usage: kv-test store (--key <key>|--keys <list>|--keys-file <path>|"
+                         "--count <n>|--prefix <p> --key-start <n> --key-end <n>) "
+                         "[--value-size <bytes>] [--seed <n>] [--check]\n";
+            break;
+        case CommandType::RETRIEVE:
+            std::cout << "Usage: kv-test retrieve (--key <key>|--keys <list>|"
+                         "--keys-file <path>|--count <n>|--prefix <p> --key-start <n> "
+                         "--key-end <n>) "
+                         "[--value-size <bytes>] [--seed <n>] [--check]\n";
+            break;
+        case CommandType::DELETE:
+            std::cout << "Usage: kv-test delete (--key <key>|--keys <list>|--keys-file <path>|"
+                         "--count <n>|--prefix <p> --key-start <n> --key-end <n>) "
+                         "[--seed <n>] [--check]\n";
+            break;
+        case CommandType::EXIST:
+            std::cout << "Usage: kv-test exist (--key <key>|--keys <list>|--keys-file <path>|"
+                         "--count <n>|--prefix <p> --key-start <n> --key-end <n>) "
+                         "[--seed <n>]\n";
+            break;
+        case CommandType::BATCH_STORE:
+            std::cout << "Usage: kv-test batch-store (--keys <list>|--keys-file <path>|"
+                         "--count <n>|--prefix <p> --key-start <n> --key-end <n>) "
+                         "[--batch-size <n>] [--value-size <bytes>] [--check]\n";
+            break;
+        case CommandType::BATCH_RETRIEVE:
+            std::cout << "Usage: kv-test batch-retrieve (--keys <list>|--keys-file <path>|"
+                         "--count <n>|--prefix <p> --key-start <n> --key-end <n>) "
+                         "[--batch-size <n>] [--value-size <bytes>] [--check]\n";
+            break;
+        case CommandType::POWER_CYCLE_PREPARE:
+            std::cout << "Usage: kv-test power-cycle prepare (--keys <list>|--keys-file <path>|"
+                         "--count <n>|--prefix <p> --key-start <n> --key-end <n>) "
+                         "[--value-size <bytes>] [--seed <n>]\n";
+            break;
+        case CommandType::POWER_CYCLE_VERIFY:
+            std::cout << "Usage: kv-test power-cycle verify (--keys <list>|--keys-file <path>|"
+                         "--count <n>|--prefix <p> --key-start <n> --key-end <n>) "
+                         "[--value-size <bytes>] [--seed <n>] [--check]\n";
+            break;
+        case CommandType::BENCH:
+            std::cout << "Usage: kv-test bench [store|retrieve|batch-store|batch-retrieve|mix] "
+                         "[--io-size <bytes>] [--concurrency <n>] [--duration <sec>]\n"
+                      << "       kv-test bench --op <op> [--batch-size <n>] [--warmup <sec>] "
+                         "[--read-ratio <n>] [--write-ratio <n>]\n";
+            break;
+        case CommandType::UNKNOWN:
+        default: PrintGeneralHelp(); break;
+    }
+}
+
+std::string LoadVersion()
+{
+    std::ifstream versionFile{"version.ini"};
+    std::string line;
+    while (std::getline(versionFile, line)) {
+        const std::string prefix = "VLLM_UC_VERSION=";
+        if (line.rfind(prefix, 0) == 0) { return line.substr(prefix.size()); }
+    }
+    return "unknown";
+}
+
+void PrintVersion() { std::cout << "kv-test version " << LoadVersion() << '\n'; }
+
+void PrintFailure(const Status& status)
+{
+    std::cerr << "kv-test: failed";
+    if (!status.message.empty()) { std::cerr << ": " << status.message; }
+    std::cerr << " (exit_code=" << ToExitCode(status) << ")\n";
+}
+
+void PrintExistSummary(const CommandOptions& options, const CommandResult& result)
+{
+    if (options.command != CommandType::EXIST) { return; }
+
+    if (options.singleKeyRequested && options.keys.size() == 1 &&
+        result.queryResult.exists.size() == 1) {
+        std::cout << "exist: key=" << options.keys.front()
+                  << " result=" << (result.queryResult.exists.front() != 0 ? "exists" : "missing")
+                  << '\n';
+        return;
+    }
+
+    const auto existsCount = static_cast<std::uint64_t>(
+        std::count_if(result.queryResult.exists.begin(), result.queryResult.exists.end(),
+                      [](std::uint8_t exists) { return exists != 0; }));
+    const auto total = static_cast<std::uint64_t>(result.queryResult.exists.size());
+    std::cout << "exist: total=" << total << " exists=" << existsCount
+              << " missing=" << (total - existsCount) << '\n';
+}
+
+void PrintConsistencySummary(const CommandResult& result)
+{
+    const auto& summary = result.consistency;
+    if (!summary.enabled) { return; }
+
+    std::cout << "check: checked=" << summary.checked << " passed=" << summary.passed
+              << " failed=" << summary.failed;
+    if (!summary.key.empty()) {
+        std::cout << " key=" << summary.key << " expected=" << summary.expected
+                  << " actual=" << summary.actual;
+    }
+    std::cout << '\n';
+}
+
+std::string FormatBytesPerSec(double bytesPerSec)
+{
+    std::ostringstream stream;
+    stream << std::fixed << std::setprecision(2) << (bytesPerSec / (1024.0 * 1024.0));
+    return stream.str();
+}
+
+void PrintBenchSummary(const CommandOptions& options, const CommandResult& result)
+{
+    if (options.command != CommandType::BENCH) { return; }
+
+    const auto& metrics = result.benchMetrics;
+    std::cout << "bench: op=" << BenchOpTypeName(metrics.op) << "\nelapsed_sec=" << std::fixed
+              << std::setprecision(3) << metrics.elapsedSec
+              << "\noperations=" << metrics.completedOperations
+              << "\nentries=" << metrics.completedEntries << "\nbytes=" << metrics.completedBytes
+              << "\nbandwidth_mib_s=" << FormatBytesPerSec(metrics.avgBandwidthBytesPerSec)
+              << "\niops=" << std::fixed << std::setprecision(2) << metrics.avgIops
+              << "\nbatch_iops=" << metrics.avgBatchIops
+              << "\nlatency_avg_us=" << metrics.latency.avgUs
+              << "\nlatency_p99_9_us=" << metrics.latency.p99_9Us
+              << "\nerrors=" << metrics.errorCount << '\n';
+}
+
+void PrintSuccess(const CommandOptions& options, const CommandResult& result)
+{
+    std::cout << "kv-test: succeeded"
+              << "\ncommand=" << CommandTypeName(options.command)
+              << "\nconfig=" << options.configPath << '\n';
+    PrintExistSummary(options, result);
+    PrintConsistencySummary(result);
+    PrintBenchSummary(options, result);
+}
+
+std::string NormalizeAttrValue(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
+std::unique_ptr<UC::ASU::AsuClient> CreateClientForConfig(const KvTestConfig& config)
+{
+    if (NormalizeAttrValue(config.asuClientMode) == "local") {
+        return UC::ASU::CreateAsuClient(CreateLocalAsuTransportFactory(config.localStorePath));
+    }
+    return UC::ASU::CreateAsuClient();
+}
+
+}  // namespace
+
+KvTestApp::KvTestApp() = default;
+
+int KvTestApp::Run(int argc, char** argv)
+{
+    CommandOptions options;
+    auto status = argParser_.Parse(argc, argv, options);
+    if (!status.Ok()) {
+        PrintFailure(status);
+        return ToExitCode(status);
+    }
+    if (options.helpRequested) {
+        if (options.command == CommandType::UNKNOWN) {
+            PrintGeneralHelp();
+        } else {
+            PrintCommandHelp(options.command);
+        }
+        return kExitSuccess;
+    }
+    if (options.command == CommandType::VERSION) {
+        PrintVersion();
+        return kExitSuccess;
+    }
+
+    status = configLoader_.ResolveConfigPath(options.configPath, options.configPath);
+    if (!status.Ok()) {
+        PrintFailure(status);
+        return ToExitCode(status);
+    }
+
+    KvTestConfig config;
+    status = configLoader_.Load(options.configPath, config);
+    if (!status.Ok()) {
+        PrintFailure(status);
+        return ToExitCode(status);
+    }
+
+    status = configLoader_.MergeCommandOptions(options, config);
+    if (!status.Ok()) {
+        PrintFailure(status);
+        return ToExitCode(status);
+    }
+
+    MaybePrepareFakeBackend(config);
+
+    status = hcommConfigAdapter_.ValidateChannelSource(config);
+    if (!status.Ok()) {
+        PrintFailure(status);
+        return ToExitCode(status);
+    }
+
+    if (options.command == CommandType::CONFIG_CHECK) {
+        std::cout << "kv-test: succeeded command=config check config=" << options.configPath
+                  << '\n';
+        std::cout << "config: key_prefix=" << config.keyPrefix << " count=" << config.count
+                  << " value_size=" << config.valueSize
+                  << " timeout_ms=" << config.asuClientConfig.defaultWaitTimeoutMs
+                  << " output=" << config.output.path << '\n';
+        return kExitSuccess;
+    }
+
+    status = resultWriter_.Open(config.output);
+    if (!status.Ok()) {
+        PrintFailure(status);
+        return ToExitCode(status);
+    }
+
+    CommandResult result;
+    AsuClientRunner clientRunner(CreateClientForConfig(config));
+    status = clientRunner.Init(config);
+    if (status.Ok()) { status = RunCommand(options, config, clientRunner, result); }
+
+    auto shutdownStatus = clientRunner.Shutdown();
+    if (status.Ok() && !shutdownStatus.Ok()) { status = shutdownStatus; }
+
+    result.status = status;
+    auto writeStatus = resultWriter_.WriteSummary(options, result);
+    if (status.Ok() && !writeStatus.Ok()) { status = writeStatus; }
+
+    auto closeStatus = resultWriter_.Close();
+    if (status.Ok() && !closeStatus.Ok()) { status = closeStatus; }
+
+    if (status.Ok()) {
+        PrintSuccess(options, result);
+    } else {
+        PrintFailure(status);
+        PrintConsistencySummary(result);
+    }
+    return ToExitCode(status);
+}
+
+Status KvTestApp::RunCommand(const CommandOptions& options, const KvTestConfig& config,
+                             AsuClientRunner& clientRunner, CommandResult& result)
+{
+    switch (options.command) {
+        case CommandType::CONNECT: return Status::Success();
+        case CommandType::CONFIG_CHECK:
+        case CommandType::VERSION: return Status::Success();
+        case CommandType::STORE:
+        case CommandType::BATCH_STORE:
+        case CommandType::POWER_CYCLE_PREPARE:
+            return RunStoreLikeCommand(options, config, clientRunner, result);
+        case CommandType::RETRIEVE:
+        case CommandType::BATCH_RETRIEVE:
+        case CommandType::POWER_CYCLE_VERIFY:
+            return RunRetrieveLikeCommand(options, config, clientRunner, result);
+        case CommandType::DELETE: return RunDeleteCommand(options, config, clientRunner, result);
+        case CommandType::EXIST: return RunExistCommand(options, config, clientRunner, result);
+        case CommandType::BENCH: return benchRunner_.Run(options, config, clientRunner, result);
+        case CommandType::UNKNOWN:
+        default: return Status::Error(kExitInvalidArgument, "unknown kv-test command");
+    }
+}
+
+Status KvTestApp::RunStoreLikeCommand(const CommandOptions& options, const KvTestConfig& config,
+                                      AsuClientRunner& clientRunner, CommandResult& result)
+{
+    GeneratedData data;
+    auto status = generator_.Generate(options, config, data);
+    if (!status.Ok()) { return status; }
+
+    BufferSet buffers;
+    status = bufferAllocator_.BuildStoreBuffers(data, buffers);
+    if (!status.Ok()) { return status; }
+
+    status = clientRunner.RegisterBuffers(buffers);
+    if (!status.Ok()) {
+        auto unregisterStatus = clientRunner.UnregisterBuffers(buffers);
+        if (unregisterStatus.Ok()) { return status; }
+        return unregisterStatus;
+    }
+
+    const SubmitMode submitMode = options.command == CommandType::STORE
+                                      ? SubmitMode::SINGLE_ENTRY_PER_CALL
+                                      : SubmitMode::ALL_ENTRIES_IN_ONE_CALL;
+    status = clientRunner.Store(buffers, submitMode, options.timeoutMs, result);
+
+    auto unregisterStatus = clientRunner.UnregisterBuffers(buffers);
+    if (status.Ok() && !unregisterStatus.Ok()) { status = unregisterStatus; }
+    if (status.Ok() && options.command == CommandType::POWER_CYCLE_PREPARE) {
+        status = WritePowerCycleMetadata(options, config);
+    }
+    if (!status.Ok() || !options.check) { return status; }
+
+    BufferSet retrievedBuffers;
+    status = bufferAllocator_.BuildRetrieveBuffers(data, retrievedBuffers);
+    if (!status.Ok()) { return status; }
+
+    status = clientRunner.RegisterBuffers(retrievedBuffers);
+    if (!status.Ok()) {
+        auto retrieveUnregisterStatus = clientRunner.UnregisterBuffers(retrievedBuffers);
+        if (retrieveUnregisterStatus.Ok()) { return status; }
+        return retrieveUnregisterStatus;
+    }
+
+    CommandResult retrieveResult;
+    status = clientRunner.Retrieve(retrievedBuffers, submitMode, options.timeoutMs, retrieveResult);
+    if (status.Ok()) {
+        status = consistencyChecker_.CheckStoreResult(data, retrievedBuffers, retrieveResult,
+                                                      result.consistency);
+    }
+
+    auto retrieveUnregisterStatus = clientRunner.UnregisterBuffers(retrievedBuffers);
+    if (status.Ok() && !retrieveUnregisterStatus.Ok()) { status = retrieveUnregisterStatus; }
+    return status;
+}
+
+Status KvTestApp::RunRetrieveLikeCommand(const CommandOptions& options, const KvTestConfig& config,
+                                         AsuClientRunner& clientRunner, CommandResult& result)
+{
+    GeneratedData data;
+    auto status = generator_.Generate(options, config, data);
+    if (!status.Ok()) { return status; }
+    if (options.command == CommandType::POWER_CYCLE_VERIFY) {
+        status = ValidatePowerCycleMetadata(options, config);
+        if (!status.Ok()) { return status; }
+    }
+
+    BufferSet buffers;
+    status = bufferAllocator_.BuildRetrieveBuffers(data, buffers);
+    if (!status.Ok()) { return status; }
+
+    status = clientRunner.RegisterBuffers(buffers);
+    if (!status.Ok()) {
+        auto unregisterStatus = clientRunner.UnregisterBuffers(buffers);
+        if (unregisterStatus.Ok()) { return status; }
+        return unregisterStatus;
+    }
+
+    const SubmitMode submitMode = options.command == CommandType::RETRIEVE
+                                      ? SubmitMode::SINGLE_ENTRY_PER_CALL
+                                      : SubmitMode::ALL_ENTRIES_IN_ONE_CALL;
+    status = clientRunner.Retrieve(buffers, submitMode, options.timeoutMs, result);
+    const bool checkResult = options.check || options.command == CommandType::POWER_CYCLE_VERIFY;
+    if (status.Ok() && checkResult) {
+        status = consistencyChecker_.CheckRetrieveResult(data, buffers, result, result.consistency);
+    }
+
+    auto unregisterStatus = clientRunner.UnregisterBuffers(buffers);
+    if (status.Ok() && !unregisterStatus.Ok()) { status = unregisterStatus; }
+    return status;
+}
+
+Status KvTestApp::RunDeleteCommand(const CommandOptions& options, const KvTestConfig& config,
+                                   AsuClientRunner& clientRunner, CommandResult& result)
+{
+    GeneratedData data;
+    auto status = generator_.Generate(options, config, data);
+    if (!status.Ok()) { return status; }
+
+    status = clientRunner.Delete(data.keys, options.timeoutMs, result);
+    if (!status.Ok() || !options.check) { return status; }
+
+    CommandResult existResult;
+    status = clientRunner.Exist(data.keys, options.timeoutMs, existResult);
+    if (!status.Ok()) { return status; }
+    return consistencyChecker_.CheckDeleteResult(data.keys, result, existResult,
+                                                 result.consistency);
+}
+
+Status KvTestApp::RunExistCommand(const CommandOptions& options, const KvTestConfig& config,
+                                  AsuClientRunner& clientRunner, CommandResult& result)
+{
+    GeneratedData data;
+    auto status = generator_.Generate(options, config, data);
+    if (!status.Ok()) { return status; }
+
+    return clientRunner.Exist(data.keys, options.timeoutMs, result);
+}
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/src/kv_test_app.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_app.cpp
@@ -17,7 +17,9 @@ namespace {
 
 constexpr int kExitSuccess = 0;
 constexpr int kExitInvalidArgument = 1;
-
+constexpr const char* kAnsiGreen = "\033[32m";
+constexpr const char* kAnsiRed = "\033[31m";
+constexpr const char* kAnsiReset = "\033[0m";
 int ToExitCode(const Status& status) { return status.Ok() ? kExitSuccess : status.code; }
 
 std::filesystem::path PowerCycleMetadataPath(const KvTestConfig& config)
@@ -184,7 +186,8 @@ void PrintGeneralHelp()
         << "\n"
         << "Bench options:\n"
         << "  --op <op>, --bench-op <op>, --io-size <bytes>, --concurrency <n>,\n"
-        << "  --duration <sec>, --warmup <sec>, --read-ratio <n>, --write-ratio <n>\n\n"
+        << "  --duration <sec>, --warmup <sec>, --read-ratio <n>, --write-ratio <n>,\n"
+        << "  --progress               Print one benchmark progress line per second.\n\n"
         << "Examples:\n"
         << "  export KV_TEST_CONFIG=/abs/path/to/asu_kv_test.conf\n"
         << "  kv-test connect\n"
@@ -251,7 +254,7 @@ void PrintCommandHelp(CommandType command)
             std::cout << "Usage: kv-test bench [store|retrieve|batch-store|batch-retrieve|mix] "
                          "[--io-size <bytes>] [--concurrency <n>] [--duration <sec>]\n"
                       << "       kv-test bench --op <op> [--batch-size <n>] [--warmup <sec>] "
-                         "[--read-ratio <n>] [--write-ratio <n>]\n";
+                         "[--read-ratio <n>] [--write-ratio <n>] [--progress]\n";
             break;
         case CommandType::UNKNOWN:
         default: PrintGeneralHelp(); break;
@@ -273,7 +276,7 @@ void PrintVersion() { std::cout << "kv-test version " << LoadVersion() << '\n'; 
 
 void PrintFailure(const Status& status)
 {
-    std::cerr << "kv-test: failed";
+    std::cerr << kAnsiRed << "kv-test: failed" << kAnsiReset;
     if (!status.message.empty()) { std::cerr << ": " << status.message; }
     std::cerr << " (exit_code=" << ToExitCode(status) << ")\n";
 }
@@ -338,7 +341,7 @@ void PrintBenchSummary(const CommandOptions& options, const CommandResult& resul
 
 void PrintSuccess(const CommandOptions& options, const CommandResult& result)
 {
-    std::cout << "kv-test: succeeded"
+    std::cout << kAnsiGreen << "kv-test: succeeded" << kAnsiReset
               << "\ncommand=" << CommandTypeName(options.command)
               << "\nconfig=" << options.configPath << '\n';
     PrintExistSummary(options, result);
@@ -414,13 +417,20 @@ int KvTestApp::Run(int argc, char** argv)
     }
 
     if (options.command == CommandType::CONFIG_CHECK) {
-        std::cout << "kv-test: succeeded command=config check config=" << options.configPath
-                  << '\n';
+        std::cout << kAnsiGreen << "kv-test: succeeded" << kAnsiReset
+                  << " command=config check config=" << options.configPath << '\n';
         std::cout << "config: key_prefix=" << config.keyPrefix << " count=" << config.count
                   << " value_size=" << config.valueSize
                   << " timeout_ms=" << config.asuClientConfig.defaultWaitTimeoutMs
                   << " output=" << config.output.path << '\n';
         return kExitSuccess;
+    }
+
+    FakeBackendAclRuntime fakeBackendAclRuntime;
+    status = fakeBackendAclRuntime.MaybeSetUp(config);
+    if (!status.Ok()) {
+        PrintFailure(status);
+        return ToExitCode(status);
     }
 
     status = resultWriter_.Open(config.output);
@@ -494,9 +504,7 @@ Status KvTestApp::RunStoreLikeCommand(const CommandOptions& options, const KvTes
         return unregisterStatus;
     }
 
-    const SubmitMode submitMode = options.command == CommandType::STORE
-                                      ? SubmitMode::SINGLE_ENTRY_PER_CALL
-                                      : SubmitMode::ALL_ENTRIES_IN_ONE_CALL;
+    const SubmitMode submitMode = SubmitMode::ALL_ENTRIES_IN_ONE_CALL;
     status = clientRunner.Store(buffers, submitMode, options.timeoutMs, result);
 
     auto unregisterStatus = clientRunner.UnregisterBuffers(buffers);
@@ -551,9 +559,7 @@ Status KvTestApp::RunRetrieveLikeCommand(const CommandOptions& options, const Kv
         return unregisterStatus;
     }
 
-    const SubmitMode submitMode = options.command == CommandType::RETRIEVE
-                                      ? SubmitMode::SINGLE_ENTRY_PER_CALL
-                                      : SubmitMode::ALL_ENTRIES_IN_ONE_CALL;
+    const SubmitMode submitMode = SubmitMode::ALL_ENTRIES_IN_ONE_CALL;
     status = clientRunner.Retrieve(buffers, submitMode, options.timeoutMs, result);
     const bool checkResult = options.check || options.command == CommandType::POWER_CYCLE_VERIFY;
     if (status.Ok() && checkResult) {

--- a/ucm/transport/kv/kv-test/src/kv_test_config_loader.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_config_loader.cpp
@@ -1,0 +1,278 @@
+﻿#include "kv_test/kv_test_config_loader.h"
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <fstream>
+#include <limits>
+#include <stdexcept>
+#include <unordered_map>
+#include "../../asu/client/src/client_config_parser.h"
+
+namespace UC::KVTest {
+
+namespace {
+
+constexpr int kExitInvalidArgument = 1;
+constexpr const char* kConfigPathEnvVar = "KV_TEST_CONFIG";
+
+std::string Trim(const std::string& value)
+{
+    const auto begin = value.find_first_not_of(" \t\r\n");
+    if (begin == std::string::npos) { return ""; }
+    const auto end = value.find_last_not_of(" \t\r\n");
+    return value.substr(begin, end - begin + 1);
+}
+
+std::string NormalizeKey(std::string key)
+{
+    std::transform(key.begin(), key.end(), key.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return key;
+}
+
+std::uint64_t ParseUint64(const std::string& value)
+{
+    std::size_t parsed{0};
+    const auto result = std::stoull(value, &parsed, 0);
+    if (parsed != value.size()) { throw std::invalid_argument("invalid unsigned integer"); }
+    return result;
+}
+
+std::uint32_t ParseUint32(const std::string& value)
+{
+    const auto result = ParseUint64(value);
+    if (result > std::numeric_limits<std::uint32_t>::max()) {
+        throw std::out_of_range("uint32 overflow");
+    }
+    return static_cast<std::uint32_t>(result);
+}
+
+std::unordered_map<std::string, std::string> LoadKeyValueFile(const std::string& configPath,
+                                                              Status& status)
+{
+    std::ifstream configFile{configPath};
+    if (!configFile.is_open()) {
+        status = Status::Error(kExitInvalidArgument,
+                               "failed to open kv-test config, path=" + configPath);
+        return {};
+    }
+
+    std::unordered_map<std::string, std::string> values;
+    std::string line;
+    while (std::getline(configFile, line)) {
+        line = Trim(line);
+        if (line.empty() || line[0] == '#') { continue; }
+
+        const auto pos = line.find('=');
+        if (pos == std::string::npos) { continue; }
+
+        const auto key = NormalizeKey(Trim(line.substr(0, pos)));
+        const auto value = Trim(line.substr(pos + 1));
+        if (!key.empty()) { values[key] = value; }
+    }
+
+    status = Status::Success();
+    return values;
+}
+
+bool GetStringValue(const std::unordered_map<std::string, std::string>& values,
+                    const std::string& key, std::string& result)
+{
+    const auto iter = values.find(NormalizeKey(key));
+    if (iter == values.end()) { return false; }
+    result = iter->second;
+    return true;
+}
+
+bool GetUint64Value(const std::unordered_map<std::string, std::string>& values,
+                    const std::string& key, std::uint64_t& result)
+{
+    const auto iter = values.find(NormalizeKey(key));
+    if (iter == values.end()) { return false; }
+    result = ParseUint64(iter->second);
+    return true;
+}
+
+bool GetUint32Value(const std::unordered_map<std::string, std::string>& values,
+                    const std::string& key, std::uint32_t& result)
+{
+    const auto iter = values.find(NormalizeKey(key));
+    if (iter == values.end()) { return false; }
+    result = ParseUint32(iter->second);
+    return true;
+}
+
+bool GetStringAny(const std::unordered_map<std::string, std::string>& values,
+                  const std::vector<std::string>& keys, std::string& result)
+{
+    for (const auto& key : keys) {
+        if (GetStringValue(values, key, result)) { return true; }
+    }
+    return false;
+}
+
+bool GetUint64Any(const std::unordered_map<std::string, std::string>& values,
+                  const std::vector<std::string>& keys, std::uint64_t& result)
+{
+    for (const auto& key : keys) {
+        if (GetUint64Value(values, key, result)) { return true; }
+    }
+    return false;
+}
+
+bool GetUint32Any(const std::unordered_map<std::string, std::string>& values,
+                  const std::vector<std::string>& keys, std::uint32_t& result)
+{
+    for (const auto& key : keys) {
+        if (GetUint32Value(values, key, result)) { return true; }
+    }
+    return false;
+}
+
+Status ToKvTestConfigStatus(const UC::ASU::Status& status)
+{
+    if (status.ok()) { return Status::Success(); }
+    return Status::Error(kExitInvalidArgument,
+                         "failed to load asu client config: " + status.message);
+}
+
+}  // namespace
+
+Status KvTestConfigLoader::ResolveConfigPath(const std::string& configPath,
+                                             std::string& resolvedPath) const
+{
+    if (!configPath.empty()) {
+        resolvedPath = configPath;
+        return Status::Success();
+    }
+
+    const char* envValue = std::getenv(kConfigPathEnvVar);
+    if (envValue != nullptr && envValue[0] != '\0') {
+        resolvedPath = envValue;
+        return Status::Success();
+    }
+
+    return Status::Error(kExitInvalidArgument,
+                         "missing config path: set KV_TEST_CONFIG or pass --configpath");
+}
+
+Status KvTestConfigLoader::Load(const std::string& configPath, KvTestConfig& config) const
+{
+    auto asuStatus = UC::ASU::LoadAsuClientConfig(configPath, config.asuClientConfig);
+    auto status = ToKvTestConfigStatus(asuStatus);
+    if (!status.Ok()) { return status; }
+
+    config.behavior = ToolBehaviorConfig{};
+    config.hcommProtocolMapping = HcommProtocolMapping{};
+    config.limits = BatchLimits{};
+    config.bench = BenchConfig{};
+    config.output = OutputConfig{};
+    config.fakeBackend = FakeBackendConfig{};
+    config.asuClientMode.clear();
+    config.localStorePath.clear();
+    config.keyPrefix.clear();
+    config.seed = 0;
+    config.valueSize = 0;
+    config.count = 0;
+    config.memoryMaxBytes = kDefaultMemoryMaxBytes;
+
+    auto values = LoadKeyValueFile(configPath, status);
+    if (!status.Ok()) { return status; }
+
+    try {
+        GetStringAny(values, {"asu.client.mode"}, config.asuClientMode);
+        GetStringAny(values, {"local_store.path"}, config.localStorePath);
+        GetStringAny(values, {"fake_backend.path", "fakebackend.path"},
+                     config.fakeBackend.storePath);
+        GetUint64Any(values,
+                     {"fake_backend.latency_ms", "fakebackend.latency_ms", "fake_backend.latencyms",
+                      "fakebackend.latencyms"},
+                     config.fakeBackend.latencyMs);
+
+        GetStringAny(values, {"kv.key_prefix"}, config.keyPrefix);
+
+        GetUint64Any(values, {"kv.value_size"}, config.valueSize);
+        GetUint64Any(values, {"kv.seed"}, config.seed);
+        GetUint64Any(values, {"kv.count"}, config.count);
+
+        GetUint32Any(values, {"limits.batch_store_max"}, config.limits.batchStoreMax);
+        GetUint32Any(values, {"limits.batch_retrieve_max"}, config.limits.batchRetrieveMax);
+        GetUint32Any(values, {"limits.delete_max"}, config.limits.deleteMax);
+        GetUint32Any(values, {"limits.exist_max"}, config.limits.existMax);
+        GetUint64Any(values, {"limits.memory_max_bytes"}, config.memoryMaxBytes);
+
+        GetUint64Any(values, {"bench.io_size"}, config.bench.ioSize);
+        GetUint32Any(values, {"bench.concurrency"}, config.bench.concurrency);
+        GetUint64Any(values, {"bench.duration_sec"}, config.bench.durationSec);
+        GetUint64Any(values, {"bench.warmup_sec"}, config.bench.warmupSec);
+        GetUint32Any(values, {"bench.read_ratio"}, config.bench.readRatio);
+        GetUint32Any(values, {"bench.write_ratio"}, config.bench.writeRatio);
+        GetUint32Any(values, {"bench.batch_size"}, config.bench.batchSize);
+
+        GetStringAny(values, {"output.path"}, config.output.path);
+        GetUint64Any(values, {"output.realtime_file_max_bytes"},
+                     config.output.realtimeFileMaxBytes);
+
+        std::uint64_t timeoutMs{0};
+        if (GetUint64Any(values, {"connection.timeout_ms"}, timeoutMs)) {
+            config.asuClientConfig.defaultWaitTimeoutMs = timeoutMs;
+        }
+    } catch (const std::exception& e) {
+        return Status::Error(kExitInvalidArgument,
+                             "invalid kv-test config value in " + configPath + ": " + e.what());
+    }
+
+    return Status::Success();
+}
+
+Status KvTestConfigLoader::MergeCommandOptions(const CommandOptions& options,
+                                               KvTestConfig& config) const
+{
+    if (options.seed != 0) { config.seed = options.seed; }
+    if (options.count != 0) { config.count = options.count; }
+    if (options.valueSize != 0) {
+        config.valueSize = options.valueSize;
+        if (options.command == CommandType::BENCH) { config.bench.ioSize = options.valueSize; }
+    }
+    if (options.batchSize != 0) { config.bench.batchSize = options.batchSize; }
+    if (options.timeoutMs != 0) { config.asuClientConfig.defaultWaitTimeoutMs = options.timeoutMs; }
+    if (!options.outputPath.empty()) { config.output.path = options.outputPath; }
+
+    if (options.benchOp != BenchOpType::UNKNOWN) { config.bench.op = options.benchOp; }
+    if (options.concurrency != 0) { config.bench.concurrency = options.concurrency; }
+    if (options.durationSec != 0) { config.bench.durationSec = options.durationSec; }
+    if (options.warmupSec != 0) { config.bench.warmupSec = options.warmupSec; }
+    if (options.readRatio != 0) { config.bench.readRatio = options.readRatio; }
+    if (options.writeRatio != 0) { config.bench.writeRatio = options.writeRatio; }
+
+    if (config.bench.batchSize > config.limits.batchStoreMax &&
+        (options.command == CommandType::BATCH_STORE ||
+         (options.command == CommandType::BENCH && config.bench.op == BenchOpType::BATCH_STORE))) {
+        return Status::Error(kExitInvalidArgument, "batch_size exceeds limits.batch_store_max");
+    }
+    if (config.bench.batchSize > config.limits.batchRetrieveMax &&
+        (options.command == CommandType::BATCH_RETRIEVE ||
+         (options.command == CommandType::BENCH &&
+          config.bench.op == BenchOpType::BATCH_RETRIEVE))) {
+        return Status::Error(kExitInvalidArgument, "batch_size exceeds limits.batch_retrieve_max");
+    }
+
+    const bool hasExplicitKeys = !options.keys.empty() || !options.keysFile.empty() ||
+                                 options.keyStartSet || options.keyEndSet;
+    if (config.count != 0 && config.keyPrefix.empty() && !hasExplicitKeys) {
+        return Status::Error(kExitInvalidArgument,
+                             "kv.key_prefix is required when count-based key generation is used");
+    }
+    if (config.count != 0 && config.valueSize == 0 && options.command != CommandType::DELETE &&
+        options.command != CommandType::EXIST) {
+        return Status::Error(kExitInvalidArgument,
+                             "kv.value_size is required when count-based value generation is used");
+    }
+    if (options.command == CommandType::BENCH && config.bench.ioSize == 0) {
+        config.bench.ioSize = config.valueSize;
+    }
+
+    return Status::Success();
+}
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/src/kv_test_config_loader.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_config_loader.cpp
@@ -14,6 +14,7 @@ namespace {
 
 constexpr int kExitInvalidArgument = 1;
 constexpr const char* kConfigPathEnvVar = "KV_TEST_CONFIG";
+constexpr std::uint64_t kMaxBenchIoSizeBytes = 0xFFFFFF;
 
 std::string Trim(const std::string& value)
 {
@@ -245,18 +246,6 @@ Status KvTestConfigLoader::MergeCommandOptions(const CommandOptions& options,
     if (options.readRatio != 0) { config.bench.readRatio = options.readRatio; }
     if (options.writeRatio != 0) { config.bench.writeRatio = options.writeRatio; }
 
-    if (config.bench.batchSize > config.limits.batchStoreMax &&
-        (options.command == CommandType::BATCH_STORE ||
-         (options.command == CommandType::BENCH && config.bench.op == BenchOpType::BATCH_STORE))) {
-        return Status::Error(kExitInvalidArgument, "batch_size exceeds limits.batch_store_max");
-    }
-    if (config.bench.batchSize > config.limits.batchRetrieveMax &&
-        (options.command == CommandType::BATCH_RETRIEVE ||
-         (options.command == CommandType::BENCH &&
-          config.bench.op == BenchOpType::BATCH_RETRIEVE))) {
-        return Status::Error(kExitInvalidArgument, "batch_size exceeds limits.batch_retrieve_max");
-    }
-
     const bool hasExplicitKeys = !options.keys.empty() || !options.keysFile.empty() ||
                                  options.keyStartSet || options.keyEndSet;
     if (config.count != 0 && config.keyPrefix.empty() && !hasExplicitKeys) {
@@ -270,6 +259,10 @@ Status KvTestConfigLoader::MergeCommandOptions(const CommandOptions& options,
     }
     if (options.command == CommandType::BENCH && config.bench.ioSize == 0) {
         config.bench.ioSize = config.valueSize;
+    }
+    if (options.command == CommandType::BENCH && config.bench.ioSize > kMaxBenchIoSizeBytes) {
+        return Status::Error(kExitInvalidArgument,
+                             "bench.io_size exceeds protocol 24-bit length limit");
     }
 
     return Status::Success();

--- a/ucm/transport/kv/kv-test/src/kv_test_main.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_main.cpp
@@ -1,0 +1,7 @@
+#include "kv_test/kv_test_app.h"
+
+int main(int argc, char** argv)
+{
+    UC::KVTest::KvTestApp app;
+    return app.Run(argc, argv);
+}

--- a/ucm/transport/kv/kv-test/src/local_asu_transport.cpp
+++ b/ucm/transport/kv/kv-test/src/local_asu_transport.cpp
@@ -1,0 +1,345 @@
+#include "kv_test/local_asu_transport.h"
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <sstream>
+#include <unordered_map>
+#include <utility>
+
+namespace UC::KVTest {
+namespace {
+
+class LocalAsuTransport final : public UC::ASU::AsuTransport {
+public:
+    explicit LocalAsuTransport(std::string storeRoot) : storeRoot_(std::move(storeRoot)) {}
+
+    UC::ASU::Status Init(const UC::ASU::TransportConfig& config) override
+    {
+        auto status = ValidateTransportAddress(config);
+        if (!status.ok()) { return status; }
+
+        config_ = config;
+        std::error_code errorCode;
+        std::filesystem::create_directories(AsuRoot(), errorCode);
+        if (errorCode) {
+            return UC::ASU::Status::Error(UC::ASU::StatusCode::IO_ERROR,
+                                          "failed to create local ASU store path=" +
+                                              AsuRoot().string() + " error=" + errorCode.message());
+        }
+        initialized_ = true;
+        return UC::ASU::Status::OK();
+    }
+
+    UC::ASU::Status Init(const std::string&) override
+    {
+        return UC::ASU::Status::Error(UC::ASU::StatusCode::UNSUPPORTED,
+                                      "local ASU transport does not load config files directly");
+    }
+
+    UC::ASU::Status Shutdown() override
+    {
+        initialized_ = false;
+        std::lock_guard<std::mutex> lock(taskResultsMu_);
+        taskResults_.clear();
+        return UC::ASU::Status::OK();
+    }
+
+    UC::ASU::Status CheckHealth() override
+    {
+        return initialized_ ? UC::ASU::Status::OK() : NotInitialized();
+    }
+
+    UC::ASU::Status Query(const std::vector<UC::ASU::CacheKey>& keys,
+                          const UC::ASU::QueryOptions& options,
+                          UC::ASU::QueryResult& result) override
+    {
+        if (!initialized_) { return NotInitialized(); }
+
+        result = UC::ASU::QueryResult{};
+        if (options.mode == UC::ASU::QueryMode::PREFIX) {
+            result.prefixHitKeys = CountPrefixHits(keys.empty() ? "" : keys.front());
+            return UC::ASU::Status::OK();
+        }
+
+        result.exists.reserve(keys.size());
+        for (const auto& key : keys) {
+            result.exists.emplace_back(std::filesystem::exists(KeyPath(key)) ? 1 : 0);
+        }
+        return UC::ASU::Status::OK();
+    }
+
+    UC::ASU::Status QueryAsync(const std::vector<UC::ASU::CacheKey>& keys,
+                               const UC::ASU::QueryOptions& options,
+                               UC::ASU::TaskId& taskId) override
+    {
+        UC::ASU::QueryResult queryResult;
+        auto status = Query(keys, options, queryResult);
+        UC::ASU::TaskResult result;
+        result.status = status;
+        result.queryResult = queryResult;
+        taskId = SaveTaskResult(result);
+        return status;
+    }
+
+    UC::ASU::Status LoadAsync(const std::vector<UC::ASU::KVBuffer>& entries,
+                              UC::ASU::TaskId& taskId) override
+    {
+        if (!initialized_) { return NotInitialized(); }
+
+        UC::ASU::TaskResult result;
+        result.status = UC::ASU::Status::OK();
+        result.entryStatus.reserve(entries.size());
+        for (const auto& entry : entries) { result.entryStatus.emplace_back(LoadEntry(entry)); }
+        FinalizeEntryTask(result);
+        taskId = SaveTaskResult(result);
+        return UC::ASU::Status::OK();
+    }
+
+    UC::ASU::Status StoreAsync(const std::vector<UC::ASU::KVBuffer>& entries,
+                               UC::ASU::TaskId& taskId) override
+    {
+        if (!initialized_) { return NotInitialized(); }
+
+        UC::ASU::TaskResult result;
+        result.status = UC::ASU::Status::OK();
+        result.entryStatus.reserve(entries.size());
+        for (const auto& entry : entries) { result.entryStatus.emplace_back(StoreEntry(entry)); }
+        FinalizeEntryTask(result);
+        taskId = SaveTaskResult(result);
+        return UC::ASU::Status::OK();
+    }
+
+    UC::ASU::Status DeleteAsync(const std::vector<UC::ASU::CacheKey>& keys,
+                                UC::ASU::TaskId& taskId) override
+    {
+        if (!initialized_) { return NotInitialized(); }
+
+        UC::ASU::TaskResult result;
+        result.status = UC::ASU::Status::OK();
+        result.entryStatus.reserve(keys.size());
+        for (const auto& key : keys) {
+            std::error_code errorCode;
+            const bool removed = std::filesystem::remove(KeyPath(key), errorCode);
+            if (errorCode) {
+                result.entryStatus.emplace_back(UC::ASU::Status::Error(
+                    UC::ASU::StatusCode::IO_ERROR,
+                    "failed to delete local key=" + key + " error=" + errorCode.message()));
+            } else if (!removed) {
+                result.entryStatus.emplace_back(UC::ASU::Status::Error(
+                    UC::ASU::StatusCode::NOT_FOUND, "local key not found=" + key));
+            } else {
+                result.entryStatus.emplace_back(UC::ASU::Status::OK());
+            }
+        }
+        FinalizeEntryTask(result);
+        taskId = SaveTaskResult(result);
+        return UC::ASU::Status::OK();
+    }
+
+    UC::ASU::Status Cancel(UC::ASU::TaskId taskId) override
+    {
+        std::lock_guard<std::mutex> lock(taskResultsMu_);
+        auto iter = taskResults_.find(taskId);
+        if (iter == taskResults_.end()) {
+            return UC::ASU::Status::Error(UC::ASU::StatusCode::TASK_NOT_FOUND,
+                                          "local task not found");
+        }
+        iter->second.status =
+            UC::ASU::Status::Error(UC::ASU::StatusCode::CANCELED, "local task canceled");
+        return UC::ASU::Status::OK();
+    }
+
+    UC::ASU::Status Check(UC::ASU::TaskId taskId, UC::ASU::TaskResult& result) override
+    {
+        std::lock_guard<std::mutex> lock(taskResultsMu_);
+        auto iter = taskResults_.find(taskId);
+        if (iter == taskResults_.end()) {
+            return UC::ASU::Status::Error(UC::ASU::StatusCode::TASK_NOT_FOUND,
+                                          "local task not found");
+        }
+        result = iter->second;
+        return UC::ASU::Status::OK();
+    }
+
+    UC::ASU::Status Wait(UC::ASU::TaskId taskId, std::uint64_t,
+                         UC::ASU::TaskResult& result) override
+    {
+        return Check(taskId, result);
+    }
+
+    UC::ASU::Status RegisterRegions(const std::vector<UC::ASU::MemoryRegion>& regions,
+                                    std::vector<UC::ASU::RegisterResult>& results) override
+    {
+        results.clear();
+        results.reserve(regions.size());
+        std::lock_guard<std::mutex> lock(taskResultsMu_);
+        for (std::size_t index = 0; index < regions.size(); ++index) {
+            results.emplace_back(UC::ASU::RegisterResult{UC::ASU::Status::OK(), nextMrHandle_++});
+        }
+        return UC::ASU::Status::OK();
+    }
+
+    UC::ASU::Status BindRegisteredRegions(const std::vector<UC::ASU::RegisteredMemory>& regions,
+                                          std::vector<UC::ASU::RegisterResult>& results) override
+    {
+        results.clear();
+        results.reserve(regions.size());
+        for (const auto& region : regions) {
+            results.emplace_back(UC::ASU::RegisterResult{UC::ASU::Status::OK(), region.handle});
+        }
+        return UC::ASU::Status::OK();
+    }
+
+    UC::ASU::Status UnregisterRegions(const std::vector<UC::ASU::MRHandle>&) override
+    {
+        return UC::ASU::Status::OK();
+    }
+
+private:
+    static UC::ASU::Status NotInitialized()
+    {
+        return UC::ASU::Status::Error(UC::ASU::StatusCode::NOT_INITIALIZED,
+                                      "local ASU transport is not initialized");
+    }
+
+    static UC::ASU::Status ValidateTransportAddress(const UC::ASU::TransportConfig& config)
+    {
+        if (config.endpoints.empty()) {
+            return UC::ASU::Status::Error(
+                UC::ASU::StatusCode::INVALID_ARGUMENT,
+                "local ASU transport endpoint is required, asuId=" + std::to_string(config.asuId));
+        }
+
+        for (std::size_t index = 0; index < config.endpoints.size(); ++index) {
+            const auto& endpoint = config.endpoints[index];
+            if (endpoint.ip.empty()) {
+                return UC::ASU::Status::Error(
+                    UC::ASU::StatusCode::INVALID_ARGUMENT,
+                    "local ASU endpoint local.comm_id is required, asuId=" +
+                        std::to_string(config.asuId) + ", endpointIndex=" + std::to_string(index));
+            }
+            if (endpoint.port == 0) {
+                return UC::ASU::Status::Error(
+                    UC::ASU::StatusCode::INVALID_ARGUMENT,
+                    "local ASU endpoint port is required, asuId=" + std::to_string(config.asuId) +
+                        ", endpointIndex=" + std::to_string(index));
+            }
+        }
+        return UC::ASU::Status::OK();
+    }
+
+    static void FinalizeEntryTask(UC::ASU::TaskResult& result)
+    {
+        const auto failed =
+            std::find_if(result.entryStatus.begin(), result.entryStatus.end(),
+                         [](const UC::ASU::Status& status) { return !status.ok(); });
+        if (failed != result.entryStatus.end()) {
+            result.status = UC::ASU::Status::Error(UC::ASU::StatusCode::PARTIAL_FAILED,
+                                                   "one or more local entries failed");
+        }
+    }
+
+    static std::string HexEncode(const std::string& value)
+    {
+        constexpr char kHex[] = "0123456789abcdef";
+        std::string output;
+        output.reserve(value.size() * 2);
+        for (unsigned char ch : value) {
+            output.push_back(kHex[ch >> 4]);
+            output.push_back(kHex[ch & 0x0F]);
+        }
+        return output;
+    }
+
+    std::filesystem::path AsuRoot() const
+    {
+        return std::filesystem::path(storeRoot_) / ("asu-" + std::to_string(config_.asuId));
+    }
+
+    std::filesystem::path KeyPath(const UC::ASU::CacheKey& key) const
+    {
+        return AsuRoot() / (HexEncode(key) + ".bin");
+    }
+
+    UC::ASU::Status StoreEntry(const UC::ASU::KVBuffer& entry)
+    {
+        std::ofstream file{KeyPath(entry.key), std::ios::binary | std::ios::trunc};
+        if (!file.is_open()) {
+            return UC::ASU::Status::Error(UC::ASU::StatusCode::IO_ERROR,
+                                          "failed to open local key for store=" + entry.key);
+        }
+        const auto* data = reinterpret_cast<const char*>(entry.buffer.region.addr);
+        file.write(data, static_cast<std::streamsize>(entry.buffer.region.size));
+        if (!file.good()) {
+            return UC::ASU::Status::Error(UC::ASU::StatusCode::IO_ERROR,
+                                          "failed to write local key=" + entry.key);
+        }
+        return UC::ASU::Status::OK();
+    }
+
+    UC::ASU::Status LoadEntry(const UC::ASU::KVBuffer& entry)
+    {
+        std::ifstream file{KeyPath(entry.key), std::ios::binary};
+        if (!file.is_open()) {
+            return UC::ASU::Status::Error(UC::ASU::StatusCode::NOT_FOUND,
+                                          "local key not found=" + entry.key);
+        }
+
+        file.seekg(0, std::ios::end);
+        const auto size = file.tellg();
+        file.seekg(0, std::ios::beg);
+        if (size < 0 || static_cast<std::uint64_t>(size) >
+                            static_cast<std::uint64_t>(entry.buffer.region.size)) {
+            return UC::ASU::Status::Error(UC::ASU::StatusCode::BUFFER_NOT_SUPPORTED,
+                                          "local value does not fit destination key=" + entry.key);
+        }
+
+        auto* data = reinterpret_cast<char*>(entry.buffer.region.addr);
+        file.read(data, size);
+        if (!file.good() && !file.eof()) {
+            return UC::ASU::Status::Error(UC::ASU::StatusCode::IO_ERROR,
+                                          "failed to read local key=" + entry.key);
+        }
+        return UC::ASU::Status::OK();
+    }
+
+    std::uint32_t CountPrefixHits(const std::string& prefix) const
+    {
+        std::uint32_t hits = 0;
+        std::error_code errorCode;
+        for (const auto& entry : std::filesystem::directory_iterator(AsuRoot(), errorCode)) {
+            if (errorCode) { break; }
+            if (entry.path().filename().string().rfind(HexEncode(prefix), 0) == 0) { ++hits; }
+        }
+        return hits;
+    }
+
+    UC::ASU::TaskId SaveTaskResult(UC::ASU::TaskResult result)
+    {
+        std::lock_guard<std::mutex> lock(taskResultsMu_);
+        const auto taskId = nextTaskId_++;
+        taskResults_[taskId] = std::move(result);
+        return taskId;
+    }
+
+    std::string storeRoot_;
+    UC::ASU::TransportConfig config_;
+    bool initialized_{false};
+    UC::ASU::TaskId nextTaskId_{1};
+    UC::ASU::MRHandle nextMrHandle_{1};
+    std::mutex taskResultsMu_;
+    std::unordered_map<UC::ASU::TaskId, UC::ASU::TaskResult> taskResults_;
+};
+
+}  // namespace
+
+UC::ASU::TransportFactory CreateLocalAsuTransportFactory(std::string storeRoot)
+{
+    if (storeRoot.empty()) { storeRoot = "./kv-test-local-store"; }
+    return [storeRoot = std::move(storeRoot)] {
+        return std::make_unique<LocalAsuTransport>(storeRoot);
+    };
+}
+
+}  // namespace UC::KVTest

--- a/ucm/transport/kv/kv-test/src/result_writer.cpp
+++ b/ucm/transport/kv/kv-test/src/result_writer.cpp
@@ -1,0 +1,673 @@
+﻿#include "kv_test/result_writer.h"
+#include <algorithm>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+
+namespace UC::KVTest {
+
+namespace {
+
+constexpr int kExitInvalidArgument = 1;
+
+constexpr std::uint64_t kDefaultRealtimeFileMaxBytes = 100ULL * 1024ULL * 1024ULL;
+
+const char* kRealtimeCsvHeader =
+    "timestamp_sec,op,bandwidth_value,bandwidth_unit,iops_value,iops_unit,avg_latency_value,"
+    "avg_latency_unit,error_count\n";
+const char* kLatencyCsvHeader =
+    "op,avg_value,avg_unit,min_value,min_unit,max_value,max_unit,p99_9_value,p99_9_unit,"
+    "p99_99_value,p99_99_unit,p99_999_value,p99_999_unit\n";
+
+std::string JsonEscape(const std::string& value)
+{
+    std::ostringstream stream;
+    for (const auto ch : value) {
+        switch (ch) {
+            case '\\': stream << "\\\\"; break;
+            case '"': stream << "\\\""; break;
+            case '\b': stream << "\\b"; break;
+            case '\f': stream << "\\f"; break;
+            case '\n': stream << "\\n"; break;
+            case '\r': stream << "\\r"; break;
+            case '\t': stream << "\\t"; break;
+            default:
+                if (static_cast<unsigned char>(ch) < 0x20) {
+                    stream << "\\u" << std::hex << std::setw(4) << std::setfill('0')
+                           << static_cast<int>(static_cast<unsigned char>(ch)) << std::dec
+                           << std::setfill(' ');
+                } else {
+                    stream << ch;
+                }
+                break;
+        }
+    }
+    return stream.str();
+}
+
+std::string JsonString(const std::string& value) { return "\"" + JsonEscape(value) + "\""; }
+
+std::string HtmlEscape(const std::string& value)
+{
+    std::ostringstream stream;
+    for (const auto ch : value) {
+        switch (ch) {
+            case '&': stream << "&amp;"; break;
+            case '<': stream << "&lt;"; break;
+            case '>': stream << "&gt;"; break;
+            case '"': stream << "&quot;"; break;
+            case '\'': stream << "&#39;"; break;
+            default: stream << ch; break;
+        }
+    }
+    return stream.str();
+}
+
+std::string FormatNumber(double value, int precision = 2)
+{
+    std::ostringstream stream;
+    stream << std::fixed << std::setprecision(precision) << value;
+    return stream.str();
+}
+
+std::string FormatLocalTimestamp(const char* format)
+{
+    const auto now = std::chrono::system_clock::now();
+    const auto time = std::chrono::system_clock::to_time_t(now);
+    std::tm localTime{};
+#ifdef _WIN32
+    localtime_s(&localTime, &time);
+#else
+    localtime_r(&time, &localTime);
+#endif
+
+    std::ostringstream stream;
+    stream << std::put_time(&localTime, format);
+    return stream.str();
+}
+
+std::string CommandTypeName(CommandType command)
+{
+    switch (command) {
+        case CommandType::CONNECT: return "connect";
+        case CommandType::CONFIG_CHECK: return "config check";
+        case CommandType::STORE: return "store";
+        case CommandType::RETRIEVE: return "retrieve";
+        case CommandType::DELETE: return "delete";
+        case CommandType::EXIST: return "exist";
+        case CommandType::BATCH_STORE: return "batch-store";
+        case CommandType::BATCH_RETRIEVE: return "batch-retrieve";
+        case CommandType::POWER_CYCLE_PREPARE: return "power-cycle prepare";
+        case CommandType::POWER_CYCLE_VERIFY: return "power-cycle verify";
+        case CommandType::BENCH: return "bench";
+        case CommandType::VERSION: return "version";
+        case CommandType::UNKNOWN:
+        default: return "unknown";
+    }
+}
+
+std::string BenchOpTypeName(BenchOpType op)
+{
+    switch (op) {
+        case BenchOpType::STORE: return "store";
+        case BenchOpType::RETRIEVE: return "retrieve";
+        case BenchOpType::BATCH_STORE: return "batch-store";
+        case BenchOpType::BATCH_RETRIEVE: return "batch-retrieve";
+        case BenchOpType::MIX: return "mix";
+        case BenchOpType::UNKNOWN:
+        default: return "unknown";
+    }
+}
+
+std::string AsuStatusCodeName(UC::ASU::StatusCode code)
+{
+    switch (code) {
+        case UC::ASU::StatusCode::OK: return "OK";
+        case UC::ASU::StatusCode::INVALID_ARGUMENT: return "INVALID_ARGUMENT";
+        case UC::ASU::StatusCode::NOT_INITIALIZED: return "NOT_INITIALIZED";
+        case UC::ASU::StatusCode::TIMEOUT: return "TIMEOUT";
+        case UC::ASU::StatusCode::NOT_FOUND: return "NOT_FOUND";
+        case UC::ASU::StatusCode::PARTIAL_FAILED: return "PARTIAL_FAILED";
+        case UC::ASU::StatusCode::CONNECTION_ERROR: return "CONNECTION_ERROR";
+        case UC::ASU::StatusCode::IO_ERROR: return "IO_ERROR";
+        case UC::ASU::StatusCode::BUFFER_NOT_REGISTERED: return "BUFFER_NOT_REGISTERED";
+        case UC::ASU::StatusCode::BUFFER_NOT_SUPPORTED: return "BUFFER_NOT_SUPPORTED";
+        case UC::ASU::StatusCode::TASK_NOT_FOUND: return "TASK_NOT_FOUND";
+        case UC::ASU::StatusCode::RESOURCE_BUSY: return "RESOURCE_BUSY";
+        case UC::ASU::StatusCode::UNSUPPORTED: return "UNSUPPORTED";
+        case UC::ASU::StatusCode::IN_PROGRESS: return "IN_PROGRESS";
+        case UC::ASU::StatusCode::INTERNAL_ERROR: return "INTERNAL_ERROR";
+        case UC::ASU::StatusCode::CANCELED: return "CANCELED";
+        default: return "UNKNOWN";
+    }
+}
+
+std::string ResultStatusName(const CommandResult& result)
+{
+    if (!result.status.Ok()) { return "failed"; }
+    if (result.taskResult.status.code == UC::ASU::StatusCode::PARTIAL_FAILED) {
+        return "partial_failed";
+    }
+    if (!result.taskResult.status.ok()) { return "failed"; }
+
+    const auto failedEntry =
+        std::find_if(result.taskResult.entryStatus.begin(), result.taskResult.entryStatus.end(),
+                     [](const UC::ASU::Status& status) { return !status.ok(); });
+    return failedEntry == result.taskResult.entryStatus.end() ? "success" : "partial_failed";
+}
+
+std::uint64_t KeyCount(const CommandOptions& options, const CommandResult& result)
+{
+    if (!options.keys.empty()) { return options.keys.size(); }
+    if (options.keyStartSet && options.keyEndSet) { return options.keyEnd - options.keyStart + 1; }
+    if (options.count != 0) { return options.count; }
+    if (!result.taskResult.entryStatus.empty()) { return result.taskResult.entryStatus.size(); }
+    if (!result.queryResult.exists.empty()) { return result.queryResult.exists.size(); }
+    return 0;
+}
+
+std::filesystem::path BuildOutputPath(const std::string& outputDir, const std::string& fileName)
+{
+    return std::filesystem::path(outputDir) / fileName;
+}
+
+std::string BuildBandwidthSvg(const std::vector<BenchRealtimeSample>& samples)
+{
+    constexpr double kWidth = 720.0;
+    constexpr double kHeight = 220.0;
+    constexpr double kPad = 32.0;
+    if (samples.empty()) { return "<p class=\"muted\">No realtime samples were recorded.</p>"; }
+
+    double maxBandwidthMiB = 0.0;
+    for (const auto& sample : samples) {
+        maxBandwidthMiB =
+            std::max(maxBandwidthMiB, sample.bandwidthBytesPerSec / (1024.0 * 1024.0));
+    }
+    if (maxBandwidthMiB <= 0.0) { maxBandwidthMiB = 1.0; }
+
+    std::ostringstream points;
+    for (std::size_t index = 0; index < samples.size(); ++index) {
+        const auto x =
+            samples.size() == 1
+                ? kPad
+                : kPad + (kWidth - 2.0 * kPad) *
+                             (static_cast<double>(index) / static_cast<double>(samples.size() - 1));
+        const auto y =
+            kHeight - kPad -
+            (kHeight - 2.0 * kPad) *
+                ((samples[index].bandwidthBytesPerSec / (1024.0 * 1024.0)) / maxBandwidthMiB);
+        points << x << ',' << y << ' ';
+    }
+
+    std::ostringstream svg;
+    svg << "<svg viewBox=\"0 0 720 220\" role=\"img\" aria-label=\"Bandwidth curve\">"
+        << "<line x1=\"32\" y1=\"188\" x2=\"688\" y2=\"188\" class=\"axis\"/>"
+        << "<line x1=\"32\" y1=\"32\" x2=\"32\" y2=\"188\" class=\"axis\"/>"
+        << "<polyline points=\"" << points.str() << "\" class=\"line\"/>"
+        << "<text x=\"36\" y=\"24\" class=\"chart-label\">Bandwidth MiB/s, max "
+        << FormatNumber(maxBandwidthMiB) << "</text>"
+        << "</svg>";
+    return svg.str();
+}
+
+}  // namespace
+
+Status ResultWriter::Open(const OutputConfig& config)
+{
+    Close();
+
+    const auto baseDir =
+        config.path.empty() ? std::filesystem::path(".") : std::filesystem::path(config.path);
+    const auto runDir = baseDir / ("run-" + FormatLocalTimestamp("%Y%m%d-%H%M%S"));
+
+    std::error_code errorCode;
+    std::filesystem::create_directories(runDir, errorCode);
+    if (errorCode) {
+        return Status::Error(
+            kExitInvalidArgument,
+            "failed to create output directory " + runDir.string() + ": " + errorCode.message());
+    }
+
+    outputDir_ = runDir.string();
+    baseOutputDir_ = baseDir.string();
+    realtimeFileMaxBytes_ = config.realtimeFileMaxBytes == 0 ? kDefaultRealtimeFileMaxBytes
+                                                             : config.realtimeFileMaxBytes;
+    realtimeFileIndex_ = 0;
+    realtimeFileBytes_ = 0;
+
+    return Status::Success();
+}
+
+Status ResultWriter::WriteSummary(const CommandOptions& options, const CommandResult& result)
+{
+    if (outputDir_.empty()) {
+        return Status::Error(kExitInvalidArgument, "ResultWriter is not open");
+    }
+
+    const auto commandName = CommandTypeName(options.command);
+    const auto opName =
+        options.command == CommandType::BENCH ? BenchOpTypeName(options.benchOp) : commandName;
+    const auto statusName = ResultStatusName(result);
+    const auto exitCode = result.status.Ok() ? 0 : result.status.code;
+    const auto keyCount = KeyCount(options, result);
+    const auto asuStatusCode = AsuStatusCodeName(result.taskResult.status.code);
+    const auto summaryTime = FormatLocalTimestamp("%Y-%m-%dT%H:%M:%S%z");
+
+    std::ofstream textFile{BuildOutputPath(outputDir_, "summary.txt")};
+    if (!textFile.is_open()) {
+        return Status::Error(kExitInvalidArgument, "failed to open summary.txt");
+    }
+    textFile << "tool: kv-test\n"
+             << "command: " << commandName << '\n'
+             << "op: " << opName << '\n'
+             << "status: " << statusName << '\n'
+             << "exit_code: " << exitCode << '\n'
+             << "configpath: " << options.configPath << '\n'
+             << "key_count: " << keyCount << '\n'
+             << "value_size: " << options.valueSize << '\n'
+             << "batch_size: " << options.batchSize << '\n'
+             << "concurrency: " << options.concurrency << '\n'
+             << "duration_sec: " << options.durationSec << '\n'
+             << "asu_status_code: " << asuStatusCode << '\n';
+    if (!result.status.Ok()) { textFile << "error: " << result.status.message << '\n'; }
+    if (!result.taskResult.status.message.empty()) {
+        textFile << "asu_message: " << result.taskResult.status.message << '\n';
+    }
+    if (!textFile.good()) {
+        return Status::Error(kExitInvalidArgument, "failed to write summary.txt");
+    }
+
+    std::ofstream jsonFile{BuildOutputPath(outputDir_, "summary.json")};
+    if (!jsonFile.is_open()) {
+        return Status::Error(kExitInvalidArgument, "failed to open summary.json");
+    }
+
+    jsonFile << "{\n"
+             << "  \"tool\": \"kv-test\",\n"
+             << "  \"command\": " << JsonString(commandName) << ",\n"
+             << "  \"status\": " << JsonString(statusName) << ",\n"
+             << "  \"exit_code\": " << exitCode << ",\n"
+             << "  \"configpath\": " << JsonString(options.configPath) << ",\n"
+             << "  \"start_time\": null,\n"
+             << "  \"end_time\": " << JsonString(summaryTime) << ",\n"
+             << "  \"connection\": {\n"
+             << "    \"status\": " << JsonString(result.status.Ok() ? "success" : "failed") << ",\n"
+             << "    \"asu_status_code\": " << JsonString(asuStatusCode) << "\n"
+             << "  },\n"
+             << "  \"request\": {\n"
+             << "    \"op\": " << JsonString(opName) << ",\n"
+             << "    \"key_count\": " << keyCount << ",\n"
+             << "    \"value_size\": " << options.valueSize << ",\n"
+             << "    \"batch_size\": " << options.batchSize << ",\n"
+             << "    \"concurrency\": " << options.concurrency << ",\n"
+             << "    \"duration_sec\": " << options.durationSec << "\n"
+             << "  },\n";
+    if (options.command == CommandType::BENCH) {
+        jsonFile << "  \"metrics\": {\n"
+                 << "    \"bandwidth\": {\"avg\": {\"value\": "
+                 << (result.benchMetrics.avgBandwidthBytesPerSec / (1024.0 * 1024.0))
+                 << ", \"unit\": \"MiB/s\"}, "
+                    "\"realtime_file_pattern\": \"bench-realtime-*.csv\"},\n"
+                 << "    \"iops\": {\"avg\": {\"value\": " << result.benchMetrics.avgIops
+                 << ", \"unit\": \"1/s\"}, \"avg_batch\": {\"value\": "
+                 << result.benchMetrics.avgBatchIops << ", \"unit\": \"1/s\"}},\n"
+                 << "    \"latency\": {\"avg\": {\"value\": " << result.benchMetrics.latency.avgUs
+                 << ", \"unit\": \"us\"}, \"min\": {\"value\": "
+                 << result.benchMetrics.latency.minUs
+                 << ", \"unit\": \"us\"}, \"max\": {\"value\": "
+                 << result.benchMetrics.latency.maxUs
+                 << ", \"unit\": \"us\"}, \"p99_9\": {\"value\": "
+                 << result.benchMetrics.latency.p99_9Us
+                 << ", \"unit\": \"us\"}, \"p99_99\": {\"value\": "
+                 << result.benchMetrics.latency.p99_99Us
+                 << ", \"unit\": \"us\"}, \"p99_999\": {\"value\": "
+                 << result.benchMetrics.latency.p99_999Us << ", \"unit\": \"us\"}}\n"
+                 << "  },\n";
+    } else {
+        jsonFile << "  \"metrics\": null,\n";
+    }
+
+    if (result.consistency.enabled) {
+        const auto passRate = result.consistency.checked == 0
+                                  ? 0.0
+                                  : static_cast<double>(result.consistency.passed) /
+                                        static_cast<double>(result.consistency.checked);
+        jsonFile << "  \"consistency\": {\"enabled\": true, \"checked\": "
+                 << result.consistency.checked << ", \"passed\": " << result.consistency.passed
+                 << ", \"failed\": " << result.consistency.failed << ", \"pass_rate\": " << passRate
+                 << ", \"key\": " << JsonString(result.consistency.key)
+                 << ", \"expected\": " << JsonString(result.consistency.expected)
+                 << ", \"actual\": " << JsonString(result.consistency.actual) << "},\n";
+    } else {
+        jsonFile << "  \"consistency\": " << (options.check ? "{\"enabled\": true}" : "null")
+                 << ",\n";
+    }
+    if (result.status.Ok() && result.taskResult.status.ok()) {
+        jsonFile << "  \"error\": null\n";
+    } else {
+        const auto message =
+            !result.status.Ok() ? result.status.message : result.taskResult.status.message;
+        jsonFile << "  \"error\": {\n"
+                 << "    \"code\": " << JsonString(statusName) << ",\n"
+                 << "    \"message\": " << JsonString(message) << ",\n"
+                 << "    \"asu_status_code\": " << JsonString(asuStatusCode) << ",\n"
+                 << "    \"retryable\": false\n"
+                 << "  }\n";
+    }
+    jsonFile << "}\n";
+    if (!jsonFile.good()) {
+        return Status::Error(kExitInvalidArgument, "failed to write summary.json");
+    }
+
+    if (options.command == CommandType::BENCH) {
+        for (const auto& sample : result.benchMetrics.realtimeSamples) {
+            std::ostringstream line;
+            line << sample.timestampSec << ',' << BenchOpTypeName(sample.op) << ','
+                 << (sample.bandwidthBytesPerSec / (1024.0 * 1024.0)) << ",MiB/s," << sample.iops
+                 << ",1/s," << sample.avgLatencyUs << ",us," << sample.errorCount;
+            auto status = WriteRealtimeSample(line.str());
+            if (!status.Ok()) { return status; }
+        }
+
+        std::ostringstream latencyLine;
+        latencyLine << BenchOpTypeName(result.benchMetrics.op) << ','
+                    << result.benchMetrics.latency.avgUs << ",us,"
+                    << result.benchMetrics.latency.minUs << ",us,"
+                    << result.benchMetrics.latency.maxUs << ",us,"
+                    << result.benchMetrics.latency.p99_9Us << ",us,"
+                    << result.benchMetrics.latency.p99_99Us << ",us,"
+                    << result.benchMetrics.latency.p99_999Us << ",us";
+        auto status = WriteLatencySample(latencyLine.str());
+        if (!status.Ok()) { return status; }
+    }
+
+    if (result.consistency.enabled && result.consistency.failed != 0) {
+        std::ostringstream line;
+        line << "{\"key\":" << JsonString(result.consistency.key)
+             << ",\"expected\":" << JsonString(result.consistency.expected)
+             << ",\"actual\":" << JsonString(result.consistency.actual)
+             << ",\"message\":" << JsonString(result.status.message) << "}";
+        auto status = WriteConsistencyError(line.str());
+        if (!status.Ok()) { return status; }
+    }
+
+    auto status = WriteHtmlReport(options, result);
+    if (!status.Ok()) { return status; }
+    return WriteReportIndex();
+}
+
+Status ResultWriter::WriteHtmlReport(const CommandOptions& options, const CommandResult& result)
+{
+    const auto commandName = CommandTypeName(options.command);
+    const auto opName = options.command == CommandType::BENCH
+                            ? BenchOpTypeName(result.benchMetrics.op)
+                            : commandName;
+    const auto statusName = ResultStatusName(result);
+    const auto keyCount = KeyCount(options, result);
+    const auto asuStatusCode = AsuStatusCodeName(result.taskResult.status.code);
+
+    std::ofstream htmlFile{BuildOutputPath(outputDir_, "report.html")};
+    if (!htmlFile.is_open()) {
+        return Status::Error(kExitInvalidArgument, "failed to open report.html");
+    }
+
+    htmlFile
+        << "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+        << "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+        << "<title>kv-test report - " << HtmlEscape(commandName) << "</title>"
+        << "<style>"
+        << "body{font-family:Arial,sans-serif;margin:0;background:#f6f7f9;color:#1f2933}"
+        << "header{background:#17202a;color:white;padding:24px 32px}"
+        << "main{padding:24px 32px;max-width:1180px;margin:auto}"
+        << ".grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:12px}"
+        << ".card,section{background:white;border:1px solid #d9dee7;border-radius:8px;padding:16px}"
+        << ".label{color:#64748b;font-size:12px;text-transform:uppercase}"
+        << ".value{font-size:24px;font-weight:700;margin-top:6px}"
+        << "table{border-collapse:collapse;width:100%;background:white}"
+        << "th,td{border-bottom:1px solid #e5e7eb;padding:9px;text-align:left}"
+        << "th{background:#f1f5f9}.ok{color:#047857}.failed{color:#b91c1c}"
+        << ".muted{color:#64748b}.axis{stroke:#94a3b8;stroke-width:1}.line{fill:none;stroke:#"
+           "2563eb;stroke-width:3}"
+        << ".chart-label{fill:#475569;font-size:13px}"
+        << "</style></head><body><header><h1>kv-test report</h1><p>" << HtmlEscape(commandName)
+        << " / " << HtmlEscape(opName) << "</p></header><main>";
+
+    htmlFile << "<div class=\"grid\">"
+             << "<div class=\"card\"><div class=\"label\">Status</div><div class=\"value "
+             << (statusName == "success" ? "ok" : "failed") << "\">" << HtmlEscape(statusName)
+             << "</div></div>"
+             << "<div class=\"card\"><div class=\"label\">Keys</div><div class=\"value\">"
+             << keyCount << "</div></div>"
+             << "<div class=\"card\"><div class=\"label\">ASU status</div><div class=\"value\">"
+             << HtmlEscape(asuStatusCode) << "</div></div>"
+             << "<div class=\"card\"><div class=\"label\">Exit code</div><div class=\"value\">"
+             << (result.status.Ok() ? 0 : result.status.code) << "</div></div></div>";
+
+    htmlFile << "<section><h2>Request</h2><table><tbody>"
+             << "<tr><th>Config</th><td>" << HtmlEscape(options.configPath) << "</td></tr>"
+             << "<tr><th>Command</th><td>" << HtmlEscape(commandName) << "</td></tr>"
+             << "<tr><th>Operation</th><td>" << HtmlEscape(opName) << "</td></tr>"
+             << "<tr><th>Value size</th><td>" << options.valueSize << "</td></tr>"
+             << "<tr><th>Batch size</th><td>" << options.batchSize << "</td></tr>"
+             << "<tr><th>Concurrency</th><td>" << options.concurrency << "</td></tr>"
+             << "<tr><th>Duration sec</th><td>" << options.durationSec << "</td></tr>"
+             << "</tbody></table></section>";
+
+    if (options.command == CommandType::BENCH) {
+        const auto& metrics = result.benchMetrics;
+        htmlFile << "<section><h2>Benchmark metrics</h2><div class=\"grid\">"
+                 << "<div class=\"card\"><div class=\"label\">Bandwidth</div><div class=\"value\">"
+                 << FormatNumber(metrics.avgBandwidthBytesPerSec / (1024.0 * 1024.0))
+                 << " MiB/s</div></div>"
+                 << "<div class=\"card\"><div class=\"label\">IOPS</div><div class=\"value\">"
+                 << FormatNumber(metrics.avgIops) << "</div></div>"
+                 << "<div class=\"card\"><div class=\"label\">Batch IOPS</div><div class=\"value\">"
+                 << FormatNumber(metrics.avgBatchIops) << "</div></div>"
+                 << "<div class=\"card\"><div class=\"label\">Errors</div><div class=\"value\">"
+                 << metrics.errorCount << "</div></div></div>"
+                 << BuildBandwidthSvg(metrics.realtimeSamples) << "<h3>Latency</h3><table><tbody>"
+                 << "<tr><th>Average us</th><td>" << FormatNumber(metrics.latency.avgUs)
+                 << "</td></tr><tr><th>Min us</th><td>" << FormatNumber(metrics.latency.minUs)
+                 << "</td></tr><tr><th>Max us</th><td>" << FormatNumber(metrics.latency.maxUs)
+                 << "</td></tr><tr><th>P99.9 us</th><td>" << FormatNumber(metrics.latency.p99_9Us)
+                 << "</td></tr><tr><th>P99.99 us</th><td>" << FormatNumber(metrics.latency.p99_99Us)
+                 << "</td></tr><tr><th>P99.999 us</th><td>"
+                 << FormatNumber(metrics.latency.p99_999Us)
+                 << "</td></tr></tbody></table></section>";
+    }
+
+    if (result.consistency.enabled) {
+        htmlFile << "<section><h2>Consistency</h2><table><tbody>"
+                 << "<tr><th>Checked</th><td>" << result.consistency.checked << "</td></tr>"
+                 << "<tr><th>Passed</th><td>" << result.consistency.passed << "</td></tr>"
+                 << "<tr><th>Failed</th><td>" << result.consistency.failed << "</td></tr>"
+                 << "<tr><th>Key</th><td>" << HtmlEscape(result.consistency.key) << "</td></tr>"
+                 << "<tr><th>Expected</th><td>" << HtmlEscape(result.consistency.expected)
+                 << "</td></tr><tr><th>Actual</th><td>" << HtmlEscape(result.consistency.actual)
+                 << "</td></tr></tbody></table></section>";
+    }
+
+    if (!result.status.Ok() || !result.taskResult.status.ok()) {
+        htmlFile << "<section><h2>Error</h2><p class=\"failed\">"
+                 << HtmlEscape(!result.status.Ok() ? result.status.message
+                                                   : result.taskResult.status.message)
+                 << "</p></section>";
+    }
+
+    htmlFile << "<section><h2>Artifacts</h2><ul>"
+             << "<li><a href=\"summary.txt\">summary.txt</a></li>"
+             << "<li><a href=\"summary.json\">summary.json</a></li>";
+    if (options.command == CommandType::BENCH) {
+        htmlFile << "<li><a href=\"bench-realtime-0.csv\">bench-realtime-0.csv</a></li>"
+                 << "<li><a href=\"latency.csv\">latency.csv</a></li>";
+    }
+    if (result.consistency.enabled && result.consistency.failed != 0) {
+        htmlFile << "<li><a href=\"consistency_errors.jsonl\">consistency_errors.jsonl</a></li>";
+    }
+    htmlFile << "</ul></section></main></body></html>";
+
+    if (!htmlFile.good()) {
+        return Status::Error(kExitInvalidArgument, "failed to write report.html");
+    }
+    return Status::Success();
+}
+
+Status ResultWriter::WriteReportIndex()
+{
+    if (baseOutputDir_.empty()) {
+        return Status::Error(kExitInvalidArgument, "ResultWriter base output dir is not set");
+    }
+
+    std::vector<std::filesystem::directory_entry> reports;
+    std::error_code errorCode;
+    for (const auto& entry : std::filesystem::directory_iterator(baseOutputDir_, errorCode)) {
+        if (errorCode) { break; }
+        if (!entry.is_directory()) { continue; }
+        const auto reportPath = entry.path() / "report.html";
+        if (std::filesystem::exists(reportPath)) { reports.emplace_back(entry); }
+    }
+    std::sort(reports.begin(), reports.end(), [](const auto& left, const auto& right) {
+        return left.path().filename().string() > right.path().filename().string();
+    });
+
+    std::ofstream indexFile{BuildOutputPath(baseOutputDir_, "index.html")};
+    if (!indexFile.is_open()) {
+        return Status::Error(kExitInvalidArgument, "failed to open report index.html");
+    }
+
+    indexFile << "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+              << "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">"
+              << "<title>kv-test reports</title><style>"
+              << "body{font-family:Arial,sans-serif;margin:0;background:#f6f7f9;color:#1f2933}"
+              << "main{padding:24px 32px;max-width:960px;margin:auto}"
+              << "table{border-collapse:collapse;width:100%;background:white}"
+              << "th,td{border-bottom:1px solid #e5e7eb;padding:10px;text-align:left}"
+              << "th{background:#f1f5f9}a{color:#2563eb;text-decoration:none}"
+              << "</style></head><body><main><h1>kv-test reports</h1><table>"
+              << "<thead><tr><th>Run</th><th>Report</th></tr></thead><tbody>";
+    for (const auto& entry : reports) {
+        const auto runName = entry.path().filename().string();
+        indexFile << "<tr><td>" << HtmlEscape(runName) << "</td><td><a href=\""
+                  << HtmlEscape(runName) << "/report.html\">open report</a></td></tr>";
+    }
+    indexFile << "</tbody></table></main></body></html>";
+    if (!indexFile.good()) {
+        return Status::Error(kExitInvalidArgument, "failed to write report index.html");
+    }
+    return Status::Success();
+}
+
+Status ResultWriter::WriteRealtimeSample(const std::string& csvLine)
+{
+    if (!realtimeFile_.is_open()) {
+        auto status = OpenRealtimeFile();
+        if (!status.Ok()) { return status; }
+    }
+
+    const auto lineBytes = csvLine.size() + 1;
+    auto status = RollRealtimeFileIfNeeded(lineBytes);
+    if (!status.Ok()) { return status; }
+
+    realtimeFile_ << csvLine << '\n';
+    if (!realtimeFile_.good()) {
+        return Status::Error(kExitInvalidArgument, "failed to write realtime CSV sample");
+    }
+    realtimeFileBytes_ += lineBytes;
+    return Status::Success();
+}
+
+Status ResultWriter::WriteLatencySample(const std::string& csvLine)
+{
+    if (!latencyFile_.is_open()) {
+        auto status = OpenLatencyFile();
+        if (!status.Ok()) { return status; }
+    }
+
+    latencyFile_ << csvLine << '\n';
+    if (!latencyFile_.good()) {
+        return Status::Error(kExitInvalidArgument, "failed to write latency CSV sample");
+    }
+    return Status::Success();
+}
+
+Status ResultWriter::WriteConsistencyError(const std::string& line)
+{
+    if (!consistencyErrorFile_.is_open()) {
+        auto status = OpenConsistencyErrorFile();
+        if (!status.Ok()) { return status; }
+    }
+
+    consistencyErrorFile_ << line << '\n';
+    if (!consistencyErrorFile_.good()) {
+        return Status::Error(kExitInvalidArgument, "failed to write consistency error");
+    }
+    return Status::Success();
+}
+
+Status ResultWriter::Close()
+{
+    if (realtimeFile_.is_open()) { realtimeFile_.close(); }
+    if (latencyFile_.is_open()) { latencyFile_.close(); }
+    if (consistencyErrorFile_.is_open()) { consistencyErrorFile_.close(); }
+
+    outputDir_.clear();
+    baseOutputDir_.clear();
+    realtimeFileBytes_ = 0;
+    realtimeFileIndex_ = 0;
+    return Status::Success();
+}
+
+Status ResultWriter::OpenLatencyFile()
+{
+    latencyFile_.open(BuildOutputPath(outputDir_, "latency.csv"));
+    if (!latencyFile_.is_open()) {
+        return Status::Error(kExitInvalidArgument, "failed to open latency.csv");
+    }
+
+    latencyFile_ << kLatencyCsvHeader;
+    if (!latencyFile_.good()) {
+        return Status::Error(kExitInvalidArgument, "failed to write latency.csv");
+    }
+    return Status::Success();
+}
+
+Status ResultWriter::OpenConsistencyErrorFile()
+{
+    consistencyErrorFile_.open(BuildOutputPath(outputDir_, "consistency_errors.jsonl"));
+    if (!consistencyErrorFile_.is_open()) {
+        return Status::Error(kExitInvalidArgument, "failed to open consistency_errors.jsonl");
+    }
+    return Status::Success();
+}
+
+Status ResultWriter::OpenRealtimeFile()
+{
+    if (realtimeFile_.is_open()) { realtimeFile_.close(); }
+
+    const auto fileName = "bench-realtime-" + std::to_string(realtimeFileIndex_) + ".csv";
+    realtimeFile_.open(BuildOutputPath(outputDir_, fileName));
+    if (!realtimeFile_.is_open()) {
+        return Status::Error(kExitInvalidArgument, "failed to open " + fileName);
+    }
+
+    realtimeFile_ << kRealtimeCsvHeader;
+    if (!realtimeFile_.good()) {
+        return Status::Error(kExitInvalidArgument, "failed to write " + fileName);
+    }
+    realtimeFileBytes_ = std::string(kRealtimeCsvHeader).size();
+    return Status::Success();
+}
+
+Status ResultWriter::RollRealtimeFileIfNeeded(std::uint64_t incomingBytes)
+{
+    if (realtimeFileMaxBytes_ == 0 || realtimeFileBytes_ + incomingBytes <= realtimeFileMaxBytes_) {
+        return Status::Success();
+    }
+
+    ++realtimeFileIndex_;
+    return OpenRealtimeFile();
+}
+
+}  // namespace UC::KVTest


### PR DESCRIPTION
## Purpose
kv-test command tool.

## Modifications 
1. Add kvtest.
2. Add FakeBackend mode to test code integration between AsuClient & AsuTransport.
3. A series of fixes or optimization for kv-test:
(1) Add test scripts.
(2) Add color to kv-test log.
(3) FakeBackend now write back CQE synchronously.
(4) For this version, "kv-test store" command is implemented by batch-store.
(5) Adjust expected value for kv-test scripts.
(6) Add option '--progress' for metric prints per second.
(7) Remove redundant batch size check.
(8) Allocate kv-test buffer by buffer pool.
(9) Add io_size check.
(10) Bench now uses the same data for all batches.
(11) Adjust environment variables.
