### PR TITLE
[Feat] Asu: build and send ASU SQE requests 

### DIFF
--- a/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
@@ -1,0 +1,170 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "asu_submit_flow.h"
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include "connection_internal.h"
+#include "transport_task_completion.h"
+
+namespace UC::ASU {
+
+namespace {
+
+std::uint32_t GetSendCountAttr(const std::unordered_map<std::string, std::string>& attrs,
+                               const std::string& name)
+{
+    return static_cast<std::uint32_t>(std::stoull(attrs.at(name), nullptr, 0));
+}
+
+void SetSubBatchSendFailed(TransportSubBatchContext& subBatchContext, const Status& status)
+{
+    std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(), status);
+    subBatchContext.state = TransportSubBatchState::FAILED;
+    subBatchContext.status = status;
+}
+
+}  // namespace
+
+Status SubmitTaskRequests(const TransportTaskContext& ctx, const IoScheduler& ioScheduler,
+                          const std::unordered_map<std::string, std::string>& attrs,
+                          const SqeCidAllocator& allocateSqeCid, BufferManager& sendBufferManager,
+                          BufferManager& flagBufferManager, ProtocolManager& protocolManager,
+                          std::vector<TransportSubBatchContext>& subBatchContexts)
+{
+    Status finalStatus = Status::OK();
+    if (IsEntryBatchOp(ctx.opType)) {
+        const auto subBatches = ioScheduler.SplitForAsu(ctx.entries, GetSqeBatchLimit(ctx.opType));
+        subBatchContexts.reserve(subBatches.size());
+        for (const auto& subBatch : subBatches) {
+            TransportSubBatchContext subBatchContext;
+            auto status = SubmitEntrySubBatchRequest(ctx.opType, subBatch, attrs, allocateSqeCid,
+                                                     sendBufferManager, flagBufferManager,
+                                                     protocolManager, subBatchContext);
+            subBatchContext.status = status;
+            if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+            subBatchContexts.push_back(std::move(subBatchContext));
+        }
+    } else if (IsKeyBatchOp(ctx.opType)) {
+        const auto subBatches = ioScheduler.SplitForAsu(ctx.keys, GetSqeBatchLimit(ctx.opType));
+        subBatchContexts.reserve(subBatches.size());
+        for (const auto& subBatch : subBatches) {
+            TransportSubBatchContext subBatchContext;
+            auto status = SubmitKeySubBatchRequest(ctx.opType, subBatch, attrs, allocateSqeCid,
+                                                   sendBufferManager, flagBufferManager,
+                                                   protocolManager, subBatchContext);
+            subBatchContext.status = status;
+            if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+            subBatchContexts.push_back(std::move(subBatchContext));
+        }
+    } else if (ctx.opType == TransportOpType::KEEP_ALIVE) {
+        TransportSubBatchContext subBatchContext;
+        auto status = SubmitKeepAliveRequest(allocateSqeCid, sendBufferManager, flagBufferManager,
+                                             protocolManager, subBatchContext);
+        subBatchContext.status = status;
+        if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+        subBatchContexts.push_back(std::move(subBatchContext));
+    } else {
+        finalStatus = Status::Error(StatusCode::UNSUPPORTED, "transport operation is unsupported");
+    }
+    return finalStatus;
+}
+
+Status BuildSubBatchSendBuffers(std::vector<TransportSubBatchContext>& subBatchContexts,
+                                std::vector<SendIoBatch>& ioBatches,
+                                std::vector<std::size_t>& subBatchIndexes,
+                                BufferManager& sendBufferManager, BufferManager& flagBufferManager)
+{
+    Status finalStatus = Status::OK();
+    ioBatches.reserve(subBatchContexts.size());
+    subBatchIndexes.reserve(subBatchContexts.size());
+
+    for (std::size_t index = 0; index < subBatchContexts.size(); ++index) {
+        auto& subBatchContext = subBatchContexts[index];
+        if (subBatchContext.state == TransportSubBatchState::FAILED) {
+            if (finalStatus.ok()) {
+                finalStatus = Status::Error(StatusCode::PARTIAL_FAILED,
+                                            "one or more sub-batches failed before send");
+            }
+            const auto releaseStatus =
+                ReleaseSubBatchResources(subBatchContext, sendBufferManager, flagBufferManager);
+            if (finalStatus.ok() && !releaseStatus.ok()) { finalStatus = releaseStatus; }
+            continue;
+        }
+
+        if (subBatchContext.flagBuffer.addr == 0 || subBatchContext.flagBuffer.length == 0) {
+            const auto status =
+                Status::Error(StatusCode::NOT_INITIALIZED, "sub-batch flag buffer is not ready");
+            SetSubBatchSendFailed(subBatchContext, status);
+            if (finalStatus.ok()) { finalStatus = status; }
+            const auto releaseStatus =
+                ReleaseSubBatchResources(subBatchContext, sendBufferManager, flagBufferManager);
+            if (finalStatus.ok() && !releaseStatus.ok()) { finalStatus = releaseStatus; }
+            continue;
+        }
+
+        ioBatches.push_back(
+            SendIoBatch{subBatchContext.channel->GetNativeQp(), &subBatchContext.sendSge});
+        subBatchIndexes.push_back(index);
+    }
+
+    return finalStatus;
+}
+
+Status SendSubBatchBuffers(std::vector<TransportSubBatchContext>& subBatchContexts,
+                           const std::vector<SendIoBatch>& ioBatches,
+                           const std::vector<std::size_t>& subBatchIndexes,
+                           const std::unordered_map<std::string, std::string>& attrs,
+                           ConnectionManager& connManager)
+{
+    Status finalStatus = Status::OK();
+    if (ioBatches.empty()) { return finalStatus; }
+
+    const auto kernelCount = GetSendCountAttr(attrs, "kernel_count");
+    const auto quietCount = GetSendCountAttr(attrs, "quiet_count");
+
+    const auto sendStatuses = Send(ioBatches, kernelCount, quietCount);
+    if (sendStatuses.size() != ioBatches.size()) {
+        const auto status = Status::Error(StatusCode::INTERNAL_ERROR,
+                                          "transport send returned unexpected status count");
+        for (auto index : subBatchIndexes) {
+            auto& subBatchContext = subBatchContexts[index];
+            SetSubBatchSendFailed(subBatchContext, status);
+        }
+        return status;
+    }
+
+    for (std::size_t index = 0; index < sendStatuses.size(); ++index) {
+        auto& subBatchContext = subBatchContexts[subBatchIndexes[index]];
+        const auto& status = sendStatuses[index];
+        if (status.ok()) { continue; }
+
+        SetSubBatchSendFailed(subBatchContext, status);
+        connManager.ReportFailure(subBatchContext.channel);
+        if (finalStatus.ok()) { finalStatus = status; }
+    }
+    return finalStatus;
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/asu_submit_flow.h
+++ b/ucm/transport/kv/asu/trans/src/asu_submit_flow.h
@@ -1,0 +1,57 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "connection_manager.h"
+#include "io_scheduler.h"
+#include "sqe_request.h"
+#include "transport_task_manager.h"
+
+namespace UC::ASU {
+
+class BufferManager;
+class ProtocolManager;
+
+Status SubmitTaskRequests(const TransportTaskContext& ctx, const IoScheduler& ioScheduler,
+                          const std::unordered_map<std::string, std::string>& attrs,
+                          const SqeCidAllocator& allocateSqeCid, BufferManager& sendBufferManager,
+                          BufferManager& flagBufferManager, ProtocolManager& protocolManager,
+                          std::vector<TransportSubBatchContext>& subBatchContexts);
+
+Status BuildSubBatchSendBuffers(std::vector<TransportSubBatchContext>& subBatchContexts,
+                                std::vector<SendIoBatch>& ioBatches,
+                                std::vector<std::size_t>& subBatchIndexes,
+                                BufferManager& sendBufferManager, BufferManager& flagBufferManager);
+
+Status SendSubBatchBuffers(std::vector<TransportSubBatchContext>& subBatchContexts,
+                           const std::vector<SendIoBatch>& ioBatches,
+                           const std::vector<std::size_t>& subBatchIndexes,
+                           const std::unordered_map<std::string, std::string>& attrs,
+                           ConnectionManager& connManager);
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/sqe_request.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.cpp
@@ -1,0 +1,401 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "sqe_request.h"
+#include <algorithm>
+#include <cctype>
+#include <limits>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+#include "buffer_manager.h"
+#include "connection_manager.h"
+#include "kv_protocol.h"
+
+namespace UC::ASU {
+
+namespace {
+
+constexpr std::size_t kFlagBufferHeaderSize = 16;
+
+std::uint32_t ToSqeMrKey(MRHandle handle)
+{
+    // TODO: 每个mrhandle对应的mrkey
+    return static_cast<std::uint32_t>(handle);
+}
+
+std::uint64_t GetResponseBufferAddr(const ScatterGatherEntry& flagBuffer)
+{
+    return flagBuffer.addr;
+}
+
+std::uint32_t GetResponseMrKey(const ScatterGatherEntry& flagBuffer) { return flagBuffer.lkey; }
+
+std::uint16_t NextSqeCid(const SqeCidAllocator& allocateSqeCid) { return allocateSqeCid(); }
+
+std::string ToLower(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
+template <typename T>
+T GetTransportConfigAttr(const std::unordered_map<std::string, std::string>& attrs,
+                         const std::string& name, T fallback = {})
+{
+    auto iter = attrs.find(name);
+    if (iter == attrs.end()) { return fallback; }
+
+    if constexpr (std::is_same_v<T, bool>) {
+        const auto value = ToLower(iter->second);
+        return value == "1" || value == "true";
+    } else {
+        return static_cast<T>(std::stoull(iter->second, nullptr, 0));
+    }
+}
+
+std::size_t GetFlagBufferSize(std::size_t batchNum)
+{
+    return kFlagBufferHeaderSize + (batchNum + 1) / 2;
+}
+
+Status AllocateSubBatchFlagBuffer(std::size_t batchNum, BufferManager& flagBufferManager,
+                                  TransportSubBatchContext& subBatchContext)
+{
+    auto status =
+        flagBufferManager.Allocate(GetFlagBufferSize(batchNum), subBatchContext.flagBuffer);
+    if (!status.ok()) {
+        subBatchContext.flagBuffer = {};
+        return status;
+    }
+    return Status::OK();
+}
+
+Status SetSubBatchBuildFailed(TransportSubBatchContext& subBatchContext, const Status& status)
+{
+    subBatchContext.state = TransportSubBatchState::FAILED;
+    subBatchContext.status = status;
+    std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(), status);
+    return status;
+}
+
+KvBatchStoreRequest BuildBatchStoreRequest(
+    const BatchView<KVBuffer>& entries, const std::unordered_map<std::string, std::string>& attrs,
+    std::uint16_t cid, const ScatterGatherEntry& flagBuffer)
+{
+    KvBatchStoreRequest request;
+    request.cid = cid;
+    request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
+    request.dtype = GetTransportConfigAttr<std::uint8_t>(attrs, "dtype");
+    request.dspec = GetTransportConfigAttr<std::uint8_t>(attrs, "dspec");
+    request.response_buffer_addr = GetResponseBufferAddr(flagBuffer);
+    request.response_mr_key = GetResponseMrKey(flagBuffer);
+    request.lr = GetTransportConfigAttr<bool>(attrs, "lr");
+    request.rflag = true;
+    request.batch_number = static_cast<std::uint16_t>(entries.size);
+    request.entries.reserve(entries.size);
+    for (std::size_t index = 0; index < entries.size; ++index) {
+        KvBatchStoreEntry entry;
+        entry.key = entries[index].key;
+        entry.offset = 0;
+        entry.buffer_addr = entries[index].buffer.region.addr;
+        entry.mr_key = ToSqeMrKey(entries[index].buffer.handle);
+        entry.length = static_cast<std::uint32_t>(entries[index].buffer.region.size);
+        request.entries.emplace_back(std::move(entry));
+    }
+    return request;
+}
+
+KvBatchRetrieveRequest BuildBatchRetrieveRequest(
+    const BatchView<KVBuffer>& entries, const std::unordered_map<std::string, std::string>& attrs,
+    std::uint16_t cid, const ScatterGatherEntry& flagBuffer)
+{
+    KvBatchRetrieveRequest request;
+    request.cid = cid;
+    request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
+    request.response_buffer_addr = GetResponseBufferAddr(flagBuffer);
+    request.response_mr_key = GetResponseMrKey(flagBuffer);
+    request.lr = GetTransportConfigAttr<bool>(attrs, "lr");
+    request.rflag = true;
+    request.batch_number = static_cast<std::uint16_t>(entries.size);
+    request.entries.reserve(entries.size);
+    for (std::size_t index = 0; index < entries.size; ++index) {
+        KvBatchRetrieveEntry entry;
+        entry.key = entries[index].key;
+        entry.offset = 0;
+        entry.buffer_addr = entries[index].buffer.region.addr;
+        entry.mr_key = ToSqeMrKey(entries[index].buffer.handle);
+        entry.length = static_cast<std::uint32_t>(entries[index].buffer.region.size);
+        request.entries.emplace_back(std::move(entry));
+    }
+    return request;
+}
+
+std::vector<std::string> CopyKeys(const BatchView<CacheKey>& keys)
+{
+    std::vector<std::string> requestKeys;
+    requestKeys.reserve(keys.size);
+    for (std::size_t index = 0; index < keys.size; ++index) {
+        requestKeys.emplace_back(keys[index]);
+    }
+    return requestKeys;
+}
+
+KvDeleteRequest BuildDeleteRequest(const BatchView<CacheKey>& keys,
+                                   const std::unordered_map<std::string, std::string>& attrs,
+                                   std::uint16_t cid, const ScatterGatherEntry& flagBuffer)
+{
+    KvDeleteRequest request;
+    request.cid = cid;
+    request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
+    request.response_buffer_addr = GetResponseBufferAddr(flagBuffer);
+    request.response_mr_key = GetResponseMrKey(flagBuffer);
+    request.rflag = true;
+    request.keys = CopyKeys(keys);
+    request.batch_number = static_cast<std::uint16_t>(request.keys.size());
+    return request;
+}
+
+KvExistRequest BuildExistRequest(const BatchView<CacheKey>& keys,
+                                 const std::unordered_map<std::string, std::string>& attrs,
+                                 std::uint16_t cid, const ScatterGatherEntry& flagBuffer)
+{
+    KvExistRequest request;
+    request.cid = cid;
+    request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
+    request.response_buffer_addr = GetResponseBufferAddr(flagBuffer);
+    request.response_mr_key = GetResponseMrKey(flagBuffer);
+    request.rflag = true;
+    request.sc = GetTransportConfigAttr<bool>(attrs, "sc");
+    request.keys = CopyKeys(keys);
+    request.batch_number = static_cast<std::uint16_t>(request.keys.size());
+    return request;
+}
+
+KvKeepAliveRequest BuildKeepAliveRequest(std::uint16_t cid, const ScatterGatherEntry& flagBuffer)
+{
+    KvKeepAliveRequest request;
+    request.cid = cid;
+    request.response_buffer_addr = GetResponseBufferAddr(flagBuffer);
+    request.response_mr_key = GetResponseMrKey(flagBuffer);
+    request.rflag = true;
+    return request;
+}
+
+}  // namespace
+
+Status ValidateSqeRequestAttrs(const std::unordered_map<std::string, std::string>& attrs)
+{
+    const auto validateInteger = [&attrs](const std::string& name, auto maxValue) -> Status {
+        auto iter = attrs.find(name);
+        if (iter == attrs.end()) { return Status::OK(); }
+        try {
+            const auto parsed = std::stoull(iter->second, nullptr, 0);
+            if (parsed > maxValue) {
+                return Status::Error(StatusCode::INVALID_ARGUMENT, name + " exceeds valid range");
+            }
+        } catch (const std::exception&) {
+            return Status::Error(StatusCode::INVALID_ARGUMENT, name + " is not a valid integer");
+        }
+        return Status::OK();
+    };
+
+    const auto validateRequiredPositiveInteger = [&attrs](const std::string& name,
+                                                          auto maxValue) -> Status {
+        auto iter = attrs.find(name);
+        if (iter == attrs.end()) {
+            return Status::Error(StatusCode::INVALID_ARGUMENT, name + " is required");
+        }
+        try {
+            const auto parsed = std::stoull(iter->second, nullptr, 0);
+            if (parsed > maxValue) {
+                return Status::Error(StatusCode::INVALID_ARGUMENT, name + " exceeds valid range");
+            }
+            if (parsed == 0) {
+                return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                     name + " must be greater than zero");
+            }
+        } catch (const std::exception&) {
+            return Status::Error(StatusCode::INVALID_ARGUMENT, name + " is not a valid integer");
+        }
+        return Status::OK();
+    };
+
+    const auto validateBool = [&attrs](const std::string& name) -> Status {
+        auto iter = attrs.find(name);
+        if (iter == attrs.end()) { return Status::OK(); }
+        const auto value = ToLower(iter->second);
+        if (value == "1" || value == "0" || value == "true" || value == "false") {
+            return Status::OK();
+        }
+        return Status::Error(StatusCode::INVALID_ARGUMENT, name + " is not a valid bool");
+    };
+
+    auto status = validateInteger("kv_ns_id", std::numeric_limits<std::uint32_t>::max());
+    if (!status.ok()) { return status; }
+    status = validateInteger("dtype", std::numeric_limits<std::uint8_t>::max());
+    if (!status.ok()) { return status; }
+    status = validateInteger("dspec", std::numeric_limits<std::uint8_t>::max());
+    if (!status.ok()) { return status; }
+    status = validateBool("sc");
+    if (!status.ok()) { return status; }
+    status = validateBool("lr");
+    if (!status.ok()) { return status; }
+    status =
+        validateRequiredPositiveInteger("kernel_count", std::numeric_limits<std::uint32_t>::max());
+    if (!status.ok()) { return status; }
+    return validateRequiredPositiveInteger("quiet_count",
+                                           std::numeric_limits<std::uint32_t>::max());
+}
+
+Status SubmitEntrySubBatchRequest(TransportOpType opType,
+                                  const IoScheduler::ScheduledIoBatch& subBatch,
+                                  const std::unordered_map<std::string, std::string>& attrs,
+                                  const SqeCidAllocator& allocateSqeCid,
+                                  BufferManager& sendBufferManager,
+                                  BufferManager& flagBufferManager,
+                                  ProtocolManager& protocolManager,
+                                  TransportSubBatchContext& subBatchContext)
+{
+    subBatchContext.entryStatus.assign(subBatch.entries.size, Status::OK());
+    subBatchContext.state = TransportSubBatchState::PENDING;
+    subBatchContext.status = Status::OK();
+
+    if (subBatch.entries.empty()) { return Status::OK(); }
+
+    if (opType == TransportOpType::BATCH_LOAD) {
+        subBatchContext.opType = opType;
+        subBatchContext.cid = NextSqeCid(allocateSqeCid);
+        auto status =
+            AllocateSubBatchFlagBuffer(subBatch.entries.size, flagBufferManager, subBatchContext);
+        if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+        auto request = BuildBatchRetrieveRequest(subBatch.entries, attrs, subBatchContext.cid,
+                                                 subBatchContext.flagBuffer);
+        auto packedSize = protocolManager.GetPackedSize(KvOpcode::BatchRetrieve, request);
+        status = sendBufferManager.Allocate(packedSize, subBatchContext.sendSge);
+        if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+        status = protocolManager.PackRequest(reinterpret_cast<void*>(subBatchContext.sendSge.addr),
+                                             KvOpcode::BatchRetrieve, request);
+        if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+        subBatchContext.status = status;
+        return status;
+    }
+
+    if (opType == TransportOpType::BATCH_STORE) {
+        subBatchContext.opType = opType;
+        subBatchContext.cid = NextSqeCid(allocateSqeCid);
+        auto status =
+            AllocateSubBatchFlagBuffer(subBatch.entries.size, flagBufferManager, subBatchContext);
+        if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+        auto request = BuildBatchStoreRequest(subBatch.entries, attrs, subBatchContext.cid,
+                                              subBatchContext.flagBuffer);
+        auto packedSize = protocolManager.GetPackedSize(KvOpcode::BatchStore, request);
+        status = sendBufferManager.Allocate(packedSize, subBatchContext.sendSge);
+        if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+        status = protocolManager.PackRequest(reinterpret_cast<void*>(subBatchContext.sendSge.addr),
+                                             KvOpcode::BatchStore, request);
+        if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+        subBatchContext.status = status;
+        return status;
+    }
+
+    auto status = Status::Error(StatusCode::UNSUPPORTED,
+                                "entry batch submit only supports batch store/retrieve operations");
+    return SetSubBatchBuildFailed(subBatchContext, status);
+}
+
+Status SubmitKeySubBatchRequest(TransportOpType opType,
+                                const IoScheduler::ScheduledKeyBatch& subBatch,
+                                const std::unordered_map<std::string, std::string>& attrs,
+                                const SqeCidAllocator& allocateSqeCid,
+                                BufferManager& sendBufferManager, BufferManager& flagBufferManager,
+                                ProtocolManager& protocolManager,
+                                TransportSubBatchContext& subBatchContext)
+{
+    subBatchContext.entryStatus.assign(subBatch.keys.size, Status::OK());
+    subBatchContext.state = TransportSubBatchState::PENDING;
+    subBatchContext.status = Status::OK();
+
+    if (subBatch.keys.empty()) { return Status::OK(); }
+
+    if (opType != TransportOpType::QUERY && opType != TransportOpType::DELETE) {
+        auto status =
+            Status::Error(StatusCode::UNSUPPORTED, "key batch submit only supports query/delete");
+        return SetSubBatchBuildFailed(subBatchContext, status);
+    }
+
+    subBatchContext.cid = NextSqeCid(allocateSqeCid);
+    subBatchContext.opType = opType;
+    auto status =
+        AllocateSubBatchFlagBuffer(subBatch.keys.size, flagBufferManager, subBatchContext);
+    if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+    if (opType == TransportOpType::DELETE) {
+        auto request = BuildDeleteRequest(subBatch.keys, attrs, subBatchContext.cid,
+                                          subBatchContext.flagBuffer);
+        auto packedSize = protocolManager.GetPackedSize(KvOpcode::Delete, request);
+        status = sendBufferManager.Allocate(packedSize, subBatchContext.sendSge);
+        if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+        status = protocolManager.PackRequest(reinterpret_cast<void*>(subBatchContext.sendSge.addr),
+                                             KvOpcode::Delete, request);
+    } else if (opType == TransportOpType::QUERY) {
+        auto request = BuildExistRequest(subBatch.keys, attrs, subBatchContext.cid,
+                                         subBatchContext.flagBuffer);
+        subBatchContext.useSeekControl = request.sc;
+        auto packedSize = protocolManager.GetPackedSize(KvOpcode::Exist, request);
+        status = sendBufferManager.Allocate(packedSize, subBatchContext.sendSge);
+        if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+        status = protocolManager.PackRequest(reinterpret_cast<void*>(subBatchContext.sendSge.addr),
+                                             KvOpcode::Exist, request);
+    }
+    if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+
+    subBatchContext.status = Status::OK();
+    return Status::OK();
+}
+
+Status SubmitKeepAliveRequest(const SqeCidAllocator& allocateSqeCid,
+                              BufferManager& sendBufferManager, BufferManager& flagBufferManager,
+                              ProtocolManager& protocolManager,
+                              TransportSubBatchContext& subBatchContext)
+{
+    subBatchContext.cid = NextSqeCid(allocateSqeCid);
+    subBatchContext.opType = TransportOpType::KEEP_ALIVE;
+    subBatchContext.state = TransportSubBatchState::PENDING;
+    subBatchContext.status = Status::OK();
+    subBatchContext.entryStatus = {Status::OK()};
+    auto status = AllocateSubBatchFlagBuffer(1, flagBufferManager, subBatchContext);
+    if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+    auto request = BuildKeepAliveRequest(subBatchContext.cid, subBatchContext.flagBuffer);
+    auto packedSize = protocolManager.GetPackedSize(KvOpcode::KeepAlive, request);
+    status = sendBufferManager.Allocate(packedSize, subBatchContext.sendSge);
+    if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+    status = protocolManager.PackRequest(reinterpret_cast<void*>(subBatchContext.sendSge.addr),
+                                         KvOpcode::KeepAlive, request);
+    if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+    subBatchContext.status = status;
+    return status;
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/sqe_request.h
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.h
@@ -1,0 +1,66 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include "asu_transport/types.h"
+#include "io_scheduler.h"
+#include "transport_task_manager.h"
+
+namespace UC::ASU {
+
+class BufferManager;
+class ProtocolManager;
+
+using SqeCidAllocator = std::function<std::uint16_t()>;
+
+Status ValidateSqeRequestAttrs(const std::unordered_map<std::string, std::string>& attrs);
+
+Status SubmitEntrySubBatchRequest(TransportOpType opType,
+                                  const IoScheduler::ScheduledIoBatch& subBatch,
+                                  const std::unordered_map<std::string, std::string>& attrs,
+                                  const SqeCidAllocator& allocateSqeCid,
+                                  BufferManager& sendBufferManager,
+                                  BufferManager& flagBufferManager,
+                                  ProtocolManager& protocolManager,
+                                  TransportSubBatchContext& subBatchContext);
+
+Status SubmitKeySubBatchRequest(TransportOpType opType,
+                                const IoScheduler::ScheduledKeyBatch& subBatch,
+                                const std::unordered_map<std::string, std::string>& attrs,
+                                const SqeCidAllocator& allocateSqeCid,
+                                BufferManager& sendBufferManager, BufferManager& flagBufferManager,
+                                ProtocolManager& protocolManager,
+                                TransportSubBatchContext& subBatchContext);
+
+Status SubmitKeepAliveRequest(const SqeCidAllocator& allocateSqeCid,
+                              BufferManager& sendBufferManager, BufferManager& flagBufferManager,
+                              ProtocolManager& protocolManager,
+                              TransportSubBatchContext& subBatchContext);
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
@@ -1,0 +1,233 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "asu_submit_flow.h"
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <unordered_map>
+#include <vector>
+#include "buffer_manager.h"
+#include "connection_internal.h"
+
+namespace UC::ASU {
+namespace {
+
+std::uint32_t g_kernelCount = 0;
+std::uint32_t g_quietCount = 0;
+std::vector<Status> g_sendStatuses;
+
+}  // namespace
+
+std::vector<Status> Send(const std::vector<SendIoBatch>& ioBatches, std::uint32_t kernelCount,
+                         std::uint32_t quietCount)
+{
+    g_kernelCount = kernelCount;
+    g_quietCount = quietCount;
+    if (!g_sendStatuses.empty()) { return g_sendStatuses; }
+    return std::vector<Status>(ioBatches.size(), Status::OK());
+}
+
+namespace {
+
+TEST(AsuSubmitFlowTest, SendSubBatchBuffersReadsSendCountsFromAttrs)
+{
+    g_kernelCount = 0;
+    g_quietCount = 0;
+    g_sendStatuses.clear();
+
+    std::unordered_map<std::string, std::string> attrs = {
+        {"kernel_count", "3"},
+        {"quiet_count",  "7"},
+    };
+
+    ScatterGatherEntry sge;
+    SendIoBatch ioBatch{nullptr, &sge};
+    std::vector<SendIoBatch> ioBatches = {ioBatch};
+    std::vector<std::size_t> subBatchIndexes = {0};
+
+    std::vector<TransportSubBatchContext> subBatchContexts(1);
+    subBatchContexts[0].state = TransportSubBatchState::PENDING;
+    subBatchContexts[0].entryStatus.assign(1, Status::OK());
+
+    ConnectionManager connManager;
+    const auto status =
+        SendSubBatchBuffers(subBatchContexts, ioBatches, subBatchIndexes, attrs, connManager);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(g_kernelCount, std::uint32_t{3});
+    EXPECT_EQ(g_quietCount, std::uint32_t{7});
+    EXPECT_EQ(subBatchContexts[0].state, TransportSubBatchState::PENDING);
+    EXPECT_TRUE(subBatchContexts[0].status.ok());
+}
+
+TEST(AsuSubmitFlowTest, SendSubBatchBuffersReportsSendFailures)
+{
+    g_sendStatuses = {
+        Status::Error(StatusCode::CONNECTION_ERROR, "fake send failure"),
+        Status::Error(StatusCode::CONNECTION_ERROR, "fake send failure"),
+    };
+
+    std::unordered_map<std::string, std::string> attrs = {
+        {"kernel_count", "3"},
+        {"quiet_count",  "7"},
+    };
+
+    ConnectionManager connManager;
+    ASSERT_TRUE(connManager.AddGroup(AsuEndpoint{}, 1).ok());
+    auto* channel0 = connManager.SelectConnection();
+    auto* channel1 = connManager.SelectConnection();
+    ASSERT_NE(channel0, nullptr);
+    ASSERT_EQ(channel0, channel1);
+
+    ScatterGatherEntry sge0;
+    ScatterGatherEntry sge1;
+    std::vector<SendIoBatch> ioBatches = {
+        SendIoBatch{channel0->GetNativeQp(), &sge0},
+        SendIoBatch{channel1->GetNativeQp(), &sge1},
+    };
+    std::vector<std::size_t> subBatchIndexes = {0, 1};
+
+    std::vector<TransportSubBatchContext> subBatchContexts(2);
+    subBatchContexts[0].state = TransportSubBatchState::PENDING;
+    subBatchContexts[0].channel = channel0;
+    subBatchContexts[0].entryStatus.assign(1, Status::OK());
+    subBatchContexts[1].state = TransportSubBatchState::PENDING;
+    subBatchContexts[1].channel = channel1;
+    subBatchContexts[1].entryStatus.assign(1, Status::OK());
+
+    const auto status =
+        SendSubBatchBuffers(subBatchContexts, ioBatches, subBatchIndexes, attrs, connManager);
+
+    EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
+    EXPECT_EQ(channel0->GetState(), ChannelState::DRAINING);
+    EXPECT_EQ(subBatchContexts[0].state, TransportSubBatchState::FAILED);
+    EXPECT_EQ(subBatchContexts[1].state, TransportSubBatchState::FAILED);
+    g_sendStatuses.clear();
+}
+
+TEST(AsuSubmitFlowTest, BuildSubBatchSendBuffersReleasesPreFailedSubBatches)
+{
+    BufferManager sendBufferManager;
+    BufferManager flagBufferManager;
+    ASSERT_TRUE(sendBufferManager.Init("test send buffer", MemoryType::HOST, 4096, 1).ok());
+    ASSERT_TRUE(flagBufferManager.Init("test flag buffer", MemoryType::HOST, 128, 1).ok());
+
+    std::vector<TransportSubBatchContext> subBatchContexts(1);
+    auto& subBatchContext = subBatchContexts[0];
+    subBatchContext.state = TransportSubBatchState::FAILED;
+    subBatchContext.status = Status::Error(StatusCode::INVALID_ARGUMENT, "pre-send failure");
+    subBatchContext.entryStatus.assign(1, subBatchContext.status);
+    ASSERT_TRUE(sendBufferManager.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(flagBufferManager.Allocate(64, subBatchContext.flagBuffer).ok());
+
+    std::vector<SendIoBatch> ioBatches;
+    std::vector<std::size_t> subBatchIndexes;
+    const auto status = BuildSubBatchSendBuffers(subBatchContexts, ioBatches, subBatchIndexes,
+                                                 sendBufferManager, flagBufferManager);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_TRUE(ioBatches.empty());
+    EXPECT_TRUE(subBatchIndexes.empty());
+    EXPECT_EQ(subBatchContext.sendSge.slot_index, UINT32_MAX);
+    EXPECT_EQ(subBatchContext.flagBuffer.slot_index, UINT32_MAX);
+    EXPECT_EQ(subBatchContext.sendSge.addr, std::uint64_t{0});
+    EXPECT_EQ(subBatchContext.flagBuffer.addr, std::uint64_t{0});
+}
+
+TEST(AsuSubmitFlowTest, BuildSubBatchSendBuffersMarksMissingFlagBufferFailed)
+{
+    BufferManager sendBufferManager;
+    BufferManager flagBufferManager;
+    ASSERT_TRUE(sendBufferManager.Init("test send buffer", MemoryType::HOST, 4096, 1).ok());
+    ASSERT_TRUE(flagBufferManager.Init("test flag buffer", MemoryType::HOST, 128, 1).ok());
+
+    ConnectionManager connManager;
+    ASSERT_TRUE(connManager.AddGroup(AsuEndpoint{}, 1).ok());
+    auto* channel = connManager.SelectConnection();
+    ASSERT_NE(channel, nullptr);
+    EXPECT_EQ(channel->GetInflightCount(), std::uint32_t{1});
+
+    std::vector<TransportSubBatchContext> subBatchContexts(1);
+    auto& subBatchContext = subBatchContexts[0];
+    subBatchContext.state = TransportSubBatchState::PENDING;
+    subBatchContext.channel = channel;
+    subBatchContext.entryStatus.assign(2, Status::OK());
+    ASSERT_TRUE(sendBufferManager.Allocate(64, subBatchContext.sendSge).ok());
+
+    std::vector<SendIoBatch> ioBatches;
+    std::vector<std::size_t> subBatchIndexes;
+    const auto status = BuildSubBatchSendBuffers(subBatchContexts, ioBatches, subBatchIndexes,
+                                                 sendBufferManager, flagBufferManager);
+
+    EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
+    EXPECT_TRUE(ioBatches.empty());
+    EXPECT_TRUE(subBatchIndexes.empty());
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::FAILED);
+    EXPECT_EQ(subBatchContext.status.code, StatusCode::NOT_INITIALIZED);
+    EXPECT_EQ(subBatchContext.channel, nullptr);
+    EXPECT_EQ(channel->GetInflightCount(), std::uint32_t{0});
+    EXPECT_EQ(subBatchContext.sendSge.slot_index, UINT32_MAX);
+    for (const auto& entryStatus : subBatchContext.entryStatus) {
+        EXPECT_EQ(entryStatus.code, StatusCode::NOT_INITIALIZED);
+    }
+}
+
+TEST(AsuSubmitFlowTest, SendSubBatchBuffersFailsAllSentSubBatchesWhenStatusCountMismatches)
+{
+    g_sendStatuses = {Status::OK()};
+
+    std::unordered_map<std::string, std::string> attrs = {
+        {"kernel_count", "3"},
+        {"quiet_count",  "7"},
+    };
+
+    ScatterGatherEntry sge0;
+    ScatterGatherEntry sge1;
+    std::vector<SendIoBatch> ioBatches = {
+        SendIoBatch{nullptr, &sge0},
+        SendIoBatch{nullptr, &sge1},
+    };
+    std::vector<std::size_t> subBatchIndexes = {0, 1};
+
+    std::vector<TransportSubBatchContext> subBatchContexts(2);
+    subBatchContexts[0].state = TransportSubBatchState::PENDING;
+    subBatchContexts[0].entryStatus.assign(1, Status::OK());
+    subBatchContexts[1].state = TransportSubBatchState::PENDING;
+    subBatchContexts[1].entryStatus.assign(1, Status::OK());
+
+    ConnectionManager connManager;
+    const auto status =
+        SendSubBatchBuffers(subBatchContexts, ioBatches, subBatchIndexes, attrs, connManager);
+
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(subBatchContexts[0].state, TransportSubBatchState::FAILED);
+    EXPECT_EQ(subBatchContexts[0].status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(subBatchContexts[0].entryStatus[0].code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(subBatchContexts[1].state, TransportSubBatchState::FAILED);
+    EXPECT_EQ(subBatchContexts[1].status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(subBatchContexts[1].entryStatus[0].code, StatusCode::INTERNAL_ERROR);
+    g_sendStatuses.clear();
+}
+
+}  // namespace
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
@@ -1,0 +1,271 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "sqe_request.h"
+#include <acl/acl.h>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "buffer_manager.h"
+#include "kv_protocol.h"
+
+namespace UC::ASU {
+
+namespace {
+
+constexpr std::size_t kFlagBufferHeaderSize = 16;
+constexpr std::size_t kTestSendBufferSlotSize = 4096;
+constexpr std::size_t kTestSendBufferSlotNum = 1;
+constexpr std::size_t kFlagBufferSlotSize = 128;
+constexpr std::size_t kFlagBufferSlotNum = 16;
+
+std::unordered_map<std::string, std::string> DefaultAttrs()
+{
+    return {
+        {"kv_ns_id",     "3"   },
+        {"dtype",        "2"   },
+        {"dspec",        "10"  },
+        {"lr",           "true"},
+        {"sc",           "true"},
+        {"kernel_count", "1"   },
+        {"quiet_count",  "5"   },
+    };
+}
+
+std::vector<KVBuffer> MakeEntries(std::size_t count)
+{
+    std::vector<KVBuffer> entries(count);
+    for (std::size_t index = 0; index < count; ++index) {
+        entries[index].key = "key_" + std::to_string(index);
+        entries[index].buffer.region.addr = 0x100000 + index * 0x1000;
+        entries[index].buffer.region.size = 4096;
+        entries[index].buffer.handle = 0x20 + index;
+    }
+    return entries;
+}
+
+}  // namespace
+
+class SqeRequestTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        aclInit(nullptr);
+        aclrtSetDevice(0);
+    }
+
+    static void TearDownTestSuite()
+    {
+        aclrtResetDevice(0);
+        aclFinalize();
+    }
+
+    void SetUp() override
+    {
+        auto status = flagBufferManager_.Init("test flag buffer", MemoryType::HOST,
+                                              kFlagBufferSlotSize, kFlagBufferSlotNum);
+        ASSERT_TRUE(status.ok()) << status.message;
+        status = sendBufferManager_.Init("test send buffer", MemoryType::HOST,
+                                         kTestSendBufferSlotSize, kTestSendBufferSlotNum);
+        ASSERT_TRUE(status.ok()) << status.message;
+        protocolManager_ = std::make_unique<ProtocolManager>();
+    }
+
+    BufferManager sendBufferManager_;
+    BufferManager flagBufferManager_;
+    std::unique_ptr<ProtocolManager> protocolManager_;
+};
+
+TEST_F(SqeRequestTest, ValidateSqeRequestAttrsRejectsMalformedValues)
+{
+    EXPECT_TRUE(ValidateSqeRequestAttrs(DefaultAttrs()).ok());
+
+    auto attrs = DefaultAttrs();
+    attrs["dtype"] = "256";
+    EXPECT_EQ(ValidateSqeRequestAttrs(attrs).code, StatusCode::INVALID_ARGUMENT);
+
+    attrs = DefaultAttrs();
+    attrs["lr"] = "maybe";
+    EXPECT_EQ(ValidateSqeRequestAttrs(attrs).code, StatusCode::INVALID_ARGUMENT);
+
+    attrs = DefaultAttrs();
+    attrs.erase("kernel_count");
+    EXPECT_EQ(ValidateSqeRequestAttrs(attrs).code, StatusCode::INVALID_ARGUMENT);
+
+    attrs = DefaultAttrs();
+    attrs["quiet_count"] = "0";
+    EXPECT_EQ(ValidateSqeRequestAttrs(attrs).code, StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(SqeRequestTest, SubmitBatchStoreAllocatesFlagBufferAndBuildsRequest)
+{
+    auto entries = MakeEntries(3);
+    IoScheduler::ScheduledIoBatch subBatch{
+        BatchView<KVBuffer>{entries.data(), entries.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+    std::uint16_t nextCid = 41;
+
+    const auto status = SubmitEntrySubBatchRequest(
+        TransportOpType::BATCH_STORE, subBatch, DefaultAttrs(), [&nextCid] { return nextCid++; },
+        sendBufferManager_, flagBufferManager_, *protocolManager_, subBatchContext);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.flagBuffer.length, kFlagBufferHeaderSize + (entries.size() + 1) / 2);
+    EXPECT_EQ(subBatchContext.cid, std::uint32_t{41});
+    EXPECT_EQ(subBatchContext.opType, TransportOpType::BATCH_STORE);
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
+    EXPECT_TRUE(subBatchContext.status.ok());
+    EXPECT_NE(subBatchContext.sendSge.addr, std::uint64_t{0});
+    ASSERT_EQ(subBatchContext.entryStatus.size(), entries.size());
+    for (const auto& entryStatus : subBatchContext.entryStatus) { EXPECT_TRUE(entryStatus.ok()); }
+}
+
+TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
+{
+    auto entries = MakeEntries(2);
+    IoScheduler::ScheduledIoBatch subBatch{
+        BatchView<KVBuffer>{entries.data(), entries.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+
+    const auto status = SubmitEntrySubBatchRequest(
+        TransportOpType::BATCH_LOAD, subBatch, DefaultAttrs(), [] { return std::uint16_t{9}; },
+        sendBufferManager_, flagBufferManager_, *protocolManager_, subBatchContext);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.opType, TransportOpType::BATCH_LOAD);
+    EXPECT_EQ(subBatchContext.cid, std::uint16_t{9});
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
+    EXPECT_TRUE(subBatchContext.status.ok());
+    EXPECT_NE(subBatchContext.sendSge.addr, std::uint64_t{0});
+}
+
+TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)
+{
+    std::vector<CacheKey> keys = {"k0", "k1"};
+    IoScheduler::ScheduledKeyBatch subBatch{
+        BatchView<CacheKey>{keys.data(), keys.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+
+    const auto status = SubmitKeySubBatchRequest(
+        TransportOpType::DELETE, subBatch, DefaultAttrs(), [] { return std::uint16_t{55}; },
+        sendBufferManager_, flagBufferManager_, *protocolManager_, subBatchContext);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.opType, TransportOpType::DELETE);
+    EXPECT_EQ(subBatchContext.cid, std::uint16_t{55});
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
+    EXPECT_TRUE(subBatchContext.status.ok());
+    EXPECT_NE(subBatchContext.sendSge.addr, std::uint64_t{0});
+    ASSERT_EQ(subBatchContext.entryStatus.size(), keys.size());
+    for (const auto& entryStatus : subBatchContext.entryStatus) { EXPECT_TRUE(entryStatus.ok()); }
+}
+
+TEST_F(SqeRequestTest, SubmitExistReadsScAttribute)
+{
+    std::vector<CacheKey> keys = {"k0"};
+    IoScheduler::ScheduledKeyBatch subBatch{
+        BatchView<CacheKey>{keys.data(), keys.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+
+    const auto status = SubmitKeySubBatchRequest(
+        TransportOpType::QUERY, subBatch, DefaultAttrs(), [] { return std::uint16_t{13}; },
+        sendBufferManager_, flagBufferManager_, *protocolManager_, subBatchContext);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.opType, TransportOpType::QUERY);
+    EXPECT_EQ(subBatchContext.cid, std::uint16_t{13});
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
+    EXPECT_TRUE(subBatchContext.status.ok());
+    EXPECT_TRUE(subBatchContext.useSeekControl);
+}
+
+TEST_F(SqeRequestTest, SubmitExistDisablesSeekControlWhenScDisabled)
+{
+    auto attrs = DefaultAttrs();
+    attrs["sc"] = "false";
+
+    std::vector<CacheKey> keys = {"k0"};
+    IoScheduler::ScheduledKeyBatch subBatch{
+        BatchView<CacheKey>{keys.data(), keys.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+
+    const auto status = SubmitKeySubBatchRequest(
+        TransportOpType::QUERY, subBatch, attrs, [] { return std::uint16_t{13}; },
+        sendBufferManager_, flagBufferManager_, *protocolManager_, subBatchContext);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_FALSE(subBatchContext.useSeekControl);
+}
+
+TEST_F(SqeRequestTest, AllocationFailureMarksWholeSubBatchFailed)
+{
+    auto entries = MakeEntries(2);
+    IoScheduler::ScheduledIoBatch subBatch{
+        BatchView<KVBuffer>{entries.data(), entries.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+    BufferManager uninitializedFlagBufferManager;
+
+    const auto status = SubmitEntrySubBatchRequest(
+        TransportOpType::BATCH_STORE, subBatch, DefaultAttrs(), [] { return std::uint16_t{3}; },
+        sendBufferManager_, uninitializedFlagBufferManager, *protocolManager_, subBatchContext);
+
+    EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::FAILED);
+    EXPECT_EQ(subBatchContext.status.code, StatusCode::NOT_INITIALIZED);
+    EXPECT_EQ(subBatchContext.flagBuffer.addr, std::uint64_t{0});
+    EXPECT_EQ(subBatchContext.sendSge.addr, std::uint64_t{0});
+    ASSERT_EQ(subBatchContext.entryStatus.size(), entries.size());
+    for (const auto& entryStatus : subBatchContext.entryStatus) {
+        EXPECT_EQ(entryStatus.code, StatusCode::NOT_INITIALIZED);
+    }
+}
+
+TEST_F(SqeRequestTest, SubmitKeepAliveBuildsFlagBackedRequest)
+{
+    TransportSubBatchContext subBatchContext;
+
+    const auto status =
+        SubmitKeepAliveRequest([] { return std::uint16_t{77}; }, sendBufferManager_,
+                               flagBufferManager_, *protocolManager_, subBatchContext);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.cid, std::uint16_t{77});
+    EXPECT_EQ(subBatchContext.opType, TransportOpType::KEEP_ALIVE);
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
+    EXPECT_TRUE(subBatchContext.status.ok());
+    EXPECT_EQ(subBatchContext.flagBuffer.length, kFlagBufferHeaderSize + 1);
+    EXPECT_NE(subBatchContext.sendSge.addr, std::uint64_t{0});
+    ASSERT_EQ(subBatchContext.entryStatus.size(), 1);
+    EXPECT_TRUE(subBatchContext.entryStatus[0].ok());
+}
+
+}  // namespace UC::ASU


### PR DESCRIPTION
## Purpose
Implement ASU SQE request construction and submit-flow handling for creating sub-batch requests, preparing send buffers, sending through configured ASU connections, and propagating send failures.

## Modifications
Add SQE request builders for BatchStore, BatchRetrieve, Delete, Exist, and KeepAlive operations.
Add transport attr validation for kv_ns_id, dtype, dspec, lr, sc, kernel_count, and quiet_count before request submission.
Allocate response flag buffers and populate response buffer address/MR key fields for SQE requests.
Pack SQE requests through ProtocolManager and store send SGE/flag buffer metadata in TransportSubBatchContext.
Add submit-flow logic to create sub-batch requests from scheduled IO/key batches.
Add send-buffer preparation and Send invocation using configured kernel_count and quiet_count attrs.
Propagate request-build and send failures to sub-batch status and per-entry status.

## Test
Added SqeRequestTest and AsuSubmitFlowTest for request validation, SQE construction, sub-batch submission, send-buffer preparation, send attr handling, and failure propagation.