### PR TITLE
[Fix] kv-test adaptations and fixes

### DIFF
--- a/docs/source/developer-guide/kv-test.md
+++ b/docs/source/developer-guide/kv-test.md
@@ -11,7 +11,8 @@ file.
 ## Build and environment
 
 `kv-test` is built from `ucm/transport/kv/kv-test/CMakeLists.txt` and links
-against `asu_client`.
+against `asu_client` and the ASU Ascend dependency interface used by the ASU
+module.
 
 `kv-test` is included only when ASU support is enabled:
 
@@ -71,7 +72,7 @@ Naming rules:
 - CLI commands and long options use kebab-case, for example `batch-store`,
   `power-cycle`, `--batch-size`, and `--read-ratio`.
 - Config keys use dot-separated snake_case, for example `bench.read_ratio`,
-  `limits.batch_store_max`, and `transport.asu_ids`.
+  `limits.memory_max_bytes`, and `transport.asu_ids`.
 - Compatibility spellings may exist in lower-level parsers, but kv-test help,
   docs, examples, and generated configs should only use the canonical forms
   above.
@@ -83,8 +84,8 @@ Supported commands:
 | `connect` | Initializes the ASU client and exits. |
 | `config check` | Loads config, validates fixed kv-test behavior constraints, prints selected config values, and exits. |
 | `version` | Prints `kv-test version <value>`, where the value is read from `version.ini`. |
-| `store` | Stores entries one by one. |
-| `retrieve` | Retrieves entries one by one. |
+| `store` | Stores all selected entries in one ASU client call in the current implementation. |
+| `retrieve` | Retrieves all selected entries in one ASU client call in the current implementation. |
 | `delete` | Deletes all selected keys in one ASU client call. |
 | `exist` | Runs a per-key ASU query and prints existence summary. |
 | `batch-store` | Stores all selected entries in one ASU client call. |
@@ -105,6 +106,7 @@ Options can use either `--option value` or `--option=value`.
 | `--check` | Enables consistency checking where supported. |
 | `--timeout <ms>` | Overrides `default_wait_timeout_ms` for this run. |
 | `--output <path>` | Overrides `output.path`. |
+| `--progress` | For `bench`, prints one progress line per measured second. |
 
 ## Key selection
 
@@ -154,29 +156,25 @@ Example:
 client_id=kv-test-client-0
 default_wait_timeout_ms=5000
 
-asu.client.mode=local
+asu.client.mode=fake_backend
 local_store.path=./kv-test-local-store
-# To exercise AsuClient + AsuTransportImpl with a local mock backend:
-# asu.client.mode=fake_backend
-# fake_backend.path=./kv-test-fake-backend-store
-# fake_backend.latency_ms=1
+fake_backend.path=./kv-test-fake-backend-store
+fake_backend.latency_ms=1
 
 view.config_path=./ucm/transport/kv/kv-test/asu_view.conf
 hash_table.type=RING_HASH
 ring_hash.virtual_node_count=128
 
-transport.asu_ids=1
+transport.asu_ids=1,2,3
 asu_info.1=protocol=TCP,local.comm_id=127.0.0.1,port=19001,local.phy_device_id=0
+asu_info.2=protocol=TCP,local.comm_id=127.0.0.1,port=19002,local.phy_device_id=0
+asu_info.3=protocol=TCP,local.comm_id=127.0.0.1,port=19003,local.phy_device_id=0
 
 kv.key_prefix=kv-test-key-
 kv.seed=20260530
 kv.value_size=4096
 kv.count=16
 
-limits.batch_store_max=110
-limits.batch_retrieve_max=110
-limits.delete_max=254
-limits.exist_max=256
 limits.memory_max_bytes=4294967296
 
 bench.io_size=4096
@@ -209,6 +207,13 @@ These fields are parsed by the ASU client config parser:
 | `contiguous_block_affinity.*` | Contiguous block affinity options. |
 | `batch_topk_affinity.*` | Batch top-k affinity options. |
 
+When `view.config_path` is set, the loaded view is the ASU membership used by
+`AsuClient`. Every ASU id in that view must have a matching `transport.asu_ids`
+entry so Client can build a transport for it. Non-mocked transports also need
+endpoint information such as `asu_info.<id>`. If `view.config_path` is omitted
+and `view_service_addrs` is empty, the default view is derived from
+`transport.asu_ids`.
+
 ### kv-test-only fields
 
 These fields are parsed by `kv-test` itself:
@@ -223,12 +228,8 @@ These fields are parsed by `kv-test` itself:
 | `kv.seed` | Seed for deterministic value generation. |
 | `kv.value_size` | Value size for normal commands. |
 | `kv.count` | Default count for count-based generation. |
-| `limits.batch_store_max` | Maximum accepted `batch-store` batch size. Default `110`. |
-| `limits.batch_retrieve_max` | Maximum accepted `batch-retrieve` batch size. Default `110`. |
-| `limits.delete_max` | Client-side sub-batch limit used after Client routes a delete request to transports. kv-test does not split the user-selected key set before calling Client. |
-| `limits.exist_max` | Client-side sub-batch limit used after Client routes an exist/query request to transports. kv-test does not split the user-selected key set before calling Client. |
-| `limits.memory_max_bytes` | Maximum generated value payload bytes held by kv-test before a command starts. Default is 4 GiB. |
-| `bench.io_size` | Bench value size. |
+| `limits.memory_max_bytes` | Maximum value payload bytes held by kv-test. For normal commands this limits generated value bytes. For `bench`, this limits the reusable buffer pool. Default is 4 GiB. |
+| `bench.io_size` | Bench value size for one key. Must not exceed the protocol 24-bit length limit `0xFFFFFF`. |
 | `bench.concurrency` | Number of benchmark operations launched concurrently in one wave. |
 | `bench.duration_sec` | Measured benchmark duration. Must be greater than zero. |
 | `bench.warmup_sec` | Warmup duration. |
@@ -238,6 +239,10 @@ These fields are parsed by `kv-test` itself:
 | `output.path` | Base output directory. Empty value uses `.`. |
 | `output.realtime_file_max_bytes` | Maximum realtime CSV size before rolling. Default is 100 MiB. |
 | `connection.timeout_ms` | Also overrides ASU client default wait timeout. |
+
+Batch and sub-batch limits are left to Client and Transport. New kv-test configs
+should not include older `limits.batch_store_max`, `limits.batch_retrieve_max`,
+`limits.delete_max`, or `limits.exist_max` fields.
 
 ## Local mode
 
@@ -269,7 +274,9 @@ The local transport stores each key under:
 ```
 
 The directory persists across separate `kv-test` commands. Delete removes the
-corresponding file. Exist checks whether the file exists.
+corresponding file when it exists. Deleting a missing key is treated as success,
+matching the current Delete result-buffer semantics. Exist checks whether the
+file exists.
 
 Because this mode replaces the ASU transport implementation, it can exercise
 `AsuClient` routing and aggregation at a high level, but it does not validate
@@ -301,6 +308,11 @@ Mocked or not covered in this mode:
 - real memory registration, `rkey`, and `lkey` semantics
 - real connection failure, drain, and recovery behavior
 
+The mock send path is installed through a temporary `AICPUTransProvider` send
+hook while fake_backend mode is enabled. `AICPUTransProvider::CreateConnection`
+also returns placeholder connection handles so `ConnectionManager` can create
+channels during this software-only integration phase.
+
 The fake backend stores each key under:
 
 ```text
@@ -320,6 +332,12 @@ During this temporary integration stage, fake backend maps each
 recover a per-ASU namespace from the send buffer without changing the Transport
 `Send` interface. This is a kv-test-only temporary semantic mapping, not a
 long-term protocol statement that KVNS_ID is ASU ID.
+
+The fake backend writes the CQE/flag buffer synchronously before `Send` returns.
+Query returns CQE status `0` when every key exists and `0x732` with a
+result-buffer payload when only some keys exist. Delete treats missing keys as
+successful entries; a result-buffer byte value of `0` means success and `1`
+means delete failed.
 
 Mode differences:
 
@@ -387,8 +405,9 @@ kv-test store --prefix user- --key-start 100 --key-end 199
 kv-test batch-store --count 16 --batch-size 16 --check
 ```
 
-`store` submits one ASU `StoreAsync` call per entry. `batch-store` submits all
-selected entries in one ASU `StoreAsync` call.
+In the current implementation, both `store` and `batch-store` submit all
+selected entries in one ASU `StoreAsync` call. The command names are kept for
+CLI compatibility while the ASU stack currently exposes the batch path.
 
 With `--check`, the tool retrieves the same entries and compares the returned
 bytes with generated expected values.
@@ -401,8 +420,9 @@ kv-test retrieve --keys key1,key2,key3 --check
 kv-test batch-retrieve --count 16 --batch-size 16 --check
 ```
 
-`retrieve` submits one ASU `LoadAsync` call per entry. `batch-retrieve` submits
-all selected entries in one ASU `LoadAsync` call.
+In the current implementation, both `retrieve` and `batch-retrieve` submit all
+selected entries in one ASU `LoadAsync` call. The command names are kept for
+CLI compatibility while the ASU stack currently exposes the batch path.
 
 With `--check`, retrieved bytes are compared with generated expected values.
 
@@ -416,7 +436,8 @@ kv-test delete --keys key1,key2,key3
 The command submits one ASU `DeleteAsync` call containing all selected keys.
 Any DHT routing or per-transport sub-batch splitting is handled inside Client.
 With `--check`, the tool runs an exist query and expects all selected keys to be
-missing.
+missing. Delete treats a missing key as a successful delete unless the backend
+reports an actual IO/delete failure.
 
 ### exist
 
@@ -453,6 +474,7 @@ kv-test bench retrieve --duration 10 --concurrency 1 --io-size 4096
 kv-test bench --op batch-store --batch-size 16 --duration 10 --concurrency 1
 kv-test bench --op batch-retrieve --batch-size 16 --duration 10 --concurrency 1
 kv-test bench mix --read-ratio 70 --write-ratio 30 --duration 10 --concurrency 1
+kv-test bench batch-store --duration 10 --progress
 ```
 
 Bench operation can be provided as `kv-test bench <op>` or through `--op` /
@@ -464,6 +486,7 @@ Requirements:
 - `bench.concurrency` must be greater than zero.
 - `bench.duration_sec` must be greater than zero.
 - `bench.io_size` must be greater than zero.
+- `bench.io_size` must be less than or equal to `0xFFFFFF`.
 - `read_ratio` and `write_ratio` must each be in `0..100`.
 - For `mix`, at least one of `read_ratio` or `write_ratio` must be greater than
   zero.
@@ -471,6 +494,15 @@ Requirements:
 
 The benchmark runner launches one asynchronous task per operation in a wave.
 Each wave contains up to `concurrency` operations.
+
+Bench uses a fixed reusable buffer pool instead of pre-generating all data for
+the whole run. The pool holds `entries_per_operation * concurrency` buffers of
+`bench.io_size` bytes. Each new batch updates metadata for the selected slot and
+reuses its value buffers.
+
+With `--progress`, bench prints one measured progress line per second instead
+of rewriting a terminal line. The final summary and report output are still
+written after the run.
 
 ## Output
 

--- a/ucm/transport/kv/asu/CMakeLists.txt
+++ b/ucm/transport/kv/asu/CMakeLists.txt
@@ -32,6 +32,10 @@ endif()
 message(STATUS "ASU ASCEND include: ${ASU_ASCEND_INCLUDE_DIR}")
 message(STATUS "ASU ASCENDCL lib: ${ASU_ASCENDCL_LIB}")
 
+add_library(asu_ascend_deps INTERFACE)
+target_include_directories(asu_ascend_deps INTERFACE ${ASU_ASCEND_INCLUDE_DIR})
+target_link_libraries(asu_ascend_deps INTERFACE ${ASU_ASCENDCL_LIB})
+
 file(GLOB ASU_COMMON_SOURCES CONFIGURE_DEPENDS common/*.cpp)
 file(GLOB ASU_TRANSPORT_SOURCES CONFIGURE_DEPENDS trans/src/*.cpp)
 file(GLOB LOGGER_SOURCES CONFIGURE_DEPENDS 
@@ -53,10 +57,14 @@ target_include_directories(asu_transport
         ${UCM_ROOT_DIR}/ucm/shared/infra/logger/cc
         ${UCM_ROOT_DIR}/ucm/shared/infra/status
         ${UCM_ROOT_DIR}/ucm/shared
-        ${ASU_ASCEND_INCLUDE_DIR}
 )
 target_compile_definitions(asu_transport PRIVATE SPDLOG_FMT_EXTERNAL)
-target_link_libraries(asu_transport PUBLIC pthread fmt spdlog z ${ASU_ASCENDCL_LIB})
+target_link_libraries(asu_transport
+    PUBLIC
+        pthread fmt spdlog z
+    PRIVATE
+        asu_ascend_deps
+)
 
 file(GLOB ASU_CLIENT_SOURCES CONFIGURE_DEPENDS client/src/*.cpp)
 add_library(asu_client SHARED ${ASU_CLIENT_SOURCES})
@@ -89,12 +97,10 @@ if(BUILD_UNIT_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/client/src
         ${CMAKE_CURRENT_SOURCE_DIR}/trans/src
         ${UCM_ROOT_DIR}/ucm/shared/infra
-        ${ASU_ASCEND_INCLUDE_DIR}
     )
     target_link_libraries(asu.test PRIVATE
         asu_client
         gtest_main gtest
-        ${ASU_ASCENDCL_LIB}
     )
     gtest_discover_tests(asu.test)
 endif()

--- a/ucm/transport/kv/asu/client/src/client_config_parser.cpp
+++ b/ucm/transport/kv/asu/client/src/client_config_parser.cpp
@@ -110,7 +110,8 @@ Status LoadAsuClientConfig(const std::string& configPath, AsuClientConfig& confi
         } else if (key == "hashTable.batchTopKAffinity.dynamicAdjustEnabled" ||
                    key == "batch_topk_affinity.dynamic_adjust_enabled") {
             config.attrs["batch_topk_affinity.dynamic_adjust_enabled"] = value;
-        } else if (key == "transport.asuIds" || key == "asuIds" || key == "asu_ids") {
+        } else if (key == "transport.asuIds" || key == "transport.asu_ids" || key == "asuIds" ||
+                   key == "asu_ids") {
             for (const auto& asuIdText : SplitConfigValue(value, ',')) {
                 TransportConfig transportConfig;
                 transportConfig.asuId = ParseConfigUint64(asuIdText);

--- a/ucm/transport/kv/asu/test/case/connection_manager_test.cc
+++ b/ucm/transport/kv/asu/test/case/connection_manager_test.cc
@@ -59,7 +59,8 @@ public:
         return std::vector<Status>(handles.size(), Status::OK());
     }
 
-    std::vector<Status> Send(const std::vector<SendIoBatch>&, uint32_t, uint32_t) override
+    std::vector<Status> Send(const std::vector<TransProvider::SendIoBatch>&, uint32_t,
+                             uint32_t) override
     {
         return {};
     }

--- a/ucm/transport/kv/asu/trans/src/aicpu_trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/aicpu_trans_provider.cpp
@@ -1,0 +1,23 @@
+#include "aicpu_trans_provider.h"
+#include <atomic>
+
+namespace UC::ASU {
+namespace {
+
+std::atomic<AICPUTransProviderSendHook> g_sendHook{nullptr};
+
+}  // namespace
+
+void SetAICPUTransProviderSendHook(AICPUTransProviderSendHook hook)
+{
+    // Temporary hook for the kv-test fake_backend phase. Production AICPU sends keep the default
+    // provider behavior when no hook is registered.
+    g_sendHook.store(hook, std::memory_order_release);
+}
+
+AICPUTransProviderSendHook GetAICPUTransProviderSendHook()
+{
+    return g_sendHook.load(std::memory_order_acquire);
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/aicpu_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/aicpu_trans_provider.h
@@ -4,11 +4,24 @@
 
 namespace UC::ASU {
 
+using AICPUTransProviderSendHook =
+    std::vector<Status> (*)(const std::vector<TransProvider::SendIoBatch>& ioBatches,
+                            uint32_t kernelCount, uint32_t quietCount);
+
+void SetAICPUTransProviderSendHook(AICPUTransProviderSendHook hook);
+AICPUTransProviderSendHook GetAICPUTransProviderSendHook();
+
 class AICPUTransProvider : public TransProvider {
 public:
-    Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t, uint32_t,
-                            std::vector<ConnectionHandle>&) override
+    Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t qpNum,
+                            uint32_t, std::vector<ConnectionHandle>& handles) override
     {
+        handles.clear();
+        handles.reserve(qpNum);
+        for (uint32_t index = 0; index < qpNum; ++index) {
+            handles.push_back(reinterpret_cast<ConnectionHandle>(
+                static_cast<std::uintptr_t>(index) + static_cast<std::uintptr_t>(1)));
+        }
         return Status::OK();
     }
 
@@ -17,8 +30,11 @@ public:
         return std::vector<Status>(handles.size(), Status::OK());
     }
 
-    std::vector<Status> Send(const std::vector<SendIoBatch>& ioBatches, uint32_t, uint32_t) override
+    std::vector<Status> Send(const std::vector<TransProvider::SendIoBatch>& ioBatches,
+                             uint32_t kernelCount, uint32_t quietCount) override
     {
+        auto hook = GetAICPUTransProviderSendHook();
+        if (hook != nullptr) { return hook(ioBatches, kernelCount, quietCount); }
         return std::vector<Status>(ioBatches.size(), Status::OK());
     }
 

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -490,6 +490,12 @@ void AsuTransportImpl::PollTaskCompletions(const TransportTaskContextPtr& ctx)
         subBatchContext.status = KvResponseStatusToSubBatchStatus(response.status);
         FillEntryStatusFromCqeResult(response, subBatchContext);
 
+        if (subBatchContext.opType == TransportOpType::QUERY &&
+            subBatchContext.status.code == StatusCode::ASU_CQE_CHECK_RESULT_BUFFER) {
+            CompleteSubBatch(*ctx, subBatchContext, Status::OK());
+            continue;
+        }
+
         if (subBatchContext.status.ok()) {
             CompleteSubBatch(*ctx, subBatchContext, Status::OK());
             continue;

--- a/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
@@ -50,7 +50,8 @@ public:
     {
         return {};
     }
-    std::vector<Status> Send(const std::vector<SendIoBatch>&, uint32_t, uint32_t) override
+    std::vector<Status> Send(const std::vector<TransProvider::SendIoBatch>&, uint32_t,
+                             uint32_t) override
     {
         return {};
     }

--- a/ucm/transport/kv/asu/trans/test/transport_task_completion_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/transport_task_completion_test.cpp
@@ -51,7 +51,8 @@ public:
     {
         return std::vector<Status>(handles.size(), Status::OK());
     }
-    std::vector<Status> Send(const std::vector<SendIoBatch>&, uint32_t, uint32_t) override
+    std::vector<Status> Send(const std::vector<TransProvider::SendIoBatch>&, uint32_t,
+                             uint32_t) override
     {
         return {};
     }

--- a/ucm/transport/kv/kv-test/CMakeLists.txt
+++ b/ucm/transport/kv/kv-test/CMakeLists.txt
@@ -20,9 +20,11 @@ target_include_directories(kv-test
         ../asu/client/include
         ../asu/trans/include
         ../asu/trans/src
+        ${UCM_ROOT_DIR}/ucm/shared/infra
 )
 
 target_link_libraries(kv-test
     PRIVATE
         asu_client
+        asu_ascend_deps
 )

--- a/ucm/transport/kv/kv-test/asu_kv_test.conf
+++ b/ucm/transport/kv/kv-test/asu_kv_test.conf
@@ -5,9 +5,10 @@
 client_id=kv-test-client-0
 default_wait_timeout_ms=5000
 
-# kv-test local mode uses a file-system backed ASU transport. It does not
-# connect to a real ViewServer, network, Hcomm, or ASU device, but the ASU
-# client still needs view and endpoint fields below to build its router.
+# kv-test fake_backend mode uses the normal AsuClient + AsuTransportImpl path
+# with a local mock Send/CQE backend. It does not connect to real ASU backend
+# hardware, but the client still needs view and endpoint fields below to build
+# its router and transports.
 asu.client.mode=fake_backend
 
 # Relative paths in this file are resolved against the process working
@@ -18,24 +19,23 @@ local_store.path=./kv-test-local-store
 # file; changing the file is the external trigger for view changes.
 view.config_path=./ucm/transport/kv/kv-test/asu_view.conf
 
-# Route all keys to a single ASU for local smoke testing.
+# Keep transport.asu_ids aligned with the ASU ids in asu_view.conf.
 hash_table.type=RING_HASH
 ring_hash.virtual_node_count=128
-transport.asu_ids=1
+transport.asu_ids=1,2,3
 
 # ASU endpoint list. Endpoint format:
 # protocol=<UB|ROCE|TCP>,local.comm_id=<ip-or-comm-id>,port=<port>,local.phy_device_id=<device>
 #
-# In local mode, protocol=TCP is a convenient placeholder for parser and
-# validation compatibility; it does not imply real TCP IO.
+# In fake_backend/local mode, protocol=TCP is a convenient placeholder for
+# parser and validation compatibility; it does not imply real TCP IO.
 # For real ASU/Hcomm testing, replace protocol/local.comm_id/port/device with
 # the target setup and use the non-local ASU client mode.
-#
-# To exercise AsuClient + AsuTransport with a local mock Send/CQE backend, set:
-# asu.client.mode=fake_backend
-# fake_backend.path=./kv-test-fake-backend-store
-# fake_backend.latency_ms=1
+fake_backend.path=./kv-test-fake-backend-store
+fake_backend.latency_ms=1
 asu_info.1=protocol=TCP,local.comm_id=127.0.0.1,port=19001,local.phy_device_id=0
+asu_info.2=protocol=TCP,local.comm_id=127.0.0.1,port=19002,local.phy_device_id=0
+asu_info.3=protocol=TCP,local.comm_id=127.0.0.1,port=19003,local.phy_device_id=0
 
 # kv-test data generation defaults.
 kv.key_prefix=kv-test-key-

--- a/ucm/transport/kv/kv-test/include/kv_test/kv_test_types.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/kv_test_types.h
@@ -125,13 +125,6 @@ struct CommandOptions {
     std::string outputPath;
 };
 
-struct BatchLimits {
-    std::uint32_t batchStoreMax{110};
-    std::uint32_t batchRetrieveMax{110};
-    std::uint32_t deleteMax{254};
-    std::uint32_t existMax{256};
-};
-
 struct BenchConfig {
     BenchOpType op{BenchOpType::UNKNOWN};
     std::uint64_t ioSize{0};
@@ -176,7 +169,6 @@ struct KvTestConfig {
     UC::ASU::AsuClientConfig asuClientConfig;
     ToolBehaviorConfig behavior;
     HcommProtocolMapping hcommProtocolMapping;
-    BatchLimits limits;
     BenchConfig bench;
     OutputConfig output;
     FakeBackendConfig fakeBackend;

--- a/ucm/transport/kv/kv-test/scripts/fake_backend_common.sh
+++ b/ucm/transport/kv/kv-test/scripts/fake_backend_common.sh
@@ -100,10 +100,6 @@ write_fake_backend_config() {
         echo "kv.value_size=4096"
         echo "kv.count=16"
         echo
-        echo "limits.batch_store_max=110"
-        echo "limits.batch_retrieve_max=110"
-        echo "limits.delete_max=254"
-        echo "limits.exist_max=256"
         echo "limits.memory_max_bytes=4294967296"
         echo
         echo "bench.io_size=4096"

--- a/ucm/transport/kv/kv-test/src/asu_client_runner.cpp
+++ b/ucm/transport/kv/kv-test/src/asu_client_runner.cpp
@@ -109,10 +109,10 @@ Status SubmitEntriesOneByOne(UC::ASU::AsuClient& client,
         }
 
         if (!status.Ok() && firstFailure.ok()) {
-            firstFailure = singleResult.taskResult.status.ok()
-                               ? UC::ASU::Status::Error(
-                                     static_cast<UC::ASU::StatusCode>(status.code), status.message)
-                               : singleResult.taskResult.status;
+            firstFailure =
+                singleResult.taskResult.status.ok()
+                    ? UC::ASU::Status::Error(UC::ASU::StatusCode::INTERNAL_ERROR, status.message)
+                    : singleResult.taskResult.status;
         }
     }
 

--- a/ucm/transport/kv/kv-test/src/fake_backend.cpp
+++ b/ucm/transport/kv/kv-test/src/fake_backend.cpp
@@ -11,9 +11,18 @@
 #include <mutex>
 #include <sstream>
 #include <thread>
+#include "aicpu_trans_provider.h"
 #include "buffer_manager.h"
 #include "connection_manager.h"
 #include "kv_protocol.h"
+#include "trans_provider.h"
+
+namespace UC::ASU {
+
+std::vector<Status> MockSend(const std::vector<TransProvider::SendIoBatch>& ioBatches,
+                             std::uint32_t kernelCount, std::uint32_t quietCount);
+
+}  // namespace UC::ASU
 
 namespace UC::KVTest {
 namespace {
@@ -329,14 +338,19 @@ UC::ASU::Status CompleteExist(const FakeBackendConfig& config, UC::ASU::AsuId as
     return UC::ASU::Status::OK();
 }
 
-UC::ASU::Status CompleteFakeBackendRequest(FakeBackendConfig config,
-                                           const UC::ASU::ScatterGatherEntry& sendSge)
+UC::ASU::Status CompleteFakeBackendRequest(FakeBackendConfig config, const void* sendBuffer,
+                                           std::uint64_t len)
 {
     if (config.latencyMs > 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(config.latencyMs));
     }
 
-    const auto* request = reinterpret_cast<const std::uint32_t*>(sendSge.addr);
+    if (sendBuffer == nullptr || len < sizeof(std::uint32_t)) {
+        return UC::ASU::Status::Error(UC::ASU::StatusCode::INVALID_ARGUMENT,
+                                      "fake backend send buffer is empty");
+    }
+
+    const auto* request = reinterpret_cast<const std::uint32_t*>(sendBuffer);
     const auto asuId = RequestAsuId(request);
     switch (RequestOpcode(request)) {
         case UC::ASU::KvOpcode::BatchStore: return CompleteBatchStore(config, asuId, request);
@@ -365,16 +379,22 @@ FakeBackendConfig GetFakeBackendConfig(bool& enabled)
 
 void SetFakeBackendConfig(FakeBackendConfig config)
 {
-    std::lock_guard<std::mutex> lock(g_fakeBackendMu);
-    g_fakeBackendConfig = std::move(config);
-    g_fakeBackendEnabled = true;
+    {
+        std::lock_guard<std::mutex> lock(g_fakeBackendMu);
+        g_fakeBackendConfig = std::move(config);
+        g_fakeBackendEnabled = true;
+    }
+    UC::ASU::SetAICPUTransProviderSendHook(&UC::ASU::MockSend);
 }
 
 void DisableFakeBackend()
 {
-    std::lock_guard<std::mutex> lock(g_fakeBackendMu);
-    g_fakeBackendConfig = FakeBackendConfig{};
-    g_fakeBackendEnabled = false;
+    UC::ASU::SetAICPUTransProviderSendHook(nullptr);
+    {
+        std::lock_guard<std::mutex> lock(g_fakeBackendMu);
+        g_fakeBackendConfig = FakeBackendConfig{};
+        g_fakeBackendEnabled = false;
+    }
 }
 
 void PatchTransportConfig(UC::ASU::TransportConfig& config)
@@ -472,8 +492,8 @@ void MaybePrepareFakeBackend(KvTestConfig& config)
 
 namespace UC::ASU {
 
-std::vector<Status> MockSend(const std::vector<SendIoBatch>& ioBatches, std::uint32_t kernelCount,
-                             std::uint32_t quietCount)
+std::vector<Status> MockSend(const std::vector<TransProvider::SendIoBatch>& ioBatches,
+                             std::uint32_t kernelCount, std::uint32_t quietCount)
 {
     (void)kernelCount;
     (void)quietCount;
@@ -489,22 +509,23 @@ std::vector<Status> MockSend(const std::vector<SendIoBatch>& ioBatches, std::uin
     std::vector<Status> statuses;
     statuses.reserve(ioBatches.size());
     for (const auto& ioBatch : ioBatches) {
-        if (ioBatch.sendSge == nullptr || ioBatch.sendSge->addr == 0) {
+        if (ioBatch.sendBuffer == nullptr || ioBatch.len == 0) {
             statuses.emplace_back(
-                Status::Error(StatusCode::INVALID_ARGUMENT, "fake backend send SGE is empty"));
+                Status::Error(StatusCode::INVALID_ARGUMENT, "fake backend send buffer is empty"));
             continue;
         }
 
         // kv-test fake backend temporarily completes the CQE before Send returns. The production
         // path still observes completion through Transport polling, while the mock avoids detached
         // threads racing with sub-batch buffer lifetime in multi sub-batch tests.
-        statuses.emplace_back(UC::KVTest::CompleteFakeBackendRequest(config, *ioBatch.sendSge));
+        statuses.emplace_back(
+            UC::KVTest::CompleteFakeBackendRequest(config, ioBatch.sendBuffer, ioBatch.len));
     }
     return statuses;
 }
 
-std::vector<Status> Send(const std::vector<SendIoBatch>& ioBatches, std::uint32_t kernelCount,
-                         std::uint32_t quietCount)
+std::vector<Status> Send(const std::vector<TransProvider::SendIoBatch>& ioBatches,
+                         std::uint32_t kernelCount, std::uint32_t quietCount)
 {
     return MockSend(ioBatches, kernelCount, quietCount);
 }

--- a/ucm/transport/kv/kv-test/src/kv_test_app.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_app.cpp
@@ -49,6 +49,27 @@ std::string EffectiveKeyPrefix(const CommandOptions& options, const KvTestConfig
     return options.keyPrefix.empty() ? config.keyPrefix : options.keyPrefix;
 }
 
+CommandOptions BuildEffectiveOptions(const CommandOptions& options, const KvTestConfig& config)
+{
+    CommandOptions effective = options;
+    effective.seed = EffectiveSeed(options, config);
+    effective.count = EffectiveCount(options, config);
+    effective.valueSize = options.command == CommandType::BENCH
+                              ? config.bench.ioSize
+                              : EffectiveValueSize(options, config);
+    effective.keyPrefix = EffectiveKeyPrefix(options, config);
+    effective.batchSize = config.bench.batchSize;
+    effective.timeoutMs = config.asuClientConfig.defaultWaitTimeoutMs;
+    effective.outputPath = config.output.path;
+    if (effective.benchOp == BenchOpType::UNKNOWN) { effective.benchOp = config.bench.op; }
+    effective.concurrency = config.bench.concurrency;
+    effective.durationSec = config.bench.durationSec;
+    effective.warmupSec = config.bench.warmupSec;
+    effective.readRatio = config.bench.readRatio;
+    effective.writeRatio = config.bench.writeRatio;
+    return effective;
+}
+
 Status WritePowerCycleMetadata(const CommandOptions& options, const KvTestConfig& config)
 {
     std::error_code errorCode;
@@ -409,6 +430,7 @@ int KvTestApp::Run(int argc, char** argv)
     }
 
     MaybePrepareFakeBackend(config);
+    const auto effectiveOptions = BuildEffectiveOptions(options, config);
 
     status = hcommConfigAdapter_.ValidateChannelSource(config);
     if (!status.Ok()) {
@@ -442,20 +464,20 @@ int KvTestApp::Run(int argc, char** argv)
     CommandResult result;
     AsuClientRunner clientRunner(CreateClientForConfig(config));
     status = clientRunner.Init(config);
-    if (status.Ok()) { status = RunCommand(options, config, clientRunner, result); }
+    if (status.Ok()) { status = RunCommand(effectiveOptions, config, clientRunner, result); }
 
     auto shutdownStatus = clientRunner.Shutdown();
     if (status.Ok() && !shutdownStatus.Ok()) { status = shutdownStatus; }
 
     result.status = status;
-    auto writeStatus = resultWriter_.WriteSummary(options, result);
+    auto writeStatus = resultWriter_.WriteSummary(effectiveOptions, result);
     if (status.Ok() && !writeStatus.Ok()) { status = writeStatus; }
 
     auto closeStatus = resultWriter_.Close();
     if (status.Ok() && !closeStatus.Ok()) { status = closeStatus; }
 
     if (status.Ok()) {
-        PrintSuccess(options, result);
+        PrintSuccess(effectiveOptions, result);
     } else {
         PrintFailure(status);
         PrintConsistencySummary(result);

--- a/ucm/transport/kv/kv-test/src/kv_test_config_loader.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_config_loader.cpp
@@ -165,7 +165,6 @@ Status KvTestConfigLoader::Load(const std::string& configPath, KvTestConfig& con
 
     config.behavior = ToolBehaviorConfig{};
     config.hcommProtocolMapping = HcommProtocolMapping{};
-    config.limits = BatchLimits{};
     config.bench = BenchConfig{};
     config.output = OutputConfig{};
     config.fakeBackend = FakeBackendConfig{};
@@ -196,10 +195,6 @@ Status KvTestConfigLoader::Load(const std::string& configPath, KvTestConfig& con
         GetUint64Any(values, {"kv.seed"}, config.seed);
         GetUint64Any(values, {"kv.count"}, config.count);
 
-        GetUint32Any(values, {"limits.batch_store_max"}, config.limits.batchStoreMax);
-        GetUint32Any(values, {"limits.batch_retrieve_max"}, config.limits.batchRetrieveMax);
-        GetUint32Any(values, {"limits.delete_max"}, config.limits.deleteMax);
-        GetUint32Any(values, {"limits.exist_max"}, config.limits.existMax);
         GetUint64Any(values, {"limits.memory_max_bytes"}, config.memoryMaxBytes);
 
         GetUint64Any(values, {"bench.io_size"}, config.bench.ioSize);

--- a/ucm/transport/kv/kv-test/src/local_asu_transport.cpp
+++ b/ucm/transport/kv/kv-test/src/local_asu_transport.cpp
@@ -120,14 +120,11 @@ public:
         result.entryStatus.reserve(keys.size());
         for (const auto& key : keys) {
             std::error_code errorCode;
-            const bool removed = std::filesystem::remove(KeyPath(key), errorCode);
+            (void)std::filesystem::remove(KeyPath(key), errorCode);
             if (errorCode) {
                 result.entryStatus.emplace_back(UC::ASU::Status::Error(
                     UC::ASU::StatusCode::IO_ERROR,
                     "failed to delete local key=" + key + " error=" + errorCode.message()));
-            } else if (!removed) {
-                result.entryStatus.emplace_back(UC::ASU::Status::Error(
-                    UC::ASU::StatusCode::NOT_FOUND, "local key not found=" + key));
             } else {
                 result.entryStatus.emplace_back(UC::ASU::Status::OK());
             }


### PR DESCRIPTION
## Purpose
Adapt to previous code changes of previous pull requests.

## Modifications 
1. Change signature of TransProvider and Send interface.
2. Use a hook to trigger fake backend transport in kv-test.
3. Modify CMakeLists to introduce dependency for kv-test.
4. AsuId now can be correctly parsed.
5. Use a placeholder in AICPUTransProvider::CreateConnection to avoid exitting.
6. Fix CompleteTask logic when query get non-existence results. Queries which have status ASU_CQE_CHECK_RESULT_BUFFER will call CompleteSubBatch with status OK to avoid PARTIAL_FAILED.
7. Modify kv-test configs.
8. Use effectiveOptions to merge cli command and config parameters.
9. Fix the logic of LocalAsuTransport::DeleteAsync, where status is OK when keys deleted do not exist.
10. Modify type cast for error code.
11. Modify domument of kv-test.
12. Remove useless struct and configs.