### PR TITLE
[Feat]Wa dump blockwise & support for vllm-ascend:0.20.2rc1

### DIFF
--- a/examples/ucm_config_example.yaml
+++ b/examples/ucm_config_example.yaml
@@ -33,6 +33,9 @@ enable_event_sync: true
 # ucm_sparse_config:
   # GSAOnDevice: {}
 
+# The frequency level to dump KV cache to the storage backend. Default/not set is true, which means each block's WA cache will be dumped.
+# Set this to false, to dump the last block's WA cache of each chunk prefill only
+wa_dump_block_wise: true
 
 # Whether to use layerwise loading/saving (optional, default: True for UCMConnector)
 use_layerwise: true

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -573,9 +573,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
             else (None, None)
         )
 
-        for group_id, group_spec in enumerate(
-            self._kv_cache_config.kv_cache_groups
-        ):
+        for group_id, group_spec in enumerate(self._kv_cache_config.kv_cache_groups):
             group_caches: dict[str, torch.Tensor] = {}
             for layer_name in group_spec.layer_names:
                 if isinstance(kv_caches[layer_name], torch.Tensor):

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -748,10 +748,16 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                 return []
             if fetch_wa_block_wise:
                 # Block-wise WA stores one tail row for each canonical boundary.
-                boundary_block_indices = window_boundary_token_idx // group_meta.token_block_size
+                boundary_block_indices = (
+                    window_boundary_token_idx // group_meta.token_block_size
+                )
                 offsets = np.arange(group_meta.tail_blocks - 1, -1, -1, dtype=np.int64)
-                boundary_block_indices = boundary_block_indices[:, None] - offsets[None, :]
-                return np.array(group_block_ids)[boundary_block_indices.flatten()].tolist()
+                boundary_block_indices = (
+                    boundary_block_indices[:, None] - offsets[None, :]
+                )
+                return np.array(group_block_ids)[
+                    boundary_block_indices.flatten()
+                ].tolist()
             else:
                 # Chunk-wise WA stores only the tail for the final boundary.
                 boundary_block_idx = (
@@ -1110,12 +1116,16 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                 tp_dump_keys = request.dump_keys[tp_block_start:tp_block_end]
                 if tp_dump_keys:
                     fa_dump_vllm_block_ids = tuple(
-                        group_block_ids[tp_block_start:tp_block_end]
-                        if group_id in self.fa_group_ids
-                        else group_block_ids
-                        for group_id, group_block_ids in enumerate(request.dump_vllm_block_ids)
+                        (
+                            group_block_ids[tp_block_start:tp_block_end]
+                            if group_id in self.fa_group_ids
+                            else group_block_ids
+                        )
+                        for group_id, group_block_ids in enumerate(
+                            request.dump_vllm_block_ids
+                        )
                     )
-                    
+
                     fa_dump_keys.extend(tp_dump_keys)
                     fa_ptr_rows.append(
                         self._extract_fa_ptr(
@@ -1128,14 +1138,21 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                 if self.wa_dump_block_wise:
                     if tp_dump_keys:
                         wa_dump_vllm_block_ids = tuple(
-                            group_block_ids[
-                                tp_block_start * self.group_metas[group_id].tail_blocks :
-                                tp_block_end * self.group_metas[group_id].tail_blocks
-                            ]
-                            if group_id in self.window_group_ids
-                            else group_block_ids
-                            for group_id, group_block_ids in enumerate(request.dump_vllm_block_ids)
-                        ) 
+                            (
+                                group_block_ids[
+                                    tp_block_start
+                                    * self.group_metas[
+                                        group_id
+                                    ].tail_blocks : tp_block_end
+                                    * self.group_metas[group_id].tail_blocks
+                                ]
+                                if group_id in self.window_group_ids
+                                else group_block_ids
+                            )
+                            for group_id, group_block_ids in enumerate(
+                                request.dump_vllm_block_ids
+                            )
+                        )
                         wa_dump_keys.extend(tp_dump_keys)
                         wa_ptr_rows.append(
                             self._extract_wa_ptr(

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -578,7 +578,10 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         ):
             group_caches: dict[str, torch.Tensor] = {}
             for layer_name in group_spec.layer_names:
-                group_caches[layer_name] = tuple(kv_caches[layer_name])
+                if isinstance(kv_caches[layer_name], torch.Tensor):
+                    group_caches[layer_name] = kv_caches[layer_name]
+                else:
+                    group_caches[layer_name] = tuple(kv_caches[layer_name])
             layout = KVCacheGroupLayout(group_caches)
             self.group_layouts[group_id] = layout
 

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -300,6 +300,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         self.wa_store: Optional[UcmKVStoreBaseV1] = None
         self.requests_meta: dict[str, FAWARequestMeta] = {}
         self.tp_dump_tasks: dict[tuple, list[FAWADumpTask]] = {}
+        self.wa_dump_block_wise = self.launch_config.get("wa_dump_block_wise", True)
 
         if role == KVConnectorRole.SCHEDULER:
             self.store = self._create_fa_store(None)
@@ -504,6 +505,8 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         config["posix_gc_enable"] = (
             self._role != KVConnectorRole.WORKER and dp_rank == 0
         )
+        if config.get("posix_capacity_gb", None) is not None:
+            config["posix_capacity_gb"] = int(config["posix_capacity_gb"]) // 2
         return name, module_path, config
 
     @staticmethod
@@ -734,6 +737,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         group_id: int,
         group_block_ids: list[int],
         window_boundary_token_idx: np.ndarray,
+        fetch_wa_block_wise: bool,
     ) -> list[int]:
         """Select the physical group blocks needed for FA or WA store rows."""
 
@@ -742,13 +746,20 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         if is_window_group:
             if not group_meta.tail_tokens:
                 return []
-            # WA loads/dumps only the tail for the final boundary in the range.
-            boundary_block_idx = (
-                window_boundary_token_idx[-1] // group_meta.token_block_size
-            ) + 1
-            return group_block_ids[
-                boundary_block_idx - group_meta.tail_blocks : boundary_block_idx
-            ]
+            if fetch_wa_block_wise:
+                # Block-wise WA stores one tail row for each canonical boundary.
+                boundary_block_indices = window_boundary_token_idx // group_meta.token_block_size
+                offsets = np.arange(group_meta.tail_blocks - 1, -1, -1, dtype=np.int64)
+                boundary_block_indices = boundary_block_indices[:, None] - offsets[None, :]
+                return np.array(group_block_ids)[boundary_block_indices.flatten()].tolist()
+            else:
+                # Chunk-wise WA stores only the tail for the final boundary.
+                boundary_block_idx = (
+                    window_boundary_token_idx[-1] // group_meta.token_block_size
+                ) + 1
+                return group_block_ids[
+                    boundary_block_idx - group_meta.tail_blocks : boundary_block_idx
+                ]
         # FA rows map each canonical hash block to its containing group block.
         return np.array(group_block_ids)[
             window_boundary_token_idx // group_meta.token_block_size
@@ -801,6 +812,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                         group_id,
                         group_block_ids,
                         window_boundary_token_idx,
+                        fetch_wa_block_wise=False,  # always fetch the full WA tail on load to simplify logic
                     )
                 )
 
@@ -823,6 +835,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                         group_id,
                         group_block_ids,
                         window_boundary_token_idx,
+                        fetch_wa_block_wise=self.wa_dump_block_wise,
                     )
                 )
         req_meta.token_processed = computed_end_token
@@ -1084,8 +1097,8 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         wa_ptr_rows: list[np.ndarray] = []
         dump_request_ids: tuple[str] = ()
         if self.tp_size > 1:
-            # Split FA rows by canonical block index and balance WA rows by
-            # assigning whole request boundaries round-robin across ranks.
+            # Split FA rows by canonical block index. Block-wise WA follows the same
+            # TP key slice; chunk-wise WA assigns one final boundary per request.
             wa_dump_ring_idx = 0
             for request_id, request in metadata.request_meta.items():
                 if not request.dump_keys:
@@ -1096,20 +1109,41 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                 tp_block_end = num_keys * (self.tp_rank + 1) // self.tp_size
                 tp_dump_keys = request.dump_keys[tp_block_start:tp_block_end]
                 if tp_dump_keys:
-                    tp_dump_vllm_block_ids = tuple(
+                    fa_dump_vllm_block_ids = tuple(
                         group_block_ids[tp_block_start:tp_block_end]
-                        for group_block_ids in request.dump_vllm_block_ids
+                        if group_id in self.fa_group_ids
+                        else group_block_ids
+                        for group_id, group_block_ids in enumerate(request.dump_vllm_block_ids)
                     )
+                    
                     fa_dump_keys.extend(tp_dump_keys)
                     fa_ptr_rows.append(
                         self._extract_fa_ptr(
                             tp_dump_keys,
                             request.dump_hash_start + tp_block_start,
                             request.dump_hash_start + tp_block_end,
-                            tp_dump_vllm_block_ids,
+                            fa_dump_vllm_block_ids,
                         )
                     )
-                if wa_dump_ring_idx % self.tp_size == self.tp_rank:
+                if self.wa_dump_block_wise:
+                    if tp_dump_keys:
+                        wa_dump_vllm_block_ids = tuple(
+                            group_block_ids[
+                                tp_block_start * self.group_metas[group_id].tail_blocks :
+                                tp_block_end * self.group_metas[group_id].tail_blocks
+                            ]
+                            if group_id in self.window_group_ids
+                            else group_block_ids
+                            for group_id, group_block_ids in enumerate(request.dump_vllm_block_ids)
+                        ) 
+                        wa_dump_keys.extend(tp_dump_keys)
+                        wa_ptr_rows.append(
+                            self._extract_wa_ptr(
+                                tp_dump_keys,
+                                wa_dump_vllm_block_ids,
+                            )
+                        )
+                elif wa_dump_ring_idx % self.tp_size == self.tp_rank:
                     wa_dump_keys.extend(request.dump_keys[-1:])
                     wa_ptr_rows.append(
                         self._extract_wa_ptr(
@@ -1132,14 +1166,22 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                         request.dump_vllm_block_ids,
                     )
                 )
-
-                wa_dump_keys.extend(request.dump_keys[-1:])
-                wa_ptr_rows.append(
-                    self._extract_wa_ptr(
-                        request.dump_keys[-1:],
-                        request.dump_vllm_block_ids,
+                if self.wa_dump_block_wise:
+                    wa_dump_keys.extend(request.dump_keys)
+                    wa_ptr_rows.append(
+                        self._extract_wa_ptr(
+                            request.dump_keys,
+                            request.dump_vllm_block_ids,
+                        )
                     )
-                )
+                else:
+                    wa_dump_keys.extend(request.dump_keys[-1:])
+                    wa_ptr_rows.append(
+                        self._extract_wa_ptr(
+                            request.dump_keys[-1:],
+                            request.dump_vllm_block_ids,
+                        )
+                    )
 
         if fa_dump_keys:
             event_handle = self._get_dump_event_handle()

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -367,12 +367,8 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                 else group_spec.kv_cache_spec
             )
             spec_names.add(type(spec).__name__)
-        ASCEND_REQUIRED_SPECS = frozenset(
-            {"Compress4AttentionSpec", "C4IndexerSpec", "Compress128AttentionSpec"}
-        )
-        npu_support = type(kv_cache_groups[0]).__name__.startswith(
-            "Ascend"
-        ) and ASCEND_REQUIRED_SPECS.issubset(spec_names)
+        ASCEND_REQUIRED_SPECS = frozenset({"AscendSlidingWindowMLASpec"})
+        npu_support = ASCEND_REQUIRED_SPECS.issubset(spec_names)
         return npu_support
 
     def _init_group_metas(self) -> None:
@@ -411,9 +407,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                 self.fa_group_ids.append(group_id)
             else:
                 tensor_name = group.layer_names[0]
-                if type(spec).__name__ in ["SWAAttentionSpec"] or tensor_name.split(
-                    "."
-                )[-1] in ["swa_cache"]:
+                if tensor_name.split(".")[-1] in ["swa_cache"]:
                     # SWA caches keep the full sliding-window tail.
                     tail_tokens = window_size
                 else:
@@ -579,31 +573,14 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
             else (None, None)
         )
 
-        if self.is_ascend_layout:
-            # Ascend may provide multiple tensors for the same layer name; each
-            # KV group consumes its slice in vllm-ascend registration order.
-            next_tensor_index_by_layer: dict[str, int] = {}
-            for group_id, group in enumerate(self._kv_cache_config.kv_cache_groups):
-                kv_cache_spec_name = type(group.kv_cache_spec).__name__
-                group_caches: dict[str, torch.Tensor] = {}
-                for layer_name in group.layer_names:
-                    tensor_count = 2 if kv_cache_spec_name == "C4IndexerSpec" else 1
-                    start = next_tensor_index_by_layer.get(layer_name, 0)
-                    end = start + tensor_count
-                    next_tensor_index_by_layer[layer_name] = end
-                    group_caches[layer_name] = tuple(kv_caches[layer_name][start:end])
-
-                layout = KVCacheGroupLayout(group_caches)
-                self.group_layouts[group_id] = layout
-        else:
-            for group_id, group_spec in enumerate(
-                self._kv_cache_config.kv_cache_groups
-            ):
-                group_caches: dict[str, torch.Tensor] = {}
-                for layer_name in group_spec.layer_names:
-                    group_caches[layer_name] = kv_caches[layer_name]
-                layout = KVCacheGroupLayout(group_caches)
-                self.group_layouts[group_id] = layout
+        for group_id, group_spec in enumerate(
+            self._kv_cache_config.kv_cache_groups
+        ):
+            group_caches: dict[str, torch.Tensor] = {}
+            for layer_name in group_spec.layer_names:
+                group_caches[layer_name] = tuple(kv_caches[layer_name])
+            layout = KVCacheGroupLayout(group_caches)
+            self.group_layouts[group_id] = layout
 
         self.store = self._create_fa_store(self.group_layouts, store_cores)
         self.fa_store = self.store


### PR DESCRIPTION
## Purpose

Add configurable block-wise WA KV cache dumping for the FAWA connector.

Previously, WA cache dumping only persisted the final WA tail block for each chunk prefill. This made WA external-cache reuse depend on chunk boundaries and could miss intermediate canonical block boundaries. This PR adds an option to dump WA cache block-wise so each canonical hash block can persist its corresponding WA tail state.

## Modifications

- Add `wa_dump_block_wise` config option, defaulting to `true`.
- Update FAWA dispatch metadata generation to support two WA dump modes:
  - block-wise WA dump: dump WA tail rows for every canonical block boundary.
  - chunk-wise WA dump: keep the old behavior and dump only the final WA tail per chunk.
- Keep WA load behavior loading only the final matched WA boundary.
- Update TP dump slicing so block-wise WA dump follows the same TP key partitioning as FA dump.
- Split configured `posix_capacity_gb` between FA and WA stores.
- Document `wa_dump_block_wise` in `examples/ucm_config_example.yaml`.

## Test