### PR TITLE
[Bugfix] Fix ASU SQE flag buffer calculation, send buffer default slots, and add debug/error logs.

### DIFF
--- a/ucm/transport/kv/asu/client/src/client_config_parser.cpp
+++ b/ucm/transport/kv/asu/client/src/client_config_parser.cpp
@@ -29,6 +29,7 @@
 #include <utility>
 #include <vector>
 #include "asu_client/asu_client.h"
+#include "config_parser_common.h"
 #include "status_utils.h"
 #include "view_server.h"
 

--- a/ucm/transport/kv/asu/client/src/view_server.cpp
+++ b/ucm/transport/kv/asu/client/src/view_server.cpp
@@ -26,6 +26,7 @@
 #include <fstream>
 #include <utility>
 #include "asu_client/asu_client.h"
+#include "config_parser_common.h"
 #include "status_utils.h"
 
 namespace UC::ASU {

--- a/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
@@ -70,8 +70,8 @@ struct TransportConfig {
     bool preconnect{true};
     bool bindCqPoller{true};
 
-    std::size_t sendBufferSlotSize{4096};
-    std::size_t sendBufferSlotNum{1};
+    std::size_t sendBufferSlotSize{4160};
+    std::size_t sendBufferSlotNum{128};
     std::size_t flagBufferSlotSize{128};
     std::size_t flagBufferSlotNum{4096};
     std::size_t asuBatchLoadIoNum{110};

--- a/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
@@ -26,6 +26,7 @@
 #include <utility>
 #include "asu_transport_impl.h"
 #include "connection_internal.h"
+#include "logger.h"
 
 namespace UC::ASU {
 
@@ -54,28 +55,44 @@ Status AsuTransportImpl::SubmitTaskRequests(const TransportTaskContext& ctx,
     if (IsEntryBatchOp(ctx.opType)) {
         const auto subBatches = ioScheduler_.SplitForAsu(ctx.entries, ctx.opType);
         subBatchContexts.reserve(subBatches.size());
-        for (const auto& subBatch : subBatches) {
+        for (std::size_t index = 0; index < subBatches.size(); ++index) {
+            const auto& subBatch = subBatches[index];
             auto& subBatchContext = subBatchContexts.emplace_back();
             auto status = SubmitEntrySubBatchRequest(ctx.opType, subBatch, subBatchContext);
             subBatchContext.status = status;
-            if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+            if (!status.ok()) {
+                UC_ERROR("Submit entry sub-batch failed index={} batch_size={} code={} message={}",
+                         index, subBatch.entries.size, static_cast<int>(status.code),
+                         status.message);
+                if (finalStatus.ok()) { finalStatus = status; }
+            }
         }
     } else if (IsKeyBatchOp(ctx.opType)) {
         const auto subBatches = ioScheduler_.SplitForAsu(ctx.keys, ctx.opType);
         subBatchContexts.reserve(subBatches.size());
-        for (const auto& subBatch : subBatches) {
+        for (std::size_t index = 0; index < subBatches.size(); ++index) {
+            const auto& subBatch = subBatches[index];
             auto& subBatchContext = subBatchContexts.emplace_back();
             auto status = SubmitKeySubBatchRequest(ctx.opType, subBatch, subBatchContext);
             subBatchContext.status = status;
-            if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+            if (!status.ok()) {
+                UC_ERROR("Submit key sub-batch failed index={} batch_size={} code={} message={}",
+                         index, subBatch.keys.size, static_cast<int>(status.code), status.message);
+                if (finalStatus.ok()) { finalStatus = status; }
+            }
         }
     } else if (IsKeepAliveOp(ctx.opType)) {
         auto& subBatchContext = subBatchContexts.emplace_back();
         auto status = SubmitKeepAliveRequest(subBatchContext);
         subBatchContext.status = status;
-        if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+        if (!status.ok()) {
+            UC_ERROR("Submit keep-alive request failed code={} message={}",
+                     static_cast<int>(status.code), status.message);
+            if (finalStatus.ok()) { finalStatus = status; }
+        }
     } else {
         finalStatus = Status::Error(StatusCode::UNSUPPORTED, "transport operation is unsupported");
+        UC_ERROR("Unsupported transport operation op_type={}", static_cast<int>(ctx.opType));
     }
     return finalStatus;
 }
@@ -91,6 +108,9 @@ Status AsuTransportImpl::BuildSubBatchSendBuffers(
     for (std::size_t index = 0; index < subBatchContexts.size(); ++index) {
         auto& subBatchContext = subBatchContexts[index];
         if (!subBatchContext.status.ok()) {
+            UC_ERROR("Skip sub-batch before send index={} cid={} code={} message={}", index,
+                     subBatchContext.cid, static_cast<int>(subBatchContext.status.code),
+                     subBatchContext.status.message);
             if (finalStatus.ok()) {
                 finalStatus = Status::Error(StatusCode::PARTIAL_FAILED,
                                             "one or more sub-batches failed before send");
@@ -102,6 +122,10 @@ Status AsuTransportImpl::BuildSubBatchSendBuffers(
         if (subBatchContext.flagBuffer.addr == 0 || subBatchContext.flagBuffer.length == 0) {
             const auto status =
                 Status::Error(StatusCode::NOT_INITIALIZED, "sub-batch flag buffer is not ready");
+            UC_ERROR(
+                "Sub-batch flag buffer is not ready index={} cid={} flag_addr={} flag_length={}",
+                index, subBatchContext.cid, subBatchContext.flagBuffer.addr,
+                subBatchContext.flagBuffer.length);
             SetSubBatchSendFailed(subBatchContext, status);
             if (finalStatus.ok()) { finalStatus = status; }
             ReleaseSubBatchResources(subBatchContext);
@@ -130,6 +154,8 @@ Status AsuTransportImpl::SendSubBatchBuffers(
     if (sendStatuses.size() != ioBatches.size()) {
         const auto status = Status::Error(StatusCode::INTERNAL_ERROR,
                                           "transport send returned unexpected status count");
+        UC_ERROR("Transport send returned unexpected status count expected={} actual={}",
+                 ioBatches.size(), sendStatuses.size());
         for (auto index : subBatchIndexes) {
             auto& subBatchContext = subBatchContexts[index];
             SetSubBatchSendFailed(subBatchContext, status);
@@ -142,6 +168,9 @@ Status AsuTransportImpl::SendSubBatchBuffers(
         const auto& status = sendStatuses[index];
         if (status.ok()) { continue; }
 
+        UC_ERROR("Send sub-batch failed sub_batch_index={} cid={} code={} message={}",
+                 subBatchIndexes[index], subBatchContext.cid, static_cast<int>(status.code),
+                 status.message);
         SetSubBatchSendFailed(subBatchContext, status);
         connManager_.ReportFailure(subBatchContext.channel);
         if (finalStatus.ok()) { finalStatus = status; }

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -335,9 +335,13 @@ Status AsuTransportImpl::AssignSubBatchConnections(
 
 void AsuTransportImpl::ProcessTask(const TransportTaskContextPtr& ctx)
 {
+    UC_DEBUG("AsuTransportImpl::ProcessTask start task_id={} op_type={} entries={} keys={}",
+             ctx->taskId, static_cast<int>(ctx->opType), ctx->entries.size, ctx->keys.size);
     TransportTaskState expected = TransportTaskState::PENDING;
     if (!ctx->state.compare_exchange_strong(expected, TransportTaskState::INFLIGHT,
                                             std::memory_order_acq_rel)) {
+        UC_DEBUG("AsuTransportImpl::ProcessTask skip task_id={} current_state={}", ctx->taskId,
+                 static_cast<int>(ctx->state.load(std::memory_order_acquire)));
         if (ctx->state.load(std::memory_order_acquire) == TransportTaskState::CANCELED) {
             ctx->cv.notify_all();
         }
@@ -346,19 +350,58 @@ void AsuTransportImpl::ProcessTask(const TransportTaskContextPtr& ctx)
 
     std::vector<TransportSubBatchContext> subBatchContexts;
     auto finalStatus = SubmitTaskRequests(*ctx, subBatchContexts);
+    UC_DEBUG(
+        "AsuTransportImpl::ProcessTask submit done task_id={} sub_batches={} code={} "
+        "message={}",
+        ctx->taskId, subBatchContexts.size(), static_cast<int>(finalStatus.code),
+        finalStatus.message);
+    if (!finalStatus.ok()) {
+        UC_ERROR("AsuTransportImpl::ProcessTask submit failed task_id={} code={} message={}",
+                 ctx->taskId, static_cast<int>(finalStatus.code), finalStatus.message);
+    }
+
     auto connectionStatus = AssignSubBatchConnections(subBatchContexts);
-    if (!connectionStatus.ok() && finalStatus.ok()) { finalStatus = connectionStatus; }
+    UC_DEBUG(
+        "AsuTransportImpl::ProcessTask assign connections done task_id={} code={} "
+        "message={}",
+        ctx->taskId, static_cast<int>(connectionStatus.code), connectionStatus.message);
+    if (!connectionStatus.ok()) {
+        UC_ERROR(
+            "AsuTransportImpl::ProcessTask assign connections failed task_id={} code={} "
+            "message={}",
+            ctx->taskId, static_cast<int>(connectionStatus.code), connectionStatus.message);
+        if (finalStatus.ok()) { finalStatus = connectionStatus; }
+    }
 
     std::vector<SendIoBatch> ioBatches;
     std::vector<std::size_t> subBatchIndexes;
     auto buildStatus = BuildSubBatchSendBuffers(subBatchContexts, ioBatches, subBatchIndexes);
-    if (!buildStatus.ok() && finalStatus.ok()) { finalStatus = buildStatus; }
+    UC_DEBUG(
+        "AsuTransportImpl::ProcessTask build send buffers done task_id={} io_batches={} "
+        "send_indexes={} code={} message={}",
+        ctx->taskId, ioBatches.size(), subBatchIndexes.size(), static_cast<int>(buildStatus.code),
+        buildStatus.message);
+    if (!buildStatus.ok()) {
+        UC_ERROR(
+            "AsuTransportImpl::ProcessTask build send buffers failed task_id={} code={} "
+            "message={}",
+            ctx->taskId, static_cast<int>(buildStatus.code), buildStatus.message);
+        if (finalStatus.ok()) { finalStatus = buildStatus; }
+    }
 
     auto sendStatus = SendSubBatchBuffers(subBatchContexts, ioBatches, subBatchIndexes);
-    if (!sendStatus.ok() && finalStatus.ok()) { finalStatus = sendStatus; }
+    UC_DEBUG("AsuTransportImpl::ProcessTask send done task_id={} code={} message={}", ctx->taskId,
+             static_cast<int>(sendStatus.code), sendStatus.message);
+    if (!sendStatus.ok()) {
+        UC_ERROR("AsuTransportImpl::ProcessTask send failed task_id={} code={} message={}",
+                 ctx->taskId, static_cast<int>(sendStatus.code), sendStatus.message);
+        if (finalStatus.ok()) { finalStatus = sendStatus; }
+    }
 
     std::lock_guard<std::mutex> lock(ctx->waitMu);
     if (ctx->state.load(std::memory_order_acquire) == TransportTaskState::CANCELED) {
+        UC_DEBUG("AsuTransportImpl::ProcessTask canceled after send task_id={} sub_batches={}",
+                 ctx->taskId, subBatchContexts.size());
         ReleaseAllSubBatchResources(subBatchContexts);
         ctx->cv.notify_all();
         return;
@@ -368,12 +411,25 @@ void AsuTransportImpl::ProcessTask(const TransportTaskContextPtr& ctx)
     ctx->finalStatus = finalStatus;
     ctx->InitializeTerminalSubBatchCount();
     ctx->TryFinalizeFromSubBatches();
+    UC_DEBUG(
+        "AsuTransportImpl::ProcessTask context updated task_id={} stored_sub_batches={} "
+        "done={} final_code={} message={}",
+        ctx->taskId, ctx->subBatchContexts.size(), ctx->Done(),
+        static_cast<int>(ctx->finalStatus.code), ctx->finalStatus.message);
 
     for (auto& subBatchContext : ctx->subBatchContexts) {
         if (subBatchContext.status.ok()) { continue; }
+        UC_DEBUG(
+            "AsuTransportImpl::ProcessTask release failed sub-batch task_id={} cid={} "
+            "code={} message={}",
+            ctx->taskId, subBatchContext.cid, static_cast<int>(subBatchContext.status.code),
+            subBatchContext.status.message);
         ReleaseSubBatchResources(subBatchContext);
     }
-    if (ctx->Done()) { ctx->cv.notify_all(); }
+    if (ctx->Done()) {
+        UC_DEBUG("AsuTransportImpl::ProcessTask notify done task_id={}", ctx->taskId);
+        ctx->cv.notify_all();
+    }
 }
 
 void AsuTransportImpl::PollTaskCompletions(const TransportTaskContextPtr& ctx)

--- a/ucm/transport/kv/asu/trans/src/sqe_request.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.cpp
@@ -33,6 +33,7 @@
 #include "buffer_manager.h"
 #include "connection_manager.h"
 #include "kv_protocol.h"
+#include "logger.h"
 
 namespace UC::ASU {
 
@@ -68,17 +69,29 @@ T GetTransportConfigAttr(const std::unordered_map<std::string, std::string>& att
     }
 }
 
-std::size_t GetFlagBufferSize(std::size_t batchNum)
+std::size_t GetFlagBufferSize(KvOpcode opcode, std::size_t batchNum)
 {
-    return kFlagBufferHeaderSize + (batchNum + 1) / 2;
+    switch (opcode) {
+        case KvOpcode::BatchStore:
+        case KvOpcode::BatchRetrieve: return kFlagBufferHeaderSize + (batchNum + 1) / 2;
+        case KvOpcode::Delete:
+        case KvOpcode::Exist: return kFlagBufferHeaderSize + (batchNum + 7) / 8;
+        default: return kFlagBufferHeaderSize + 1;
+    }
 }
 
-Status AllocateSubBatchFlagBuffer(std::size_t batchNum, BufferManager& flagBufferManager,
+Status AllocateSubBatchFlagBuffer(KvOpcode opcode, std::size_t batchNum,
+                                  BufferManager& flagBufferManager,
                                   TransportSubBatchContext& subBatchContext)
 {
-    auto status =
-        flagBufferManager.Allocate(GetFlagBufferSize(batchNum), subBatchContext.flagBuffer);
+    const auto flagBufferSize = GetFlagBufferSize(opcode, batchNum);
+    auto status = flagBufferManager.Allocate(flagBufferSize, subBatchContext.flagBuffer);
     if (!status.ok()) {
+        UC_ERROR(
+            "Allocate sub-batch flag buffer failed opcode={} batch_num={} size={} code={} "
+            "message={}",
+            static_cast<int>(opcode), batchNum, flagBufferSize, static_cast<int>(status.code),
+            status.message);
         subBatchContext.flagBuffer = {};
         return status;
     }
@@ -117,13 +130,13 @@ void ResetSubBatchContext(std::size_t batchNum, TransportSubBatchContext& subBat
     subBatchContext.status = Status::OK();
 }
 
-Status PrepareSubBatchRequest(TransportOpType opType, std::uint16_t cid, std::size_t batchNum,
-                              BufferManager& flagBufferManager,
+Status PrepareSubBatchRequest(TransportOpType opType, KvOpcode opcode, std::uint16_t cid,
+                              std::size_t batchNum, BufferManager& flagBufferManager,
                               TransportSubBatchContext& subBatchContext)
 {
     subBatchContext.opType = opType;
     subBatchContext.cid = cid;
-    auto status = AllocateSubBatchFlagBuffer(batchNum, flagBufferManager, subBatchContext);
+    auto status = AllocateSubBatchFlagBuffer(opcode, batchNum, flagBufferManager, subBatchContext);
     if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
     return Status::OK();
 }
@@ -134,11 +147,23 @@ Status PackSubBatchRequest(ProtocolManager& protocolManager, BufferManager& send
 {
     auto packedSize = protocolManager.GetPackedSize(opcode, request);
     auto status = sendBufferManager.Allocate(packedSize, subBatchContext.sendSge);
-    if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+    if (!status.ok()) {
+        UC_ERROR(
+            "Allocate sub-batch send buffer failed opcode={} cid={} packed_size={} code={} "
+            "message={}",
+            static_cast<int>(opcode), subBatchContext.cid, packedSize,
+            static_cast<int>(status.code), status.message);
+        return SetSubBatchBuildFailed(subBatchContext, status);
+    }
 
     status = protocolManager.PackRequest(reinterpret_cast<void*>(subBatchContext.sendSge.addr),
                                          opcode, request);
-    if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+    if (!status.ok()) {
+        UC_ERROR("Pack sub-batch request failed opcode={} cid={} code={} message={}",
+                 static_cast<int>(opcode), subBatchContext.cid, static_cast<int>(status.code),
+                 status.message);
+        return SetSubBatchBuildFailed(subBatchContext, status);
+    }
 
     subBatchContext.status = status;
     return status;
@@ -156,6 +181,8 @@ Status InitializeSubBatchSubmission(TransportOpType opType, std::size_t batchNum
 
     if (!isSupported) {
         auto status = Status::Error(StatusCode::UNSUPPORTED, unsupportedMessage);
+        UC_ERROR("Unsupported sub-batch submission op_type={} batch_num={} message={}",
+                 static_cast<int>(opType), batchNum, unsupportedMessage);
         return SetSubBatchBuildFailed(subBatchContext, status);
     }
     opcode = ToKvOpcode(opType);
@@ -292,7 +319,10 @@ std::unique_ptr<SqeRequest> BuildSqeRequest(
         }
         case KvOpcode::KeepAlive:
             return std::make_unique<KvKeepAliveRequest>(BuildKeepAliveRequest(cid, flagBuffer));
-        default: return nullptr;
+        default:
+            UC_ERROR("Build SQE request failed: unsupported opcode={} cid={}",
+                     static_cast<int>(opcode), cid);
+            return nullptr;
     }
 }
 
@@ -306,9 +336,13 @@ Status AsuTransportImpl::ValidateSqeRequestAttrs()
         try {
             const auto parsed = std::stoull(iter->second, nullptr, 0);
             if (parsed > maxValue) {
+                UC_ERROR("Validate SQE attr failed name={} value={} reason=exceeds_range", name,
+                         iter->second);
                 return Status::Error(StatusCode::INVALID_ARGUMENT, name + " exceeds valid range");
             }
         } catch (const std::exception&) {
+            UC_ERROR("Validate SQE attr failed name={} value={} reason=invalid_integer", name,
+                     iter->second);
             return Status::Error(StatusCode::INVALID_ARGUMENT, name + " is not a valid integer");
         }
         return Status::OK();
@@ -318,18 +352,25 @@ Status AsuTransportImpl::ValidateSqeRequestAttrs()
                                                         auto maxValue) -> Status {
         auto iter = config_.attrs.find(name);
         if (iter == config_.attrs.end()) {
+            UC_ERROR("Validate SQE attr failed name={} reason=missing_required", name);
             return Status::Error(StatusCode::INVALID_ARGUMENT, name + " is required");
         }
         try {
             const auto parsed = std::stoull(iter->second, nullptr, 0);
             if (parsed > maxValue) {
+                UC_ERROR("Validate SQE attr failed name={} value={} reason=exceeds_range", name,
+                         iter->second);
                 return Status::Error(StatusCode::INVALID_ARGUMENT, name + " exceeds valid range");
             }
             if (parsed == 0) {
+                UC_ERROR("Validate SQE attr failed name={} value={} reason=must_be_positive", name,
+                         iter->second);
                 return Status::Error(StatusCode::INVALID_ARGUMENT,
                                      name + " must be greater than zero");
             }
         } catch (const std::exception&) {
+            UC_ERROR("Validate SQE attr failed name={} value={} reason=invalid_integer", name,
+                     iter->second);
             return Status::Error(StatusCode::INVALID_ARGUMENT, name + " is not a valid integer");
         }
         return Status::OK();
@@ -342,6 +383,8 @@ Status AsuTransportImpl::ValidateSqeRequestAttrs()
         if (value == "1" || value == "0" || value == "true" || value == "false") {
             return Status::OK();
         }
+        UC_ERROR("Validate SQE attr failed name={} value={} reason=invalid_bool", name,
+                 iter->second);
         return Status::Error(StatusCode::INVALID_ARGUMENT, name + " is not a valid bool");
     };
 
@@ -358,8 +401,10 @@ Status AsuTransportImpl::ValidateSqeRequestAttrs()
     status =
         validateRequiredPositiveInteger("kernel_count", std::numeric_limits<std::uint32_t>::max());
     if (!status.ok()) { return status; }
-    return validateRequiredPositiveInteger("quiet_count",
-                                           std::numeric_limits<std::uint32_t>::max());
+    status =
+        validateRequiredPositiveInteger("quiet_count", std::numeric_limits<std::uint32_t>::max());
+    if (!status.ok()) { return status; }
+    return Status::OK();
 }
 
 Status AsuTransportImpl::SubmitEntrySubBatchRequest(TransportOpType opType,
@@ -376,7 +421,7 @@ Status AsuTransportImpl::SubmitEntrySubBatchRequest(TransportOpType opType,
                                      kUnsupportedMessage, subBatchContext, opcode, shouldSubmit);
     if (!status.ok() || !shouldSubmit) { return status; }
 
-    status = PrepareSubBatchRequest(opType, AllocateRequestCid(), subBatch.entries.size,
+    status = PrepareSubBatchRequest(opType, opcode, AllocateRequestCid(), subBatch.entries.size,
                                     flagBufferManager_, subBatchContext);
     if (!status.ok()) { return status; }
 
@@ -399,7 +444,7 @@ Status AsuTransportImpl::SubmitKeySubBatchRequest(TransportOpType opType,
                                      kUnsupportedMessage, subBatchContext, opcode, shouldSubmit);
     if (!status.ok() || !shouldSubmit) { return status; }
 
-    status = PrepareSubBatchRequest(opType, AllocateRequestCid(), subBatch.keys.size,
+    status = PrepareSubBatchRequest(opType, opcode, AllocateRequestCid(), subBatch.keys.size,
                                     flagBufferManager_, subBatchContext);
     if (!status.ok()) { return status; }
 
@@ -420,7 +465,7 @@ Status AsuTransportImpl::SubmitKeepAliveRequest(TransportSubBatchContext& subBat
                                                subBatchContext, opcode, shouldSubmit);
     if (!status.ok() || !shouldSubmit) { return status; }
 
-    status = PrepareSubBatchRequest(opType, AllocateRequestCid(), 1, flagBufferManager_,
+    status = PrepareSubBatchRequest(opType, opcode, AllocateRequestCid(), 1, flagBufferManager_,
                                     subBatchContext);
     if (!status.ok()) { return status; }
 

--- a/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
@@ -172,7 +172,7 @@ TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
 
 TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)
 {
-    std::vector<CacheKey> keys = {"k0", "k1"};
+    std::vector<CacheKey> keys = {"k0", "k1", "k2", "k3", "k4", "k5", "k6", "k7", "k8"};
     IoScheduler::ScheduledKeyBatch subBatch{
         BatchView<CacheKey>{keys.data(), keys.size()}
     };
@@ -187,6 +187,7 @@ TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)
     EXPECT_EQ(subBatchContext.cid, std::uint16_t{55});
     EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
     EXPECT_TRUE(subBatchContext.status.ok());
+    EXPECT_EQ(subBatchContext.flagBuffer.length, kFlagBufferHeaderSize + (keys.size() + 7) / 8);
     EXPECT_NE(subBatchContext.sendSge.addr, std::uint64_t{0});
     ASSERT_EQ(subBatchContext.entryStatus.size(), keys.size());
     for (const auto& entryStatus : subBatchContext.entryStatus) { EXPECT_TRUE(entryStatus.ok()); }
@@ -194,7 +195,7 @@ TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)
 
 TEST_F(SqeRequestTest, SubmitExistReadsScAttribute)
 {
-    std::vector<CacheKey> keys = {"k0"};
+    std::vector<CacheKey> keys = {"k0", "k1", "k2", "k3", "k4", "k5", "k6", "k7", "k8"};
     IoScheduler::ScheduledKeyBatch subBatch{
         BatchView<CacheKey>{keys.data(), keys.size()}
     };
@@ -210,6 +211,7 @@ TEST_F(SqeRequestTest, SubmitExistReadsScAttribute)
     EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
     EXPECT_TRUE(subBatchContext.status.ok());
     EXPECT_TRUE(subBatchContext.useSeekControl);
+    EXPECT_EQ(subBatchContext.flagBuffer.length, kFlagBufferHeaderSize + (keys.size() + 7) / 8);
 }
 
 TEST_F(SqeRequestTest, SubmitExistDisablesSeekControlWhenScDisabled)


### PR DESCRIPTION
## Purpose
**Bugfix:** Fix ASU SQE response flag buffer sizing so each opcode allocates enough completion status space without over-allocating, and keep submit-flow logging focused on actionable errors.
## Modifications 
- Fix SQE flag buffer sizing by opcode: batch store/retrieve use 4-bit entry status, while delete/exist use 1-bit key status.
- Pass KvOpcode into flag-buffer allocation so each request type allocates the correct response buffer after the common header.
- Keep submit/SQE hot-path logs error-only and add diagnostics for allocation, pack, validation, and send failures.
- Update delete/exist SQE tests for compact multi-key flag buffer sizing.
- Change default ASU send buffer slot size/count for SQE submission.
## Test
Covered paths are validated through ASU SQE request unit tests for delete/exist flag buffer sizing and request submission behavior.