### PR TITLE
[Feat] use host-pinned memory with dual CPU/device addresses for transport buffers

### DIFF
--- a/ucm/shared/trans/ascend/ascend_buffer.cc
+++ b/ucm/shared/trans/ascend/ascend_buffer.cc
@@ -23,10 +23,35 @@
  * */
 #include "ascend_buffer.h"
 #include <acl/acl.h>
+#include <limits>
 #include <sys/mman.h>
 #include "logger/logger.h"
 
 namespace UC::Trans {
+
+namespace {
+
+constexpr std::uintptr_t HOST_REGISTER_PAGE_SIZE = 4096;
+
+void FreeHostMemory(void* host)
+{
+    auto ret = aclrtFreeHost(host);
+    if (ret != ACL_SUCCESS) { UC_ERROR("Failed to free host memory addr={} ret={}", host, ret); }
+}
+
+void* AlignUp(void* ptr, std::uintptr_t alignment)
+{
+    const auto addr = reinterpret_cast<std::uintptr_t>(ptr);
+    return reinterpret_cast<void*>((addr + alignment - 1) / alignment * alignment);
+}
+
+void ReleaseHostPinnedMemory(void* registeredHost, void* allocatedHost)
+{
+    Buffer::UnregisterHostBuffer(registeredHost);
+    FreeHostMemory(allocatedHost);
+}
+
+}  // namespace
 
 class HostHugePages : public std::enable_shared_from_this<HostHugePages> {
     struct ConstructorKey {};
@@ -122,6 +147,35 @@ std::shared_ptr<void> Trans::AscendBuffer::MakeHostBuffer(size_t size)
     auto ret = aclrtMallocHost(&host, size);
     if (ret == ACL_SUCCESS) { return std::shared_ptr<void>(host, aclrtFreeHost); }
     return nullptr;
+}
+
+std::shared_ptr<void> Trans::AscendBuffer::MakeHostPinnedBuffer(size_t size, void** pDevice)
+{
+    if (pDevice) { *pDevice = nullptr; }
+
+    constexpr auto kMaxSize = std::numeric_limits<size_t>::max();
+    if (size > kMaxSize - (HOST_REGISTER_PAGE_SIZE - 1)) { return nullptr; }
+
+    void* allocatedHost = nullptr;
+    const auto allocationSize = size + HOST_REGISTER_PAGE_SIZE - 1;
+    auto ret = aclrtMallocHost(&allocatedHost, allocationSize);
+    if (ret != ACL_SUCCESS) { return nullptr; }
+
+    void* host = AlignUp(allocatedHost, HOST_REGISTER_PAGE_SIZE);
+
+    void* device = nullptr;
+    auto status = Buffer::RegisterHostBuffer(host, size, &device);
+    if (status.Failure()) {
+        UC_ERROR("Failed to register host-pinned memory addr={} size={} status={}", host, size,
+                 status);
+        FreeHostMemory(allocatedHost);
+        return nullptr;
+    }
+
+    if (pDevice) { *pDevice = device; }
+    return std::shared_ptr<void>(host, [allocatedHost](void* registeredHost) {
+        ReleaseHostPinnedMemory(registeredHost, allocatedHost);
+    });
 }
 
 std::shared_ptr<void> Trans::AscendBuffer::MakeHostBuffer4DirectIo(size_t size)

--- a/ucm/shared/trans/ascend/ascend_buffer.h
+++ b/ucm/shared/trans/ascend/ascend_buffer.h
@@ -32,6 +32,7 @@ class AscendBuffer : public ReservedBuffer {
 public:
     std::shared_ptr<void> MakeDeviceBuffer(size_t size) override;
     std::shared_ptr<void> MakeHostBuffer(size_t size) override;
+    std::shared_ptr<void> MakeHostPinnedBuffer(size_t size, void** pDevice = nullptr) override;
     std::shared_ptr<void> MakeHostBuffer4DirectIo(size_t size) override;
 };
 

--- a/ucm/shared/trans/buffer.h
+++ b/ucm/shared/trans/buffer.h
@@ -39,6 +39,7 @@ public:
 
     virtual std::shared_ptr<void> MakeHostBuffer(size_t size) = 0;
     virtual std::shared_ptr<void> MakeHostBuffer4DirectIo(size_t size) = 0;
+    virtual std::shared_ptr<void> MakeHostPinnedBuffer(size_t size, void** pDevice = nullptr) = 0;
     virtual Status MakeHostBuffers(size_t size, size_t number) = 0;
     virtual std::shared_ptr<void> GetHostBuffer(size_t size) = 0;
 

--- a/ucm/shared/trans/detail/reserved_buffer.h
+++ b/ucm/shared/trans/detail/reserved_buffer.h
@@ -78,6 +78,12 @@ public:
         return this->MakeHostBuffer(size);
     }
 
+    std::shared_ptr<void> MakeHostPinnedBuffer(size_t size, void** pDevice = nullptr) override
+    {
+        if (pDevice) { *pDevice = nullptr; }
+        return this->MakeHostBuffer(size);
+    }
+
     Status MakeHostBuffers(size_t size, size_t number) override
     {
         auto totalSize = size * number;

--- a/ucm/transport/kv/asu/test/case/buffer_manager_test.cc
+++ b/ucm/transport/kv/asu/test/case/buffer_manager_test.cc
@@ -71,6 +71,20 @@ TEST_F(BufferManagerTest, InitWithZeroSlotNum)
     ASSERT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
 }
 
+TEST_F(BufferManagerTest, InitHostWithUnalignedSlotCapacity)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 1000, 10);
+    ASSERT_TRUE(status.ok()) << status.message;
+}
+
+TEST_F(BufferManagerTest, InitDeviceWithUnalignedSlotCapacity)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::ASCEND_DEVICE, 1000, 10);
+    ASSERT_TRUE(status.ok()) << status.message;
+}
+
 TEST_F(BufferManagerTest, DoubleInit)
 {
     BufferManager mgr;
@@ -123,12 +137,13 @@ TEST_F(BufferManagerTest, SingleAllocateAndFree)
     ScatterGatherEntry sge;
     status = mgr.Allocate(64, sge);
     ASSERT_TRUE(status.ok()) << status.message;
-    ASSERT_NE(sge.addr, 0);
+    ASSERT_NE(sge.local_addr, 0);
     ASSERT_EQ(sge.length, 64);
     ASSERT_EQ(sge.tokenId, 0);
     ASSERT_NE(sge.slot_index, UINT32_MAX);
+    ASSERT_EQ(sge.memory_type, MemoryType::HOST);
 
-    auto* ptr = reinterpret_cast<void*>(sge.addr);
+    auto* ptr = reinterpret_cast<void*>(sge.local_addr);
     std::memset(ptr, 0xAB, 64);
 
     status = mgr.Free(sge.slot_index);
@@ -147,12 +162,12 @@ TEST_F(BufferManagerTest, MultipleAllocatesAndFrees)
     for (int i = 0; i < kCount; ++i) {
         status = mgr.Allocate(128, sges[i]);
         ASSERT_TRUE(status.ok()) << "Failed at i=" << i << ": " << status.message;
-        ASSERT_NE(sges[i].addr, 0);
-        std::memset(reinterpret_cast<void*>(sges[i].addr), i, 128);
+        ASSERT_NE(sges[i].local_addr, 0);
+        std::memset(reinterpret_cast<void*>(sges[i].local_addr), i, 128);
     }
 
     for (int i = 0; i < kCount; ++i) {
-        auto* data = reinterpret_cast<unsigned char*>(sges[i].addr);
+        auto* data = reinterpret_cast<unsigned char*>(sges[i].local_addr);
         for (int j = 0; j < 128; ++j) { ASSERT_EQ(data[j], static_cast<unsigned char>(i)); }
     }
 
@@ -191,10 +206,61 @@ TEST_F(BufferManagerTest, AllocateFullSlotSize)
     status = mgr.Allocate(1024, sge);
     ASSERT_TRUE(status.ok()) << status.message;
     ASSERT_EQ(sge.length, 1024);
+}
 
-    std::memset(reinterpret_cast<void*>(sge.addr), 0xFF, 1024);
+TEST_F(BufferManagerTest, AllocateFull4160ByteSlotCapacity)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 4160, 10);
+    ASSERT_TRUE(status.ok());
 
-    mgr.Free(sge.slot_index);
+    ScatterGatherEntry sge;
+    status = mgr.Allocate(4160, sge);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(sge.length, 4160);
+}
+
+TEST_F(BufferManagerTest, AllocateExceeds4160ByteSlotCapacity)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 4160, 10);
+    ASSERT_TRUE(status.ok());
+
+    ScatterGatherEntry sge;
+    status = mgr.Allocate(4161, sge);
+    ASSERT_FALSE(status.ok());
+    ASSERT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(BufferManagerTest, AllMemoryTypesUseAlignedSlotStride)
+{
+    for (const auto type : {MemoryType::HOST, MemoryType::HOST_PINNED, MemoryType::ASCEND_DEVICE}) {
+        BufferManager mgr;
+        auto status = mgr.Init("test_buffer", type, 4160, 2);
+        ASSERT_TRUE(status.ok()) << status.message;
+
+        ScatterGatherEntry first;
+        ScatterGatherEntry second;
+        ASSERT_TRUE(mgr.Allocate(4160, first).ok());
+        ASSERT_TRUE(mgr.Allocate(4160, second).ok());
+        ASSERT_EQ(second.local_addr - first.local_addr, 4160);
+        ASSERT_EQ(second.device_addr - first.device_addr, 4160);
+    }
+}
+
+TEST_F(BufferManagerTest, FlagBufferCapacity71Uses128ByteStride)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("flag_buffer", MemoryType::HOST_PINNED, 71, 2);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    ScatterGatherEntry first;
+    ScatterGatherEntry second;
+    ASSERT_TRUE(mgr.Allocate(71, first).ok());
+    ASSERT_TRUE(mgr.Allocate(71, second).ok());
+    ASSERT_EQ(first.length, 71);
+    ASSERT_EQ(second.local_addr - first.local_addr, 128);
+    ASSERT_EQ(second.device_addr - first.device_addr, 128);
 }
 
 TEST_F(BufferManagerTest, ReuseAfterFree)
@@ -212,7 +278,7 @@ TEST_F(BufferManagerTest, ReuseAfterFree)
     ScatterGatherEntry sge2;
     status = mgr.Allocate(64, sge2);
     ASSERT_TRUE(status.ok());
-    ASSERT_EQ(sge2.addr, sge1.addr);
+    ASSERT_EQ(sge2.local_addr, sge1.local_addr);
     ASSERT_EQ(sge2.slot_index, sge1.slot_index);
 
     mgr.Free(sge2.slot_index);
@@ -233,7 +299,7 @@ TEST_F(BufferManagerTest, ConcurrentAllocateAndFree)
             auto s = mgr.Allocate(64, sge);
             ASSERT_TRUE(s.ok()) << "Thread " << thread_id << " op " << i << ": " << s.message;
 
-            std::memset(reinterpret_cast<void*>(sge.addr), thread_id, 64);
+            std::memset(reinterpret_cast<void*>(sge.local_addr), thread_id, 64);
 
             s = mgr.Free(sge.slot_index);
             ASSERT_TRUE(s.ok()) << s.message;
@@ -260,10 +326,10 @@ TEST_F(BufferManagerTest, ConcurrentStressTest)
             auto s = mgr.Allocate(128, sge);
             ASSERT_TRUE(s.ok());
 
-            std::memset(reinterpret_cast<void*>(sge.addr), thread_id, 128);
+            std::memset(reinterpret_cast<void*>(sge.local_addr), thread_id, 128);
 
             for (int j = 0; j < 128; ++j) {
-                ASSERT_EQ(reinterpret_cast<unsigned char*>(sge.addr)[j], thread_id);
+                ASSERT_EQ(reinterpret_cast<unsigned char*>(sge.local_addr)[j], thread_id);
             }
 
             s = mgr.Free(sge.slot_index);
@@ -286,7 +352,7 @@ TEST_F(BufferManagerTest, FreeZeroesMemory)
     status = mgr.Allocate(64, sge1);
     ASSERT_TRUE(status.ok());
 
-    auto* ptr = reinterpret_cast<uint8_t*>(sge1.addr);
+    auto* ptr = reinterpret_cast<uint8_t*>(sge1.local_addr);
     std::memset(ptr, 0xAB, 1024);
 
     status = mgr.Free(sge1.slot_index);
@@ -295,10 +361,10 @@ TEST_F(BufferManagerTest, FreeZeroesMemory)
     ScatterGatherEntry sge2;
     status = mgr.Allocate(64, sge2);
     ASSERT_TRUE(status.ok());
-    ASSERT_EQ(sge2.addr, sge1.addr);
+    ASSERT_EQ(sge2.local_addr, sge1.local_addr);
     ASSERT_EQ(sge2.slot_index, sge1.slot_index);
 
-    auto* ptr2 = reinterpret_cast<uint8_t*>(sge2.addr);
+    auto* ptr2 = reinterpret_cast<uint8_t*>(sge2.local_addr);
     for (size_t i = 0; i < 1024; ++i) {
         ASSERT_EQ(ptr2[i], 0) << "byte " << i << " not zeroed after free";
     }
@@ -395,6 +461,33 @@ TEST_F(BufferManagerTest, InitWithProviderRegistersMemory)
     ASSERT_NE(provider.lastAddr, 0);
     ASSERT_EQ(provider.lastSize, 1024 * 10);
     ASSERT_EQ(mgr.GetTokenId(), 42);
+
+    ScatterGatherEntry sge;
+    ASSERT_TRUE(mgr.Allocate(64, sge).ok());
+    ASSERT_EQ(sge.local_addr, sge.device_addr);
+}
+
+TEST_F(BufferManagerTest, HostPinnedRegistersDeviceAddress)
+{
+    StubTransProvider provider;
+
+    BufferManager mgr;
+    auto status = mgr.Init("test_rdma_pinned", MemoryType::HOST_PINNED, 4096, 1, &provider);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(provider.registerCount, 1);
+    ASSERT_EQ(provider.lastMemType, TransProvider::MemType::MEM_DEVICE);
+
+    ScatterGatherEntry sge;
+    ASSERT_TRUE(mgr.Allocate(64, sge).ok());
+    ASSERT_NE(sge.local_addr, 0);
+    ASSERT_NE(sge.device_addr, 0);
+    ASSERT_NE(sge.local_addr, sge.device_addr);
+    ASSERT_EQ(sge.local_addr % 4096, 0);
+    ASSERT_EQ(provider.lastAddr, sge.device_addr);
+
+    // The CPU writes through addr while HCOMM and remote RDMA use device_addr.
+    std::memset(reinterpret_cast<void*>(sge.local_addr), 0x5A, sge.length);
+    ASSERT_EQ(*reinterpret_cast<unsigned char*>(sge.local_addr), 0x5A);
 }
 
 TEST_F(BufferManagerTest, InitWithProviderAllocateReturnsTokenId)

--- a/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
@@ -72,9 +72,12 @@ struct TransportConfig {
     bool preconnect{true};
     bool bindCqPoller{true};
 
+    // Slot sizes are caller-visible capacities; BufferManager computes the
+    // aligned physical stride used for allocation and memory registration.
     std::size_t sendBufferSlotSize{4160};
     std::size_t sendBufferSlotNum{128};
-    std::size_t flagBufferSlotSize{128};
+    // Maximum memory required by a batch store/retrieve response flag buffer.
+    std::size_t flagBufferSlotSize{71};
     std::size_t flagBufferSlotNum{4096};
     std::size_t asuBatchLoadIoNum{110};
     std::size_t asuBatchStoreIoNum{110};

--- a/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
@@ -130,24 +130,31 @@ Status AsuTransportImpl::BuildSubBatchSendBuffers(
             continue;
         }
 
-        if (subBatchContext.flagBuffer.addr == 0 || subBatchContext.flagBuffer.length == 0) {
-            const auto subBatchStatus =
-                Status::Error(StatusCode::NOT_INITIALIZED, "sub-batch flag buffer is not ready");
+        if (subBatchContext.channel == nullptr ||
+            !IsTransportBufferReady(subBatchContext.sendSge) ||
+            !IsTransportBufferReady(subBatchContext.flagBuffer)) {
+            const auto subBatchStatus = Status::Error(StatusCode::NOT_INITIALIZED,
+                                                      "sub-batch transport buffers are not ready");
             UC_ERROR(
-                "Sub-batch flag buffer is not ready index={} cid={} flag_addr={} flag_length={}",
-                index, subBatchContext.cid, subBatchContext.flagBuffer.addr,
-                subBatchContext.flagBuffer.length);
+                "Sub-batch transport buffers are not ready index={} cid={} channel={} "
+                "send_local_addr={} send_device_addr={} send_length={} send_slot={} "
+                "flag_local_addr={} flag_device_addr={} flag_length={} flag_slot={}",
+                index, subBatchContext.cid, subBatchContext.channel != nullptr,
+                subBatchContext.sendSge.local_addr, subBatchContext.sendSge.device_addr,
+                subBatchContext.sendSge.length, subBatchContext.sendSge.slot_index,
+                subBatchContext.flagBuffer.local_addr, subBatchContext.flagBuffer.device_addr,
+                subBatchContext.flagBuffer.length, subBatchContext.flagBuffer.slot_index);
             SetSubBatchSendFailed(subBatchContext, subBatchStatus);
             if (status.ok()) { status = subBatchStatus; }
             ReleaseSubBatchResources(subBatchContext);
             continue;
         }
 
-        ioBatches.push_back(
-            TransProvider::SendIoBatch{subBatchContext.channel->GetConnection(),
-                                       reinterpret_cast<void*>(subBatchContext.sendSge.addr),
-                                       reinterpret_cast<void*>(subBatchContext.flagBuffer.addr),
-                                       subBatchContext.sendSge.length});
+        ioBatches.push_back(TransProvider::SendIoBatch{
+            subBatchContext.channel->GetConnection(),
+            reinterpret_cast<void*>(subBatchContext.sendSge.device_addr),
+            reinterpret_cast<void*>(subBatchContext.flagBuffer.device_addr),
+            subBatchContext.sendSge.length});
         subBatchIndexes.emplace_back(index);
     }
 

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -22,9 +22,13 @@
  * SOFTWARE.
  * */
 #include "asu_transport_impl.h"
+#include <acl/acl.h>
 #include <algorithm>
+#include <array>
 #include <chrono>
+#include <cstdint>
 #include <memory>
+#include <string>
 #include <thread>
 #include <utility>
 #include "aicpu_trans_provider.h"
@@ -37,6 +41,26 @@
 #include "transport_config_parser.h"
 
 namespace UC::ASU {
+
+namespace {
+
+constexpr std::size_t kFlagBufferHeaderCopySize = kCqeDwordCount * sizeof(std::uint32_t);
+
+Status CopyDeviceToHost(const ScatterGatherEntry& sge, void* host, std::size_t size)
+{
+    if (size > sge.length) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "copy size exceeds buffer length");
+    }
+    const auto ret = aclrtMemcpy(host, size, reinterpret_cast<void*>(sge.device_addr), size,
+                                 ACL_MEMCPY_DEVICE_TO_HOST);
+    if (ret != ACL_SUCCESS) {
+        return Status::Error(StatusCode::INTERNAL_ERROR,
+                             "copy device memory to host failed ret=" + std::to_string(ret));
+    }
+    return Status::OK();
+}
+
+}  // namespace
 
 AsuTransportImpl::~AsuTransportImpl() { Shutdown(); }
 
@@ -106,14 +130,14 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
 
     connManager_->StartRecoverLoop();
 
-    auto status =
-        sendBufferManager_.Init("asu send buffer", MemoryType::HOST, config_.sendBufferSlotSize,
-                                config_.sendBufferSlotNum, transProvider_.get());
+    auto status = sendBufferManager_.Init("asu send buffer", MemoryType::HOST_PINNED,
+                                          config_.sendBufferSlotSize, config_.sendBufferSlotNum,
+                                          transProvider_.get());
     if (!status.ok()) { return status; }
 
-    status =
-        flagBufferManager_.Init("asu flag buffer", MemoryType::HOST, config_.flagBufferSlotSize,
-                                config_.flagBufferSlotNum, transProvider_.get());
+    status = flagBufferManager_.Init("asu flag buffer", MemoryType::HOST_PINNED,
+                                     config_.flagBufferSlotSize, config_.flagBufferSlotNum,
+                                     transProvider_.get());
     if (!status.ok()) { return status; }
     protocolManager_ = std::make_unique<ProtocolManager>();
 
@@ -436,23 +460,58 @@ void AsuTransportImpl::PollTaskCompletions(const TransportTaskContextPtr& ctx)
     for (auto& subBatchContext : ctx->subBatchContexts) {
         if (subBatchContext.state != TransportSubBatchState::PENDING) { continue; }
 
+        auto completeWithError = [this, &ctx, &subBatchContext](const Status& status) {
+            std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(),
+                      status);
+            CompleteSubBatch(*ctx, subBatchContext, status);
+        };
+
         std::uint16_t completedCid = 0;
-        if (const auto status = protocolManager_->PollResponseCid(
-                reinterpret_cast<void*>(subBatchContext.flagBuffer.addr), completedCid);
+        const void* responseData = nullptr;
+        std::array<std::uint8_t, kFlagBufferHeaderCopySize> flagHeader{};
+        std::vector<std::uint8_t> flagBuffer;
+        if (subBatchContext.flagBuffer.memory_type == MemoryType::ASCEND_DEVICE) {
+            auto status =
+                CopyDeviceToHost(subBatchContext.flagBuffer, flagHeader.data(), flagHeader.size());
+            if (!status.ok()) {
+                // Without a readable header, this sub-batch cannot be polled or unpacked.
+                UC_ERROR("Copy flag buffer header from device failed cid={} code={} message={}",
+                         subBatchContext.cid, static_cast<int>(status.code), status.message);
+                completeWithError(status);
+                continue;
+            }
+            responseData = flagHeader.data();
+        } else {
+            responseData = reinterpret_cast<void*>(subBatchContext.flagBuffer.local_addr);
+        }
+
+        if (const auto status = protocolManager_->PollResponseCid(responseData, completedCid);
             !status.ok()) {
             continue;
         }
         if (completedCid == 0 || completedCid != subBatchContext.cid) { continue; }
 
+        if (subBatchContext.flagBuffer.memory_type == MemoryType::ASCEND_DEVICE) {
+            // The header matched; copy the full CQE before unpacking entry status.
+            flagBuffer.resize(subBatchContext.flagBuffer.length);
+            auto status =
+                CopyDeviceToHost(subBatchContext.flagBuffer, flagBuffer.data(), flagBuffer.size());
+            if (!status.ok()) {
+                // The matched CQE cannot be decoded without the complete flag buffer.
+                UC_ERROR("Copy flag buffer from device failed cid={} code={} message={}",
+                         subBatchContext.cid, static_cast<int>(status.code), status.message);
+                completeWithError(status);
+                continue;
+            }
+            responseData = flagBuffer.data();
+        }
+
         KvResponse response;
         const auto batchNumber = static_cast<std::uint16_t>(subBatchContext.entryStatus.size());
         if (const auto status = protocolManager_->UnpackResponse(
-                reinterpret_cast<void*>(subBatchContext.flagBuffer.addr),
-                ToKvOpcode(subBatchContext.opType), batchNumber, response);
+                responseData, ToKvOpcode(subBatchContext.opType), batchNumber, response);
             !status.ok()) {
-            std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(),
-                      status);
-            CompleteSubBatch(*ctx, subBatchContext, status);
+            completeWithError(status);
             continue;
         }
 

--- a/ucm/transport/kv/asu/trans/src/buffer_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/buffer_manager.cpp
@@ -25,9 +25,79 @@
 #include <acl/acl.h>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include "trans/ascend/ascend_buffer.h"
 
 namespace UC::ASU {
+
+constexpr std::size_t kSlotAddressAlignment = 64;
+
+bool GetSlotStride(std::size_t capacity, std::size_t& stride)
+{
+    // NOTE: Ascend ACL documents an aclrtMallocHost large-block suballocation
+    // layout of ALIGN_UP(len, 32) + 32 bytes with 64-byte-aligned segment
+    // starts. Current HCOMM/RDMA validation did not reproduce failures without
+    // the extra 32-byte tail room, so ASU keeps only the 64-byte slot-start
+    // alignment for now.
+    // Keep one layout for every memory type by aligning each slot start to a
+    // 64-byte boundary.
+    constexpr auto kMaxSize = std::numeric_limits<std::size_t>::max();
+    if (capacity > kMaxSize - (kSlotAddressAlignment - 1)) { return false; }
+
+    stride = (capacity + kSlotAddressAlignment - 1) / kSlotAddressAlignment * kSlotAddressAlignment;
+    return true;
+}
+
+Status BufferManager::BufferRegion::Create(MemoryType type, std::size_t size, BufferRegion& region)
+{
+    Trans::AscendBuffer ascendBuffer;
+    switch (type) {
+        case MemoryType::HOST: {
+            auto owner = ascendBuffer.MakeHostBuffer(size);
+            if (!owner) {
+                return Status::Error(StatusCode::INTERNAL_ERROR, "failed to allocate host memory");
+            }
+            // HOST has one CPU-visible address, which is also passed to the
+            // provider when it registers the region as MEM_HOST.
+            region = {owner, owner.get(), owner.get(), TransProvider::MemType::MEM_HOST};
+            return Status::OK();
+        }
+        case MemoryType::HOST_PINNED: {
+            void* deviceAddr = nullptr;
+            auto owner = ascendBuffer.MakeHostPinnedBuffer(size, &deviceAddr);
+            if (!owner) {
+                return Status::Error(StatusCode::INTERNAL_ERROR,
+                                     "failed to allocate host-pinned memory");
+            }
+            region = {owner, owner.get(), deviceAddr, TransProvider::MemType::MEM_DEVICE};
+            return Status::OK();
+        }
+        case MemoryType::ASCEND_DEVICE: {
+            auto owner = ascendBuffer.MakeDeviceBuffer(size);
+            if (!owner) {
+                return Status::Error(StatusCode::INTERNAL_ERROR,
+                                     "failed to allocate device memory");
+            }
+            region = {owner, owner.get(), owner.get(), TransProvider::MemType::MEM_DEVICE};
+            return Status::OK();
+        }
+        default: return Status::Error(StatusCode::INVALID_ARGUMENT, "unsupported memory type");
+    }
+}
+
+void BufferManager::BufferRegion::Reset()
+{
+    owner.reset();
+    localAddr = nullptr;
+    deviceAddr = nullptr;
+    providerMemType = TransProvider::MemType::MEM_HOST;
+}
+
+bool IsTransportBufferReady(const ScatterGatherEntry& sge)
+{
+    return sge.local_addr != 0 && sge.device_addr != 0 && sge.length != 0 &&
+           sge.slot_index != UINT32_MAX;
+}
 
 BufferManager::~BufferManager()
 {
@@ -37,50 +107,47 @@ BufferManager::~BufferManager()
         };
         provider_->UnregisterMemory(descs);
     }
-    memory_.reset();
-    slot_size_ = 0;
+    region_.Reset();
+    slot_capacity_ = 0;
+    slot_stride_ = 0;
     slot_num_ = 0;
 }
 
-Status BufferManager::Init(std::string name, MemoryType type, std::size_t slot_size,
+Status BufferManager::Init(std::string name, MemoryType type, std::size_t slot_capacity,
                            std::size_t slot_num, TransProvider* provider)
 {
-    if (memory_) {
+    if (region_) {
         return Status::Error(StatusCode::INVALID_ARGUMENT, name + " already initialized");
     }
-    if (slot_size == 0 || slot_num == 0) {
+    if (slot_capacity == 0 || slot_num == 0) {
         return Status::Error(StatusCode::INVALID_ARGUMENT,
-                             name + ": slot_size and slot_num must be non-zero");
+                             name + ": slot_capacity and slot_num must be non-zero");
+    }
+    std::size_t slotStride = 0;
+    if (!GetSlotStride(slot_capacity, slotStride) ||
+        slot_num > std::numeric_limits<std::size_t>::max() / slotStride) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, name + ": slot layout size overflow");
     }
 
     name_ = std::move(name);
     memory_type_ = type;
-    slot_size_ = slot_size;
+    slot_capacity_ = slot_capacity;
+    slot_stride_ = slotStride;
     slot_num_ = slot_num;
 
-    std::size_t total = slot_size * slot_num;
+    std::size_t total = slot_stride_ * slot_num_;
 
-    Trans::AscendBuffer allocator;
-    switch (memory_type_) {
-        case MemoryType::HOST: memory_ = allocator.MakeHostBuffer(total); break;
-        case MemoryType::HOST_PINNED: memory_ = allocator.MakeHostBuffer4DirectIo(total); break;
-        case MemoryType::ASCEND_DEVICE: memory_ = allocator.MakeDeviceBuffer(total); break;
-        default:
-            return Status::Error(StatusCode::INVALID_ARGUMENT, name_ + ": unsupported memory type");
-    }
-
-    if (!memory_) {
-        return Status::Error(StatusCode::INTERNAL_ERROR, name_ + ": failed to allocate memory");
-    }
+    auto allocStatus = BufferRegion::Create(memory_type_, total, region_);
+    if (!allocStatus.ok()) { return allocStatus; }
 
     if (memory_type_ == MemoryType::ASCEND_DEVICE) {
-        if (aclrtMemset(memory_.get(), total, 0, total) != ACL_SUCCESS) {
-            memory_.reset();
+        if (aclrtMemset(region_.localAddr, total, 0, total) != ACL_SUCCESS) {
+            region_.Reset();
             return Status::Error(StatusCode::INTERNAL_ERROR,
                                  name_ + ": failed to zero device memory");
         }
     } else {
-        std::memset(memory_.get(), 0, total);
+        std::memset(region_.localAddr, 0, total);
     }
 
     index_pool_.Setup(static_cast<IndexPool::Index>(slot_num));
@@ -90,7 +157,7 @@ Status BufferManager::Init(std::string name, MemoryType type, std::size_t slot_s
         auto regStatus = RegisterMemory();
         if (!regStatus.ok()) {
             provider_ = nullptr;
-            memory_.reset();
+            region_.Reset();
             return regStatus;
         }
     }
@@ -100,11 +167,9 @@ Status BufferManager::Init(std::string name, MemoryType type, std::size_t slot_s
 
 Status BufferManager::RegisterMemory()
 {
-    auto memType = (memory_type_ == MemoryType::ASCEND_DEVICE) ? TransProvider::MemType::MEM_DEVICE
-                                                               : TransProvider::MemType::MEM_HOST;
-    std::size_t total = slot_size_ * slot_num_;
+    std::size_t total = slot_stride_ * slot_num_;
     std::vector<TransProvider::RegisterMemoryDesc> descs{
-        {memType, reinterpret_cast<uintptr_t>(memory_.get()), total}
+        {region_.providerMemType, reinterpret_cast<uintptr_t>(region_.deviceAddr), total}
     };
     std::vector<TransProvider::MemHandle> memHandles;
     auto regStatus = provider_->RegisterMemory(nullptr, descs, memHandles);
@@ -129,40 +194,44 @@ Status BufferManager::RegisterMemory()
 
 Status BufferManager::Allocate(std::size_t size, ScatterGatherEntry& sge)
 {
-    if (!memory_) { return Status::Error(StatusCode::NOT_INITIALIZED, name_ + " not initialized"); }
+    if (!region_) { return Status::Error(StatusCode::NOT_INITIALIZED, name_ + " not initialized"); }
     if (size == 0) {
         return Status::Error(StatusCode::INVALID_ARGUMENT, name_ + ": size must be non-zero");
     }
-    if (size > slot_size_) {
-        return Status::Error(StatusCode::INVALID_ARGUMENT, name_ + ": size exceeds slot_size");
+    if (size > slot_capacity_) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, name_ + ": size exceeds slot_capacity");
     }
 
     auto idx = index_pool_.Acquire();
     if (idx == IndexPool::npos) {
         return Status::Error(StatusCode::RESOURCE_BUSY, name_ + ": no free slots");
     }
-    void* addr = static_cast<char*>(memory_.get()) + idx * slot_size_;
-    sge.addr = reinterpret_cast<std::uint64_t>(addr);
+    const auto offset = idx * slot_stride_;
+    sge.local_addr =
+        reinterpret_cast<std::uint64_t>(static_cast<char*>(region_.localAddr) + offset);
+    sge.device_addr =
+        reinterpret_cast<std::uint64_t>(static_cast<char*>(region_.deviceAddr) + offset);
     sge.length = static_cast<std::uint32_t>(size);
     sge.tokenId = tokenId_;
     sge.slot_index = idx;
+    sge.memory_type = memory_type_;
     return Status::OK();
 }
 
 Status BufferManager::Free(std::uint32_t slot_index)
 {
-    if (!memory_) { return Status::Error(StatusCode::NOT_INITIALIZED, name_ + " not initialized"); }
+    if (!region_) { return Status::Error(StatusCode::NOT_INITIALIZED, name_ + " not initialized"); }
     if (slot_index >= slot_num_) {
         return Status::Error(StatusCode::INVALID_ARGUMENT, name_ + ": slot_index out of range");
     }
-    auto* p = static_cast<char*>(memory_.get()) + slot_index * slot_size_;
+    auto* p = static_cast<char*>(region_.localAddr) + slot_index * slot_stride_;
     if (memory_type_ == MemoryType::ASCEND_DEVICE) {
-        if (aclrtMemset(p, slot_size_, 0, slot_size_) != ACL_SUCCESS) {
+        if (aclrtMemset(p, slot_stride_, 0, slot_stride_) != ACL_SUCCESS) {
             return Status::Error(StatusCode::INTERNAL_ERROR,
                                  name_ + ": failed to zero device memory");
         }
     } else {
-        std::memset(p, 0, slot_size_);
+        std::memset(p, 0, slot_stride_);
     }
     index_pool_.Release(static_cast<IndexPool::Index>(slot_index));
     return Status::OK();
@@ -170,12 +239,12 @@ Status BufferManager::Free(std::uint32_t slot_index)
 
 bool BufferManager::IsValidPointer(const void* ptr) const
 {
-    if (!ptr || !memory_) { return false; }
-    auto* base = static_cast<const char*>(memory_.get());
+    if (!ptr || !region_) { return false; }
+    auto* base = static_cast<const char*>(region_.localAddr);
     auto* p = static_cast<const char*>(ptr);
-    if (p < base || p >= base + slot_size_ * slot_num_) { return false; }
+    if (p < base || p >= base + slot_stride_ * slot_num_) { return false; }
     auto offset = static_cast<std::size_t>(p - base);
-    return (offset % slot_size_) == 0;
+    return (offset % slot_stride_) == 0;
 }
 
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/buffer_manager.h
+++ b/ucm/transport/kv/asu/trans/src/buffer_manager.h
@@ -34,11 +34,18 @@
 namespace UC::ASU {
 
 struct ScatterGatherEntry {
-    std::uint64_t addr{0};
+    // Local-side address. CPU-accessible for HOST/HOST_PINNED and a local
+    // device address for ASCEND_DEVICE.
+    std::uint64_t local_addr{0};
+    // Device-visible address used by HCOMM/HIXL and remote RDMA operations.
+    std::uint64_t device_addr{0};
     std::uint32_t length{0};
     std::uint32_t tokenId{0};
     std::uint32_t slot_index{UINT32_MAX};
+    MemoryType memory_type{MemoryType::HOST};
 };
+
+bool IsTransportBufferReady(const ScatterGatherEntry& sge);
 
 class BufferManager {
 public:
@@ -48,7 +55,7 @@ public:
     BufferManager(const BufferManager&) = delete;
     BufferManager& operator=(const BufferManager&) = delete;
 
-    Status Init(std::string name, MemoryType type, std::size_t slot_size, std::size_t slot_num,
+    Status Init(std::string name, MemoryType type, std::size_t slot_capacity, std::size_t slot_num,
                 TransProvider* provider = nullptr);
 
     Status Allocate(std::size_t size, ScatterGatherEntry& sge);
@@ -59,13 +66,26 @@ public:
     std::uint32_t GetTokenId() const { return tokenId_; }
 
 private:
+    struct BufferRegion {
+        static Status Create(MemoryType type, std::size_t size, BufferRegion& region);
+
+        explicit operator bool() const { return owner != nullptr; }
+        void Reset();
+
+        std::shared_ptr<void> owner;
+        void* localAddr{nullptr};
+        void* deviceAddr{nullptr};
+        TransProvider::MemType providerMemType{TransProvider::MemType::MEM_HOST};
+    };
+
     Status RegisterMemory();
     std::string name_;
-    std::size_t slot_size_{0};
+    std::size_t slot_capacity_{0};
+    std::size_t slot_stride_{0};
     std::size_t slot_num_{0};
     MemoryType memory_type_{MemoryType::HOST};
 
-    std::shared_ptr<void> memory_;
+    BufferRegion region_;
     IndexPool index_pool_;
 
     TransProvider* provider_{nullptr};

--- a/ucm/transport/kv/asu/trans/src/sqe_request.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.cpp
@@ -21,8 +21,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  * */
+#include <acl/acl.h>
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -148,8 +150,23 @@ Status PackSubBatchRequest(ProtocolManager& protocolManager, BufferManager& send
         return SetSubBatchBuildFailed(subBatchContext, status);
     }
 
-    status = protocolManager.PackRequest(reinterpret_cast<void*>(subBatchContext.sendSge.addr),
-                                         opcode, request);
+    if (subBatchContext.sendSge.memory_type == MemoryType::ASCEND_DEVICE) {
+        std::vector<std::uint8_t> staging(packedSize, 0);
+        status = protocolManager.PackRequest(staging.data(), opcode, request);
+        if (status.ok()) {
+            const auto ret =
+                aclrtMemcpy(reinterpret_cast<void*>(subBatchContext.sendSge.device_addr),
+                            packedSize, staging.data(), packedSize, ACL_MEMCPY_HOST_TO_DEVICE);
+            if (ret != ACL_SUCCESS) {
+                status = Status::Error(
+                    StatusCode::INTERNAL_ERROR,
+                    "copy packed SQE to device memory failed ret=" + std::to_string(ret));
+            }
+        }
+    } else {
+        status = protocolManager.PackRequest(
+            reinterpret_cast<void*>(subBatchContext.sendSge.local_addr), opcode, request);
+    }
     if (!status.ok()) {
         UC_ERROR("Pack sub-batch request failed opcode={} cid={} code={} message={}",
                  static_cast<int>(opcode), subBatchContext.cid, static_cast<int>(status.code),
@@ -170,7 +187,7 @@ KvBatchStoreRequest BuildBatchStoreRequest(
     request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
     request.dtype = GetTransportConfigAttr<std::uint8_t>(attrs, "dtype");
     request.dspec = GetTransportConfigAttr<std::uint8_t>(attrs, "dspec");
-    request.response_buffer_addr = flagBuffer.addr;
+    request.response_buffer_addr = flagBuffer.device_addr;
     request.response_mr_key = flagBuffer.tokenId;
     request.lr = GetTransportConfigAttr<bool>(attrs, "lr");
     request.rflag = true;
@@ -195,7 +212,7 @@ KvBatchRetrieveRequest BuildBatchRetrieveRequest(
     KvBatchRetrieveRequest request;
     request.cid = cid;
     request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
-    request.response_buffer_addr = flagBuffer.addr;
+    request.response_buffer_addr = flagBuffer.device_addr;
     request.response_mr_key = flagBuffer.tokenId;
     request.lr = GetTransportConfigAttr<bool>(attrs, "lr");
     request.rflag = true;
@@ -230,7 +247,7 @@ KvDeleteRequest BuildDeleteRequest(const BatchView<CacheKey>& keys,
     KvDeleteRequest request;
     request.cid = cid;
     request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
-    request.response_buffer_addr = flagBuffer.addr;
+    request.response_buffer_addr = flagBuffer.device_addr;
     request.response_mr_key = flagBuffer.tokenId;
     request.rflag = true;
     request.keys = CopyKeys(keys);
@@ -245,7 +262,7 @@ KvExistRequest BuildExistRequest(const BatchView<CacheKey>& keys,
     KvExistRequest request;
     request.cid = cid;
     request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
-    request.response_buffer_addr = flagBuffer.addr;
+    request.response_buffer_addr = flagBuffer.device_addr;
     request.response_mr_key = flagBuffer.tokenId;
     request.rflag = true;
     request.sc = GetTransportConfigAttr<bool>(attrs, "sc");
@@ -258,7 +275,7 @@ KvKeepAliveRequest BuildKeepAliveRequest(std::uint16_t cid, const ScatterGatherE
 {
     KvKeepAliveRequest request;
     request.cid = cid;
-    request.response_buffer_addr = flagBuffer.addr;
+    request.response_buffer_addr = flagBuffer.device_addr;
     request.response_mr_key = flagBuffer.tokenId;
     request.rflag = true;
     return request;

--- a/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
@@ -216,8 +216,8 @@ TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersReleasesPreFailedSubBatc
     EXPECT_TRUE(subBatchIndexes.empty());
     EXPECT_EQ(subBatchContext.sendSge.slot_index, UINT32_MAX);
     EXPECT_EQ(subBatchContext.flagBuffer.slot_index, UINT32_MAX);
-    EXPECT_EQ(subBatchContext.sendSge.addr, std::uint64_t{0});
-    EXPECT_EQ(subBatchContext.flagBuffer.addr, std::uint64_t{0});
+    EXPECT_EQ(subBatchContext.sendSge.local_addr, std::uint64_t{0});
+    EXPECT_EQ(subBatchContext.flagBuffer.local_addr, std::uint64_t{0});
 }
 
 TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersMarksMissingFlagBufferFailed)
@@ -257,6 +257,97 @@ TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersMarksMissingFlagBufferFa
     for (const auto& entryStatus : subBatchContext.entryStatus) {
         EXPECT_EQ(entryStatus.code, StatusCode::NOT_INITIALIZED);
     }
+}
+
+TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersRejectsZeroSendLength)
+{
+    ASSERT_TRUE(
+        transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST, 4096, 1).ok());
+    ASSERT_TRUE(
+        transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST, 128, 1).ok());
+
+    transport_->connManager_ =
+        std::make_unique<ConnectionManager>(*transport_->transProvider_, "", 5000);
+    ASSERT_TRUE(transport_->connManager_->AddGroup(AsuEndpoint{}, 1).ok());
+
+    std::vector<TransportSubBatchContext> subBatchContexts(1);
+    auto& subBatchContext = subBatchContexts[0];
+    subBatchContext.state = TransportSubBatchState::PENDING;
+    subBatchContext.channel = transport_->connManager_->SelectConnection();
+    subBatchContext.entryStatus.assign(1, Status::OK());
+    ASSERT_TRUE(transport_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
+    subBatchContext.sendSge.length = 0;
+
+    std::vector<TransProvider::SendIoBatch> ioBatches;
+    std::vector<std::size_t> subBatchIndexes;
+    const auto status =
+        transport_->BuildSubBatchSendBuffers(subBatchContexts, ioBatches, subBatchIndexes);
+
+    EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
+    EXPECT_TRUE(ioBatches.empty());
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
+}
+
+TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersRejectsMissingChannel)
+{
+    ASSERT_TRUE(
+        transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST, 4096, 1).ok());
+    ASSERT_TRUE(
+        transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST, 128, 1).ok());
+
+    std::vector<TransportSubBatchContext> subBatchContexts(1);
+    auto& subBatchContext = subBatchContexts[0];
+    subBatchContext.state = TransportSubBatchState::PENDING;
+    subBatchContext.entryStatus.assign(1, Status::OK());
+    ASSERT_TRUE(transport_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
+
+    std::vector<TransProvider::SendIoBatch> ioBatches;
+    std::vector<std::size_t> subBatchIndexes;
+    const auto status =
+        transport_->BuildSubBatchSendBuffers(subBatchContexts, ioBatches, subBatchIndexes);
+
+    EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
+    EXPECT_TRUE(ioBatches.empty());
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
+}
+
+TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersUsesHostPinnedDeviceAddresses)
+{
+    ASSERT_TRUE(
+        transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST_PINNED, 4096, 1)
+            .ok());
+    ASSERT_TRUE(
+        transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST_PINNED, 128, 1)
+            .ok());
+
+    transport_->connManager_ =
+        std::make_unique<ConnectionManager>(*transport_->transProvider_, "", 5000);
+    ASSERT_TRUE(transport_->connManager_->AddGroup(AsuEndpoint{}, 1).ok());
+
+    std::vector<TransportSubBatchContext> subBatchContexts(1);
+    auto& subBatchContext = subBatchContexts[0];
+    subBatchContext.state = TransportSubBatchState::PENDING;
+    subBatchContext.channel = transport_->connManager_->SelectConnection();
+    subBatchContext.entryStatus.assign(1, Status::OK());
+    ASSERT_NE(subBatchContext.channel, nullptr);
+    ASSERT_TRUE(transport_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
+    ASSERT_NE(subBatchContext.sendSge.local_addr, subBatchContext.sendSge.device_addr);
+    ASSERT_NE(subBatchContext.flagBuffer.local_addr, subBatchContext.flagBuffer.device_addr);
+
+    std::vector<TransProvider::SendIoBatch> ioBatches;
+    std::vector<std::size_t> subBatchIndexes;
+    const auto status =
+        transport_->BuildSubBatchSendBuffers(subBatchContexts, ioBatches, subBatchIndexes);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(ioBatches.size(), std::size_t{1});
+    EXPECT_EQ(ioBatches[0].sendBuffer,
+              reinterpret_cast<void*>(subBatchContext.sendSge.device_addr));
+    EXPECT_EQ(ioBatches[0].flagBuffer,
+              reinterpret_cast<void*>(subBatchContext.flagBuffer.device_addr));
 }
 
 TEST(AsuSubmitFlowTest, SendSubBatchBuffersFailsAllSentSubBatchesWhenStatusCountMismatches)

--- a/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
@@ -133,10 +133,10 @@ protected:
         transport_->nextRequestCid_.store(1, std::memory_order_relaxed);
         auto* provider = transport_->transProvider_.get();
         auto status =
-            transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST,
+            transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST_PINNED,
                                                 kFlagBufferSlotSize, kFlagBufferSlotNum, provider);
         ASSERT_TRUE(status.ok()) << status.message;
-        status = transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST,
+        status = transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST_PINNED,
                                                      kTestSendBufferSlotSize,
                                                      kTestSendBufferSlotNum, provider);
         ASSERT_TRUE(status.ok()) << status.message;
@@ -185,9 +185,55 @@ TEST_F(SqeRequestTest, SubmitBatchStoreAllocatesFlagBufferAndBuildsRequest)
     EXPECT_EQ(subBatchContext.opType, TransportOpType::BATCH_STORE);
     EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
     EXPECT_TRUE(subBatchContext.status.ok());
-    EXPECT_NE(subBatchContext.sendSge.addr, std::uint64_t{0});
+    EXPECT_NE(subBatchContext.sendSge.local_addr, std::uint64_t{0});
+    EXPECT_NE(subBatchContext.sendSge.local_addr, subBatchContext.sendSge.device_addr);
+    EXPECT_NE(subBatchContext.flagBuffer.local_addr, subBatchContext.flagBuffer.device_addr);
+
+    const auto* packedSqe =
+        reinterpret_cast<const std::uint32_t*>(subBatchContext.sendSge.local_addr);
+    const auto packedResponseAddr =
+        static_cast<std::uint64_t>(packedSqe[3]) | (static_cast<std::uint64_t>(packedSqe[4]) << 32);
+    EXPECT_EQ(packedResponseAddr, subBatchContext.flagBuffer.device_addr);
     ASSERT_EQ(subBatchContext.entryStatus.size(), entries.size());
     for (const auto& entryStatus : subBatchContext.entryStatus) { EXPECT_TRUE(entryStatus.ok()); }
+}
+
+TEST_F(SqeRequestTest, SubmitBatchStorePacksSqeIntoDeviceSendBuffer)
+{
+    AsuTransportImpl deviceTransport;
+    deviceTransport.SetTransProvider(std::make_unique<StubTransProvider>());
+    deviceTransport.config_.attrs = DefaultAttrs();
+    deviceTransport.nextRequestCid_.store(41, std::memory_order_relaxed);
+    auto* provider = deviceTransport.transProvider_.get();
+    ASSERT_TRUE(deviceTransport.flagBufferManager_
+                    .Init("test flag buffer", MemoryType::HOST_PINNED, kFlagBufferSlotSize,
+                          kFlagBufferSlotNum, provider)
+                    .ok());
+    ASSERT_TRUE(deviceTransport.sendBufferManager_
+                    .Init("test send buffer", MemoryType::ASCEND_DEVICE, kTestSendBufferSlotSize,
+                          kTestSendBufferSlotNum, provider)
+                    .ok());
+    deviceTransport.protocolManager_ = std::make_unique<ProtocolManager>();
+
+    auto entries = MakeEntries(3);
+    IoScheduler::ScheduledIoBatch subBatch{
+        BatchView<KVBuffer>{entries.data(), entries.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+
+    const auto status = deviceTransport.SubmitEntrySubBatchRequest(TransportOpType::BATCH_STORE,
+                                                                   subBatch, subBatchContext);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.sendSge.memory_type, MemoryType::ASCEND_DEVICE);
+    EXPECT_NE(subBatchContext.sendSge.device_addr, std::uint64_t{0});
+    std::vector<std::uint8_t> packed(subBatchContext.sendSge.length);
+    ASSERT_EQ(aclrtMemcpy(packed.data(), packed.size(),
+                          reinterpret_cast<void*>(subBatchContext.sendSge.device_addr),
+                          packed.size(), ACL_MEMCPY_DEVICE_TO_HOST),
+              ACL_SUCCESS);
+    EXPECT_TRUE(
+        deviceTransport.protocolManager_->VerifyPackedBuffer(packed.data(), packed.size()).ok());
 }
 
 TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
@@ -207,7 +253,7 @@ TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
     EXPECT_EQ(subBatchContext.cid, std::uint16_t{9});
     EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
     EXPECT_TRUE(subBatchContext.status.ok());
-    EXPECT_NE(subBatchContext.sendSge.addr, std::uint64_t{0});
+    EXPECT_NE(subBatchContext.sendSge.local_addr, std::uint64_t{0});
 }
 
 TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)
@@ -228,7 +274,7 @@ TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)
     EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
     EXPECT_TRUE(subBatchContext.status.ok());
     EXPECT_EQ(subBatchContext.flagBuffer.length, kFlagBufferHeaderSize + (keys.size() + 7) / 8);
-    EXPECT_NE(subBatchContext.sendSge.addr, std::uint64_t{0});
+    EXPECT_NE(subBatchContext.sendSge.local_addr, std::uint64_t{0});
     ASSERT_EQ(subBatchContext.entryStatus.size(), keys.size());
     for (const auto& entryStatus : subBatchContext.entryStatus) { EXPECT_TRUE(entryStatus.ok()); }
 }
@@ -297,8 +343,8 @@ TEST_F(SqeRequestTest, AllocationFailureMarksWholeSubBatchFailed)
     EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
     EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
     EXPECT_EQ(subBatchContext.status.code, StatusCode::NOT_INITIALIZED);
-    EXPECT_EQ(subBatchContext.flagBuffer.addr, std::uint64_t{0});
-    EXPECT_EQ(subBatchContext.sendSge.addr, std::uint64_t{0});
+    EXPECT_EQ(subBatchContext.flagBuffer.local_addr, std::uint64_t{0});
+    EXPECT_EQ(subBatchContext.sendSge.local_addr, std::uint64_t{0});
     ASSERT_EQ(subBatchContext.entryStatus.size(), entries.size());
     for (const auto& entryStatus : subBatchContext.entryStatus) {
         EXPECT_EQ(entryStatus.code, StatusCode::NOT_INITIALIZED);
@@ -318,7 +364,7 @@ TEST_F(SqeRequestTest, SubmitKeepAliveBuildsFlagBackedRequest)
     EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
     EXPECT_TRUE(subBatchContext.status.ok());
     EXPECT_EQ(subBatchContext.flagBuffer.length, kFlagBufferHeaderSize + 1);
-    EXPECT_NE(subBatchContext.sendSge.addr, std::uint64_t{0});
+    EXPECT_NE(subBatchContext.sendSge.local_addr, std::uint64_t{0});
     ASSERT_EQ(subBatchContext.entryStatus.size(), 1);
     EXPECT_TRUE(subBatchContext.entryStatus[0].ok());
 }

--- a/ucm/transport/kv/asu/trans/test/transport_task_completion_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/transport_task_completion_test.cpp
@@ -22,6 +22,7 @@
  * SOFTWARE.
  * */
 #include <acl/acl.h>
+#include <array>
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -150,8 +151,58 @@ TEST_F(TransportTaskCompletionTest, ReleaseSubBatchResourcesClearsAllocatedSlots
 
     EXPECT_EQ(subBatchContext.sendSge.slot_index, UINT32_MAX);
     EXPECT_EQ(subBatchContext.flagBuffer.slot_index, UINT32_MAX);
-    EXPECT_EQ(subBatchContext.sendSge.addr, std::uint64_t{0});
-    EXPECT_EQ(subBatchContext.flagBuffer.addr, std::uint64_t{0});
+    EXPECT_EQ(subBatchContext.sendSge.local_addr, std::uint64_t{0});
+    EXPECT_EQ(subBatchContext.flagBuffer.local_addr, std::uint64_t{0});
+}
+
+TEST_F(TransportTaskCompletionTest, PollTaskCompletionsReadsDeviceFlagBuffer)
+{
+    AsuTransportImpl deviceTransport;
+    deviceTransport.SetTransProvider(std::make_unique<StubTransProvider>());
+    auto* provider = deviceTransport.transProvider_.get();
+    ASSERT_TRUE(deviceTransport.sendBufferManager_
+                    .Init("test send buffer", MemoryType::HOST, kTestBufferSlotSize,
+                          kTestBufferSlotNum, provider)
+                    .ok());
+    ASSERT_TRUE(deviceTransport.flagBufferManager_
+                    .Init("test flag buffer", MemoryType::ASCEND_DEVICE, kTestBufferSlotSize,
+                          kTestBufferSlotNum, provider)
+                    .ok());
+    deviceTransport.protocolManager_ = std::make_unique<ProtocolManager>();
+
+    auto ctx = std::make_shared<TransportTaskContext>();
+    ctx->state.store(TransportTaskState::INFLIGHT, std::memory_order_release);
+    ctx->subBatchContexts.resize(1);
+    ctx->completedSubBatchCount = 0;
+
+    auto& subBatchContext = ctx->subBatchContexts[0];
+    subBatchContext.cid = 123;
+    subBatchContext.opType = TransportOpType::BATCH_STORE;
+    subBatchContext.entryStatus.assign(2, Status::OK());
+    ASSERT_TRUE(
+        deviceTransport.flagBufferManager_
+            .Allocate((kCqeDwordCount + 1) * sizeof(std::uint32_t), subBatchContext.flagBuffer)
+            .ok());
+    ASSERT_EQ(subBatchContext.flagBuffer.memory_type, MemoryType::ASCEND_DEVICE);
+
+    std::array<std::uint32_t, kCqeDwordCount + 1> cqe{};
+    cqe[3] = subBatchContext.cid;
+    ASSERT_EQ(aclrtMemcpy(reinterpret_cast<void*>(subBatchContext.flagBuffer.device_addr),
+                          cqe.size() * sizeof(std::uint32_t), cqe.data(),
+                          cqe.size() * sizeof(std::uint32_t), ACL_MEMCPY_HOST_TO_DEVICE),
+              ACL_SUCCESS);
+
+    deviceTransport.PollTaskCompletions(ctx);
+
+    EXPECT_EQ(ctx->completedSubBatchCount, std::uint32_t{1});
+    EXPECT_EQ(ctx->state.load(std::memory_order_acquire), TransportTaskState::COMPLETED);
+    EXPECT_TRUE(ctx->finalStatus.ok()) << ctx->finalStatus.message;
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
+    EXPECT_TRUE(subBatchContext.status.ok()) << subBatchContext.status.message;
+    ASSERT_EQ(subBatchContext.entryStatus.size(), std::size_t{2});
+    EXPECT_TRUE(subBatchContext.entryStatus[0].ok());
+    EXPECT_TRUE(subBatchContext.entryStatus[1].ok());
+    EXPECT_EQ(subBatchContext.flagBuffer.slot_index, UINT32_MAX);
 }
 
 TEST_F(TransportTaskCompletionTest, ReleaseSubBatchResourcesPreservesSubBatchStatus)


### PR DESCRIPTION
## Purpose
Switch ASU send/flag buffers from plain host memory to host-pinned
memory so that CPU code packs SQEs through the local mapping while
HCOMM/RDMA uses the device-visible mapping of the same allocation.

## Modifications
1. BufferManager: allocate host-pinned memory via aclrtMallocHost +
aclrtHostRegisterV2, obtain device pointer via
aclrtHostGetDevicePointer. ScatterGatherEntry gains device_addr.
RegisterMemory uses device address for host-pinned regions.
2. AsuTransportImpl: send/flag buffers use HOST_PINNED instead of HOST.
3. asu_submit_flow: pass device_addr to SendIoBatch.
4. sqe_request: use flagBuffer.device_addr for response_buffer_addr.
5. Tests: added host-pinned dual-address and device_addr assertions.

## Test
- buffer_manager_test: HostPinnedRegistersDeviceAddress.
- asu_submit_flow_test: BuildSubBatchSendBuffersUsesHostPinnedDeviceAddresses.
- sqe_request_test: packed response address matches device_addr.