### PR TITLE
[Feat] Add opt-in reshape cache event sync

### DIFF
--- a/docs/source/user-guide/metrics/metrics.md
+++ b/docs/source/user-guide/metrics/metrics.md
@@ -224,7 +224,7 @@ The default metrics configuration contains the following UCM metrics.
 | `ucm:load_bytes_total` | Total bytes loaded through the UCM connector. |
 | `ucm:save_bytes_total` | Total bytes saved through the UCM connector. |
 | `ucm:dump_event_reshape_cache_direct_used_total` | Dump submissions synchronized with `attn_metadata.reshape_cache_event`. |
-| `ucm:dump_event_reshape_cache_mla_layer_used_total` | Dump submissions synchronized with `attn_metadata[layer_name].reshape_cache_event`. |
+| `ucm:dump_event_reshape_cache_layer_used_total` | Dump submissions synchronized with `attn_metadata[layer_name].reshape_cache_event`. |
 | `ucm:dump_event_current_stream_used_total` | Dump submissions synchronized with a UCM-recorded current stream event fallback. |
 | `ucm:dump_event_sync_fallback_used_total` | Dump submissions that fell back to device synchronization because no event handle was available. |
 

--- a/docs/source/user-guide/metrics/metrics.md
+++ b/docs/source/user-guide/metrics/metrics.md
@@ -223,6 +223,10 @@ The default metrics configuration contains the following UCM metrics.
 | `ucm:posix_h2s_bytes_total` | Total bytes transferred from host buffer to Posix storage. |
 | `ucm:load_bytes_total` | Total bytes loaded through the UCM connector. |
 | `ucm:save_bytes_total` | Total bytes saved through the UCM connector. |
+| `ucm:dump_event_reshape_cache_direct_used_total` | Dump submissions synchronized with `attn_metadata.reshape_cache_event`. |
+| `ucm:dump_event_reshape_cache_mla_layer_used_total` | Dump submissions synchronized with `attn_metadata[layer_name].reshape_cache_event`. |
+| `ucm:dump_event_current_stream_used_total` | Dump submissions synchronized with a UCM-recorded current stream event fallback. |
+| `ucm:dump_event_sync_fallback_used_total` | Dump submissions that fell back to device synchronization because no event handle was available. |
 
 ### Gauges
 

--- a/docs/source/user-guide/prefix-cache/pipeline_store.md
+++ b/docs/source/user-guide/prefix-cache/pipeline_store.md
@@ -216,6 +216,7 @@ ucm_connectors:
       use_gdr: false
 enable_event_sync: true
 use_layerwise: true
+enable_reshape_cache_event_sync: false
 enable_record_traces: false
 use_lite: false
 persist_token_threshold: 0

--- a/examples/metrics/metrics_configs.yaml
+++ b/examples/metrics/metrics_configs.yaml
@@ -63,6 +63,14 @@ counter:
     documentation: "Total bytes loaded through the UCM connector (summed across all start_load_kv calls)"
   - name: "save_bytes_total"
     documentation: "Total bytes saved through the UCM connector (summed across all wait_for_save calls)"
+  - name: "dump_event_reshape_cache_direct_used_total"
+    documentation: "Number of dump submissions synchronized with attn_metadata.reshape_cache_event"
+  - name: "dump_event_reshape_cache_mla_layer_used_total"
+    documentation: "Number of dump submissions synchronized with attn_metadata[layer_name].reshape_cache_event"
+  - name: "dump_event_current_stream_used_total"
+    documentation: "Number of dump submissions synchronized with a UCM-recorded current stream event fallback"
+  - name: "dump_event_sync_fallback_used_total"
+    documentation: "Number of dump submissions that fell back to device synchronization because no event handle was available"
 
 # Gauge metrics configuration
 gauge:

--- a/examples/metrics/metrics_configs.yaml
+++ b/examples/metrics/metrics_configs.yaml
@@ -65,7 +65,7 @@ counter:
     documentation: "Total bytes saved through the UCM connector (summed across all wait_for_save calls)"
   - name: "dump_event_reshape_cache_direct_used_total"
     documentation: "Number of dump submissions synchronized with attn_metadata.reshape_cache_event"
-  - name: "dump_event_reshape_cache_mla_layer_used_total"
+  - name: "dump_event_reshape_cache_layer_used_total"
     documentation: "Number of dump submissions synchronized with attn_metadata[layer_name].reshape_cache_event"
   - name: "dump_event_current_stream_used_total"
     documentation: "Number of dump submissions synchronized with a UCM-recorded current stream event fallback"

--- a/examples/ucm_config_example.yaml
+++ b/examples/ucm_config_example.yaml
@@ -26,6 +26,9 @@ ucm_connectors:
 
 # When you use UcmNfsStore, you should set enable_event_sync to false.
 enable_event_sync: true
+# Use event from vllm ascend to do D2H immediatly after kv cache dump.
+# Enable for better dump performance.
+enable_reshape_cache_event_sync: false
 # Enable UCM metrics so they can be monitored online via Grafana and Prometheus.
 # metrics_config_path: "/workspace/unified-cache-management/examples/metrics/metrics_configs.yaml"
 

--- a/examples/ucm_config_example.yaml
+++ b/examples/ucm_config_example.yaml
@@ -26,7 +26,7 @@ ucm_connectors:
 
 # When you use UcmNfsStore, you should set enable_event_sync to false.
 enable_event_sync: true
-# Use event from vllm ascend to do D2H immediatly after kv cache dump.
+# Use vLLM-Ascend reshape cache events to start D2H immediately after KV cache is ready.
 # Enable for better dump performance.
 enable_reshape_cache_event_sync: false
 # Enable UCM metrics so they can be monitored online via Grafana and Prometheus.

--- a/ucm/integration/vllm/device.py
+++ b/ucm/integration/vllm/device.py
@@ -13,7 +13,7 @@ import subprocess
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from itertools import accumulate
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 from vllm.platforms import current_platform
@@ -26,11 +26,15 @@ logger = init_logger(__name__)
 class Device(ABC):
     def __init__(self):
         self.events = {}
+        self.borrowed_events = []
 
     @abstractmethod
     def get_event_handle(self) -> int:
         """Return event handle for stream sync. 0 means no event (use synchronize instead)."""
         pass
+
+    def get_event_handle_from_event(self, event: Any) -> int:
+        return 0
 
     @abstractmethod
     def synchronize(self):
@@ -114,11 +118,23 @@ class CudaDevice(Device):
             logger.error(f"get cuda event handle failed. {e}")
             return 0
 
+    def get_event_handle_from_event(self, event: Any) -> int:
+        try:
+            handle = getattr(event, "cuda_event", None)
+            if handle is None or int(handle) == 0:
+                return 0
+            self.borrowed_events.append(event)
+            return int(handle)
+        except Exception as e:
+            logger.error(f"get cuda event handle from existing event failed. {e}")
+            return 0
+
     def synchronize(self):
         torch.cuda.current_stream().synchronize()
 
     def destroy_event_handles(self):
         self.events.clear()
+        self.borrowed_events.clear()
 
     def destroy_event_handle(self, handle: int):
         self.events.pop(handle, None)
@@ -248,6 +264,22 @@ class NpuDevice(Device):
             logger.error(f"get npu event handle failed. {e}")
             return 0
 
+    def get_event_handle_from_event(self, event: Any) -> int:
+        try:
+            handle = getattr(event, "npu_event", None)
+            if handle is None:
+                parameter = getattr(event, "_as_parameter_", None)
+                if callable(parameter):
+                    parameter = parameter()
+                handle = getattr(parameter, "value", None)
+            if handle is None or int(handle) == 0:
+                return 0
+            self.borrowed_events.append(event)
+            return int(handle)
+        except Exception as e:
+            logger.error(f"get npu event handle from existing event failed. {e}")
+            return 0
+
     def synchronize(self):
         torch.npu.current_stream().synchronize()
 
@@ -260,6 +292,7 @@ class NpuDevice(Device):
             except Exception as e:
                 logger.error(f"destroy npu event failed. {e}")
         self.events.clear()
+        self.borrowed_events.clear()
 
     def destroy_event_handle(self, handle: int):
         import acl

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -323,6 +323,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self.tp_rank = self._vllm_config.parallel_config.rank
         self.block_size = self._vllm_config.cache_config.block_size
         self.is_mla = self._vllm_config.model_config.is_deepseek_mla
+        self.use_mla = getattr(self._vllm_config.model_config, "use_mla", self.is_mla)
         self.num_layers = self._vllm_config.model_config.get_num_layers(
             self._vllm_config.parallel_config
         )
@@ -826,14 +827,67 @@ class UCMDirectConnector(KVConnectorBase_V1):
     def wait_for_layer_load(self, layer_name: str) -> None:
         pass
 
-    def _get_dump_event_handle(self) -> int:
+    def _get_reshape_cache_event(
+        self, layer_name: Optional[str], attn_metadata: Optional["AttentionMetadata"]
+    ) -> tuple[Optional[Any], str]:
+        if attn_metadata is None:
+            return None, "none"
+
+        if self.use_mla:
+            if not layer_name:
+                return None, "mla_missing_layer"
+            try:
+                layer_metadata = attn_metadata[layer_name]
+                event = getattr(layer_metadata, "reshape_cache_event", None)
+                if event is not None:
+                    return event, "mla_layer"
+            except (KeyError, TypeError, AttributeError):
+                pass
+            return None, "mla_missing"
+
+        event = getattr(attn_metadata, "reshape_cache_event", None)
+        if event is not None:
+            return event, "direct"
+        return None, "direct_missing"
+
+    def _get_dump_event_handle(
+        self,
+        layer_name: Optional[str] = None,
+        attn_metadata: Optional["AttentionMetadata"] = None,
+    ) -> int:
         if not self.enable_event_sync:
             self.device.synchronize()
+            logger.debug("dump event sync disabled; synchronized current stream.")
             return 0
+
+        reshape_cache_event, event_source = self._get_reshape_cache_event(
+            layer_name, attn_metadata
+        )
+        event_handle = (
+            self.device.get_event_handle_from_event(reshape_cache_event)
+            if reshape_cache_event is not None
+            else 0
+        )
+        if event_handle != 0:
+            logger.debug(
+                f"dump event handle from reshape_cache_event source={event_source}, "
+                f"layer_name={layer_name}, handle={event_handle}."
+            )
+            return event_handle
 
         event_handle = self.device.get_event_handle()
         if event_handle == 0:
             self.device.synchronize()
+            logger.debug(
+                f"dump event fallback synchronized current stream, "
+                f"reshape_event_source={event_source}, layer_name={layer_name}."
+            )
+        else:
+            logger.debug(
+                f"dump event handle from current stream fallback, "
+                f"reshape_event_source={event_source}, layer_name={layer_name}, "
+                f"handle={event_handle}."
+            )
         return event_handle
 
     def save_kv_layer(
@@ -1140,7 +1194,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             shard_indexs = [layer_id] * len(total_ucm_block_ids)
             try:
                 layer_ptrs = np.ascontiguousarray(self.dump_total_ptrs[local_layer_id])
-                event_handle = self._get_dump_event_handle()
+                event_handle = self._get_dump_event_handle(layer_name, attn_metadata)
                 task = self.store.dump_data(
                     total_ucm_block_ids, shard_indexs, layer_ptrs, event_handle
                 )

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -882,13 +882,9 @@ class UCMDirectConnector(KVConnectorBase_V1):
         event_handle = self.device.get_event_handle()
         if event_handle == 0:
             self.device.synchronize()
-            ucmmetrics.update_stats(
-                "dump_event_sync_fallback_used_total", 1.0
-            )
+            ucmmetrics.update_stats("dump_event_sync_fallback_used_total", 1.0)
         else:
-            ucmmetrics.update_stats(
-                "dump_event_current_stream_used_total", 1.0
-            )
+            ucmmetrics.update_stats("dump_event_current_stream_used_total", 1.0)
         return event_handle
 
     def save_kv_layer(

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -836,17 +836,14 @@ class UCMDirectConnector(KVConnectorBase_V1):
         if attn_metadata is None:
             return None, "none"
 
-        if self.use_mla:
-            if not layer_name:
-                return None, "mla_missing_layer"
+        if layer_name:
             try:
                 layer_metadata = attn_metadata[layer_name]
                 event = getattr(layer_metadata, "reshape_cache_event", None)
                 if event is not None:
-                    return event, "mla_layer"
+                    return event, "layer"
             except (KeyError, TypeError, AttributeError):
                 pass
-            return None, "mla_missing"
 
         event = getattr(attn_metadata, "reshape_cache_event", None)
         if event is not None:
@@ -876,9 +873,9 @@ class UCMDirectConnector(KVConnectorBase_V1):
                     ucmmetrics.update_stats(
                         "dump_event_reshape_cache_direct_used_total", 1.0
                     )
-                elif event_source == "mla_layer":
+                elif event_source == "layer":
                     ucmmetrics.update_stats(
-                        "dump_event_reshape_cache_mla_layer_used_total", 1.0
+                        "dump_event_reshape_cache_layer_used_total", 1.0
                     )
                 return event_handle
 

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -364,6 +364,9 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self.launch_config = ucm_config.get_config()
         self.connector_configs = self.launch_config.get("ucm_connectors", [])
         self.enable_event_sync = self.launch_config.get("enable_event_sync", True)
+        self.enable_reshape_cache_event_sync = self.launch_config.get(
+            "enable_reshape_cache_event_sync", False
+        )
         self.enable_record_traces = self.launch_config.get(
             "enable_record_traces", False
         )
@@ -857,36 +860,37 @@ class UCMDirectConnector(KVConnectorBase_V1):
     ) -> int:
         if not self.enable_event_sync:
             self.device.synchronize()
-            logger.debug("dump event sync disabled; synchronized current stream.")
             return 0
 
-        reshape_cache_event, event_source = self._get_reshape_cache_event(
-            layer_name, attn_metadata
-        )
-        event_handle = (
-            self.device.get_event_handle_from_event(reshape_cache_event)
-            if reshape_cache_event is not None
-            else 0
-        )
-        if event_handle != 0:
-            logger.debug(
-                f"dump event handle from reshape_cache_event source={event_source}, "
-                f"layer_name={layer_name}, handle={event_handle}."
+        if self.enable_reshape_cache_event_sync:
+            reshape_cache_event, event_source = self._get_reshape_cache_event(
+                layer_name, attn_metadata
             )
-            return event_handle
+            event_handle = (
+                self.device.get_event_handle_from_event(reshape_cache_event)
+                if reshape_cache_event is not None
+                else 0
+            )
+            if event_handle != 0:
+                if event_source == "direct":
+                    ucmmetrics.update_stats(
+                        "dump_event_reshape_cache_direct_used_total", 1.0
+                    )
+                elif event_source == "mla_layer":
+                    ucmmetrics.update_stats(
+                        "dump_event_reshape_cache_mla_layer_used_total", 1.0
+                    )
+                return event_handle
 
         event_handle = self.device.get_event_handle()
         if event_handle == 0:
             self.device.synchronize()
-            logger.debug(
-                f"dump event fallback synchronized current stream, "
-                f"reshape_event_source={event_source}, layer_name={layer_name}."
+            ucmmetrics.update_stats(
+                "dump_event_sync_fallback_used_total", 1.0
             )
         else:
-            logger.debug(
-                f"dump event handle from current stream fallback, "
-                f"reshape_event_source={event_source}, layer_name={layer_name}, "
-                f"handle={event_handle}."
+            ucmmetrics.update_stats(
+                "dump_event_current_stream_used_total", 1.0
             )
         return event_handle
 


### PR DESCRIPTION
﻿## Summary

This PR splits the cache dump reshape-event synchronization optimization into its own branch, without the dump queue pipeline refactor from `cache-dump-event-optimize`.

Changes:
- Add opt-in `enable_reshape_cache_event_sync` config, defaulting to `false` to preserve current behavior.
- When enabled, layerwise dump first tries to reuse vLLM/vLLM-Ascend `reshape_cache_event` from `attn_metadata[layer_name]`, then falls back to `attn_metadata.reshape_cache_event`.
- If no usable reshape event exists, UCM keeps the existing current-stream event fallback; if event creation fails, it falls back to device synchronization.
- Preserve borrowed torch event references in `Device` so raw event handles remain valid until UCM clears event handles.
- Add focused metrics for event-source selection:
  - `dump_event_reshape_cache_direct_used_total`
  - `dump_event_reshape_cache_layer_used_total`
  - `dump_event_current_stream_used_total`
  - `dump_event_sync_fallback_used_total`
- Update config example and docs.

## Why

For layerwise cache dump, vLLM-Ascend may already record a `reshape_cache_event` immediately after KV cache writes are ready. Waiting on that event lets UCM's C++ cache copy stream synchronize at the KV-ready point instead of recording a later current-stream event in Python.

The switch is opt-in because model/version behavior differs. The default remains the pre-existing path.

## Scope

This PR intentionally does **not** include dump queue optimization or `DumpQueue` changes. The diff is limited to connector/device Python code plus config, metric config, and docs.

## Verification

Ran locally on Windows worktree `cache-dump-event-sync-only`:

- `git diff --check origin/develop...HEAD`
- `python -m py_compile ucm/integration/vllm/device.py ucm/integration/vllm/ucm_connector.py`
- `python -m black --check ucm/integration/vllm/device.py ucm/integration/vllm/ucm_connector.py`
- `python -m isort --check-only --profile=black ucm/integration/vllm/device.py ucm/integration/vllm/ucm_connector.py`
- `codespell docs/source/user-guide/metrics/metrics.md docs/source/user-guide/prefix-cache/pipeline_store.md examples/metrics/metrics_configs.yaml examples/ucm_config_example.yaml ucm/integration/vllm/device.py ucm/integration/vllm/ucm_connector.py --skip ucm/csrc/**,ucm.egg-info/**,.github/**,ucm/sparse/gsa_on_device/csrc/** -L CANN,cann,NNAL,nnal,ASCEND,ascend,EnQue,CopyIn,Collet,DElt,re-use`
- Parsed `examples/metrics/metrics_configs.yaml` and `examples/ucm_config_example.yaml` with PyYAML.
- Confirmed PR diff does not include dump queue files.

Note: full local `pre-commit run --files ...` could not complete on this machine because the actionlint hook attempted to download Go from `go.dev` and hit a local SSL/network failure. The changed files do not include GitHub Actions files; black/isort/codespell were run directly with matching configured versions.
