### PR TITLE
[Feat] Add RDMA memory registration to BufferManager

### DIFF
--- a/ucm/transport/kv/asu/test/case/buffer_manager_test.cc
+++ b/ucm/transport/kv/asu/test/case/buffer_manager_test.cc
@@ -27,6 +27,7 @@
 #include <gtest/gtest.h>
 #include <thread>
 #include <vector>
+#include "trans_provider.h"
 
 namespace UC::ASU {
 namespace {
@@ -124,7 +125,7 @@ TEST_F(BufferManagerTest, SingleAllocateAndFree)
     ASSERT_TRUE(status.ok()) << status.message;
     ASSERT_NE(sge.addr, 0);
     ASSERT_EQ(sge.length, 64);
-    ASSERT_NE(sge.lkey, 0);
+    ASSERT_EQ(sge.tokenId, 0);
     ASSERT_NE(sge.slot_index, UINT32_MAX);
 
     auto* ptr = reinterpret_cast<void*>(sge.addr);
@@ -321,6 +322,132 @@ TEST_F(BufferManagerTest, AllocateReturnsBusyWhenFull)
 
     mgr.Free(sge1.slot_index);
     mgr.Free(sge2.slot_index);
+}
+
+class StubTransProvider : public TransProvider {
+public:
+    uint32_t registerCount = 0;
+    uint32_t unregisterCount = 0;
+    uint32_t fakeTokenId = 42;
+    bool failRegister = false;
+    bool failGetToken = false;
+    MemType lastMemType = MemType::MEM_HOST;
+    uintptr_t lastAddr = 0;
+    size_t lastSize = 0;
+
+    Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t, uint32_t,
+                            std::vector<ConnectionHandle>&) override
+    {
+        return Status::OK();
+    }
+    std::vector<Status> DeleteConnections(const std::vector<ConnectionHandle>&) override
+    {
+        return {};
+    }
+    std::vector<Status> Send(const std::vector<SendIoBatch>&, uint32_t, uint32_t) override
+    {
+        return {};
+    }
+    Status RegisterMemory(ConnectionHandle, const std::vector<RegisterMemoryDesc>& descs,
+                          std::vector<MemHandle>& handles) override
+    {
+        registerCount++;
+        if (!descs.empty()) {
+            lastMemType = descs[0].memoryType;
+            lastAddr = descs[0].addr;
+            lastSize = descs[0].size;
+        }
+        if (failRegister) {
+            return Status::Error(StatusCode::INTERNAL_ERROR, "stub register failed");
+        }
+        handles.push_back(reinterpret_cast<MemHandle>(static_cast<uintptr_t>(registerCount)));
+        return Status::OK();
+    }
+    std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& descs) override
+    {
+        unregisterCount += static_cast<uint32_t>(descs.size());
+        return std::vector<Status>(descs.size(), Status::OK());
+    }
+    Status AllocThread(uint32_t, const std::vector<uint32_t>&, std::vector<ThreadHandle>&) override
+    {
+        return Status::OK();
+    }
+    std::vector<Status> FreeThread(const std::vector<ThreadHandle>&) override { return {}; }
+    Status GetMemTokenId(MemHandle, uint32_t& tokenId) override
+    {
+        if (failGetToken) {
+            return Status::Error(StatusCode::INTERNAL_ERROR, "stub get token failed");
+        }
+        tokenId = fakeTokenId;
+        return Status::OK();
+    }
+};
+
+TEST_F(BufferManagerTest, InitWithProviderRegistersMemory)
+{
+    StubTransProvider provider;
+
+    BufferManager mgr;
+    auto status = mgr.Init("test_rdma", MemoryType::HOST, 1024, 10, &provider);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(provider.registerCount, 1);
+    ASSERT_EQ(provider.lastMemType, TransProvider::MemType::MEM_HOST);
+    ASSERT_NE(provider.lastAddr, 0);
+    ASSERT_EQ(provider.lastSize, 1024 * 10);
+    ASSERT_EQ(mgr.GetTokenId(), 42);
+}
+
+TEST_F(BufferManagerTest, InitWithProviderAllocateReturnsTokenId)
+{
+    StubTransProvider provider;
+    provider.fakeTokenId = 99;
+
+    BufferManager mgr;
+    auto status = mgr.Init("test_rdma", MemoryType::HOST, 1024, 10, &provider);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    ScatterGatherEntry sge;
+    status = mgr.Allocate(64, sge);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(sge.tokenId, 99);
+
+    mgr.Free(sge.slot_index);
+}
+
+TEST_F(BufferManagerTest, DestroyWithProviderUnregistersMemory)
+{
+    StubTransProvider provider;
+    {
+        BufferManager mgr;
+        auto status = mgr.Init("test_rdma", MemoryType::HOST, 1024, 10, &provider);
+        ASSERT_TRUE(status.ok()) << status.message;
+        ASSERT_EQ(provider.unregisterCount, 0);
+    }
+    ASSERT_EQ(provider.unregisterCount, 1);
+}
+
+TEST_F(BufferManagerTest, InitWithProviderRegisterFails)
+{
+    StubTransProvider provider;
+    provider.failRegister = true;
+
+    BufferManager mgr;
+    auto status = mgr.Init("test_rdma", MemoryType::HOST, 1024, 10, &provider);
+    ASSERT_FALSE(status.ok());
+    ASSERT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    ASSERT_EQ(provider.unregisterCount, 0);
+}
+
+TEST_F(BufferManagerTest, InitWithProviderGetTokenFailsCleansUp)
+{
+    StubTransProvider provider;
+    provider.failGetToken = true;
+
+    BufferManager mgr;
+    auto status = mgr.Init("test_rdma", MemoryType::HOST, 1024, 10, &provider);
+    ASSERT_FALSE(status.ok());
+    ASSERT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    ASSERT_EQ(provider.unregisterCount, 1);
 }
 
 }  // namespace

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -37,10 +37,6 @@
 
 namespace UC::ASU {
 
-namespace {
-
-}  // namespace
-
 AsuTransportImpl::~AsuTransportImpl() { Shutdown(); }
 
 Status AsuTransportImpl::Init(const std::string& configPath)
@@ -102,12 +98,14 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
     auto status = ValidateSqeRequestAttrs();
     if (!status.ok()) { return status; }
 
-    status = sendBufferManager_.Init("asu send buffer", MemoryType::HOST,
-                                     config_.sendBufferSlotSize, config_.sendBufferSlotNum);
+    status =
+        sendBufferManager_.Init("asu send buffer", MemoryType::HOST, config_.sendBufferSlotSize,
+                                config_.sendBufferSlotNum, transProvider_.get());
     if (!status.ok()) { return status; }
 
-    status = flagBufferManager_.Init("asu flag buffer", MemoryType::HOST,
-                                     config_.flagBufferSlotSize, config_.flagBufferSlotNum);
+    status =
+        flagBufferManager_.Init("asu flag buffer", MemoryType::HOST, config_.flagBufferSlotSize,
+                                config_.flagBufferSlotNum, transProvider_.get());
     if (!status.ok()) { return status; }
     protocolManager_ = std::make_unique<ProtocolManager>();
 

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
@@ -124,11 +124,11 @@ private:
 
     TransportConfig config_;
     IoScheduler ioScheduler_;
+    std::unique_ptr<TransProvider> transProvider_;
     BufferManager sendBufferManager_;
     BufferManager flagBufferManager_;
     std::unique_ptr<ProtocolManager> protocolManager_;
 
-    std::unique_ptr<TransProvider> transProvider_;
     std::unique_ptr<ConnectionManager> connManager_;
     TransportTaskManager taskManager_;
     UC::SpscRingQueue<TransportTaskContextPtr> executeQueue_;

--- a/ucm/transport/kv/asu/trans/src/buffer_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/buffer_manager.cpp
@@ -31,13 +31,19 @@ namespace UC::ASU {
 
 BufferManager::~BufferManager()
 {
+    if (provider_ && memHandle_) {
+        std::vector<TransProvider::UnregisterMemoryDesc> descs{
+            {nullptr, memHandle_}
+        };
+        provider_->UnregisterMemory(descs);
+    }
     memory_.reset();
     slot_size_ = 0;
     slot_num_ = 0;
 }
 
 Status BufferManager::Init(std::string name, MemoryType type, std::size_t slot_size,
-                           std::size_t slot_num)
+                           std::size_t slot_num, TransProvider* provider)
 {
     if (memory_) {
         return Status::Error(StatusCode::INVALID_ARGUMENT, name + " already initialized");
@@ -79,6 +85,45 @@ Status BufferManager::Init(std::string name, MemoryType type, std::size_t slot_s
 
     index_pool_.Setup(static_cast<IndexPool::Index>(slot_num));
 
+    if (provider) {
+        provider_ = provider;
+        auto regStatus = RegisterMemory();
+        if (!regStatus.ok()) {
+            provider_ = nullptr;
+            memory_.reset();
+            return regStatus;
+        }
+    }
+
+    return Status::OK();
+}
+
+Status BufferManager::RegisterMemory()
+{
+    auto memType = (memory_type_ == MemoryType::ASCEND_DEVICE) ? TransProvider::MemType::MEM_DEVICE
+                                                               : TransProvider::MemType::MEM_HOST;
+    std::size_t total = slot_size_ * slot_num_;
+    std::vector<TransProvider::RegisterMemoryDesc> descs{
+        {memType, reinterpret_cast<uintptr_t>(memory_.get()), total}
+    };
+    std::vector<TransProvider::MemHandle> memHandles;
+    auto regStatus = provider_->RegisterMemory(nullptr, descs, memHandles);
+    if (!regStatus.ok() || memHandles.empty()) {
+        return Status::Error(StatusCode::INTERNAL_ERROR,
+                             name_ + ": failed to register memory: " + regStatus.message);
+    }
+
+    auto tokenStatus = provider_->GetMemTokenId(memHandles[0], tokenId_);
+    if (!tokenStatus.ok()) {
+        std::vector<TransProvider::UnregisterMemoryDesc> unregDescs{
+            {nullptr, memHandles[0]}
+        };
+        provider_->UnregisterMemory(unregDescs);
+        return Status::Error(StatusCode::INTERNAL_ERROR,
+                             name_ + ": failed to get token id: " + tokenStatus.message);
+    }
+
+    memHandle_ = memHandles[0];
     return Status::OK();
 }
 
@@ -99,7 +144,7 @@ Status BufferManager::Allocate(std::size_t size, ScatterGatherEntry& sge)
     void* addr = static_cast<char*>(memory_.get()) + idx * slot_size_;
     sge.addr = reinterpret_cast<std::uint64_t>(addr);
     sge.length = static_cast<std::uint32_t>(size);
-    sge.lkey = static_cast<std::uint32_t>(idx + 1);
+    sge.tokenId = tokenId_;
     sge.slot_index = idx;
     return Status::OK();
 }

--- a/ucm/transport/kv/asu/trans/src/buffer_manager.h
+++ b/ucm/transport/kv/asu/trans/src/buffer_manager.h
@@ -29,13 +29,14 @@
 #include <string>
 #include "asu_transport/types.h"
 #include "thread/index_pool.h"
+#include "trans_provider.h"
 
 namespace UC::ASU {
 
 struct ScatterGatherEntry {
     std::uint64_t addr{0};
     std::uint32_t length{0};
-    std::uint32_t lkey{0};
+    std::uint32_t tokenId{0};
     std::uint32_t slot_index{UINT32_MAX};
 };
 
@@ -47,14 +48,18 @@ public:
     BufferManager(const BufferManager&) = delete;
     BufferManager& operator=(const BufferManager&) = delete;
 
-    Status Init(std::string name, MemoryType type, std::size_t slot_size, std::size_t slot_num);
+    Status Init(std::string name, MemoryType type, std::size_t slot_size, std::size_t slot_num,
+                TransProvider* provider = nullptr);
 
     Status Allocate(std::size_t size, ScatterGatherEntry& sge);
     Status Free(std::uint32_t slot_index);
 
     bool IsValidPointer(const void* ptr) const;
 
+    std::uint32_t GetTokenId() const { return tokenId_; }
+
 private:
+    Status RegisterMemory();
     std::string name_;
     std::size_t slot_size_{0};
     std::size_t slot_num_{0};
@@ -62,6 +67,10 @@ private:
 
     std::shared_ptr<void> memory_;
     IndexPool index_pool_;
+
+    TransProvider* provider_{nullptr};
+    TransProvider::MemHandle memHandle_{nullptr};
+    std::uint32_t tokenId_{0};
 };
 
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/sqe_request.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.cpp
@@ -200,7 +200,7 @@ KvBatchStoreRequest BuildBatchStoreRequest(
     request.dtype = GetTransportConfigAttr<std::uint8_t>(attrs, "dtype");
     request.dspec = GetTransportConfigAttr<std::uint8_t>(attrs, "dspec");
     request.response_buffer_addr = flagBuffer.addr;
-    request.response_mr_key = flagBuffer.lkey;
+    request.response_mr_key = flagBuffer.tokenId;
     request.lr = GetTransportConfigAttr<bool>(attrs, "lr");
     request.rflag = true;
     request.batch_number = static_cast<std::uint16_t>(entries.size);
@@ -225,7 +225,7 @@ KvBatchRetrieveRequest BuildBatchRetrieveRequest(
     request.cid = cid;
     request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
     request.response_buffer_addr = flagBuffer.addr;
-    request.response_mr_key = flagBuffer.lkey;
+    request.response_mr_key = flagBuffer.tokenId;
     request.lr = GetTransportConfigAttr<bool>(attrs, "lr");
     request.rflag = true;
     request.batch_number = static_cast<std::uint16_t>(entries.size);
@@ -260,7 +260,7 @@ KvDeleteRequest BuildDeleteRequest(const BatchView<CacheKey>& keys,
     request.cid = cid;
     request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
     request.response_buffer_addr = flagBuffer.addr;
-    request.response_mr_key = flagBuffer.lkey;
+    request.response_mr_key = flagBuffer.tokenId;
     request.rflag = true;
     request.keys = CopyKeys(keys);
     request.batch_number = static_cast<std::uint16_t>(request.keys.size());
@@ -275,7 +275,7 @@ KvExistRequest BuildExistRequest(const BatchView<CacheKey>& keys,
     request.cid = cid;
     request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
     request.response_buffer_addr = flagBuffer.addr;
-    request.response_mr_key = flagBuffer.lkey;
+    request.response_mr_key = flagBuffer.tokenId;
     request.rflag = true;
     request.sc = GetTransportConfigAttr<bool>(attrs, "sc");
     request.keys = CopyKeys(keys);
@@ -288,7 +288,7 @@ KvKeepAliveRequest BuildKeepAliveRequest(std::uint16_t cid, const ScatterGatherE
     KvKeepAliveRequest request;
     request.cid = cid;
     request.response_buffer_addr = flagBuffer.addr;
-    request.response_mr_key = flagBuffer.lkey;
+    request.response_mr_key = flagBuffer.tokenId;
     request.rflag = true;
     return request;
 }

--- a/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
@@ -56,8 +56,9 @@ public:
         return {};
     }
     Status RegisterMemory(ConnectionHandle, const std::vector<RegisterMemoryDesc>&,
-                          std::vector<MemHandle>&) override
+                          std::vector<MemHandle>& handles) override
     {
+        handles.push_back(reinterpret_cast<MemHandle>(static_cast<uintptr_t>(1)));
         return Status::OK();
     }
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>&) override
@@ -69,7 +70,11 @@ public:
         return Status::OK();
     }
     std::vector<Status> FreeThread(const std::vector<ThreadHandle>&) override { return {}; }
-    Status GetMemTokenId(MemHandle, uint32_t&) override { return Status::OK(); }
+    Status GetMemTokenId(MemHandle, uint32_t& tokenId) override
+    {
+        tokenId = 1;
+        return Status::OK();
+    }
 };
 
 constexpr std::size_t kFlagBufferHeaderSize = 16;
@@ -125,11 +130,14 @@ protected:
         transport_->SetTransProvider(std::make_unique<StubTransProvider>());
         transport_->config_.attrs = DefaultAttrs();
         transport_->nextRequestCid_.store(1, std::memory_order_relaxed);
-        auto status = transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST,
-                                                          kFlagBufferSlotSize, kFlagBufferSlotNum);
+        auto* provider = transport_->transProvider_.get();
+        auto status =
+            transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST,
+                                                kFlagBufferSlotSize, kFlagBufferSlotNum, provider);
         ASSERT_TRUE(status.ok()) << status.message;
-        status = transport_->sendBufferManager_.Init(
-            "test send buffer", MemoryType::HOST, kTestSendBufferSlotSize, kTestSendBufferSlotNum);
+        status = transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST,
+                                                     kTestSendBufferSlotSize,
+                                                     kTestSendBufferSlotNum, provider);
         ASSERT_TRUE(status.ok()) << status.message;
         transport_->protocolManager_ = std::make_unique<ProtocolManager>();
     }

--- a/ucm/transport/kv/asu/trans/test/transport_task_completion_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/transport_task_completion_test.cpp
@@ -91,11 +91,14 @@ protected:
     {
         transport_ = std::make_unique<AsuTransportImpl>();
         transport_->SetTransProvider(std::make_unique<StubTransProvider>());
-        auto status = transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST,
-                                                          kTestBufferSlotSize, kTestBufferSlotNum);
+        auto* provider = transport_->transProvider_.get();
+        auto status =
+            transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST,
+                                                kTestBufferSlotSize, kTestBufferSlotNum, provider);
         ASSERT_TRUE(status.ok()) << status.message;
-        status = transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST,
-                                                     kTestBufferSlotSize, kTestBufferSlotNum);
+        status =
+            transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST,
+                                                kTestBufferSlotSize, kTestBufferSlotNum, provider);
         ASSERT_TRUE(status.ok()) << status.message;
     }
 


### PR DESCRIPTION
## Purpose
Register send/flag buffers to RDMA during BufferManager::Init, obtain
tokenId (rkey) via GetMemTokenId, and use it in SQE requests instead
of the previous placeholder lkey.

## Modifications
1. BufferManager: Init() accepts optional TransProvider* and
ConnectionHandle; after allocation, calls RegisterRdma() to register
the entire buffer as a single MR and obtain tokenId; destructor calls
UnregisterMemory for cleanup. ScatterGatherEntry::lkey renamed to
tokenId. Added GetTokenId() accessor.
2. AsuTransportImpl::Init: passes transProvider_ and a ConnectionHandle
from connManager_ to both buffer managers' Init.
3. sqe_request.cpp: flagBuffer.lkey -> flagBuffer.tokenId (5 places).
4. buffer_manager_test.cc: adapted lkey assertion to tokenId.

## Test
- Existing buffer_manager_test cases remain valid