### PR TITLE
[Feat] Wire TransProviderType::AIV to the static-library backend

### DIFF
--- a/ucm/transport/kv/asu/CMakeLists.txt
+++ b/ucm/transport/kv/asu/CMakeLists.txt
@@ -75,6 +75,33 @@ target_link_libraries(asu_transport
         asu_ascend_deps
 )
 
+option(BUILD_UCM_ASU_AIV "Enable AIV transport backend (requires external libumc.a)" OFF)
+
+if(BUILD_UCM_ASU_AIV)
+    if(NOT DEFINED ASU_AIV_PROVIDER_ROOT)
+        if(DEFINED ENV{ASU_AIV_PROVIDER_ROOT})
+            set(ASU_AIV_PROVIDER_ROOT "$ENV{ASU_AIV_PROVIDER_ROOT}" CACHE PATH "Install prefix of libumc.a")
+        else()
+            set(ASU_AIV_PROVIDER_ROOT "" CACHE PATH "Install prefix of libumc.a")
+        endif()
+    endif()
+
+    find_library(ASU_AIV_PROVIDER_LIB
+        NAMES libumc.a umc
+        HINTS
+            ${ASU_AIV_PROVIDER_ROOT}/lib
+            ${ASU_AIV_PROVIDER_ROOT}/lib64
+        NO_DEFAULT_PATH
+    )
+    if(NOT ASU_AIV_PROVIDER_LIB)
+        message(FATAL_ERROR "Cannot find libumc.a under ASU_AIV_PROVIDER_ROOT=${ASU_AIV_PROVIDER_ROOT}")
+    endif()
+
+    message(STATUS "ASU AIV provider lib: ${ASU_AIV_PROVIDER_LIB}")
+    target_link_libraries(asu_transport PRIVATE ${ASU_AIV_PROVIDER_LIB} dl)
+    target_compile_definitions(asu_transport PRIVATE UCM_ASU_ENABLE_AIV)
+endif()
+
 file(GLOB ASU_CLIENT_SOURCES CONFIGURE_DEPENDS client/src/*.cpp)
 add_library(asu_client SHARED ${ASU_CLIENT_SOURCES})
 target_include_directories(asu_client

--- a/ucm/transport/kv/asu/trans/include/aiv_transport/aiv_transport.h
+++ b/ucm/transport/kv/asu/trans/include/aiv_transport/aiv_transport.h
@@ -1,0 +1,84 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+#include "asu_transport/types.h"
+
+namespace UC::ASU {
+
+class AIVTransport {
+public:
+    using ConnectionHandle = void*;
+    using MemHandle = void*;
+
+    virtual ~AIVTransport() = default;
+
+    virtual Status CreateConnection(const std::string& localIp, const std::string& remoteIp,
+                                    uint32_t port, uint32_t qpNum, uint32_t timeout,
+                                    std::vector<ConnectionHandle>& connectionHandles) = 0;
+
+    virtual std::vector<Status> DeleteConnections(
+        const std::vector<ConnectionHandle>& connectionHandles) = 0;
+
+    struct SendIoBatch {
+        ConnectionHandle connectionHandle;
+        void* sendBuffer;
+        void* flagBuffer;
+        uint64_t len;
+    };
+
+    virtual std::vector<Status> Send(const std::vector<SendIoBatch>& ioBatches,
+                                     uint32_t kernelCount, uint32_t quietCount) = 0;
+
+    enum class MemType { MEM_DEVICE, MEM_HOST };
+
+    struct RegisterMemoryDesc {
+        MemType memoryType;
+        uintptr_t addr;
+        size_t size;
+    };
+
+    virtual Status RegisterMemory(ConnectionHandle connectionHandle,
+                                  const std::vector<RegisterMemoryDesc>& memoryDescs,
+                                  std::vector<MemHandle>& memoryHandles) = 0;
+
+    struct UnregisterMemoryDesc {
+        ConnectionHandle connectionHandle;
+        MemHandle memoryHandle;
+    };
+
+    virtual std::vector<Status> UnregisterMemory(
+        const std::vector<UnregisterMemoryDesc>& memoryDescs) = 0;
+
+    virtual Status GetMemTokenId(MemHandle memHandle, uint32_t& tokenId) = 0;
+};
+
+std::unique_ptr<AIVTransport> CreateAIVTransProvider();
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/aiv_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/aiv_trans_provider.h
@@ -1,0 +1,117 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <memory>
+#include "aiv_transport/aiv_transport.h"
+#include "trans_provider.h"
+
+namespace UC::ASU {
+
+class AIVTransProvider : public TransProvider {
+public:
+    AIVTransProvider() : impl_(CreateAIVTransProvider()) {}
+
+    Status CreateConnection(const std::string& localIp, const std::string& remoteIp, uint32_t port,
+                            uint32_t qpNum, uint32_t timeout,
+                            std::vector<ConnectionHandle>& connectionHandles) override
+    {
+        return FromImpl(
+            impl_->CreateConnection(localIp, remoteIp, port, qpNum, timeout, connectionHandles));
+    }
+
+    std::vector<Status> DeleteConnections(
+        const std::vector<ConnectionHandle>& connectionHandles) override
+    {
+        return FromImpl(impl_->DeleteConnections(connectionHandles));
+    }
+
+    std::vector<Status> Send(const std::vector<SendIoBatch>& ioBatches, uint32_t kernelCount,
+                             uint32_t quietCount) override
+    {
+        std::vector<AIVTransport::SendIoBatch> batches;
+        batches.reserve(ioBatches.size());
+        for (const auto& io : ioBatches) {
+            batches.push_back({io.connectionHandle, io.sendBuffer, io.flagBuffer, io.len});
+        }
+        return FromImpl(impl_->Send(batches, kernelCount, quietCount));
+    }
+
+    Status RegisterMemory(ConnectionHandle connectionHandle,
+                          const std::vector<RegisterMemoryDesc>& memoryDescs,
+                          std::vector<MemHandle>& memoryHandles) override
+    {
+        std::vector<AIVTransport::RegisterMemoryDesc> descs;
+        descs.reserve(memoryDescs.size());
+        for (const auto& desc : memoryDescs) {
+            descs.push_back(
+                {static_cast<AIVTransport::MemType>(desc.memoryType), desc.addr, desc.size});
+        }
+        return FromImpl(impl_->RegisterMemory(connectionHandle, descs, memoryHandles));
+    }
+
+    std::vector<Status> UnregisterMemory(
+        const std::vector<UnregisterMemoryDesc>& memoryDescs) override
+    {
+        std::vector<AIVTransport::UnregisterMemoryDesc> descs;
+        descs.reserve(memoryDescs.size());
+        for (const auto& desc : memoryDescs) {
+            descs.push_back({desc.connectionHandle, desc.memoryHandle});
+        }
+        return FromImpl(impl_->UnregisterMemory(descs));
+    }
+
+    Status AllocThread(uint32_t, const std::vector<uint32_t>&, std::vector<ThreadHandle>&) override
+    {
+        return Status::OK();
+    }
+
+    std::vector<Status> FreeThread(const std::vector<ThreadHandle>& threads) override
+    {
+        return std::vector<Status>(threads.size(), Status::OK());
+    }
+
+    Status GetMemTokenId(MemHandle memHandle, uint32_t& tokenId) override
+    {
+        return FromImpl(impl_->GetMemTokenId(memHandle, tokenId));
+    }
+
+private:
+    static Status FromImpl(const Status& s)
+    {
+        return s.ok() ? Status::OK() : Status::Error(s.code, s.message);
+    }
+
+    static std::vector<Status> FromImpl(const std::vector<Status>& vec)
+    {
+        std::vector<Status> out;
+        out.reserve(vec.size());
+        for (const auto& s : vec) { out.push_back(FromImpl(s)); }
+        return out;
+    }
+
+    std::unique_ptr<AIVTransport> impl_;
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -32,6 +32,9 @@
 #include <thread>
 #include <utility>
 #include "aicpu_trans_provider.h"
+#ifdef UCM_ASU_ENABLE_AIV
+#include "aiv_trans_provider.h"
+#endif
 #include "asu_response_status.h"
 #include "asu_transport/asu_transport.h"
 #include "connection_internal.h"
@@ -92,8 +95,12 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
                     std::make_unique<FakeTransProvider>(MakeFakeTransProviderConfig(config_));
                 break;
             case TransProviderType::AIV:
-                return Status::Error(StatusCode::UNSUPPORTED,
-                                     "AIV trans provider is not implemented");
+#ifdef UCM_ASU_ENABLE_AIV
+                transProvider_ = std::make_unique<AIVTransProvider>();
+#else
+                return Status::Error(StatusCode::UNSUPPORTED, "AIV backend not enabled");
+#endif
+                break;
             case TransProviderType::UNSUPPORTED:
                 return Status::Error(StatusCode::UNSUPPORTED,
                                      "ASU trans provider backend is not supported");


### PR DESCRIPTION
## 内容
将 `asu_transport_impl.cpp` 中 `case TransProviderType::AIV` 的 UNSUPPORTED 占位替换为构造 `AIVTransProvider`；CMake 增加 `ASU_AIV_PROVIDER_ROOT` 配置项