### PR TITLE
[opt]Defer UCM KV Dump Waiting Until Request Completion

### DIFF
--- a/docs/source/user-guide/metrics/metrics.md
+++ b/docs/source/user-guide/metrics/metrics.md
@@ -146,7 +146,7 @@ Open `http://<your-host>:3000`, add a Prometheus data source pointing to
 |------|----------|
 | `examples/metrics/grafana_connector.json` | Connector-level activity: hit rate, request/block sizes, end-to-end load/save durations and speeds. |
 | `examples/metrics/grafana_pipeline_store.json` | Cache Store and Posix Store diagnosis: task breakdowns, queue wait, transfer duration, bandwidth, backend load ratio. |
-| `examples/metrics/grafana_layerwise.json` | `use_layerwise=true` diagnosis: `wait_for_layer_load()` blocking, inter-call interval, submit diagnostics, `wait_for_save()` tail. |
+| `examples/metrics/grafana_layerwise.json` | `use_layerwise=true` diagnosis: `wait_for_layer_load()` blocking, inter-call interval, and asynchronous dump submit diagnostics. |
 | `examples/metrics/grafana_vllm.json` | vLLM service-side request latency, token throughput, scheduler state, and cache state. |
 
 The dashboards share the `ucm` Grafana tag. After importing them, the dashboard
@@ -271,4 +271,4 @@ The default metrics configuration contains the following UCM metrics.
 | `ucm:layerwise_first_layer_submit_ms` | Time to submit first layer load tasks during `start_load_kv`. |
 | `ucm:layerwise_first_layer_requests` | Number of requests whose first-layer load was submitted in `start_load_kv`. |
 | `ucm:layerwise_save_submit_ms` | Time to submit one layer's dump task in `save_kv_layer()`. |
-| `ucm:layerwise_save_tail_total_ms` | Total `wait_for_save()` duration. |
+| `ucm:layerwise_save_tail_total_ms` | Legacy metric; LayerWise no longer waits for dump completion in `wait_for_save()`. |

--- a/docs/source/user-guide/prefix-cache/pipeline_store.md
+++ b/docs/source/user-guide/prefix-cache/pipeline_store.md
@@ -78,7 +78,6 @@ ucm_connectors:
       use_gdr: false
 enable_event_sync: true
 use_layerwise: true
-layerwise_wait_for_save: true
 enable_record_traces: false
 use_lite: false
 persist_token_threshold: 0
@@ -152,11 +151,6 @@ Top-level parameters (outside `ucm_connector_config`):
   Whether to use layerwise loading/saving of KV cache blocks.  
   Enabled by default for `UCMConnector`.
 
-* **layerwise_wait_for_save** *(optional, default: true)*
-  Controls when LayerWise waits for asynchronous dump tasks. When `true`,
-  `wait_for_save()` waits for all layer dumps as before. When `false`, the wait
-  and event cleanup are deferred until request completion or preemption.
-
 * **hit_ratio** *(optional)*  
   When set, limits the number of hit tokens to `hit_ratio × num_prompt_tokens`.  
   Useful for controlling the proportion of cached tokens that are actually loaded.
@@ -222,7 +216,6 @@ ucm_connectors:
       use_gdr: false
 enable_event_sync: true
 use_layerwise: true
-layerwise_wait_for_save: true
 enable_record_traces: false
 use_lite: false
 persist_token_threshold: 0

--- a/docs/source/user-guide/prefix-cache/pipeline_store.md
+++ b/docs/source/user-guide/prefix-cache/pipeline_store.md
@@ -78,6 +78,7 @@ ucm_connectors:
       use_gdr: false
 enable_event_sync: true
 use_layerwise: true
+layerwise_wait_for_save: true
 enable_record_traces: false
 use_lite: false
 persist_token_threshold: 0
@@ -151,6 +152,11 @@ Top-level parameters (outside `ucm_connector_config`):
   Whether to use layerwise loading/saving of KV cache blocks.  
   Enabled by default for `UCMConnector`.
 
+* **layerwise_wait_for_save** *(optional, default: true)*
+  Controls when LayerWise waits for asynchronous dump tasks. When `true`,
+  `wait_for_save()` waits for all layer dumps as before. When `false`, the wait
+  and event cleanup are deferred until request completion or preemption.
+
 * **hit_ratio** *(optional)*  
   When set, limits the number of hit tokens to `hit_ratio × num_prompt_tokens`.  
   Useful for controlling the proportion of cached tokens that are actually loaded.
@@ -216,6 +222,7 @@ ucm_connectors:
       use_gdr: false
 enable_event_sync: true
 use_layerwise: true
+layerwise_wait_for_save: true
 enable_record_traces: false
 use_lite: false
 persist_token_threshold: 0

--- a/examples/metrics/metrics_configs.yaml
+++ b/examples/metrics/metrics_configs.yaml
@@ -211,5 +211,5 @@ histogram:
     documentation: "Time to submit one layer's dump task in save_kv_layer (ms)"
     buckets: [0.01, 0.05, 0.1, 0.5, 1, 2, 5, 10, 20, 50]
   - name: "layerwise_save_tail_total_ms"
-    documentation: "Total wait_for_save duration - unoverlappable dump tail at end of forward (ms)"
+    documentation: "Legacy metric; LayerWise no longer waits for dump completion in wait_for_save"
     buckets: [0.1, 0.5, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000]

--- a/examples/ucm_config_example.yaml
+++ b/examples/ucm_config_example.yaml
@@ -39,9 +39,6 @@ wa_dump_block_wise: true
 
 # Whether to use layerwise loading/saving (optional, default: True for UCMConnector)
 use_layerwise: true
-# Whether LayerWise waits for dump completion in wait_for_save (optional, default: True).
-# Set to false to defer the wait and event cleanup until request completion or preemption.
-layerwise_wait_for_save: true
 # hit_ratio: 0.9
 
 # Whether to record requests' traces (optional, default: False)

--- a/examples/ucm_config_example.yaml
+++ b/examples/ucm_config_example.yaml
@@ -39,6 +39,9 @@ wa_dump_block_wise: true
 
 # Whether to use layerwise loading/saving (optional, default: True for UCMConnector)
 use_layerwise: true
+# Whether LayerWise waits for dump completion in wait_for_save (optional, default: True).
+# Set to false to defer the wait and event cleanup until request completion or preemption.
+layerwise_wait_for_save: true
 # hit_ratio: 0.9
 
 # Whether to record requests' traces (optional, default: False)

--- a/ucm/integration/vllm/device.py
+++ b/ucm/integration/vllm/device.py
@@ -41,7 +41,7 @@ class Device(ABC):
         pass
 
     @abstractmethod
-    def destroy_event_handle(self, handle: int):
+    def destroy_event_handle(self, event_handle: int):
         pass
 
     @abstractmethod
@@ -120,8 +120,8 @@ class CudaDevice(Device):
     def destroy_event_handles(self):
         self.events.clear()
 
-    def destroy_event_handle(self, handle: int):
-        self.events.pop(handle, None)
+    def destroy_event_handle(self, event_handle: int):
+        self.events.pop(event_handle, None)
 
     def get_cpu_affinity(self, local_rank: int) -> Optional[str]:
         """
@@ -238,8 +238,8 @@ class NpuDevice(Device):
                 return 0
             ret = acl.rt.record_event(event, stream)
             if ret != 0:
-                acl.rt.destroy_event(event)
                 logger.error(f"acl record_event failed: {ret}")
+                acl.rt.destroy_event(event)
                 return 0
             handle = int(event)
             self.events[handle] = event
@@ -261,10 +261,10 @@ class NpuDevice(Device):
                 logger.error(f"destroy npu event failed. {e}")
         self.events.clear()
 
-    def destroy_event_handle(self, handle: int):
+    def destroy_event_handle(self, event_handle: int):
         import acl
 
-        event = self.events.pop(handle, None)
+        event = self.events.pop(event_handle, None)
         if event is not None:
             try:
                 acl.rt.destroy_event(event)

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -259,6 +259,14 @@ class KVCacheLayout:
 @dataclass
 class UCMConnectorMetadata(KVConnectorMetadata):
     request_meta: dict[str, RequestDispatchMeta] = field(default_factory=dict)
+    preempted_req_ids: set[str] = field(default_factory=set)
+
+
+@dataclass
+class PendingDumpTask:
+    task: Task
+    request_ids: set[str]
+    event_handle: int = 0
 
 
 class RequestHasher:
@@ -407,6 +415,10 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
         # invalid block ids due to load errors
         self._invalid_block_ids: set[int] = set()
+        self._async_dump_req_ids: set[str] = set()
+        self._pending_dump_tasks: list[PendingDumpTask] = []
+        self._pending_dump_count_by_req: dict[str, int] = defaultdict(int)
+        self._delayed_finished_req_ids: set[str] = set()
         self.cp_world_size = 1
         self.hash_block_size = self.block_size
         self.block_size *= self.cp_world_size
@@ -743,7 +755,14 @@ class UCMDirectConnector(KVConnectorBase_V1):
         for request_id in scheduler_output.finished_req_ids:
             self.requests_meta.pop(request_id, None)
 
-        return UCMConnectorMetadata(requests_dispatch_meta)
+        for request_id, dispatch_meta in requests_dispatch_meta.items():
+            if len(dispatch_meta.dump_block_ids[0]) > 0:
+                self._async_dump_req_ids.add(request_id)
+
+        return UCMConnectorMetadata(
+            requests_dispatch_meta,
+            scheduler_output.preempted_req_ids or set(),
+        )
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         metadata = self._get_connector_metadata()
@@ -845,19 +864,83 @@ class UCMDirectConnector(KVConnectorBase_V1):
     ) -> None:
         pass
 
+    def _wait_pending_dump_task(self, pending_dump_task: PendingDumpTask) -> None:
+        try:
+            self.store.wait(pending_dump_task.task)
+        finally:
+            self._release_dump_event_handle(pending_dump_task)
+        self._mark_pending_dump_task_done(pending_dump_task)
+
+    def _release_dump_event_handle(self, pending_dump_task: PendingDumpTask) -> None:
+        if (
+            self.enable_event_sync
+            and pending_dump_task.event_handle
+            and self.device is not None
+        ):
+            self.device.destroy_event_handle(pending_dump_task.event_handle)
+            pending_dump_task.event_handle = 0
+
+    def _mark_pending_dump_task_done(self, pending_dump_task: PendingDumpTask) -> None:
+        for request_id in pending_dump_task.request_ids:
+            pending_count = self._pending_dump_count_by_req.get(request_id, 0)
+            if pending_count <= 1:
+                self._pending_dump_count_by_req.pop(request_id, None)
+            else:
+                self._pending_dump_count_by_req[request_id] = pending_count - 1
+
+    def _poll_pending_dump_tasks(self) -> None:
+        remaining_tasks: list[PendingDumpTask] = []
+        for pending_dump_task in self._pending_dump_tasks:
+            try:
+                if self.store.check(pending_dump_task.task):
+                    self._wait_pending_dump_task(pending_dump_task)
+                else:
+                    remaining_tasks.append(pending_dump_task)
+            except Exception as e:
+                logger.error(f"check dump kv cache failed. {type(e).__name__}: {e}")
+                self._mark_pending_dump_task_done(pending_dump_task)
+        self._pending_dump_tasks = remaining_tasks
+
+    def _flush_pending_dump_tasks(self, request_ids: Optional[set[str]] = None) -> None:
+        pending_dump_tasks = self._pending_dump_tasks
+        self._pending_dump_tasks = []
+        remaining_tasks: list[PendingDumpTask] = []
+        for pending_dump_task in pending_dump_tasks:
+            if request_ids is not None and not (
+                pending_dump_task.request_ids & request_ids
+            ):
+                remaining_tasks.append(pending_dump_task)
+                continue
+            try:
+                self._wait_pending_dump_task(pending_dump_task)
+            except Exception as e:
+                logger.error(f"wait for dump kv cache failed. {type(e).__name__}: {e}")
+                self._mark_pending_dump_task_done(pending_dump_task)
+        self._pending_dump_tasks = remaining_tasks
+
+    def handle_preemptions(self, kv_connector_metadata: KVConnectorMetadata):
+        preempted_req_ids = getattr(kv_connector_metadata, "preempted_req_ids", None)
+        if preempted_req_ids:
+            self._flush_pending_dump_tasks(preempted_req_ids)
+
     def wait_for_save(self) -> None:
         # TODO support PP
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, UCMConnectorMetadata)
+        metadata_dump_request_ids = {
+            request_id
+            for request_id, request in metadata.request_meta.items()
+            if len(request.dump_block_ids[0]) > 0
+        }
+        self._async_dump_req_ids.update(metadata_dump_request_ids)
+
         if self.is_mla and self.tp_rank != 0:
             return
 
-        metadata = self._get_connector_metadata()
-        assert isinstance(metadata, UCMConnectorMetadata)
-
         dump_tasks: List[Task] = []
         is_save = False
-        num_saved_block = 0
-        num_saved_request = 0
         total_ucm_block_ids, total_vllm_block_ids = [], []
+        dump_request_ids: set[str] = set()
         for request_id, request in metadata.request_meta.items():
             if len(request.dump_block_ids[0]) == 0:
                 continue
@@ -872,8 +955,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
                 if len(ucm_block_ids) == 0:
                     continue
             is_save = True
-            num_saved_block += len(ucm_block_ids)
-            num_saved_request += 1
+            dump_request_ids.add(request_id)
             if self.tp_rank != 0:
                 for i, ucm_block_id in enumerate(ucm_block_ids):
                     ucm_block_ids[i] = self.request_hasher(ucm_block_id)
@@ -881,6 +963,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
             total_vllm_block_ids.extend(vllm_block_ids)
 
         if is_save:
+            event_handle = 0
             try:
                 total_ptrs = self.kv_cache_layout.extract_block_addrs(
                     total_vllm_block_ids
@@ -888,36 +971,25 @@ class UCMDirectConnector(KVConnectorBase_V1):
                 total_ptrs = total_ptrs.reshape(total_ptrs.shape[0], -1)
                 shard_indexs = [0] * len(total_ucm_block_ids)
                 event_handle = self._get_dump_event_handle()
-                save_start_time = time.perf_counter() * 1000
                 task = self.store.dump_data(
                     total_ucm_block_ids, shard_indexs, total_ptrs, event_handle
                 )
                 dump_tasks.append(task)
             except Exception as e:
                 logger.error(f"dump kv cache failed. {type(e).__name__}: {e}")
+                if self.enable_event_sync and event_handle and self.device is not None:
+                    self.device.destroy_event_handle(event_handle)
                 return
 
-            try:
-                for task in dump_tasks:
-                    self.store.wait(task)
-                save_end_time = time.perf_counter() * 1000
-            except Exception as e:
-                logger.error(f"wait for dump kv cache failed. {type(e).__name__}: {e}")
-                return
-
-            save_bytes = num_saved_block * self.block_data_size
-            save_speed = (
-                save_bytes / (save_end_time - save_start_time) / 1024 / 1024
-            )  # GB/s
-            ucmmetrics.update_stats(
-                {
-                    "save_requests_num": num_saved_request,
-                    "save_blocks_num": num_saved_block,
-                    "save_duration": save_end_time - save_start_time,
-                    "save_speed": save_speed,
-                    "save_bytes_total": save_bytes,
-                },
-            )
+            for task in dump_tasks:
+                pending_dump_task = PendingDumpTask(
+                    task=task,
+                    request_ids=set(dump_request_ids),
+                    event_handle=event_handle,
+                )
+                self._pending_dump_tasks.append(pending_dump_task)
+                for request_id in pending_dump_task.request_ids:
+                    self._pending_dump_count_by_req[request_id] += 1
 
     def clear_connector_metadata(self) -> None:
         super().clear_connector_metadata()
@@ -952,12 +1024,64 @@ class UCMDirectConnector(KVConnectorBase_V1):
             logger.info(f"Request {req_id} failed to load, skip caching.")
             self.requests_meta.pop(req_id, None)
 
+    def request_finished(
+        self,
+        request: "Request",
+        block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        if request.request_id in self._async_dump_req_ids:
+            self._async_dump_req_ids.discard(request.request_id)
+            return True, None
+        return False, None
+
     def request_finished_all_groups(
         self,
         request: "Request",
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, object] | None]:
-        return False, None
+        if block_ids:
+            return self.request_finished(request, block_ids[0])
+        return self.request_finished(request, [])
+
+    def get_finished(
+        self,
+        finished_req_ids: set[str],
+    ) -> tuple[Optional[set[str]], Optional[set[str]]]:
+        self._poll_pending_dump_tasks()
+
+        async_finished_req_ids = {
+            request_id
+            for request_id in finished_req_ids
+            if request_id in self._pending_dump_count_by_req
+            or request_id in self._delayed_finished_req_ids
+            or request_id in self._async_dump_req_ids
+        }
+        self._delayed_finished_req_ids.update(async_finished_req_ids)
+
+        if async_finished_req_ids:
+            remaining_tasks: list[PendingDumpTask] = []
+            for pending_dump_task in self._pending_dump_tasks:
+                if pending_dump_task.request_ids & async_finished_req_ids:
+                    try:
+                        self._wait_pending_dump_task(pending_dump_task)
+                    except Exception as e:
+                        logger.error(
+                            f"wait for dump kv cache failed. {type(e).__name__}: {e}"
+                        )
+                        self._mark_pending_dump_task_done(pending_dump_task)
+                else:
+                    remaining_tasks.append(pending_dump_task)
+            self._pending_dump_tasks = remaining_tasks
+
+        finished_sending = {
+            request_id
+            for request_id in self._delayed_finished_req_ids
+            if request_id not in self._pending_dump_count_by_req
+        }
+        self._delayed_finished_req_ids.difference_update(finished_sending)
+        self._async_dump_req_ids.difference_update(finished_sending)
+
+        return finished_sending or None, None
 
 
 class UCMLayerWiseConnector(UCMDirectConnector):
@@ -2652,7 +2776,10 @@ class UCMHMAConnector(UCMDirectConnector, SupportsHMA):
         for request_id in scheduler_output.finished_req_ids:
             self.requests_meta.pop(request_id, None)
 
-        return UCMConnectorMetadata(requests_dispatch_meta)
+        return UCMConnectorMetadata(
+            requests_dispatch_meta,
+            scheduler_output.preempted_req_ids or set(),
+        )
 
     def request_finished_all_groups(
         self,
@@ -2850,6 +2977,9 @@ class UCMConnector(KVConnectorBase_V1, SupportsHMA):
             connector_metadata (dict): the connector metadata.
         """
         self.connector.bind_connector_metadata(connector_metadata)
+
+    def handle_preemptions(self, kv_connector_metadata: KVConnectorMetadata):
+        self.connector.handle_preemptions(kv_connector_metadata)
 
     def has_connector_metadata(self) -> bool:
         """Check whether the connector metadata is currently set.

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -753,13 +753,21 @@ class UCMDirectConnector(KVConnectorBase_V1):
         for request_id in scheduler_output.finished_req_ids:
             self.requests_meta.pop(request_id, None)
 
-        for request_id, dispatch_meta in requests_dispatch_meta.items():
-            if len(dispatch_meta.dump_block_ids[0]) > 0:
-                self._async_dump_req_ids.add(request_id)
+        self._track_async_dump_requests(requests_dispatch_meta)
 
         return UCMConnectorMetadata(
             requests_dispatch_meta,
             scheduler_output.preempted_req_ids or set(),
+        )
+
+    def _track_async_dump_requests(
+        self,
+        requests_dispatch_meta: dict[str, RequestDispatchMeta],
+    ) -> None:
+        self._async_dump_req_ids.update(
+            request_id
+            for request_id, dispatch_meta in requests_dispatch_meta.items()
+            if len(dispatch_meta.dump_block_ids[0]) > 0
         )
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
@@ -2724,6 +2732,8 @@ class UCMHMAConnector(UCMDirectConnector, SupportsHMA):
         for request_id in scheduler_output.finished_req_ids:
             self.requests_meta.pop(request_id, None)
 
+        self._track_async_dump_requests(requests_dispatch_meta)
+
         return UCMConnectorMetadata(
             requests_dispatch_meta,
             scheduler_output.preempted_req_ids or set(),
@@ -2734,7 +2744,9 @@ class UCMHMAConnector(UCMDirectConnector, SupportsHMA):
         request: "Request",
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
-        return False, None
+        if block_ids:
+            return self.request_finished(request, block_ids[0])
+        return self.request_finished(request, [])
 
 
 def use_hybrid_linear_attention_layout(

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -3009,6 +3009,13 @@ class UCMConnector(KVConnectorBase_V1, SupportsHMA):
             return self.connector.request_finished(request, block_ids[0])
         return self.connector.request_finished(request, [])
 
+    def request_finished(
+        self,
+        request: "Request",
+        block_ids: list[int],
+    ) -> tuple[bool, dict[str, object] | None]:
+        return self.connector.request_finished(request, block_ids)
+
     def get_finished(
         self,
         finished_req_ids: set[str],

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -887,6 +887,27 @@ class UCMDirectConnector(KVConnectorBase_V1):
             self.device.destroy_event_handle(pending_dump_task.event_handle)
             pending_dump_task.event_handle = 0
 
+    def _poll_pending_dump_tasks(self) -> None:
+        remaining_tasks: list[PendingDumpTask] = []
+        for pending_dump_task in self._pending_dump_tasks:
+            try:
+                if not self.store.check(pending_dump_task.task):
+                    remaining_tasks.append(pending_dump_task)
+                    continue
+            except Exception as e:
+                logger.error(f"check dump kv cache failed. {type(e).__name__}: {e}")
+                remaining_tasks.append(pending_dump_task)
+                continue
+
+            try:
+                # Check does not consume the task handle. Wait is non-blocking
+                # after completion and removes the task from the store.
+                self._wait_pending_dump_task(pending_dump_task)
+            except Exception as e:
+                logger.error(f"wait for dump kv cache failed. {type(e).__name__}: {e}")
+
+        self._pending_dump_tasks = remaining_tasks
+
     def _flush_pending_dump_tasks(self, request_ids: Optional[set[str]] = None) -> None:
         pending_dump_tasks = self._pending_dump_tasks
         self._pending_dump_tasks = []
@@ -919,6 +940,8 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
     def wait_for_save(self) -> None:
         # TODO support PP
+        self._poll_pending_dump_tasks()
+
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, UCMConnectorMetadata)
         metadata_dump_request_ids = {
@@ -1242,6 +1265,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                     total_vllm_block_ids, layer_first=True
                 )
             shard_indexs = [layer_id] * len(total_ucm_block_ids)
+            event_handle = 0
             try:
                 layer_ptrs = np.ascontiguousarray(self.dump_total_ptrs[local_layer_id])
                 event_handle = self._get_dump_event_handle()
@@ -1250,7 +1274,9 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                 )
                 self.dump_tasks[layer_name] = task
             except Exception as e:
-                logger.error(f"submit dump task for {layer_name} failed. {type(e).__name__}: {e}")
+                logger.error(
+                    f"submit dump task for {layer_name} failed. {type(e).__name__}: {e}"
+                )
                 if self.enable_event_sync and event_handle and self.device is not None:
                     self.device.destroy_event_handle(event_handle)
         if self.is_save:

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -2763,6 +2763,7 @@ class UCMHMAConnector(UCMDirectConnector, SupportsHMA):
             scheduler_output.preempted_req_ids or set(),
         )
 
+
 def use_hybrid_linear_attention_layout(
     kv_cache_config: Optional["KVCacheConfig"],
 ) -> bool:

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -371,6 +371,9 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self.launch_config = ucm_config.get_config()
         self.connector_configs = self.launch_config.get("ucm_connectors", [])
         self.enable_event_sync = self.launch_config.get("enable_event_sync", True)
+        self.layerwise_wait_for_save = self.launch_config.get(
+            "layerwise_wait_for_save", True
+        )
         self.enable_record_traces = self.launch_config.get(
             "enable_record_traces", False
         )
@@ -764,13 +767,16 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self,
         requests_dispatch_meta: dict[str, RequestDispatchMeta],
     ) -> None:
-        if self.use_layerwise:
+        if not self._wait_dump_on_request_finished():
             return
         self._async_dump_req_ids.update(
             request_id
             for request_id, dispatch_meta in requests_dispatch_meta.items()
             if len(dispatch_meta.dump_block_ids[0]) > 0
         )
+
+    def _wait_dump_on_request_finished(self) -> bool:
+        return not self.use_layerwise or not self.layerwise_wait_for_save
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         metadata = self._get_connector_metadata()
@@ -928,7 +934,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self,
         kv_connector_metadata: KVConnectorMetadata | set[str],
     ) -> None:
-        if self.use_layerwise:
+        if not self._wait_dump_on_request_finished():
             return
         preempted_req_ids = (
             kv_connector_metadata
@@ -1044,7 +1050,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
         request: "Request",
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
-        if self.use_layerwise:
+        if not self._wait_dump_on_request_finished():
             return False, None
         if request.request_id in self._async_dump_req_ids:
             self._async_dump_req_ids.discard(request.request_id)
@@ -1064,7 +1070,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self,
         finished_req_ids: set[str],
     ) -> tuple[Optional[set[str]], Optional[set[str]]]:
-        if self.use_layerwise:
+        if not self._wait_dump_on_request_finished():
             return None, None
         async_finished_req_ids = finished_req_ids & self._async_dump_req_ids
 
@@ -1245,6 +1251,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
 
         submit_start = time.perf_counter()
         total_ucm_block_ids, total_vllm_block_ids = [], []
+        dump_request_ids: set[str] = set()
         layer_id = self.layer_name_to_id[layer_name]
         local_layer_id = layer_id - self.first_layer_id
         for request_id, request in metadata.request_meta.items():
@@ -1252,6 +1259,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                 continue
 
             self.is_save = True
+            dump_request_ids.add(request_id)
             ucm_block_ids, vllm_block_ids = request.dump_block_ids
             if self.tp_rank % self.tp_size != 0 and local_layer_id == 0:
                 for i, ucm_block_id in enumerate(ucm_block_ids):
@@ -1259,7 +1267,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             total_ucm_block_ids.extend(ucm_block_ids)
             total_vllm_block_ids.extend(vllm_block_ids)
 
-        if self.is_save:
+        if dump_request_ids:
             if self.dump_total_ptrs is None:
                 self.dump_total_ptrs = self.kv_cache_layout.extract_block_addrs(
                     total_vllm_block_ids, layer_first=True
@@ -1272,7 +1280,16 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                 task = self.store.dump_data(
                     total_ucm_block_ids, shard_indexs, layer_ptrs, event_handle
                 )
-                self.dump_tasks[layer_name] = task
+                if self._wait_dump_on_request_finished():
+                    self._pending_dump_tasks.append(
+                        PendingDumpTask(
+                            task=task,
+                            request_ids=set(dump_request_ids),
+                            event_handle=event_handle,
+                        )
+                    )
+                else:
+                    self.dump_tasks[layer_name] = task
             except Exception as e:
                 logger.error(
                     f"submit dump task for {layer_name} failed. {type(e).__name__}: {e}"
@@ -1286,6 +1303,27 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             )
 
     def wait_for_save(self) -> None:
+        if self._wait_dump_on_request_finished():
+            self._poll_pending_dump_tasks()
+            if self._connector_metadata:
+                metadata = self._get_connector_metadata()
+                self._async_dump_req_ids.update(
+                    request_id
+                    for request_id, request in metadata.request_meta.items()
+                    if len(request.dump_block_ids[0]) > 0
+                )
+
+            total_end = time.perf_counter()
+            if self._layerwise_batch_start is not None:
+                batch_total_ms = (total_end - self._layerwise_batch_start) * 1000
+                ucmmetrics.update_stats({"layerwise_batch_total_ms": batch_total_ms})
+                self._layerwise_batch_start = None
+
+            self.dump_tasks.clear()
+            self.is_save = False
+            self.dump_total_ptrs = None
+            return
+
         if not self.is_save:
             total_end = time.perf_counter()
             if self._layerwise_batch_start is not None:

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -903,10 +903,17 @@ class UCMDirectConnector(KVConnectorBase_V1):
                 logger.error(f"wait for dump kv cache failed. {type(e).__name__}: {e}")
         self._pending_dump_tasks = remaining_tasks
 
-    def handle_preemptions(self, kv_connector_metadata: KVConnectorMetadata):
+    def handle_preemptions(
+        self,
+        kv_connector_metadata: KVConnectorMetadata | set[str],
+    ) -> None:
         if self.use_layerwise:
             return
-        preempted_req_ids = getattr(kv_connector_metadata, "preempted_req_ids", None)
+        preempted_req_ids = (
+            kv_connector_metadata
+            if isinstance(kv_connector_metadata, set)
+            else getattr(kv_connector_metadata, "preempted_req_ids", None)
+        )
         if preempted_req_ids:
             self._flush_pending_dump_tasks(preempted_req_ids)
 
@@ -2755,16 +2762,6 @@ class UCMHMAConnector(UCMDirectConnector, SupportsHMA):
             requests_dispatch_meta,
             scheduler_output.preempted_req_ids or set(),
         )
-
-    def request_finished_all_groups(
-        self,
-        request: "Request",
-        block_ids: tuple[list[int], ...],
-    ) -> tuple[bool, dict[str, Any] | None]:
-        if block_ids:
-            return self.request_finished(request, block_ids[0])
-        return self.request_finished(request, [])
-
 
 def use_hybrid_linear_attention_layout(
     kv_cache_config: Optional["KVCacheConfig"],

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -1242,13 +1242,15 @@ class UCMLayerWiseConnector(UCMDirectConnector):
 
         submit_start = time.perf_counter()
         total_ucm_block_ids, total_vllm_block_ids = [], []
+        dump_request_ids: set[str] = set()
         layer_id = self.layer_name_to_id[layer_name]
         local_layer_id = layer_id - self.first_layer_id
-        for _, request in metadata.request_meta.items():
+        for request_id, request in metadata.request_meta.items():
             if len(request.dump_block_ids[0]) == 0:
                 continue
 
             self.is_save = True
+            dump_request_ids.add(request_id)
             ucm_block_ids, vllm_block_ids = request.dump_block_ids
             if self.tp_rank % self.tp_size != 0 and local_layer_id == 0:
                 for i, ucm_block_id in enumerate(ucm_block_ids):
@@ -1256,23 +1258,32 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             total_ucm_block_ids.extend(ucm_block_ids)
             total_vllm_block_ids.extend(vllm_block_ids)
 
-        if self.is_save:
+        if dump_request_ids:
+            self._async_dump_req_ids.update(dump_request_ids)
             if self.dump_total_ptrs is None:
                 self.dump_total_ptrs = self.kv_cache_layout.extract_block_addrs(
                     total_vllm_block_ids, layer_first=True
                 )
             shard_indexs = [layer_id] * len(total_ucm_block_ids)
+            event_handle = 0
             try:
                 layer_ptrs = np.ascontiguousarray(self.dump_total_ptrs[local_layer_id])
                 event_handle = self._get_dump_event_handle()
                 task = self.store.dump_data(
                     total_ucm_block_ids, shard_indexs, layer_ptrs, event_handle
                 )
-                self.dump_tasks[layer_name] = task
-            except Exception as e:
-                logger.error(
-                    f"submit dump task for {layer_name} failed. {type(e).__name__}: {e}"
+                pending_dump_task = PendingDumpTask(
+                    task=task,
+                    request_ids=set(dump_request_ids),
+                    event_handle=event_handle,
                 )
+                self._pending_dump_tasks.append(pending_dump_task)
+                for request_id in pending_dump_task.request_ids:
+                    self._pending_dump_count_by_req[request_id] += 1
+            except Exception as e:
+                logger.error(f"submit dump task for {layer_name} failed. {type(e).__name__}: {e}")
+                if self.enable_event_sync and event_handle and self.device is not None:
+                    self.device.destroy_event_handle(event_handle)
         if self.is_save:
             submit_end = time.perf_counter()
             ucmmetrics.update_stats(
@@ -1280,34 +1291,16 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             )
 
     def wait_for_save(self) -> None:
-        if not self.is_save:
-            total_end = time.perf_counter()
-            if self._layerwise_batch_start is not None:
-                batch_total_ms = (total_end - self._layerwise_batch_start) * 1000
-                ucmmetrics.update_stats({"layerwise_batch_total_ms": batch_total_ms})
-                self._layerwise_batch_start = None
-            return
-        total_start = time.perf_counter()
-        try:
-            for layer_name in self.kv_caches:
-                if layer_name not in self.dump_tasks:
-                    continue
-                self.store.wait(self.dump_tasks[layer_name])
-        except Exception as e:
-            logger.error(f"wait for dump kv cache failed. {type(e).__name__}: {e}")
-        total_end = time.perf_counter()
-        stats = {"layerwise_save_tail_total_ms": (total_end - total_start) * 1000}
-        if self._layerwise_batch_start is not None:
-            stats["layerwise_batch_total_ms"] = (
-                total_end - self._layerwise_batch_start
-            ) * 1000
-            self._layerwise_batch_start = None
-        ucmmetrics.update_stats(stats)
+        if self._connector_metadata:
+            metadata = self._get_connector_metadata()
+            self._async_dump_req_ids.update(
+                request_id
+                for request_id, request in metadata.request_meta.items()
+                if len(request.dump_block_ids[0]) > 0
+            )
         self.dump_tasks.clear()
         self.is_save = False
         self.dump_total_ptrs = None
-        if self.enable_event_sync:
-            self.device.destroy_event_handles()
 
 
 class UCMCPConnector(UCMLayerWiseConnector):

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -371,9 +371,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self.launch_config = ucm_config.get_config()
         self.connector_configs = self.launch_config.get("ucm_connectors", [])
         self.enable_event_sync = self.launch_config.get("enable_event_sync", True)
-        self.layerwise_wait_for_save = self.launch_config.get(
-            "layerwise_wait_for_save", True
-        )
         self.enable_record_traces = self.launch_config.get(
             "enable_record_traces", False
         )
@@ -767,16 +764,11 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self,
         requests_dispatch_meta: dict[str, RequestDispatchMeta],
     ) -> None:
-        if not self._wait_dump_on_request_finished():
-            return
         self._async_dump_req_ids.update(
             request_id
             for request_id, dispatch_meta in requests_dispatch_meta.items()
             if len(dispatch_meta.dump_block_ids[0]) > 0
         )
-
-    def _wait_dump_on_request_finished(self) -> bool:
-        return not self.use_layerwise or not self.layerwise_wait_for_save
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         metadata = self._get_connector_metadata()
@@ -934,8 +926,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self,
         kv_connector_metadata: KVConnectorMetadata | set[str],
     ) -> None:
-        if not self._wait_dump_on_request_finished():
-            return
         preempted_req_ids = (
             kv_connector_metadata
             if isinstance(kv_connector_metadata, set)
@@ -1050,8 +1040,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
         request: "Request",
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
-        if not self._wait_dump_on_request_finished():
-            return False, None
         if request.request_id in self._async_dump_req_ids:
             self._async_dump_req_ids.discard(request.request_id)
             return True, None
@@ -1070,8 +1058,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self,
         finished_req_ids: set[str],
     ) -> tuple[Optional[set[str]], Optional[set[str]]]:
-        if not self._wait_dump_on_request_finished():
-            return None, None
         async_finished_req_ids = finished_req_ids & self._async_dump_req_ids
 
         if async_finished_req_ids:
@@ -1110,7 +1096,6 @@ class UCMLayerWiseConnector(UCMDirectConnector):
         super().__init__(vllm_config, role, kv_cache_config)
         # {layer_id: {request_id: Task}}
         self.load_tasks: dict[int, dict[str, Task]] = defaultdict(dict)
-        self.dump_tasks: dict[str, Task] = {}
         self.use_layerwise = True
         self.is_save = False
         self.need_load = False
@@ -1280,16 +1265,13 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                 task = self.store.dump_data(
                     total_ucm_block_ids, shard_indexs, layer_ptrs, event_handle
                 )
-                if self._wait_dump_on_request_finished():
-                    self._pending_dump_tasks.append(
-                        PendingDumpTask(
-                            task=task,
-                            request_ids=set(dump_request_ids),
-                            event_handle=event_handle,
-                        )
+                self._pending_dump_tasks.append(
+                    PendingDumpTask(
+                        task=task,
+                        request_ids=set(dump_request_ids),
+                        event_handle=event_handle,
                     )
-                else:
-                    self.dump_tasks[layer_name] = task
+                )
             except Exception as e:
                 logger.error(
                     f"submit dump task for {layer_name} failed. {type(e).__name__}: {e}"
@@ -1303,55 +1285,25 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             )
 
     def wait_for_save(self) -> None:
-        if self._wait_dump_on_request_finished():
-            self._poll_pending_dump_tasks()
-            if self._connector_metadata:
-                metadata = self._get_connector_metadata()
-                self._async_dump_req_ids.update(
-                    request_id
-                    for request_id, request in metadata.request_meta.items()
-                    if len(request.dump_block_ids[0]) > 0
-                )
+        # Only reap completed tasks here. Unfinished dumps are waited when the
+        # request finishes or is preempted.
+        self._poll_pending_dump_tasks()
+        if self._connector_metadata:
+            metadata = self._get_connector_metadata()
+            self._async_dump_req_ids.update(
+                request_id
+                for request_id, request in metadata.request_meta.items()
+                if len(request.dump_block_ids[0]) > 0
+            )
 
-            total_end = time.perf_counter()
-            if self._layerwise_batch_start is not None:
-                batch_total_ms = (total_end - self._layerwise_batch_start) * 1000
-                ucmmetrics.update_stats({"layerwise_batch_total_ms": batch_total_ms})
-                self._layerwise_batch_start = None
-
-            self.dump_tasks.clear()
-            self.is_save = False
-            self.dump_total_ptrs = None
-            return
-
-        if not self.is_save:
-            total_end = time.perf_counter()
-            if self._layerwise_batch_start is not None:
-                batch_total_ms = (total_end - self._layerwise_batch_start) * 1000
-                ucmmetrics.update_stats({"layerwise_batch_total_ms": batch_total_ms})
-                self._layerwise_batch_start = None
-            return
-        total_start = time.perf_counter()
-        try:
-            for layer_name in self.kv_caches:
-                if layer_name not in self.dump_tasks:
-                    continue
-                self.store.wait(self.dump_tasks[layer_name])
-        except Exception as e:
-            logger.error(f"wait for dump kv cache failed. {type(e).__name__}: {e}")
         total_end = time.perf_counter()
-        stats = {"layerwise_save_tail_total_ms": (total_end - total_start) * 1000}
         if self._layerwise_batch_start is not None:
-            stats["layerwise_batch_total_ms"] = (
-                total_end - self._layerwise_batch_start
-            ) * 1000
+            batch_total_ms = (total_end - self._layerwise_batch_start) * 1000
+            ucmmetrics.update_stats({"layerwise_batch_total_ms": batch_total_ms})
             self._layerwise_batch_start = None
-        ucmmetrics.update_stats(stats)
-        self.dump_tasks.clear()
+
         self.is_save = False
         self.dump_total_ptrs = None
-        if self.enable_event_sync:
-            self.device.destroy_event_handles()
 
 
 class UCMCPConnector(UCMLayerWiseConnector):

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -764,6 +764,8 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self,
         requests_dispatch_meta: dict[str, RequestDispatchMeta],
     ) -> None:
+        if self.use_layerwise:
+            return
         self._async_dump_req_ids.update(
             request_id
             for request_id, dispatch_meta in requests_dispatch_meta.items()
@@ -902,6 +904,8 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self._pending_dump_tasks = remaining_tasks
 
     def handle_preemptions(self, kv_connector_metadata: KVConnectorMetadata):
+        if self.use_layerwise:
+            return
         preempted_req_ids = getattr(kv_connector_metadata, "preempted_req_ids", None)
         if preempted_req_ids:
             self._flush_pending_dump_tasks(preempted_req_ids)
@@ -1010,6 +1014,8 @@ class UCMDirectConnector(KVConnectorBase_V1):
         request: "Request",
         block_ids: list[int],
     ) -> tuple[bool, dict[str, Any] | None]:
+        if self.use_layerwise:
+            return False, None
         if request.request_id in self._async_dump_req_ids:
             self._async_dump_req_ids.discard(request.request_id)
             return True, None
@@ -1028,6 +1034,8 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self,
         finished_req_ids: set[str],
     ) -> tuple[Optional[set[str]], Optional[set[str]]]:
+        if self.use_layerwise:
+            return None, None
         async_finished_req_ids = finished_req_ids & self._async_dump_req_ids
 
         if async_finished_req_ids:
@@ -1224,25 +1232,18 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             total_vllm_block_ids.extend(vllm_block_ids)
 
         if dump_request_ids:
-            self._async_dump_req_ids.update(dump_request_ids)
             if self.dump_total_ptrs is None:
                 self.dump_total_ptrs = self.kv_cache_layout.extract_block_addrs(
                     total_vllm_block_ids, layer_first=True
                 )
             shard_indexs = [layer_id] * len(total_ucm_block_ids)
-            event_handle = 0
             try:
                 layer_ptrs = np.ascontiguousarray(self.dump_total_ptrs[local_layer_id])
                 event_handle = self._get_dump_event_handle()
                 task = self.store.dump_data(
                     total_ucm_block_ids, shard_indexs, layer_ptrs, event_handle
                 )
-                pending_dump_task = PendingDumpTask(
-                    task=task,
-                    request_ids=set(dump_request_ids),
-                    event_handle=event_handle,
-                )
-                self._pending_dump_tasks.append(pending_dump_task)
+                self.dump_tasks[layer_name] = task
             except Exception as e:
                 logger.error(f"submit dump task for {layer_name} failed. {type(e).__name__}: {e}")
                 if self.enable_event_sync and event_handle and self.device is not None:
@@ -1254,16 +1255,37 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             )
 
     def wait_for_save(self) -> None:
-        if self._connector_metadata:
-            metadata = self._get_connector_metadata()
-            self._async_dump_req_ids.update(
-                request_id
-                for request_id, request in metadata.request_meta.items()
-                if len(request.dump_block_ids[0]) > 0
-            )
+        if not self.is_save:
+            total_end = time.perf_counter()
+            if self._layerwise_batch_start is not None:
+                batch_total_ms = (total_end - self._layerwise_batch_start) * 1000
+                ucmmetrics.update_stats({"layerwise_batch_total_ms": batch_total_ms})
+                self._layerwise_batch_start = None
+            return
+
+        total_start = time.perf_counter()
+        try:
+            for layer_name in self.kv_caches:
+                if layer_name not in self.dump_tasks:
+                    continue
+                self.store.wait(self.dump_tasks[layer_name])
+        except Exception as e:
+            logger.error(f"wait for dump kv cache failed. {type(e).__name__}: {e}")
+
+        total_end = time.perf_counter()
+        stats = {"layerwise_save_tail_total_ms": (total_end - total_start) * 1000}
+        if self._layerwise_batch_start is not None:
+            stats["layerwise_batch_total_ms"] = (
+                total_end - self._layerwise_batch_start
+            ) * 1000
+            self._layerwise_batch_start = None
+        ucmmetrics.update_stats(stats)
+
         self.dump_tasks.clear()
         self.is_save = False
         self.dump_total_ptrs = None
+        if self.enable_event_sync:
+            self.device.destroy_event_handles()
 
 
 class UCMCPConnector(UCMLayerWiseConnector):

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -417,8 +417,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self._invalid_block_ids: set[int] = set()
         self._async_dump_req_ids: set[str] = set()
         self._pending_dump_tasks: list[PendingDumpTask] = []
-        self._pending_dump_count_by_req: dict[str, int] = defaultdict(int)
-        self._delayed_finished_req_ids: set[str] = set()
         self.cp_world_size = 1
         self.hash_block_size = self.block_size
         self.block_size *= self.cp_world_size
@@ -869,7 +867,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
             self.store.wait(pending_dump_task.task)
         finally:
             self._release_dump_event_handle(pending_dump_task)
-        self._mark_pending_dump_task_done(pending_dump_task)
 
     def _release_dump_event_handle(self, pending_dump_task: PendingDumpTask) -> None:
         if (
@@ -879,27 +876,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
         ):
             self.device.destroy_event_handle(pending_dump_task.event_handle)
             pending_dump_task.event_handle = 0
-
-    def _mark_pending_dump_task_done(self, pending_dump_task: PendingDumpTask) -> None:
-        for request_id in pending_dump_task.request_ids:
-            pending_count = self._pending_dump_count_by_req.get(request_id, 0)
-            if pending_count <= 1:
-                self._pending_dump_count_by_req.pop(request_id, None)
-            else:
-                self._pending_dump_count_by_req[request_id] = pending_count - 1
-
-    def _poll_pending_dump_tasks(self) -> None:
-        remaining_tasks: list[PendingDumpTask] = []
-        for pending_dump_task in self._pending_dump_tasks:
-            try:
-                if self.store.check(pending_dump_task.task):
-                    self._wait_pending_dump_task(pending_dump_task)
-                else:
-                    remaining_tasks.append(pending_dump_task)
-            except Exception as e:
-                logger.error(f"check dump kv cache failed. {type(e).__name__}: {e}")
-                self._mark_pending_dump_task_done(pending_dump_task)
-        self._pending_dump_tasks = remaining_tasks
 
     def _flush_pending_dump_tasks(self, request_ids: Optional[set[str]] = None) -> None:
         pending_dump_tasks = self._pending_dump_tasks
@@ -915,7 +891,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
                 self._wait_pending_dump_task(pending_dump_task)
             except Exception as e:
                 logger.error(f"wait for dump kv cache failed. {type(e).__name__}: {e}")
-                self._mark_pending_dump_task_done(pending_dump_task)
         self._pending_dump_tasks = remaining_tasks
 
     def handle_preemptions(self, kv_connector_metadata: KVConnectorMetadata):
@@ -988,8 +963,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
                     event_handle=event_handle,
                 )
                 self._pending_dump_tasks.append(pending_dump_task)
-                for request_id in pending_dump_task.request_ids:
-                    self._pending_dump_count_by_req[request_id] += 1
 
     def clear_connector_metadata(self) -> None:
         super().clear_connector_metadata()
@@ -1047,16 +1020,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self,
         finished_req_ids: set[str],
     ) -> tuple[Optional[set[str]], Optional[set[str]]]:
-        self._poll_pending_dump_tasks()
-
-        async_finished_req_ids = {
-            request_id
-            for request_id in finished_req_ids
-            if request_id in self._pending_dump_count_by_req
-            or request_id in self._delayed_finished_req_ids
-            or request_id in self._async_dump_req_ids
-        }
-        self._delayed_finished_req_ids.update(async_finished_req_ids)
+        async_finished_req_ids = finished_req_ids & self._async_dump_req_ids
 
         if async_finished_req_ids:
             remaining_tasks: list[PendingDumpTask] = []
@@ -1068,20 +1032,13 @@ class UCMDirectConnector(KVConnectorBase_V1):
                         logger.error(
                             f"wait for dump kv cache failed. {type(e).__name__}: {e}"
                         )
-                        self._mark_pending_dump_task_done(pending_dump_task)
                 else:
                     remaining_tasks.append(pending_dump_task)
             self._pending_dump_tasks = remaining_tasks
 
-        finished_sending = {
-            request_id
-            for request_id in self._delayed_finished_req_ids
-            if request_id not in self._pending_dump_count_by_req
-        }
-        self._delayed_finished_req_ids.difference_update(finished_sending)
-        self._async_dump_req_ids.difference_update(finished_sending)
+        self._async_dump_req_ids.difference_update(async_finished_req_ids)
 
-        return finished_sending or None, None
+        return async_finished_req_ids or None, None
 
 
 class UCMLayerWiseConnector(UCMDirectConnector):
@@ -1278,8 +1235,6 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                     event_handle=event_handle,
                 )
                 self._pending_dump_tasks.append(pending_dump_task)
-                for request_id in pending_dump_task.request_ids:
-                    self._pending_dump_count_by_req[request_id] += 1
             except Exception as e:
                 logger.error(f"submit dump task for {layer_name} failed. {type(e).__name__}: {e}")
                 if self.enable_event_sync and event_handle and self.device is not None:

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -1215,7 +1215,6 @@ class UCMLayerWiseConnector(UCMDirectConnector):
 
         submit_start = time.perf_counter()
         total_ucm_block_ids, total_vllm_block_ids = [], []
-        dump_request_ids: set[str] = set()
         layer_id = self.layer_name_to_id[layer_name]
         local_layer_id = layer_id - self.first_layer_id
         for request_id, request in metadata.request_meta.items():
@@ -1223,7 +1222,6 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                 continue
 
             self.is_save = True
-            dump_request_ids.add(request_id)
             ucm_block_ids, vllm_block_ids = request.dump_block_ids
             if self.tp_rank % self.tp_size != 0 and local_layer_id == 0:
                 for i, ucm_block_id in enumerate(ucm_block_ids):
@@ -1231,7 +1229,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             total_ucm_block_ids.extend(ucm_block_ids)
             total_vllm_block_ids.extend(vllm_block_ids)
 
-        if dump_request_ids:
+        if self.is_save:
             if self.dump_total_ptrs is None:
                 self.dump_total_ptrs = self.kv_cache_layout.extract_block_addrs(
                     total_vllm_block_ids, layer_first=True
@@ -1262,7 +1260,6 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                 ucmmetrics.update_stats({"layerwise_batch_total_ms": batch_total_ms})
                 self._layerwise_batch_start = None
             return
-
         total_start = time.perf_counter()
         try:
             for layer_name in self.kv_caches:
@@ -1271,7 +1268,6 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                 self.store.wait(self.dump_tasks[layer_name])
         except Exception as e:
             logger.error(f"wait for dump kv cache failed. {type(e).__name__}: {e}")
-
         total_end = time.perf_counter()
         stats = {"layerwise_save_tail_total_ms": (total_end - total_start) * 1000}
         if self._layerwise_batch_start is not None:
@@ -1280,7 +1276,6 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             ) * 1000
             self._layerwise_batch_start = None
         ucmmetrics.update_stats(stats)
-
         self.dump_tasks.clear()
         self.is_save = False
         self.dump_total_ptrs = None


### PR DESCRIPTION
## Purpose

Move UCM KV dump completion waiting out of `wait_for_save()` so model execution is no longer blocked by async dump tasks, while still preserving delayed block release correctness for finished requests.

This also fixes the non-HMA `MultiConnector` path by forwarding `request_finished()` from the outer `UCMConnector` to the actual inner connector, ensuring requests that UCM saves asynchronously are properly marked for delayed free before they are returned from `get_finished()`.

## Modifications

- Added async dump task tracking for UCM Direct and LayerWise connectors.
- Changed `wait_for_save()` to submit dump tasks without blocking on task completion.
- Moved dump completion waiting to `get_finished()` for requests that have finished and require delayed block release.
- Added preemption handling to wait only for pending dump tasks related to preempted requests.
- Added per-task event handle release after dump task completion or submission failure.
- Removed save-duration metrics from the delayed `wait_for_save()` path because the timing is no longer accurate after deferring completion.
- Updated LayerWise save flow to use the same delayed dump completion mechanism.
- Added `UCMConnector.request_finished()` forwarding for the non-HMA path so `MultiConnector` can correctly count UCM async saves.
- Rebased the branch on latest `origin/develop` and resolved conflicts with the new layerwise / pipeline store metrics changes.
## Test
Tested on 8*NPU on A3 for Minimax2.7
direct connector
16K concurrancy 8 TTFT decrease(3.6605->3.2271)
64K concurrancy 4 TTFT decrease(13.0390->11.4577)
layerwise connector
slight improve almost the same
