### PR TITLE
[Bugfix] fix dump error when load failure

### DIFF
--- a/ucm/integration/vllm/patch/apply_patch.py
+++ b/ucm/integration/vllm/patch/apply_patch.py
@@ -153,6 +153,11 @@ def apply_all_patches() -> None:
             case _:
                 pass
 
+        major, minor, *_ = version.split(".")
+        if (int(major), int(minor)) >= (0, 21):
+            logger.info("UCM patching vllm for load-failure recovery...")
+            import ucm.integration.vllm.patch.load_failure_patch
+
         # vllm_ascend patches
         ascend_version = get_vllm_ascend_version()
         match ascend_version:

--- a/ucm/integration/vllm/patch/load_failure_patch.py
+++ b/ucm/integration/vllm/patch/load_failure_patch.py
@@ -1,0 +1,32 @@
+﻿from ucm.integration.vllm.patch.utils import patch_or_inject, when_imported
+
+
+@when_imported("vllm.v1.core.sched.scheduler")
+def patch_core_sched_scheduler(mod):
+    """Wrap Scheduler._update_requests_with_invalid_blocks for KV load-failure
+    recovery. Delegates to each version's own implementation, then applies
+    UCM-specific post-processing."""
+
+    # Capture the original method if it exists; use UCM fallback otherwise.
+    original = getattr(mod.Scheduler, "_update_requests_with_invalid_blocks", None)
+
+    if original is not None:
+
+        def wrapped_update(self, requests, *args, **kwargs):
+            # Delegate to the version-specific implementation
+            result = original(self, requests, *args, **kwargs)
+
+            # UCM post-processing: track requests with KV load failures
+            if result:
+                affected_req_ids = result[0]
+                for request in requests:
+                    if request.request_id in affected_req_ids:
+                        request.num_output_placeholders = 0
+
+            return result
+
+        patch_or_inject(
+            mod.Scheduler,
+            "_update_requests_with_invalid_blocks",
+            wrapped_update,
+        )

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -17,6 +17,14 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
     SupportsHMA,
 )
+
+try:
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+        KVConnectorWorkerMetadata,
+    )
+except ImportError:
+    KVConnectorWorkerMetadata = object
+
 from vllm.distributed.parallel_state import get_world_group
 from vllm.model_executor.models.utils import extract_layer_index
 from vllm.platforms import current_platform
@@ -270,6 +278,26 @@ class RequestHasher:
         return h.digest()
 
 
+@dataclass
+class UCMWorkerMetadata(KVConnectorWorkerMetadata):
+    """Worker -> Scheduler metadata for tracking failed load requests.
+
+    This class stores and aggregates IDs of load requests that failed on the worker.
+    """
+
+    load_failed_reqs: set[str] = field(default_factory=set)
+
+    def mark_failed(self, req_id: str) -> None:
+        """Record a failed load request from this worker."""
+        self.load_failed_reqs.add(req_id)
+
+    def aggregate(self, other: Any) -> Any:
+        assert isinstance(other, UCMWorkerMetadata)
+
+        self.load_failed_reqs.update(other.load_failed_reqs)
+        return self
+
+
 class UCMDirectConnector(KVConnectorBase_V1):
     """
     This connector means synchronize:
@@ -355,6 +383,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
             self.request_hasher = RequestHasher(
                 vllm_config, self.tp_rank % self.tp_size
             )
+            self._connector_worker_meta = UCMWorkerMetadata()
 
         metrics_config = self.launch_config.get("metrics_config_path", "")
         if metrics_config:
@@ -692,19 +721,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
                         resumed_from_preemption = (
                             request_id in scheduled_cached_reqs.resumed_req_ids
                         )
-                    if (
-                        scheduled_cached_reqs.num_computed_tokens[i]
-                        < req_meta.token_processed
-                        and not resumed_from_preemption
-                    ):
-                        logger.warning(
-                            f"Request {request_id} has fewer computed tokens "
-                            f"({scheduled_cached_reqs.num_computed_tokens[i]}) than previously processed "
-                            f"tokens ({req_meta.token_processed}), "
-                            f"skipping caching."
-                        )
-                        self.requests_meta.pop(request_id, None)
-                        continue
                     requests_dispatch_meta[request_id] = self._generate_dispatch_meta(
                         req_meta,
                         scheduler_output.num_scheduled_tokens[request_id],
@@ -775,6 +791,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
                 self._invalid_block_ids.update(
                     metadata.request_meta[request_id].load_block_ids[1]
                 )
+                self._connector_worker_meta.mark_failed(request_id)
                 num_loaded_block -= len(ucm_block_ids)
 
         for request_id, task in request_to_task.items():
@@ -787,6 +804,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
                 self._invalid_block_ids.update(
                     metadata.request_meta[request_id].load_block_ids[1]
                 )
+                self._connector_worker_meta.mark_failed(request_id)
                 num_loaded_block -= request_to_load_blocks.get(request_id, 0)
 
         load_end_time = time.perf_counter() * 1000
@@ -916,6 +934,24 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self._invalid_block_ids = set()
         return res
 
+    def build_connector_worker_meta(self) -> UCMWorkerMetadata | None:
+        """Return load failed request IDs since the last call."""
+        if not self._connector_worker_meta.load_failed_reqs:
+            return None
+        meta = self._connector_worker_meta
+        self._connector_worker_meta = UCMWorkerMetadata()
+        return meta
+
+    def update_connector_output(self, connector_output: KVConnectorOutput):
+        meta = getattr(connector_output, "kv_connector_worker_meta", None)
+        if meta is None:
+            return
+        if not isinstance(meta, UCMWorkerMetadata):
+            return
+        for req_id in meta.load_failed_reqs:
+            logger.info(f"Request {req_id} failed to load, skip caching.")
+            self.requests_meta.pop(req_id, None)
+
     def request_finished_all_groups(
         self,
         request: "Request",
@@ -974,6 +1010,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                     metadata.request_meta[request_id].load_block_ids[1]
                 )
                 self._failure_req_ids.add(request_id)
+                self._connector_worker_meta.mark_failed(request_id)
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         self._layerwise_batch_start = time.perf_counter()
@@ -1037,6 +1074,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                 self._invalid_block_ids.update(
                     metadata.request_meta[request_id].load_block_ids[1]
                 )
+                self._connector_worker_meta.mark_failed(request_id)
                 self._failure_req_ids.add(request_id)
 
         wait_end = time.perf_counter()

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -544,16 +544,17 @@ class UCMDirectConnector(KVConnectorBase_V1):
             return 0, False
 
         external_block_ids = ucm_block_ids[hbm_hit_block_num * self.cp_world_size :]
-        if not external_block_ids:
-            return 0, False
-        try:
-            external_hit_blocks = self.store.lookup_on_prefix(external_block_ids) + 1
-            external_hit_blocks //= self.cp_world_size
-        except Exception as e:
-            external_hit_blocks = 0
-            logger.error(
-                f"request {request.request_id} look up error. {type(e).__name__}: {e}"
-            )
+        external_hit_blocks = 0
+        if external_block_ids:
+            try:
+                external_hit_blocks = (
+                    self.store.lookup_on_prefix(external_block_ids) + 1
+                )
+                external_hit_blocks //= self.cp_world_size
+            except Exception as e:
+                logger.error(
+                    f"request {request.request_id} look up error. {type(e).__name__}: {e}"
+                )
 
         logger.info_once(
             f"request_id: {request.request_id}, "
@@ -561,6 +562,10 @@ class UCMDirectConnector(KVConnectorBase_V1):
             f"hit hbm: {hbm_hit_block_num * self.cp_world_size}, "
             f"hit external: {external_hit_blocks * self.cp_world_size}"
         )
+
+        if not external_block_ids:
+            return 0, False
+
         ucmmetrics.update_stats(
             {
                 "interval_lookup_hit_rates": external_hit_blocks
@@ -637,6 +642,14 @@ class UCMDirectConnector(KVConnectorBase_V1):
             ]
             dump_vllm_block_ids = req_meta.vllm_block_ids[start_idx:end_idx]
             req_meta.token_processed += new_tokens
+            if req_meta.token_processed > req_meta.num_token_ids:
+                logger.warning(
+                    f"Processed tokens "
+                    f"({req_meta.token_processed}) exceed total tokens "
+                    f"({req_meta.num_token_ids}). Truncating dump_vllm_block_ids "
+                    f"to the length of dump_ucm_block_ids."
+                )
+                dump_vllm_block_ids = dump_vllm_block_ids[: len(dump_ucm_block_ids)]
 
         return RequestDispatchMeta(
             (load_ucm_block_ids, load_vllm_block_ids),
@@ -679,6 +692,19 @@ class UCMDirectConnector(KVConnectorBase_V1):
                         resumed_from_preemption = (
                             request_id in scheduled_cached_reqs.resumed_req_ids
                         )
+                    if (
+                        scheduled_cached_reqs.num_computed_tokens[i]
+                        < req_meta.token_processed
+                        and not resumed_from_preemption
+                    ):
+                        logger.warning(
+                            f"Request {request_id} has fewer computed tokens "
+                            f"({scheduled_cached_reqs.num_computed_tokens[i]}) than previously processed "
+                            f"tokens ({req_meta.token_processed}), "
+                            f"skipping caching."
+                        )
+                        self.requests_meta.pop(request_id, None)
+                        continue
                     requests_dispatch_meta[request_id] = self._generate_dispatch_meta(
                         req_meta,
                         scheduler_output.num_scheduled_tokens[request_id],
@@ -942,7 +968,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                 self.load_tasks[layer_id][request_id] = task
             except Exception as e:
                 logger.error(
-                    f"request {request_id} submit load task error. {type(e).__name__}: {e}"
+                    f"request {request_id} submit load task for layer {layer_id} error. {type(e).__name__}: {e}"
                 )
                 self._invalid_block_ids.update(
                     metadata.request_meta[request_id].load_block_ids[1]
@@ -1082,7 +1108,9 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                 )
                 self.dump_tasks[layer_name] = task
             except Exception as e:
-                logger.error(f"submit dump task failed. {type(e).__name__}: {e}")
+                logger.error(
+                    f"submit dump task for {layer_name} failed. {type(e).__name__}: {e}"
+                )
         if self.is_save:
             submit_end = time.perf_counter()
             ucmmetrics.update_stats(


### PR DESCRIPTION
## Purpose
Fix dump error (invalid dims, ucm blocks > vllm blocks) triggered on load failure, add more logs to help locate problems. For ucm, when load failure occurs, it would start recomputing which made _request.num_computed_tokens = 0_ while processed_tokens remains. 
## Modifications 

- Add logs and condition check in ucm_connector.py, skip caching when load failure happens 
-- Add _update_connector_output_ and _build_connector_worker_meta_ for getting workers' load failed req ids
- Add file ucm/integration/vllm/patch/load_failure_patch.py to solve the problem that load failed requests can't finish, issue: https://github.com/vllm-project/vllm/issues/45138

## Test
Setting max_num_batched_tokens = 256 and kv_load_failure_policy = recompute, checking whether dump error occurs, tested with vllm 0.17.0 0.18.0 and 0.21.0 version
1. Send a short prompt (3 blocks)
2. Delete a saved file
3. Sending a long prompt (3 + 4) 

--kv-transfer-config like below
```
--kv-transfer-config {
            "kv_connector":"UCMConnector",
            "kv_connector_module_path":"ucm.integration.vllm.ucm_connector",
            "kv_role":"kv_both",
            "kv_connector_extra_config":{
                "UCM_CONFIG_FILE":"/vllm-workspace/unified-cache-management/examples/ucm_config_example.yaml"
            },
            "kv_load_failure_policy": "recompute"
        }
```