### PR TITLE
feat(test): add AISBench prefix test tool 

### DIFF
--- a/test/common/aisbench_utils/README.md
+++ b/test/common/aisbench_utils/README.md
@@ -1,0 +1,296 @@
+# AISBench Utilities
+
+This module provides utilities for AISBench Prefix Cache performance testing.
+
+## Module Structure
+
+```
+aisbench_utils/
+├── __init__.py           # Module initialization and exports
+├── data_class.py         # Configuration and result data classes
+├── data_picker.py        # GSM8K dataset picker with auto-reset
+├── generate_dataset.py   # Dataset generation (normal/prefix_cache, GSM8K/random tokens)
+├── api_config.py         # AISBench API configuration generation
+├── prefix_hit_rate.py    # Prefix cache hit rate calculation
+├── result_parser.py      # AISBench log parsing and result saving
+├── README.md             # English documentation
+└── README_zh.md          # Chinese documentation
+```
+
+## Features
+
+### Data Picker (`data_picker.py`)
+- **Non-repeat mode**: Pick from unused data randomly, auto-reset when data exhausted
+- **Repeatable mode**: Pick from all data randomly
+- **In-memory tracking**: No file dependency, picked IDs tracked in memory only
+
+```python
+from common.aisbench_utils import DataPicker
+
+# Non-repeat mode (auto-reset when exhausted)
+picker = DataPicker("GSM8K.jsonl", prefix_flag=1)
+
+# Repeatable mode
+picker = DataPicker("GSM8K.jsonl", prefix_flag=0)
+
+# Manual reset
+picker.reset()
+```
+
+### Dataset Generation (`generate_dataset.py`)
+
+Supports two data source modes:
+- **GSM8K mode** (`use_gsm8k=True`): Use GSM8K dataset as content source
+- **Random token mode** (`use_gsm8k=False`): Generate random tokens directly (no dataset dependency)
+
+```python
+from common.aisbench_utils import create_multi_prefix_dataset, create_dataset_from_random_tokens, parse_prefix_ratio
+
+# Parse repeat rate (supports "50%", "0.5", or integer 50)
+repeat_rate = parse_prefix_ratio("50%")  # -> 0.5
+
+# Create prefix cache dataset using GSM8K
+prefix_path, dataset_path = create_multi_prefix_dataset(
+    tokenizer_path="/path/to/model",
+    input_len=2048,
+    number=160,
+    save_path="/path/to/save",
+    prefix_flag=1,          # 1=prefix_cache, 0=normal
+    dp=2,
+    repeat_rate=0.5,
+    seed=1,
+    prefix_num=1,
+    use_gsm8k=True          # Use GSM8K dataset
+)
+
+# Create prefix cache dataset using random tokens (no GSM8K dependency)
+prefix_path, dataset_path = create_multi_prefix_dataset(
+    tokenizer_path="/path/to/model",
+    input_len=2048,
+    number=160,
+    save_path="/path/to/save",
+    prefix_flag=1,
+    dp=2,
+    repeat_rate=0.5,
+    seed=1,
+    prefix_num=1,
+    use_gsm8k=False         # Generate random tokens directly
+)
+
+# Create simple random token dataset
+samples = create_dataset_from_random_tokens(
+    tokenizer_path="/path/to/model",
+    input_len=512,
+    number=10,
+    seed=42,
+    use_time_offset=True    # Add time-based offset for unique prefixes
+)
+```
+
+#### Prefix Num Effect
+
+The `prefix_num` parameter controls how many different prefix patterns are generated:
+- `prefix_num=1`: All requests share the same prefix (maximum cache hit rate)
+- `prefix_num=2`: Requests alternate between 2 different prefixes (50% hit rate)
+- `prefix_num=4`: Requests rotate among 4 prefixes (25% hit rate)
+
+#### Time-based Offset
+
+When using random token mode, a time-based offset is automatically added to the seed to ensure different prefixes across test runs:
+
+```python
+# Same test run at different times will generate different prefixes
+time_offset = int(time.time()) % 1000000
+effective_seed = seed + time_offset
+```
+
+### Configuration Data Classes (`data_class.py`)
+- **AisbenchConfig**: Test configuration with all parameters
+- **AisbenchResult**: Test result with performance metrics
+- **Auto type conversion**: `request_rate` and `repeat_rate` accept multiple formats
+
+```python
+from common.aisbench_utils import AisbenchConfig, AisbenchResult
+
+# Create config - type conversion is automatic
+config = AisbenchConfig(
+    input_len=2048,
+    output_len=2048,
+    data_num=160,
+    concurrency=40,
+    dataset_type="prefix_cache",
+    repeat_rate=50,         # Accepts: 50, 0.5, "50%", "0.5" -> all convert to "0.5"
+    request_rate=10,        # Accepts: 10, 0, "10", "0" -> all convert to string
+    prefix_test=True,
+    dp=2,
+    test_name="prefix_50pct_dp2"
+)
+
+# Convert to dict
+config_dict = config.to_dict()
+```
+
+### API Configuration (`api_config.py`)
+- Generate AISBench API configuration dynamically
+- Support stream and text test types
+- Support domain names via `url` parameter (bypasses IP validation)
+- Support DeepSeek V3.1 thinking mode
+
+```python
+from common.aisbench_utils import generate_api_config
+
+# Using IP address (validated as IPv4/IPv6)
+generate_api_config(
+    model_path="/path/to/model",
+    model_name="Qwen3-4B",
+    concurrency=40,
+    output_len=2048,
+    request_rate="10",
+    host_ip="127.0.0.1",
+    host_port="8000",
+    test_type="stream",
+    work_path="/home/benchmark"
+)
+
+# Using domain name URL (bypasses IP validation)
+generate_api_config(
+    model_path="/path/to/model",
+    model_name="Qwen3-4B",
+    concurrency=40,
+    output_len=2048,
+    request_rate="10",
+    url="http://api.example.com:8080",  # Supports domain names
+    test_type="stream",
+    work_path="/home/benchmark"
+)
+```
+
+### Prefix Hit Rate (`prefix_hit_rate.py`)
+- Query vLLM metrics API
+- Calculate HBM and external cache hit rates
+
+```python
+from common.aisbench_utils import get_pod_metrics_info, cal_prefix_hit_info
+
+pod_info = ["127.0.0.1:8000"]
+
+# Get metrics before test
+query_tokens, query_tokens_external, hit_tokens, hit_tokens_external = get_pod_metrics_info(pod_info)
+
+# Run test...
+
+# Get metrics after test
+query_tokens_new, query_tokens_external_new, hit_tokens_new, hit_tokens_external_new = get_pod_metrics_info(pod_info)
+
+# Calculate hit rate
+hit_info = cal_prefix_hit_info(
+    query_tokens, query_tokens_external, hit_tokens, hit_tokens_external,
+    query_tokens_new, query_tokens_external_new, hit_tokens_new, hit_tokens_external_new
+)
+```
+
+### Result Parser (`result_parser.py`)
+- Parse AISBench log file
+- Extract performance metrics (TTFT, TPOT, throughput, etc.)
+- Save results to CSV
+
+```python
+from common.aisbench_utils import get_data, save_log, save_csv
+
+# Parse log
+ans, log_dir = get_data("aisbench.log", "10", 1)
+
+# Save log and CSV
+save_log("aisbench.log", log_dir)
+save_csv(ans, "aisbench_result.csv")
+```
+
+## Dependencies
+
+| Dependency | Required | Notes |
+|------------|----------|-------|
+| `transformers` | Optional | For tokenizer (fallback) |
+| `tokenizers` | Optional | Rust tokenizer (preferred, no torch) |
+| `pandas` | Yes | For CSV output |
+| `torch` | No | Removed (uses `random` instead) |
+| `tqdm` | No | Optional (progress bar) |
+
+## Error Handling
+
+Data exhaustion in non-repeat mode is handled automatically — the DataPicker auto-resets when all GSM8K items have been used, so no manual intervention is needed.
+
+```python
+# Manual reset (optional)
+picker = DataPicker("GSM8K.jsonl")
+picker.reset()
+```
+
+## Test Configuration
+
+See `test_aisbench_prefix_cache.py` for complete test examples.
+
+### Parameter Passing Methods
+
+1. **Environment variable**: `AISBENCH_TEST_CASE` (JSON format)
+2. **Config file**: `config.yaml` under `aisbench_prefix_cache.test_scenarios`
+3. **Default**: Built-in test scenarios in test file
+
+```bash
+# Using environment variable
+export AISBENCH_TEST_CASE='[
+    {"input_len": 2048, "output_len": 2048, "data_num": 160, "concurrency": 40, "test_name": "2k_perf"},
+    {"input_len": 4096, "output_len": 1024, "dataset_type": "prefix_cache", "repeat_rate": "50%", "test_name": "prefix_50pct"}
+]'
+
+pytest --feature=aisbench_prefix_cache
+```
+
+### Configuration File Example
+
+```yaml
+# config.yaml
+aisbench_prefix_cache:
+  dataset:
+    base_path: "/mnt/host/d/Dataset/gsm"
+    gsm8k_source: "/mnt/host/d/Dataset/gsm/GSM8K.jsonl"
+    use_gsm8k: false  # false = random tokens (no dataset dependency)
+
+  model:
+    name: "qwen3:0.6b"
+    path: "/mnt/host/d/Models/Qwen3-32B"
+    tokenizer_path: "/mnt/host/d/Models/Qwen3-32B"
+
+  server:
+    url: "http://192.168.65.254:9090"  # Supports domain names
+
+  test:
+    default_perf: "default_perf"
+    test_type: "stream"
+```
+
+## AisbenchConfig Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `input_len` | int | 2048 | Input token length |
+| `output_len` | int | 2048 | Output token length |
+| `data_num` | int | 160 | Dataset sample count |
+| `concurrency` | int | 40 | Maximum concurrency |
+| `request_rate` | int/float/str | 0 | Request rate (auto-converts: 0, 10, "10" -> "0", "10") |
+| `test_type` | str | "stream" | stream or text |
+| `repeat` | int | 1 | Test repeat count |
+| `dataset` | str | "" | Specified dataset path |
+| `dataset_type` | str | "normal" | normal or prefix_cache |
+| `prefix_num` | int | 1 | Number of prefix types |
+| `repeat_rate` | int/float/str | 0.5 | Prefix repeat rate (auto-converts: 50, 0.5, "50%" -> "0.5") |
+| `prefix_test` | bool | False | Whether to warmup prefix |
+| `dp` | int | 1 | Number of DP domains |
+| `seed` | int | 1 | Random seed |
+| `length_mean` | int | None | Input length mean (Gaussian) |
+| `length_std` | float | None | Input length std dev |
+| `length_min` | int | None | Input length minimum |
+| `length_max` | int | None | Input length maximum |
+| `test_accuracy` | bool | False | Whether to test accuracy |
+| `enable_think` | bool | False | DeepSeek V3.1 thinking mode |
+| `npu_num` | int | 1 | NPU card count |
+| `test_name` | str | "Default" | Test name |

--- a/test/common/aisbench_utils/README.md
+++ b/test/common/aisbench_utils/README.md
@@ -198,11 +198,11 @@ hit_info = cal_prefix_hit_info(
 from common.aisbench_utils import get_data, save_log, save_csv
 
 # Parse log
-ans, log_dir = get_data("aisbench.log", "10", 1)
+perf_result, log_dir = get_data("aisbench.log", "10", 1)
 
 # Save log and CSV
 save_log("aisbench.log", log_dir)
-save_csv(ans, "aisbench_result.csv")
+save_csv(perf_result, "aisbench_result.csv")
 ```
 
 ## Dependencies

--- a/test/common/aisbench_utils/README_zh.md
+++ b/test/common/aisbench_utils/README_zh.md
@@ -1,0 +1,296 @@
+# AISBench 工具模块
+
+本模块提供 AISBench Prefix Cache 性能测试的工具函数。
+
+## 模块结构
+
+```
+aisbench_utils/
+├── __init__.py           # 模块初始化和导出
+├── data_class.py         # 配置和结果数据类
+├── data_picker.py        # GSM8K数据选择器（支持自动重置）
+├── generate_dataset.py   # 数据集生成（普通/prefix_cache，支持GSM8K/随机token）
+├── api_config.py         # AISBench API配置生成
+├── prefix_hit_rate.py    # Prefix Cache命中率计算
+├── result_parser.py      # AISBench日志解析和结果保存
+├── README.md             # 英文文档
+└── README_zh.md          # 中文文档
+```
+
+## 功能特性
+
+### 数据选择器 (`data_picker.py`)
+- **不重复模式**: 从未使用的数据中随机选择，数据耗尽时自动重置
+- **可重复模式**: 从所有数据中随机选择
+- **纯内存追踪**: 无文件依赖，已选ID仅在内存中维护
+
+```python
+from common.aisbench_utils import DataPicker
+
+# 不重复模式（数据耗尽时自动重置）
+picker = DataPicker("GSM8K.jsonl", prefix_flag=1)
+
+# 可重复模式
+picker = DataPicker("GSM8K.jsonl", prefix_flag=0)
+
+# 手动重置
+picker.reset()
+```
+
+### 数据集生成 (`generate_dataset.py`)
+
+支持两种数据来源模式：
+- **GSM8K模式** (`use_gsm8k=True`): 使用GSM8K数据集作为内容源
+- **随机token模式** (`use_gsm8k=False`): 直接生成随机token（无数据集依赖）
+
+```python
+from common.aisbench_utils import create_multi_prefix_dataset, create_dataset_from_random_tokens, parse_prefix_ratio
+
+# 解析重复率（支持"50%"、"0.5"或整数50）
+repeat_rate = parse_prefix_ratio("50%")  # -> 0.5
+
+# 使用GSM8K创建Prefix Cache数据集
+prefix_path, dataset_path = create_multi_prefix_dataset(
+    tokenizer_path="/path/to/model",
+    input_len=2048,
+    number=160,
+    save_path="/path/to/save",
+    prefix_flag=1,          # 1=prefix_cache, 0=normal
+    dp=2,
+    repeat_rate=0.5,
+    seed=1,
+    prefix_num=1,
+    use_gsm8k=True          # 使用GSM8K数据集
+)
+
+# 使用随机token创建Prefix Cache数据集（无需GSM8K）
+prefix_path, dataset_path = create_multi_prefix_dataset(
+    tokenizer_path="/path/to/model",
+    input_len=2048,
+    number=160,
+    save_path="/path/to/save",
+    prefix_flag=1,
+    dp=2,
+    repeat_rate=0.5,
+    seed=1,
+    prefix_num=1,
+    use_gsm8k=False         # 直接生成随机token
+)
+
+# 创建简单的随机token数据集
+samples = create_dataset_from_random_tokens(
+    tokenizer_path="/path/to/model",
+    input_len=512,
+    number=10,
+    seed=42,
+    use_time_offset=True    # 添加时间偏移确保前缀唯一
+)
+```
+
+#### prefix_num 参数效果
+
+`prefix_num` 参数控制生成多少种不同的前缀模式：
+- `prefix_num=1`: 所有请求共用同一个前缀（最大缓存命中率）
+- `prefix_num=2`: 请求轮流使用2个不同前缀（50%命中率）
+- `prefix_num=4`: 请求在4个前缀间轮转（25%命中率）
+
+#### 时间偏移机制
+
+使用随机token模式时，会自动添加基于时间的偏移量，确保不同测试运行的前缀不重复：
+
+```python
+# 不同时间的测试运行会生成不同的前缀
+time_offset = int(time.time()) % 1000000
+effective_seed = seed + time_offset
+```
+
+### 配置数据类 (`data_class.py`)
+- **AisbenchConfig**: 包含所有测试参数的配置类
+- **AisbenchResult**: 包含性能指标的结果类
+- **自动类型转换**: `request_rate`和`repeat_rate`接受多种格式
+
+```python
+from common.aisbench_utils import AisbenchConfig, AisbenchResult
+
+# 创建配置 - 类型自动转换
+config = AisbenchConfig(
+    input_len=2048,
+    output_len=2048,
+    data_num=160,
+    concurrency=40,
+    dataset_type="prefix_cache",
+    repeat_rate=50,         # 接受: 50, 0.5, "50%", "0.5" -> 都转换为 "0.5"
+    request_rate=10,        # 接受: 10, 0, "10", "0" -> 都转换为字符串
+    prefix_test=True,
+    dp=2,
+    test_name="prefix_50pct_dp2"
+)
+
+# 转换为字典
+config_dict = config.to_dict()
+```
+
+### API配置生成 (`api_config.py`)
+- 动态生成AISBench API配置
+- 支持stream和text测试类型
+- 通过`url`参数支持域名访问（绕过IP验证）
+- 支持DeepSeek V3.1思考模式
+
+```python
+from common.aisbench_utils import generate_api_config
+
+# 使用IP地址（验证为IPv4/IPv6）
+generate_api_config(
+    model_path="/path/to/model",
+    model_name="Qwen3-4B",
+    concurrency=40,
+    output_len=2048,
+    request_rate="10",
+    host_ip="127.0.0.1",
+    host_port="8000",
+    test_type="stream",
+    work_path="/home/benchmark"
+)
+
+# 使用域名URL（绕过IP验证）
+generate_api_config(
+    model_path="/path/to/model",
+    model_name="Qwen3-4B",
+    concurrency=40,
+    output_len=2048,
+    request_rate="10",
+    url="http://api.example.com:8080",  # 支持域名
+    test_type="stream",
+    work_path="/home/benchmark"
+)
+```
+
+### 命中率计算 (`prefix_hit_rate.py`)
+- 查询vLLM metrics API
+- 计算HBM和external cache命中率
+
+```python
+from common.aisbench_utils import get_pod_metrics_info, cal_prefix_hit_info
+
+pod_info = ["127.0.0.1:8000"]
+
+# 测试前获取metrics
+query_tokens, query_tokens_external, hit_tokens, hit_tokens_external = get_pod_metrics_info(pod_info)
+
+# 运行测试...
+
+# 测试后获取metrics
+query_tokens_new, query_tokens_external_new, hit_tokens_new, hit_tokens_external_new = get_pod_metrics_info(pod_info)
+
+# 计算命中率
+hit_info = cal_prefix_hit_info(
+    query_tokens, query_tokens_external, hit_tokens, hit_tokens_external,
+    query_tokens_new, query_tokens_external_new, hit_tokens_new, hit_tokens_external_new
+)
+```
+
+### 结果解析 (`result_parser.py`)
+- 解析AISBench日志文件
+- 提取性能指标（TTFT、TPOT、吞吐量等）
+- 保存结果到CSV
+
+```python
+from common.aisbench_utils import get_data, save_log, save_csv
+
+# 解析日志
+ans, log_dir = get_data("aisbench.log", "10", 1)
+
+# 保存日志和CSV
+save_log("aisbench.log", log_dir)
+save_csv(ans, "aisbench_result.csv")
+```
+
+## 依赖
+
+| 依赖 | 是否必需 | 说明 |
+|------|----------|------|
+| `transformers` | 可选 | 用于tokenizer（备用） |
+| `tokenizers` | 可选 | Rust tokenizer（推荐，无torch依赖） |
+| `pandas` | 是 | 用于CSV输出 |
+| `torch` | 否 | 已移除（使用`random`替代） |
+| `tqdm` | 否 | 可选（进度条） |
+
+## 错误处理
+
+不重复模式下数据耗尽时会自动重置，无需手动干预。
+
+```python
+# 手动重置（可选）
+picker = DataPicker("GSM8K.jsonl")
+picker.reset()
+```
+
+## 测试配置
+
+完整测试示例参见 `test_aisbench_prefix_cache.py`。
+
+### 参数传递方式
+
+1. **环境变量**: `AISBENCH_TEST_CASE`（JSON格式）
+2. **配置文件**: `config.yaml` 中的 `aisbench_prefix_cache.test_scenarios`
+3. **默认配置**: 测试文件中内置的测试场景
+
+```bash
+# 使用环境变量传递多个测试配置
+export AISBENCH_TEST_CASE='[
+    {"input_len": 2048, "output_len": 2048, "data_num": 160, "concurrency": 40, "test_name": "2k_perf"},
+    {"input_len": 4096, "output_len": 1024, "dataset_type": "prefix_cache", "repeat_rate": "50%", "test_name": "prefix_50pct"}
+]'
+
+pytest --feature=aisbench_prefix_cache
+```
+
+### 配置文件示例
+
+```yaml
+# config.yaml
+aisbench_prefix_cache:
+  dataset:
+    base_path: "/mnt/host/d/Dataset/gsm"
+    gsm8k_source: "/mnt/host/d/Dataset/gsm/GSM8K.jsonl"
+    use_gsm8k: false  # false = 随机token（无数据集依赖）
+
+  model:
+    name: "qwen3:0.6b"
+    path: "/mnt/host/d/Models/Qwen3-32B"
+    tokenizer_path: "/mnt/host/d/Models/Qwen3-32B"
+
+  server:
+    url: "http://192.168.65.254:9090"  # 支持域名
+
+  test:
+    default_perf: "default_perf"
+    test_type: "stream"
+```
+
+## AisbenchConfig 参数说明
+
+| 参数 | 类型 | 默认值 | 说明 |
+|------|------|--------|------|
+| `input_len` | int | 2048 | 输入token长度 |
+| `output_len` | int | 2048 | 输出token长度 |
+| `data_num` | int | 160 | 数据集条数 |
+| `concurrency` | int | 40 | 系统最大并发数 |
+| `request_rate` | int/float/str | 0 | 请求频率（自动转换: 0, 10, "10" -> "0", "10"） |
+| `test_type` | str | "stream" | stream或text |
+| `repeat` | int | 1 | 测试重复次数 |
+| `dataset` | str | "" | 指定数据集路径 |
+| `dataset_type` | str | "normal" | normal或prefix_cache |
+| `prefix_num` | int | 1 | 前缀个数 |
+| `repeat_rate` | int/float/str | 0.5 | 前缀重复率（自动转换: 50, 0.5, "50%" -> "0.5"） |
+| `prefix_test` | bool | False | 是否预热前缀 |
+| `dp` | int | 1 | DP域数量 |
+| `seed` | int | 1 | 随机种子 |
+| `length_mean` | int | None | 输入长度均值（高斯分布） |
+| `length_std` | float | None | 输入长度标准差 |
+| `length_min` | int | None | 输入长度最小值 |
+| `length_max` | int | None | 输入长度最大值 |
+| `test_accuracy` | bool | False | 是否测试精度 |
+| `enable_think` | bool | False | DeepSeek V3.1思考模式 |
+| `npu_num` | int | 1 | NPU卡数 |
+| `test_name` | str | "Default" | 测试名称 |

--- a/test/common/aisbench_utils/README_zh.md
+++ b/test/common/aisbench_utils/README_zh.md
@@ -198,11 +198,11 @@ hit_info = cal_prefix_hit_info(
 from common.aisbench_utils import get_data, save_log, save_csv
 
 # 解析日志
-ans, log_dir = get_data("aisbench.log", "10", 1)
+perf_result, log_dir = get_data("aisbench.log", "10", 1)
 
 # 保存日志和CSV
 save_log("aisbench.log", log_dir)
-save_csv(ans, "aisbench_result.csv")
+save_csv(perf_result, "aisbench_result.csv")
 ```
 
 ## 依赖

--- a/test/common/aisbench_utils/__init__.py
+++ b/test/common/aisbench_utils/__init__.py
@@ -1,0 +1,22 @@
+# aisbench_utils module initialization
+# AISBench test utilities and dataset generation
+
+from .data_picker import DataPicker, LightTokenizer
+from .generate_dataset import (
+    create_dataset,
+    create_dataset_from_random_tokens,
+    create_multi_prefix_dataset,
+    generate_unique_tokens,
+    parse_prefix_ratio,
+    sample_target_length,
+    write_data,
+)
+from .api_config import generate_api_config, symlink_force
+from .result_parser import get_data, save_log, save_csv
+from .prefix_hit_rate import (
+    get_prefix_queries_total,
+    get_prefix_hits_total,
+    get_pod_metrics_info,
+    cal_prefix_hit_info,
+)
+from .data_class import AisbenchConfig, AisbenchResult

--- a/test/common/aisbench_utils/__init__.py
+++ b/test/common/aisbench_utils/__init__.py
@@ -1,6 +1,8 @@
 # aisbench_utils module initialization
 # AISBench test utilities and dataset generation
 
+from .api_config import generate_api_config, symlink_force
+from .data_class import AisbenchConfig, AisbenchResult
 from .data_picker import DataPicker, LightTokenizer
 from .generate_dataset import (
     create_dataset,
@@ -11,12 +13,10 @@ from .generate_dataset import (
     sample_target_length,
     write_data,
 )
-from .api_config import generate_api_config, symlink_force
-from .result_parser import get_data, save_log, save_csv
 from .prefix_hit_rate import (
-    get_prefix_queries_total,
-    get_prefix_hits_total,
-    get_pod_metrics_info,
     cal_prefix_hit_info,
+    get_pod_metrics_info,
+    get_prefix_hits_total,
+    get_prefix_queries_total,
 )
-from .data_class import AisbenchConfig, AisbenchResult
+from .result_parser import get_data, save_csv, save_log

--- a/test/common/aisbench_utils/api_config.py
+++ b/test/common/aisbench_utils/api_config.py
@@ -2,6 +2,7 @@
 AISBench API configuration generation module
 Generate AISBench test API configuration file based on template
 """
+
 import errno
 import logging
 import os
@@ -59,7 +60,7 @@ def generate_api_config(
     enable_think: bool = False,
     test_accuracy: bool = False,
     work_path: str = "/home/benchmark",
-    test_abbr: Optional[str] = None
+    test_abbr: Optional[str] = None,
 ) -> str:
     """
     Generate AISBench API configuration file
@@ -105,7 +106,10 @@ def generate_api_config(
         generation_kwargs = "temperature=0,\n\t\t\tignore_eos=True"
 
     if enable_think:
-        generation_kwargs = generation_kwargs + ",\n\t\t\tchat_template_kwargs={\"enable_thinking\": True}"
+        generation_kwargs = (
+            generation_kwargs
+            + ',\n\t\t\tchat_template_kwargs={"enable_thinking": True}'
+        )
 
     # Build host configuration based on url or host_ip/host_port
     if url:
@@ -118,7 +122,7 @@ def generate_api_config(
         logging.info(f"Using host_ip: {host_ip}, host_port: {host_port}")
 
     # API config template content
-    template_content = f'''from ais_bench.benchmark.models import {api_test_type}
+    template_content = f"""from ais_bench.benchmark.models import {api_test_type}
 
 models = [
     dict(
@@ -137,11 +141,11 @@ models = [
         )
     )
 ]
-'''
+"""
 
     # Write to temporary config file
     temp_api_path = os.path.join(os.getcwd(), "temp_api.py")
-    with open(temp_api_path, 'w', encoding='utf-8') as f:
+    with open(temp_api_path, "w", encoding="utf-8") as f:
         f.write(template_content)
 
     logging.info(f"API config file generated: {temp_api_path}")
@@ -151,7 +155,12 @@ models = [
     logging.info(f"Output len: {output_len}")
 
     # Create symlink to AISBench config directory
-    target_path = os.path.normpath(os.path.join(work_path, "ais_bench/benchmark/configs/models/vllm_api/vllm_api_chat_temp.py"))
+    target_path = os.path.normpath(
+        os.path.join(
+            work_path,
+            "ais_bench/benchmark/configs/models/vllm_api/vllm_api_chat_temp.py",
+        )
+    )
     symlink_force(temp_api_path, target_path)
 
     return temp_api_path
@@ -171,7 +180,7 @@ def modify_aisbench_api_from_template(
     enable_think: bool = False,
     test_accuracy: bool = False,
     work_path: str = "/home/benchmark",
-    test_abbr: Optional[str] = None
+    test_abbr: Optional[str] = None,
 ) -> str:
     """
     Generate AISBench API config from template file (using regex substitution)
@@ -201,7 +210,7 @@ def modify_aisbench_api_from_template(
     # Read template file
     temp_api_path = os.path.join(os.getcwd(), "temp_api.py")
 
-    with open(template_path, 'r', encoding='utf-8') as file_default:
+    with open(template_path, "r", encoding="utf-8") as file_default:
         content = file_default.read()
 
     # Use regex substitution
@@ -216,14 +225,22 @@ def modify_aisbench_api_from_template(
         # Use url parameter (supports domain names)
         content = re.sub("url_for_replace", url, content)
         # Remove host_ip/host_port lines if present in template
-        content = re.sub(r'host_ip="ip_for_replace",\s*\n\s*host_port=port_for_replace,', 'url="url_for_replace",', content)
+        content = re.sub(
+            r'host_ip="ip_for_replace",\s*\n\s*host_port=port_for_replace,',
+            'url="url_for_replace",',
+            content,
+        )
         logging.info(f"Using custom URL: {url}")
     else:
         # Use host_ip + host_port
         content = re.sub("ip_for_replace", host_ip, content)
         content = re.sub("port_for_replace", host_port, content)
         # Remove url line if present in template
-        content = re.sub(r'url="url_for_replace",', f'host_ip="{host_ip}",\n        host_port={host_port},', content)
+        content = re.sub(
+            r'url="url_for_replace",',
+            f'host_ip="{host_ip}",\n        host_port={host_port},',
+            content,
+        )
         logging.info(f"Using host_ip: {host_ip}, host_port: {host_port}")
 
     content = re.sub("outputlen_for_replace", str(output_len), content)
@@ -236,18 +253,28 @@ def modify_aisbench_api_from_template(
         generation_kwargs = "temperature=0,\n\t\t\tignore_eos=True"
 
     if enable_think:
-        generation_kwargs = generation_kwargs + ",\n\t\t\tchat_template_kwargs={\"enable_thinking\": True}"
+        generation_kwargs = (
+            generation_kwargs
+            + ',\n\t\t\tchat_template_kwargs={"enable_thinking": True}'
+        )
 
-    content = re.sub("generation_kwargs_for_replace", generation_kwargs.expandtabs(4), content)
+    content = re.sub(
+        "generation_kwargs_for_replace", generation_kwargs.expandtabs(4), content
+    )
 
     # Write to temporary file
-    with open(temp_api_path, 'w', encoding='utf-8') as file_temp:
+    with open(temp_api_path, "w", encoding="utf-8") as file_temp:
         file_temp.write(content)
 
     logging.info(f"API config file generated from template: {temp_api_path}")
 
     # Create symlink to AISBench config directory
-    target_path = os.path.normpath(os.path.join(work_path, "ais_bench/benchmark/configs/models/vllm_api/vllm_api_chat_temp.py"))
+    target_path = os.path.normpath(
+        os.path.join(
+            work_path,
+            "ais_bench/benchmark/configs/models/vllm_api/vllm_api_chat_temp.py",
+        )
+    )
     symlink_force(temp_api_path, target_path)
 
     return temp_api_path

--- a/test/common/aisbench_utils/api_config.py
+++ b/test/common/aisbench_utils/api_config.py
@@ -1,0 +1,253 @@
+"""
+AISBench API configuration generation module
+Generate AISBench test API configuration file based on template
+"""
+import errno
+import logging
+import os
+import re
+import shutil
+import sys
+from typing import Optional
+
+logging.getLogger().setLevel(logging.INFO)
+
+
+def symlink_force(target: str, link_name: str):
+    """
+    Force create symlink or copy on Windows (delete existing target first if needed)
+
+    On Linux: uses os.symlink for symbolic links.
+    On Windows: uses shutil.copy2 because os.symlink requires admin privileges
+                or developer mode, and may fail with WinError 4392.
+
+    Args:
+        target: Target path (source file)
+        link_name: Link name (destination path)
+    """
+    if sys.platform == "win32":
+        # Windows: use file copy instead of symlink
+        logging.info(f"copy file: {link_name} ==> {target}")
+        if os.path.exists(link_name):
+            os.remove(link_name)
+        # Ensure destination directory exists
+        os.makedirs(os.path.dirname(link_name), exist_ok=True)
+        shutil.copy2(target, link_name)
+    else:
+        # Linux: use symlink
+        logging.info(f"make symlink: {link_name} ==> {target}")
+        try:
+            os.symlink(target, link_name)
+        except OSError as e:
+            if e.errno == errno.EEXIST:
+                os.remove(link_name)
+                os.symlink(target, link_name)
+            else:
+                raise e
+
+
+def generate_api_config(
+    model_path: str,
+    model_name: str,
+    concurrency: int,
+    output_len: int,
+    request_rate: str,
+    host_ip: str = "",
+    host_port: str = "",
+    url: str = "",
+    test_type: str = "stream",
+    enable_think: bool = False,
+    test_accuracy: bool = False,
+    work_path: str = "/home/benchmark",
+    test_abbr: Optional[str] = None
+) -> str:
+    """
+    Generate AISBench API configuration file
+
+    Supports two connection modes:
+    1. host_ip + host_port: For IP address based connection (validated as IPv4/IPv6)
+    2. url: For domain name or custom URL path (host_ip/host_port will be ignored)
+
+    Args:
+        model_path: Model weights path
+        model_name: Service model name
+        concurrency: Maximum concurrency
+        output_len: Output token length
+        request_rate: Request rate
+        host_ip: Service IP address (optional if url is provided)
+        host_port: Service port (optional if url is provided)
+        url: Custom URL path for domain-based connection (e.g., "http://api.example.com:8080")
+             When url is set, host_ip and host_port will be ignored
+        test_type: Test type (stream/text)
+        enable_think: Whether to enable thinking mode (DeepSeek V3.1)
+        test_accuracy: Whether to test accuracy
+        work_path: AISBench work path
+        test_abbr: Test abbreviation name
+
+    Returns:
+        Generated temporary config file path
+    """
+    # Distinguish stream and non-stream
+    if test_type == "text":
+        api_test_type = "VLLMCustomAPIChat"
+        api_test_abbr = test_abbr or "vllm-api-general-chat"
+    elif test_type == "stream":
+        api_test_type = "VLLMCustomAPIChatStream"
+        api_test_abbr = test_abbr or "vllm-api-stream-chat"
+    else:
+        api_test_type = "VLLMCustomAPIChatStream"
+        api_test_abbr = test_abbr or "vllm-api-stream-chat"
+
+    # Generate generation_kwargs
+    if test_accuracy:
+        generation_kwargs = "temperature=0.6,\n\t\t\ttop_p = 0.95"
+    else:
+        generation_kwargs = "temperature=0,\n\t\t\tignore_eos=True"
+
+    if enable_think:
+        generation_kwargs = generation_kwargs + ",\n\t\t\tchat_template_kwargs={\"enable_thinking\": True}"
+
+    # Build host configuration based on url or host_ip/host_port
+    if url:
+        # Use custom URL (supports domain names)
+        host_config = f'url="{url}"'
+        logging.info(f"Using custom URL: {url}")
+    else:
+        # Use host_ip + host_port (must be valid IP address)
+        host_config = f'host_ip="{host_ip}",\n        host_port={host_port}'
+        logging.info(f"Using host_ip: {host_ip}, host_port: {host_port}")
+
+    # API config template content
+    template_content = f'''from ais_bench.benchmark.models import {api_test_type}
+
+models = [
+    dict(
+        attr="service",
+        type={api_test_type},
+        abbr='{api_test_abbr}',
+        path="{model_path}",
+        model="{model_name}",
+        request_rate={request_rate},
+        retry=2,
+        {host_config},
+        max_out_len={output_len},
+        batch_size={concurrency},
+        generation_kwargs=dict(
+            {generation_kwargs.expandtabs(4)}
+        )
+    )
+]
+'''
+
+    # Write to temporary config file
+    temp_api_path = os.path.join(os.getcwd(), "temp_api.py")
+    with open(temp_api_path, 'w', encoding='utf-8') as f:
+        f.write(template_content)
+
+    logging.info(f"API config file generated: {temp_api_path}")
+    logging.info(f"Model path: {model_path}")
+    logging.info(f"Model name: {model_name}")
+    logging.info(f"Concurrency: {concurrency}")
+    logging.info(f"Output len: {output_len}")
+
+    # Create symlink to AISBench config directory
+    target_path = os.path.normpath(os.path.join(work_path, "ais_bench/benchmark/configs/models/vllm_api/vllm_api_chat_temp.py"))
+    symlink_force(temp_api_path, target_path)
+
+    return temp_api_path
+
+
+def modify_aisbench_api_from_template(
+    template_path: str,
+    model_path: str,
+    model_name: str,
+    concurrency: int,
+    output_len: int,
+    request_rate: str,
+    host_ip: str = "",
+    host_port: str = "",
+    url: str = "",
+    test_type: str = "stream",
+    enable_think: bool = False,
+    test_accuracy: bool = False,
+    work_path: str = "/home/benchmark",
+    test_abbr: Optional[str] = None
+) -> str:
+    """
+    Generate AISBench API config from template file (using regex substitution)
+
+    Supports two connection modes:
+    1. host_ip + host_port: For IP address based connection
+    2. url: For domain name or custom URL path (host_ip/host_port will be ignored)
+
+    Args:
+        template_path: Template file path
+        Other args same as generate_api_config
+
+    Returns:
+        Generated temporary config file path
+    """
+    # Distinguish stream and non-stream
+    if test_type == "text":
+        api_test_type = "VLLMCustomAPIChat"
+        api_test_abbr = test_abbr or "vllm-api-general-chat"
+    elif test_type == "stream":
+        api_test_type = "VLLMCustomAPIChatStream"
+        api_test_abbr = test_abbr or "vllm-api-stream-chat"
+    else:
+        api_test_type = "VLLMCustomAPIChatStream"
+        api_test_abbr = test_abbr or "vllm-api-stream-chat"
+
+    # Read template file
+    temp_api_path = os.path.join(os.getcwd(), "temp_api.py")
+
+    with open(template_path, 'r', encoding='utf-8') as file_default:
+        content = file_default.read()
+
+    # Use regex substitution
+    content = re.sub("model_path_for_replace", model_path, content)
+    content = re.sub("model_name_for_replace", model_name, content)
+    content = re.sub("rr_for_replace", request_rate, content)
+    content = re.sub("test_type_for_replace", api_test_type, content)
+    content = re.sub("test_abbr_for_replace", api_test_abbr, content)
+
+    # Handle host configuration based on url or host_ip/host_port
+    if url:
+        # Use url parameter (supports domain names)
+        content = re.sub("url_for_replace", url, content)
+        # Remove host_ip/host_port lines if present in template
+        content = re.sub(r'host_ip="ip_for_replace",\s*\n\s*host_port=port_for_replace,', 'url="url_for_replace",', content)
+        logging.info(f"Using custom URL: {url}")
+    else:
+        # Use host_ip + host_port
+        content = re.sub("ip_for_replace", host_ip, content)
+        content = re.sub("port_for_replace", host_port, content)
+        # Remove url line if present in template
+        content = re.sub(r'url="url_for_replace",', f'host_ip="{host_ip}",\n        host_port={host_port},', content)
+        logging.info(f"Using host_ip: {host_ip}, host_port: {host_port}")
+
+    content = re.sub("outputlen_for_replace", str(output_len), content)
+    content = re.sub("concurrency_for_replace", str(concurrency), content)
+
+    # Generate generation_kwargs
+    if test_accuracy:
+        generation_kwargs = "temperature=0.6,\n\t\t\ttop_p = 0.95"
+    else:
+        generation_kwargs = "temperature=0,\n\t\t\tignore_eos=True"
+
+    if enable_think:
+        generation_kwargs = generation_kwargs + ",\n\t\t\tchat_template_kwargs={\"enable_thinking\": True}"
+
+    content = re.sub("generation_kwargs_for_replace", generation_kwargs.expandtabs(4), content)
+
+    # Write to temporary file
+    with open(temp_api_path, 'w', encoding='utf-8') as file_temp:
+        file_temp.write(content)
+
+    logging.info(f"API config file generated from template: {temp_api_path}")
+
+    # Create symlink to AISBench config directory
+    target_path = os.path.normpath(os.path.join(work_path, "ais_bench/benchmark/configs/models/vllm_api/vllm_api_chat_temp.py"))
+    symlink_force(temp_api_path, target_path)
+
+    return temp_api_path

--- a/test/common/aisbench_utils/data_class.py
+++ b/test/common/aisbench_utils/data_class.py
@@ -1,0 +1,219 @@
+"""
+AISBench Prefix Cache test configuration data classes
+"""
+from dataclasses import dataclass, field
+from typing import Optional, List, Any, Dict, Union
+
+
+class DatasetType(str):
+    """Dataset type enumeration"""
+    NORMAL = "normal"
+    PREFIX_CACHE = "prefix_cache"
+
+
+class TestMode(str):
+    """Test mode enumeration"""
+    PERFORMANCE = "perf"
+    ACCURACY = "accuracy"
+
+
+@dataclass
+class AisbenchConfig:
+    """
+    AISBench Prefix Cache test configuration
+
+    Contains all test parameters, supports variable-length dataset testing
+
+    Note: Users can pass any reasonable type for numeric/string parameters,
+          automatic type conversion will be performed in __post_init__
+    """
+    # Basic configuration (required)
+    input_len: int = 2048              # Input token length
+    output_len: int = 2048             # Output token length
+    data_num: int = 160                # Number of dataset samples
+    concurrency: int = 40              # Maximum concurrency
+
+    # Request configuration
+    request_rate: Union[int, float, str] = 0  # Request rate, auto-convert to str
+    test_type: str = "stream"          # stream or text
+    repeat: int = 1                    # Test repeat count
+
+    # Dataset configuration
+    dataset: str = ""                  # Specified dataset path (optional)
+    dataset_type: str = DatasetType.NORMAL  # normal or prefix_cache
+
+    # Prefix Cache configuration
+    prefix_num: int = 1                # Number of prefix types
+    repeat_rate: Union[int, float, str] = 0.5  # Prefix repeat rate, auto-parse (50%, 0.5, 50 all work)
+    prefix_test: bool = False          # Whether to warmup prefix first
+    dp: int = 1                        # Number of DP domains
+    seed: int = 1                      # Random seed
+
+    # Variable-length dataset configuration
+    length_mean: Optional[int] = None  # Input length mean (Gaussian distribution)
+    length_std: Optional[float] = None # Input length standard deviation
+    length_min: Optional[int] = None   # Input length minimum
+    length_max: Optional[int] = None   # Input length maximum
+
+    # Test mode configuration
+    test_accuracy: bool = False        # Whether to test accuracy
+    enable_think: bool = False         # DeepSeek V3.1 thinking mode
+
+    # Hardware configuration
+    npu_num: int = 1                   # Number of NPU cards
+
+    # Test name (for result recording)
+    test_name: str = "Default"
+
+    def __post_init__(self):
+        """Auto-convert types after initialization"""
+        # Convert request_rate to string format
+        # Accepts: int (0, 10), float (0.5), str ("0", "10", "0.5")
+        self._request_rate_raw = self.request_rate  # Store original value
+        self.request_rate = self._parse_request_rate(self.request_rate)
+
+        # Convert repeat_rate to string format (percentage or decimal)
+        # Accepts: int (50), float (0.5), str ("50%", "0.5", "50")
+        self._repeat_rate_raw = self.repeat_rate  # Store original value
+        self.repeat_rate = self._parse_repeat_rate(self.repeat_rate)
+
+    def _parse_request_rate(self, value: Union[int, float, str]) -> str:
+        """
+        Parse request_rate to string format
+
+        Args:
+            value: Can be int (0=unlimited, 10=10 req/s), float, or str
+
+        Returns:
+            String representation for AISBench
+        """
+        if isinstance(value, str):
+            # Already string, just return it
+            return value
+        else:
+            # Convert int/float to string
+            return str(int(value) if isinstance(value, float) and value.is_integer() else value)
+
+    def _parse_repeat_rate(self, value: Union[int, float, str]) -> str:
+        """
+        Parse repeat_rate to standard format
+
+        Args:
+            value: Can be:
+                - int: 50 -> "0.5" (interpreted as percentage)
+                - float: 0.5 -> "0.5"
+                - str: "50%" -> "0.5", "0.5" -> "0.5", "50" -> "0.5"
+
+        Returns:
+            Decimal string format (e.g., "0.5", "0.3")
+        """
+        if isinstance(value, str):
+            # Handle string input
+            if value.endswith('%'):
+                # Percentage format: "50%" -> 0.5
+                pct = float(value.rstrip('%'))
+                return str(pct / 100)
+            else:
+                # Already decimal or plain number string
+                try:
+                    num = float(value)
+                    if num > 1:
+                        # Assume percentage: "50" -> 0.5
+                        return str(num / 100)
+                    return str(num)
+                except ValueError:
+                    return value
+        elif isinstance(value, (int, float)):
+            # Handle numeric input
+            num = float(value)
+            if num > 1:
+                # Assume percentage: 50 -> 0.5
+                return str(num / 100)
+            return str(num)
+        return str(value)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary"""
+        return {
+            'input_len': self.input_len,
+            'output_len': self.output_len,
+            'data_num': self.data_num,
+            'concurrency': self.concurrency,
+            'request_rate': self.request_rate,
+            'test_type': self.test_type,
+            'repeat': self.repeat,
+            'dataset': self.dataset,
+            'dataset_type': self.dataset_type,
+            'prefix_num': self.prefix_num,
+            'repeat_rate': self.repeat_rate,
+            'prefix_test': self.prefix_test,
+            'dp': self.dp,
+            'seed': self.seed,
+            'length_mean': self.length_mean,
+            'length_std': self.length_std,
+            'length_min': self.length_min,
+            'length_max': self.length_max,
+            'test_accuracy': self.test_accuracy,
+            'enable_think': self.enable_think,
+            'npu_num': self.npu_num,
+            'test_name': self.test_name,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> 'AisbenchConfig':
+        """Create config from dictionary"""
+        return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
+
+
+@dataclass
+class AisbenchResult:
+    """
+    AISBench test result data class
+    """
+    test_name: str = ""
+    status: str = ""
+
+    # Basic parameters
+    input_len: int = 0
+    output_len: int = 0
+    data_num: int = 0
+    concurrency: int = 0
+    request_rate: str = "0"
+    dataset_type: str = ""
+    repeat_rate: str = ""
+
+    # Performance metrics
+    ttft_avg: float = 99999
+    ttft_p90: float = 99999
+    tpot_avg: float = 99999
+    tpot_p90: float = 99999
+    total_time: float = 99999
+
+    # Throughput metrics
+    output_throughput: float = 99999
+    single_output_throughput: float = 99999
+    e2e_throughput: float = 99999
+    single_e2e_throughput: float = 99999
+    input_token_throughput: float = 99999
+    prefill_throughput: float = 99999
+
+    # QPS metrics
+    qps: float = 99999
+    qpm: float = 99999
+
+    # Token statistics
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_requests: int = 0
+
+    # Prefix Cache hit rate
+    hbm_hit_rate: str = ""
+    hbm_hits: int = 0
+    hbm_queries: int = 0
+    external_hit_rate: str = ""
+    external_hits: int = 0
+    external_queries: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary"""
+        return vars(self)

--- a/test/common/aisbench_utils/data_class.py
+++ b/test/common/aisbench_utils/data_class.py
@@ -1,18 +1,21 @@
 """
 AISBench Prefix Cache test configuration data classes
 """
+
 from dataclasses import dataclass, field
-from typing import Optional, List, Any, Dict, Union
+from typing import Any, Dict, List, Optional, Union
 
 
 class DatasetType(str):
     """Dataset type enumeration"""
+
     NORMAL = "normal"
     PREFIX_CACHE = "prefix_cache"
 
 
 class TestMode(str):
     """Test mode enumeration"""
+
     PERFORMANCE = "perf"
     ACCURACY = "accuracy"
 
@@ -27,40 +30,43 @@ class AisbenchConfig:
     Note: Users can pass any reasonable type for numeric/string parameters,
           automatic type conversion will be performed in __post_init__
     """
+
     # Basic configuration (required)
-    input_len: int = 2048              # Input token length
-    output_len: int = 2048             # Output token length
-    data_num: int = 160                # Number of dataset samples
-    concurrency: int = 40              # Maximum concurrency
+    input_len: int = 2048  # Input token length
+    output_len: int = 2048  # Output token length
+    data_num: int = 160  # Number of dataset samples
+    concurrency: int = 40  # Maximum concurrency
 
     # Request configuration
     request_rate: Union[int, float, str] = 0  # Request rate, auto-convert to str
-    test_type: str = "stream"          # stream or text
-    repeat: int = 1                    # Test repeat count
+    test_type: str = "stream"  # stream or text
+    repeat: int = 1  # Test repeat count
 
     # Dataset configuration
-    dataset: str = ""                  # Specified dataset path (optional)
+    dataset: str = ""  # Specified dataset path (optional)
     dataset_type: str = DatasetType.NORMAL  # normal or prefix_cache
 
     # Prefix Cache configuration
-    prefix_num: int = 1                # Number of prefix types
-    repeat_rate: Union[int, float, str] = 0.5  # Prefix repeat rate, auto-parse (50%, 0.5, 50 all work)
-    prefix_test: bool = False          # Whether to warmup prefix first
-    dp: int = 1                        # Number of DP domains
-    seed: int = 1                      # Random seed
+    prefix_num: int = 1  # Number of prefix types
+    repeat_rate: Union[int, float, str] = (
+        0.5  # Prefix repeat rate, auto-parse (50%, 0.5, 50 all work)
+    )
+    prefix_test: bool = False  # Whether to warmup prefix first
+    dp: int = 1  # Number of DP domains
+    seed: int = 1  # Random seed
 
     # Variable-length dataset configuration
     length_mean: Optional[int] = None  # Input length mean (Gaussian distribution)
-    length_std: Optional[float] = None # Input length standard deviation
-    length_min: Optional[int] = None   # Input length minimum
-    length_max: Optional[int] = None   # Input length maximum
+    length_std: Optional[float] = None  # Input length standard deviation
+    length_min: Optional[int] = None  # Input length minimum
+    length_max: Optional[int] = None  # Input length maximum
 
     # Test mode configuration
-    test_accuracy: bool = False        # Whether to test accuracy
-    enable_think: bool = False         # DeepSeek V3.1 thinking mode
+    test_accuracy: bool = False  # Whether to test accuracy
+    enable_think: bool = False  # DeepSeek V3.1 thinking mode
 
     # Hardware configuration
-    npu_num: int = 1                   # Number of NPU cards
+    npu_num: int = 1  # Number of NPU cards
 
     # Test name (for result recording)
     test_name: str = "Default"
@@ -92,7 +98,9 @@ class AisbenchConfig:
             return value
         else:
             # Convert int/float to string
-            return str(int(value) if isinstance(value, float) and value.is_integer() else value)
+            return str(
+                int(value) if isinstance(value, float) and value.is_integer() else value
+            )
 
     def _parse_repeat_rate(self, value: Union[int, float, str]) -> str:
         """
@@ -109,9 +117,9 @@ class AisbenchConfig:
         """
         if isinstance(value, str):
             # Handle string input
-            if value.endswith('%'):
+            if value.endswith("%"):
                 # Percentage format: "50%" -> 0.5
-                pct = float(value.rstrip('%'))
+                pct = float(value.rstrip("%"))
                 return str(pct / 100)
             else:
                 # Already decimal or plain number string
@@ -135,32 +143,32 @@ class AisbenchConfig:
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary"""
         return {
-            'input_len': self.input_len,
-            'output_len': self.output_len,
-            'data_num': self.data_num,
-            'concurrency': self.concurrency,
-            'request_rate': self.request_rate,
-            'test_type': self.test_type,
-            'repeat': self.repeat,
-            'dataset': self.dataset,
-            'dataset_type': self.dataset_type,
-            'prefix_num': self.prefix_num,
-            'repeat_rate': self.repeat_rate,
-            'prefix_test': self.prefix_test,
-            'dp': self.dp,
-            'seed': self.seed,
-            'length_mean': self.length_mean,
-            'length_std': self.length_std,
-            'length_min': self.length_min,
-            'length_max': self.length_max,
-            'test_accuracy': self.test_accuracy,
-            'enable_think': self.enable_think,
-            'npu_num': self.npu_num,
-            'test_name': self.test_name,
+            "input_len": self.input_len,
+            "output_len": self.output_len,
+            "data_num": self.data_num,
+            "concurrency": self.concurrency,
+            "request_rate": self.request_rate,
+            "test_type": self.test_type,
+            "repeat": self.repeat,
+            "dataset": self.dataset,
+            "dataset_type": self.dataset_type,
+            "prefix_num": self.prefix_num,
+            "repeat_rate": self.repeat_rate,
+            "prefix_test": self.prefix_test,
+            "dp": self.dp,
+            "seed": self.seed,
+            "length_mean": self.length_mean,
+            "length_std": self.length_std,
+            "length_min": self.length_min,
+            "length_max": self.length_max,
+            "test_accuracy": self.test_accuracy,
+            "enable_think": self.enable_think,
+            "npu_num": self.npu_num,
+            "test_name": self.test_name,
         }
 
     @classmethod
-    def from_dict(cls, data: Dict[str, Any]) -> 'AisbenchConfig':
+    def from_dict(cls, data: Dict[str, Any]) -> "AisbenchConfig":
         """Create config from dictionary"""
         return cls(**{k: v for k, v in data.items() if k in cls.__dataclass_fields__})
 
@@ -170,6 +178,7 @@ class AisbenchResult:
     """
     AISBench test result data class
     """
+
     test_name: str = ""
     status: str = ""
 

--- a/test/common/aisbench_utils/data_picker.py
+++ b/test/common/aisbench_utils/data_picker.py
@@ -5,6 +5,7 @@ Supports non-repeat mode and repeatable mode, with auto-reset feature
 Changes: Removed file-based picked_ids.txt dependency, using in-memory tracking only.
 When data is exhausted in non-repeat mode, auto-reset is always applied.
 """
+
 import json
 import logging
 import os
@@ -32,9 +33,7 @@ class LightTokenizer:
         # Resolve tokenizer.json path from model directory
         tokenizer_json = os.path.join(model_path, "tokenizer.json")
         if not os.path.isfile(tokenizer_json):
-            raise FileNotFoundError(
-                f"tokenizer.json not found in {model_path}"
-            )
+            raise FileNotFoundError(f"tokenizer.json not found in {model_path}")
 
         from tokenizers import Tokenizer
 
@@ -114,7 +113,7 @@ class DataPicker:
 
     def _count_lines(self) -> int:
         """Count total lines in jsonl file"""
-        with open(self.jsonl_file, 'r', encoding='utf-8') as f:
+        with open(self.jsonl_file, "r", encoding="utf-8") as f:
             return sum(1 for _ in f)
 
     def _save_picked_ids(self):
@@ -168,12 +167,12 @@ class DataPicker:
 
     def _read_line(self, line_id: int) -> Optional[str]:
         """Read data from specified line"""
-        with open(self.jsonl_file, 'r', encoding='utf-8') as f:
+        with open(self.jsonl_file, "r", encoding="utf-8") as f:
             for i, line in enumerate(f):
                 if i == line_id:
                     try:
                         data = json.loads(line)
-                        return data.get('question', '')
+                        return data.get("question", "")
                     except json.JSONDecodeError:
                         logging.warning(f"Line {line_id} JSON parse failed")
                         return None

--- a/test/common/aisbench_utils/data_picker.py
+++ b/test/common/aisbench_utils/data_picker.py
@@ -1,0 +1,187 @@
+"""
+Data Picker - Randomly select data from GSM8K dataset
+Supports non-repeat mode and repeatable mode, with auto-reset feature
+
+Changes: Removed file-based picked_ids.txt dependency, using in-memory tracking only.
+When data is exhausted in non-repeat mode, auto-reset is always applied.
+"""
+import json
+import logging
+import os
+from typing import Dict, List, Optional, Set
+
+logging.basicConfig(level=logging.INFO)
+
+
+class LightTokenizer:
+    """
+    Lightweight tokenizer wrapper using the `tokenizers` Rust library.
+    Avoids importing `transformers`/`torch`, which causes DLL issues on
+    Windows systems without CUDA drivers installed.
+
+    Provides the same public interface as `transformers.AutoTokenizer`
+    for the operations used in dataset generation:
+      - encode(text, add_special_tokens=False) -> List[int]
+      - decode(ids, skip_special_tokens=True) -> str
+      - get_vocab() -> Dict[str, int]
+      - __len__() -> vocab_size
+      - all_special_ids -> List[int]
+    """
+
+    def __init__(self, model_path: str) -> None:
+        # Resolve tokenizer.json path from model directory
+        tokenizer_json = os.path.join(model_path, "tokenizer.json")
+        if not os.path.isfile(tokenizer_json):
+            raise FileNotFoundError(
+                f"tokenizer.json not found in {model_path}"
+            )
+
+        from tokenizers import Tokenizer
+
+        self._tok = Tokenizer.from_file(tokenizer_json)
+
+        # Build special IDs from tokenizer_config.json (if available)
+        self._all_special_ids: List[int] = self._load_special_ids(model_path)
+
+    def _load_special_ids(self, model_path: str) -> List[int]:
+        """Extract special token IDs from tokenizer_config.json."""
+        config_path = os.path.join(model_path, "tokenizer_config.json")
+        special_ids: List[int] = []
+
+        if os.path.isfile(config_path):
+            try:
+                with open(config_path, "r", encoding="utf-8") as f:
+                    cfg = json.load(f)
+                for sid, info in cfg.get("added_tokens_decoder", {}).items():
+                    if info.get("special", False):
+                        special_ids.append(int(sid))
+            except (json.JSONDecodeError, OSError):
+                pass  # non-critical; empty list is safe
+
+        return special_ids
+
+    # ---- Public interface (mirrors transformers.PreTrainedTokenizer) ----
+
+    def encode(self, text: str, add_special_tokens: bool = False) -> List[int]:
+        """Encode text to a list of token IDs."""
+        if not text:
+            return []
+        return self._tok.encode(text, add_special_tokens=add_special_tokens).ids
+
+    def decode(self, ids: List[int], skip_special_tokens: bool = True) -> str:
+        """Decode a list of token IDs back to text."""
+        if not ids:
+            return ""
+        return self._tok.decode(ids, skip_special_tokens=skip_special_tokens)
+
+    def get_vocab(self) -> Dict[str, int]:
+        """Return the vocabulary mapping {token_str: token_id}."""
+        return self._tok.get_vocab()
+
+    @property
+    def all_special_ids(self) -> List[int]:
+        """List of special token IDs."""
+        return self._all_special_ids
+
+    def __len__(self) -> int:
+        """Return vocabulary size."""
+        return self._tok.get_vocab_size()
+
+
+class DataPicker:
+    """
+    GSM8K dataset picker
+
+    Features:
+    - Non-repeat mode (prefix_flag=1): Pick from unused data randomly, auto-reset when exhausted
+    - Repeatable mode (prefix_flag=0): Pick from all data randomly
+    - In-memory tracking: No file dependency, picked IDs tracked in memory only
+    """
+
+    def __init__(self, jsonl_file: str, prefix_flag: int = 0):
+        """
+        Initialize the picker
+
+        Args:
+            jsonl_file: Path to GSM8K dataset file
+            prefix_flag: 1 for non-repeat mode, 0 for repeatable mode
+        """
+        self.jsonl_file = jsonl_file
+        self.prefix_flag = prefix_flag
+
+        self.total_lines = self._count_lines()
+        self.picked_ids = set()
+
+    def _count_lines(self) -> int:
+        """Count total lines in jsonl file"""
+        with open(self.jsonl_file, 'r', encoding='utf-8') as f:
+            return sum(1 for _ in f)
+
+    def _save_picked_ids(self):
+        """Save picked ID records (in-memory only, no file writing)"""
+        # No file operation needed - picked_ids is maintained in memory
+        pass
+
+    def get_unpicked_ids(self) -> list:
+        """Get all unpicked IDs"""
+        all_ids = set(range(self.total_lines))
+        return list(all_ids - self.picked_ids)
+
+    def get_usage_ratio(self) -> float:
+        """Get usage ratio (picked / total)"""
+        if self.total_lines == 0:
+            return 0.0
+        return len(self.picked_ids) / self.total_lines
+
+    def pick_one(self) -> Optional[str]:
+        """
+        Randomly pick one data item
+
+        Returns:
+            The picked data content, or None if no unpicked data available
+        """
+        import random
+
+        # Repeatable mode
+        if self.prefix_flag == 0:
+            selected_id = random.randint(0, self.total_lines - 1)
+            return self._read_line(selected_id)
+
+        # Non-repeat mode
+        available_ids = self.get_unpicked_ids()
+
+        if not available_ids:
+            # Data exhausted - auto-reset
+            logging.warning(
+                f"Data exhausted ({self.total_lines} items), auto-resetting picked IDs"
+            )
+            self.picked_ids.clear()
+            available_ids = self.get_unpicked_ids()
+
+        # Randomly select an unpicked ID
+        selected_id = random.choice(available_ids)
+
+        # Record the picked ID in memory
+        self.picked_ids.add(selected_id)
+
+        return self._read_line(selected_id)
+
+    def _read_line(self, line_id: int) -> Optional[str]:
+        """Read data from specified line"""
+        with open(self.jsonl_file, 'r', encoding='utf-8') as f:
+            for i, line in enumerate(f):
+                if i == line_id:
+                    try:
+                        data = json.loads(line)
+                        return data.get('question', '')
+                    except json.JSONDecodeError:
+                        logging.warning(f"Line {line_id} JSON parse failed")
+                        return None
+        return None
+
+    def reset(self):
+        """
+        Reset records (clear picked records in memory)
+        """
+        self.picked_ids.clear()
+        logging.info(f"DataPicker reset, all {self.total_lines} items available again")

--- a/test/common/aisbench_utils/generate_dataset.py
+++ b/test/common/aisbench_utils/generate_dataset.py
@@ -1,0 +1,642 @@
+"""
+Dataset Generation Module - Supports normal and prefix-cache datasets
+Supports fixed-length and variable-length modes
+
+Data source modes:
+1. GSM8K mode (default): Use GSM8K dataset as content source
+2. Random token mode: Directly generate random tokens (no dataset dependency)
+
+Improvements:
+- Removed torch dependency, using random instead
+- Added random token generation mode (reuse token_counter.HuggingFaceTokenizer)
+- Added time-based random offset to ensure different prefixes across test runs
+- Improved error handling with user-friendly messages
+"""
+import json
+import logging
+import os
+import random
+import time
+from pathlib import Path
+from typing import Optional, Tuple, List, Union
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+try:
+    from tqdm import tqdm
+except ImportError:
+    tqdm = None
+
+from .data_picker import DataPicker
+
+
+def _get_tokenizer(tokenizer_path: str):
+    """Load tokenizer - prefer HuggingFaceTokenizer (no torch dependency)"""
+    try:
+        from common.llm_connection.token_counter import HuggingFaceTokenizer
+        return HuggingFaceTokenizer(tokenizer_path)
+    except ImportError:
+        # Fallback to LightTokenizer or AutoTokenizer
+        try:
+            from .data_picker import LightTokenizer
+            return LightTokenizer(tokenizer_path)
+        except FileNotFoundError:
+            try:
+                from transformers import AutoTokenizer
+                return AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
+            except Exception as e:
+                raise RuntimeError(f"Failed to load tokenizer: {tokenizer_path}, error: {e}") from e
+        except ImportError as e:
+            try:
+                from transformers import AutoTokenizer
+                return AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
+            except Exception as inner:
+                raise RuntimeError(f"Failed to load tokenizer: {tokenizer_path}, error: {inner}") from e
+
+
+def create_dataset(
+    tokenizer_path: str,
+    input_len: int,
+    number: int,
+    prefix_flag: int,
+    gsm8k_path: str = None
+) -> Optional[List[str]]:
+    """
+    Create dataset with specified token length from GSM8K
+
+    Args:
+        tokenizer_path: Path to tokenizer
+        input_len: Target token length
+        number: Number of samples to generate
+        prefix_flag: 1 for non-repeat mode, 0 for repeatable mode
+        gsm8k_path: Path to GSM8K dataset, defaults to GSM8K.jsonl in project root
+
+    Returns:
+        List of generated samples, None if failed
+    """
+    # Get GSM8K dataset path
+    if gsm8k_path is None:
+        current_dir = Path(__file__).resolve()
+        # aisbench_utils -> common -> test -> project_root
+        project_root = current_dir.parents[3]
+        gsm8k_path = project_root / "GSM8K.jsonl"
+
+    gsm8k_path = Path(gsm8k_path)
+    if not gsm8k_path.exists():
+        logging.error(f"GSM8K dataset not found: {gsm8k_path}")
+        return None
+
+    logging.info(f"Loading tokenizer: {tokenizer_path}")
+    tokenizer = _get_tokenizer(tokenizer_path)
+
+    output_samples = []
+    attempts = 0
+    max_attempts = number * 10
+
+    picker = DataPicker(
+        str(gsm8k_path),
+        prefix_flag
+    )
+
+    pbar = tqdm(total=number, desc="Generating dataset", unit="row") if tqdm else None
+
+    while len(output_samples) < number and attempts < max_attempts:
+        attempts += 1
+        raw_text = picker.pick_one()
+
+        if raw_text is None:
+            if pbar:
+                pbar.close()
+            logging.error(
+                f"Dataset generation interrupted: {len(output_samples)}/{number} samples generated\n"
+                f"Reason: GSM8K data exhausted or insufficient"
+            )
+            if len(output_samples) > 0:
+                logging.warning(f"Returning {len(output_samples)} generated samples")
+            return None
+
+        tokens = tokenizer.encode(raw_text, add_special_tokens=False)
+        if len(tokens) == 0:
+            continue
+
+        # Adjust length: repeat or truncate
+        if len(tokens) >= input_len:
+            adjusted_tokens = tokens[:input_len]
+        else:
+            repeat_times = (input_len + len(tokens) - 1) // len(tokens)
+            adjusted_tokens = (tokens * repeat_times)[:input_len]
+
+        adjusted_text = tokenizer.decode(adjusted_tokens, skip_special_tokens=True)
+
+        # Verify and fix length
+        final_len = len(tokenizer.encode(adjusted_text, add_special_tokens=False))
+        if final_len != input_len:
+            corrected_tokens = tokenizer.encode(adjusted_text, add_special_tokens=False)
+            if len(corrected_tokens) >= input_len:
+                corrected_tokens = corrected_tokens[:input_len]
+            else:
+                corrected_tokens = (corrected_tokens * ((input_len // len(corrected_tokens)) + 1))[:input_len]
+            adjusted_text = tokenizer.decode(corrected_tokens, skip_special_tokens=True)
+
+        output_samples.append(adjusted_text)
+        if pbar:
+            pbar.update(1)
+
+    if pbar:
+        pbar.close()
+
+    if len(output_samples) < number:
+        logging.warning(f"Only generated {len(output_samples)}/{number} samples")
+        if len(output_samples) == 0:
+            return None
+
+    return output_samples
+
+
+def create_dataset_from_random_tokens(
+    tokenizer_path: str,
+    input_len: int,
+    number: int,
+    seed: int = 42,
+    use_time_offset: bool = True
+) -> List[str]:
+    """
+    Create dataset using random token generation (no dataset dependency)
+
+    Uses HuggingFaceTokenizer.get_some_tokens() which:
+    - Generates random tokens directly from tokenizer vocabulary
+    - Has length calibration to prevent tokenizer merge issues
+    - Seed-based reproducibility with time offset for uniqueness
+
+    Args:
+        tokenizer_path: Path to tokenizer
+        input_len: Target token length for each sample
+        number: Number of samples to generate
+        seed: Base random seed for reproducibility
+        use_time_offset: If True, add time-based offset to ensure
+                         different content across test runs (default: True)
+
+    Returns:
+        List of generated samples
+    """
+    # Add time-based offset to ensure different prefixes across test runs
+    # This prevents prefix collision between different test executions
+    time_offset = int(time.time()) % 1000000 if use_time_offset else 0
+    effective_seed = seed + time_offset
+
+    logging.info(f"Generating {number} samples with {input_len} tokens each (seed={seed}, time_offset={time_offset}, effective_seed={effective_seed})")
+    tokenizer = _get_tokenizer(tokenizer_path)
+
+    output_samples = []
+    pbar = tqdm(total=number, desc="Generating random tokens", unit="row") if tqdm else None
+
+    for i in range(number):
+        # Use different seed for each sample for variety
+        sample_seed = effective_seed + i
+        text = tokenizer.get_some_tokens(input_len, seed=sample_seed)
+        output_samples.append(text)
+        if pbar:
+            pbar.update(1)
+
+    if pbar:
+        pbar.close()
+
+    logging.info(f"Generated {len(output_samples)} samples using random tokens")
+    return output_samples
+
+
+def generate_unique_tokens(
+    tokenizer_path: str,
+    seed: int,
+    n: int,
+    number: int
+) -> List[str]:
+    """
+    Generate n unique tokens for number rows based on tokenizer and random seed
+
+    Note: torch dependency removed, using random instead
+
+    Args:
+        tokenizer_path: Path to tokenizer
+        seed: Random seed
+        n: Number of tokens per row
+        number: Number of rows to generate
+
+    Returns:
+        List containing number rows of data
+    """
+    tokenizer = _get_tokenizer(tokenizer_path)
+    vocab_size = len(tokenizer)
+
+    if n > vocab_size:
+        raise ValueError(f"Requested tokens per row {n} exceeds vocab size {vocab_size}")
+
+    all_lines = []
+    pbar = tqdm(total=number, desc="Generating unique tokens", unit="row") if tqdm else None
+
+    for line_idx in range(number):
+        if pbar:
+            pbar.update(1)
+
+        # Use Python random instead of torch
+        line_seed = seed + line_idx
+        rng = random.Random(line_seed)
+
+        unique_tokens = []
+        seen_tokens = set()
+        max_attempts = n * 10
+        attempts = 0
+
+        while len(unique_tokens) < n and attempts < max_attempts:
+            token_id = rng.randint(0, vocab_size - 1)
+
+            if token_id in seen_tokens:
+                attempts += 1
+                continue
+
+            try:
+                token_text = tokenizer.decode([token_id])
+                # Filter empty and special tokens
+                if token_text.strip():
+                    unique_tokens.append(token_text)
+                    seen_tokens.add(token_id)
+            except Exception:
+                pass
+
+            attempts += 1
+
+        if len(unique_tokens) < n:
+            logging.warning(f"Row {line_idx + 1} only generated {len(unique_tokens)} unique tokens")
+
+        all_lines.append(''.join(unique_tokens))
+
+    if pbar:
+        pbar.close()
+
+    return all_lines
+
+
+def write_data(path: str, dataset: List[str], num: Optional[int] = None):
+    """Write dataset to jsonl file"""
+    if num is not None:
+        if len(dataset) < num:
+            repeats = num // len(dataset)
+            remainder = num % len(dataset)
+            dataset = dataset * repeats + dataset[:remainder]
+        else:
+            dataset = dataset[:num]
+
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    with open(path, "w", encoding="utf-8") as f:
+        for item in dataset:
+            f.write(json.dumps({"question": item, "answer": "none"}, ensure_ascii=False))
+            f.write("\n")
+
+    logging.info(f"Dataset saved: {path} ({len(dataset)} samples)")
+
+
+def sample_target_length(
+    rng: random.Random,
+    fixed_length: int,
+    length_mean: Optional[int] = None,
+    length_std: Optional[float] = None,
+    length_min: Optional[int] = None,
+    length_max: Optional[int] = None
+) -> int:
+    """Sample target length from Gaussian or uniform distribution"""
+    fixed_length = max(1, int(fixed_length))
+    has_gauss = (length_mean is not None) and (length_std is not None)
+    has_range = (length_min is not None) and (length_max is not None)
+
+    lo = 1 if length_min is None else max(1, int(length_min))
+    hi = None if length_max is None else max(1, int(length_max))
+
+    if hi is not None and lo > hi:
+        lo, hi = hi, lo
+
+    if has_gauss:
+        mu = max(1, int(length_mean))
+        sigma = max(0.0, float(length_std))
+        val = mu if sigma == 0 else int(round(rng.gauss(mu, sigma)))
+        if hi is not None:
+            val = min(val, hi)
+        val = max(lo, val)
+        return max(1, val)
+
+    if has_range:
+        return rng.randint(lo, hi)
+
+    return fixed_length
+
+
+def _build_length_tag(
+    input_len: int,
+    length_mean: Optional[int],
+    length_std: Optional[float],
+    length_min: Optional[int],
+    length_max: Optional[int]
+) -> str:
+    """Build length tag for file naming"""
+    if (length_mean is not None) and (length_std is not None):
+        tag = f"G{int(length_mean)}_{str(length_std).replace('.', 'd')}"
+        if (length_min is not None) and (length_max is not None):
+            tag += f"_C{int(length_min)}_{int(length_max)}"
+        return tag
+
+    if (length_min is not None) and (length_max is not None):
+        return f"U{int(length_min)}_{int(length_max)}"
+
+    return f"L{int(input_len)}"
+
+
+def _truncate_or_pad_text(tokenizer, text: str, target_len: int) -> str:
+    """Adjust text token length to target_len (truncate or repeat padding)"""
+    tokens = tokenizer.encode(text, add_special_tokens=False)
+
+    if len(tokens) >= target_len:
+        tokens = tokens[:target_len]
+    else:
+        repeat_times = (target_len + len(tokens) - 1) // len(tokens)
+        tokens = (tokens * repeat_times)[:target_len]
+
+    return tokenizer.decode(tokens, skip_special_tokens=True)
+
+
+def create_multi_prefix_dataset(
+    tokenizer_path: str,
+    input_len: int,
+    number: int,
+    save_path: str,
+    prefix_flag: int,
+    dp: int,
+    repeat_rate: float,
+    seed: int,
+    prefix_num: int,
+    length_mean: Optional[int] = None,
+    length_std: Optional[float] = None,
+    length_min: Optional[int] = None,
+    length_max: Optional[int] = None,
+    gsm8k_path: Optional[str] = None,
+    use_gsm8k: bool = True
+) -> Tuple[str, str]:
+    """
+    Create multi-prefix dataset
+
+    Supports two data source modes:
+    1. GSM8K mode (use_gsm8k=True): Use GSM8K dataset as content source
+    2. Random token mode (use_gsm8k=False): Generate random tokens directly (no dataset dependency)
+
+    Args:
+        tokenizer_path: Path to tokenizer
+        input_len: Input length
+        number: Number of samples
+        save_path: Save path
+        prefix_flag: Prefix flag (0=normal, 1=prefix mode)
+        dp: Number of DP domains
+        repeat_rate: Prefix repeat rate
+        seed: Random seed
+        prefix_num: Number of prefix types
+        length_mean/length_std/length_min/length_max: Variable-length parameters
+        gsm8k_path: Path to GSM8K dataset (only used when use_gsm8k=True)
+        use_gsm8k: Whether to use GSM8K dataset. False = generate random tokens directly
+
+    Returns:
+        (prefix_path, dataset_path) - Prefix file path and dataset file path
+    """
+    base_name = os.path.basename(os.path.normpath(tokenizer_path))
+    use_variable_length = (
+        (length_mean is not None and length_std is not None)
+        or (length_min is not None and length_max is not None)
+    )
+
+    # Data source tag for file naming
+    source_tag = "GSM8K" if use_gsm8k else "Random"
+
+    # Helper function to get dataset based on mode
+    def _get_dataset(length: int, count: int, prefix_flag_val: int) -> Optional[List[str]]:
+        if use_gsm8k:
+            return create_dataset(tokenizer_path, length, count, prefix_flag_val, gsm8k_path)
+        else:
+            return create_dataset_from_random_tokens(tokenizer_path, length, count, seed)
+
+    # ========== Normal dataset (no prefix) ==========
+    if prefix_flag == 0:
+        if use_variable_length:
+            rng = random.Random(seed)
+            real_lens = [
+                sample_target_length(rng, input_len, length_mean, length_std, length_min, length_max)
+                for _ in range(number)
+            ]
+            max_len = max(real_lens)
+            long_texts = _get_dataset(max_len, number, 0)
+
+            if long_texts is None:
+                logging.error("Dataset generation failed")
+                return "", ""
+
+            tokenizer = _get_tokenizer(tokenizer_path)
+            dataset = []
+
+            pbar = tqdm(total=number, desc="Truncating to variable lengths", unit="row") if tqdm else None
+            for i, rl in enumerate(real_lens):
+                adjusted = _truncate_or_pad_text(tokenizer, long_texts[i], rl)
+                dataset.append(adjusted)
+                if pbar:
+                    pbar.update(1)
+            if pbar:
+                pbar.close()
+
+            length_tag = _build_length_tag(input_len, length_mean, length_std, length_min, length_max)
+            dataset_path = os.path.join(save_path, f'{source_tag}-{length_tag}-num{number}-{base_name}.jsonl')
+            write_data(dataset_path, dataset, number)
+            return "", dataset_path
+        else:
+            dataset = _get_dataset(input_len, number, 0)
+            if dataset is None:
+                return "", ""
+            dataset_path = os.path.join(save_path, f'{source_tag}-in{input_len}-num{number}-{base_name}.jsonl')
+            write_data(dataset_path, dataset, number)
+            return "", dataset_path
+
+    # ========== Prefix dataset ==========
+    if use_variable_length:
+        return _create_prefix_dataset_variable(
+            tokenizer_path, input_len, number, save_path, base_name, dp,
+            repeat_rate, seed, prefix_num, length_mean, length_std,
+            length_min, length_max, gsm8k_path, use_gsm8k
+        )
+
+    # -------- Fixed-length prefix dataset --------
+    prefix_len = int(input_len * repeat_rate)
+    prefix_data = _get_dataset(prefix_len, prefix_num, 1)
+
+    if prefix_data is None and repeat_rate > 0:
+        logging.error("Prefix dataset generation failed")
+        return "", ""
+
+    prefix_dataset = []
+    for i in range(prefix_num):
+        for j in range(dp):
+            prefix_dataset.append(prefix_data[i])
+
+    prefix_path = os.path.join(save_path, f'prefix-{source_tag}-in{prefix_len}-num{dp*prefix_num}-{base_name}.jsonl')
+    write_data(prefix_path, prefix_dataset, dp * prefix_num)
+
+    if repeat_rate >= 1:
+        dataset_path = os.path.join(save_path, f'{source_tag}-in{prefix_len}-num{number}-{base_name}-repeatRate{repeat_rate}.jsonl')
+        write_data(dataset_path, prefix_dataset, number)
+        return prefix_path, dataset_path
+
+    # Insert 3 random tokens after prefix (use tokenizer.get_some_tokens for consistency)
+    tokenizer = _get_tokenizer(tokenizer_path)
+    uniq_token_set = []
+    for i in range(number):
+        uniq_token_set.append(tokenizer.get_some_tokens(3, seed=seed + i + 1000))
+
+    suffix_len = int(input_len - prefix_len - 3)
+    suffix_dataset = _get_dataset(suffix_len, number, 0)
+
+    if suffix_dataset is None:
+        logging.error("Suffix dataset generation failed")
+        return "", ""
+
+    # Stitch complete dataset
+    dataset = []
+    pbar = tqdm(total=number, desc="Stitching dataset", unit="row") if tqdm else None
+    for data_len in range(number):
+        single_data = prefix_data[data_len % prefix_num] + uniq_token_set[data_len] + suffix_dataset[data_len]
+        dataset.append(single_data)
+        if pbar:
+            pbar.update(1)
+    if pbar:
+        pbar.close()
+
+    dataset_path = os.path.join(save_path, f'{source_tag}-in{input_len}-num{number}-{base_name}-repeatRate{repeat_rate}.jsonl')
+    write_data(dataset_path, dataset, number)
+
+    return prefix_path, dataset_path
+
+
+def _create_prefix_dataset_variable(
+    tokenizer_path: str,
+    input_len: int,
+    number: int,
+    save_path: str,
+    base_name: str,
+    dp: int,
+    repeat_rate: float,
+    seed: int,
+    prefix_num: int,
+    length_mean: Optional[int],
+    length_std: Optional[float],
+    length_min: Optional[int],
+    length_max: Optional[int],
+    gsm8k_path: Optional[str],
+    use_gsm8k: bool = True
+) -> Tuple[str, str]:
+    """Variable-length prefix dataset generation"""
+    rng = random.Random(seed)
+    source_tag = "GSM8K" if use_gsm8k else "Random"
+
+    # Helper function to get dataset based on mode
+    def _get_dataset(length: int, count: int, prefix_flag_val: int) -> Optional[List[str]]:
+        if use_gsm8k:
+            return create_dataset(tokenizer_path, length, count, prefix_flag_val, gsm8k_path)
+        else:
+            return create_dataset_from_random_tokens(tokenizer_path, length, count, seed)
+
+    real_lens = [
+        sample_target_length(rng, input_len, length_mean, length_std, length_min, length_max)
+        for _ in range(number)
+    ]
+    common_lens = [max(0, min(rl, int(round(rl * repeat_rate)))) for rl in real_lens]
+    max_common_len = max(common_lens) if common_lens else 0
+
+    prefix_data = []
+    if max_common_len > 0:
+        prefix_data = _get_dataset(max_common_len, prefix_num, 1)
+        if prefix_data is None:
+            logging.error("Prefix dataset generation failed")
+            return "", ""
+    else:
+        prefix_data = [""] * prefix_num
+
+    prefix_dataset = []
+    for i in range(prefix_num):
+        for j in range(dp):
+            prefix_dataset.append(prefix_data[i])
+
+    prefix_path = os.path.join(save_path, f'prefix-{source_tag}-in{max_common_len}-num{dp*prefix_num}-{base_name}.jsonl')
+    write_data(prefix_path, prefix_dataset, dp * prefix_num)
+
+    if repeat_rate >= 1:
+        dataset_path = os.path.join(save_path, f'{source_tag}-in{max_common_len}-num{number}-{base_name}-repeatRate{repeat_rate}.jsonl')
+        write_data(dataset_path, prefix_dataset, number)
+        return prefix_path, dataset_path
+
+    # Use tokenizer.get_some_tokens for unique tokens (more consistent)
+    tokenizer = _get_tokenizer(tokenizer_path)
+    uniq_token_set = []
+    for i in range(number):
+        uniq_token_set.append(tokenizer.get_some_tokens(3, seed=seed + i + 1000))
+
+    max_suffix_len = max(rl - cl - 3 for rl, cl in zip(real_lens, common_lens))
+    if max_suffix_len < 1:
+        max_suffix_len = 1
+
+    suffix_pool = _get_dataset(max_suffix_len, number, 0)
+    if suffix_pool is None:
+        logging.error("Suffix dataset generation failed")
+        return "", ""
+
+    dataset = []
+    pbar = tqdm(total=number, desc="Stitching dataset (variable)", unit="row") if tqdm else None
+    for idx in range(number):
+        rl = real_lens[idx]
+        cl = common_lens[idx]
+        suffix_len_needed = max(0, rl - cl - 3)
+
+        prefix_text = prefix_data[idx % prefix_num]
+        if cl > 0 and prefix_text:
+            prefix_text = _truncate_or_pad_text(tokenizer, prefix_text, cl)
+        else:
+            prefix_text = ""
+
+        suffix_text = suffix_pool[idx]
+        if suffix_len_needed > 0 and suffix_text:
+            suffix_text = _truncate_or_pad_text(tokenizer, suffix_text, suffix_len_needed)
+        else:
+            suffix_text = ""
+
+        single_data = prefix_text + uniq_token_set[idx] + suffix_text
+        dataset.append(single_data)
+        if pbar:
+            pbar.update(1)
+    if pbar:
+        pbar.close()
+
+    length_tag = _build_length_tag(input_len, length_mean, length_std, length_min, length_max)
+    dataset_path = os.path.join(save_path, f'{source_tag}-{length_tag}-num{number}-{base_name}-repeatRate{repeat_rate}.jsonl')
+    write_data(dataset_path, dataset, number)
+
+    logging.info(f"  max_common_len={max_common_len}, max_suffix_len={max_suffix_len}")
+    logging.info(f"  avg_hit_ratio={sum(c / r for c, r in zip(common_lens, real_lens)) / len(real_lens):.2%}")
+
+    return prefix_path, dataset_path
+
+
+def parse_prefix_ratio(r: str) -> float:
+    """
+    Parse prefix repeat rate parameter
+    "50%" -> 0.5, "0.5" -> 0.5, "0.500" -> 0.5
+    """
+    r = str(r).strip()
+    if r.endswith("%"):
+        v = float(r[:-1]) / 100.0
+    else:
+        v = float(r)
+    if not (0.0 <= v <= 1.0):
+        raise ValueError("prefix-ratio must be in [0,1] range or percentage [0%,100%]")
+    return v

--- a/test/common/aisbench_utils/generate_dataset.py
+++ b/test/common/aisbench_utils/generate_dataset.py
@@ -12,15 +12,18 @@ Improvements:
 - Added time-based random offset to ensure different prefixes across test runs
 - Improved error handling with user-friendly messages
 """
+
 import json
 import logging
 import os
 import random
 import time
 from pathlib import Path
-from typing import Optional, Tuple, List, Union
+from typing import List, Optional, Tuple, Union
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
 
 try:
     from tqdm import tqdm
@@ -34,24 +37,36 @@ def _get_tokenizer(tokenizer_path: str):
     """Load tokenizer - prefer HuggingFaceTokenizer (no torch dependency)"""
     try:
         from common.llm_connection.token_counter import HuggingFaceTokenizer
+
         return HuggingFaceTokenizer(tokenizer_path)
     except ImportError:
         # Fallback to LightTokenizer or AutoTokenizer
         try:
             from .data_picker import LightTokenizer
+
             return LightTokenizer(tokenizer_path)
         except FileNotFoundError:
             try:
                 from transformers import AutoTokenizer
-                return AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
+
+                return AutoTokenizer.from_pretrained(
+                    tokenizer_path, trust_remote_code=True
+                )
             except Exception as e:
-                raise RuntimeError(f"Failed to load tokenizer: {tokenizer_path}, error: {e}") from e
+                raise RuntimeError(
+                    f"Failed to load tokenizer: {tokenizer_path}, error: {e}"
+                ) from e
         except ImportError as e:
             try:
                 from transformers import AutoTokenizer
-                return AutoTokenizer.from_pretrained(tokenizer_path, trust_remote_code=True)
+
+                return AutoTokenizer.from_pretrained(
+                    tokenizer_path, trust_remote_code=True
+                )
             except Exception as inner:
-                raise RuntimeError(f"Failed to load tokenizer: {tokenizer_path}, error: {inner}") from e
+                raise RuntimeError(
+                    f"Failed to load tokenizer: {tokenizer_path}, error: {inner}"
+                ) from e
 
 
 def create_dataset(
@@ -59,7 +74,7 @@ def create_dataset(
     input_len: int,
     number: int,
     prefix_flag: int,
-    gsm8k_path: str = None
+    gsm8k_path: str = None,
 ) -> Optional[List[str]]:
     """
     Create dataset with specified token length from GSM8K
@@ -93,10 +108,7 @@ def create_dataset(
     attempts = 0
     max_attempts = number * 10
 
-    picker = DataPicker(
-        str(gsm8k_path),
-        prefix_flag
-    )
+    picker = DataPicker(str(gsm8k_path), prefix_flag)
 
     pbar = tqdm(total=number, desc="Generating dataset", unit="row") if tqdm else None
 
@@ -135,7 +147,9 @@ def create_dataset(
             if len(corrected_tokens) >= input_len:
                 corrected_tokens = corrected_tokens[:input_len]
             else:
-                corrected_tokens = (corrected_tokens * ((input_len // len(corrected_tokens)) + 1))[:input_len]
+                corrected_tokens = (
+                    corrected_tokens * ((input_len // len(corrected_tokens)) + 1)
+                )[:input_len]
             adjusted_text = tokenizer.decode(corrected_tokens, skip_special_tokens=True)
 
         output_samples.append(adjusted_text)
@@ -158,7 +172,7 @@ def create_dataset_from_random_tokens(
     input_len: int,
     number: int,
     seed: int = 42,
-    use_time_offset: bool = True
+    use_time_offset: bool = True,
 ) -> List[str]:
     """
     Create dataset using random token generation (no dataset dependency)
@@ -184,11 +198,17 @@ def create_dataset_from_random_tokens(
     time_offset = int(time.time()) % 1000000 if use_time_offset else 0
     effective_seed = seed + time_offset
 
-    logging.info(f"Generating {number} samples with {input_len} tokens each (seed={seed}, time_offset={time_offset}, effective_seed={effective_seed})")
+    logging.info(
+        f"Generating {number} samples with {input_len} tokens each (seed={seed}, time_offset={time_offset}, effective_seed={effective_seed})"
+    )
     tokenizer = _get_tokenizer(tokenizer_path)
 
     output_samples = []
-    pbar = tqdm(total=number, desc="Generating random tokens", unit="row") if tqdm else None
+    pbar = (
+        tqdm(total=number, desc="Generating random tokens", unit="row")
+        if tqdm
+        else None
+    )
 
     for i in range(number):
         # Use different seed for each sample for variety
@@ -206,10 +226,7 @@ def create_dataset_from_random_tokens(
 
 
 def generate_unique_tokens(
-    tokenizer_path: str,
-    seed: int,
-    n: int,
-    number: int
+    tokenizer_path: str, seed: int, n: int, number: int
 ) -> List[str]:
     """
     Generate n unique tokens for number rows based on tokenizer and random seed
@@ -229,10 +246,16 @@ def generate_unique_tokens(
     vocab_size = len(tokenizer)
 
     if n > vocab_size:
-        raise ValueError(f"Requested tokens per row {n} exceeds vocab size {vocab_size}")
+        raise ValueError(
+            f"Requested tokens per row {n} exceeds vocab size {vocab_size}"
+        )
 
     all_lines = []
-    pbar = tqdm(total=number, desc="Generating unique tokens", unit="row") if tqdm else None
+    pbar = (
+        tqdm(total=number, desc="Generating unique tokens", unit="row")
+        if tqdm
+        else None
+    )
 
     for line_idx in range(number):
         if pbar:
@@ -266,9 +289,11 @@ def generate_unique_tokens(
             attempts += 1
 
         if len(unique_tokens) < n:
-            logging.warning(f"Row {line_idx + 1} only generated {len(unique_tokens)} unique tokens")
+            logging.warning(
+                f"Row {line_idx + 1} only generated {len(unique_tokens)} unique tokens"
+            )
 
-        all_lines.append(''.join(unique_tokens))
+        all_lines.append("".join(unique_tokens))
 
     if pbar:
         pbar.close()
@@ -291,7 +316,9 @@ def write_data(path: str, dataset: List[str], num: Optional[int] = None):
 
     with open(path, "w", encoding="utf-8") as f:
         for item in dataset:
-            f.write(json.dumps({"question": item, "answer": "none"}, ensure_ascii=False))
+            f.write(
+                json.dumps({"question": item, "answer": "none"}, ensure_ascii=False)
+            )
             f.write("\n")
 
     logging.info(f"Dataset saved: {path} ({len(dataset)} samples)")
@@ -303,7 +330,7 @@ def sample_target_length(
     length_mean: Optional[int] = None,
     length_std: Optional[float] = None,
     length_min: Optional[int] = None,
-    length_max: Optional[int] = None
+    length_max: Optional[int] = None,
 ) -> int:
     """Sample target length from Gaussian or uniform distribution"""
     fixed_length = max(1, int(fixed_length))
@@ -336,7 +363,7 @@ def _build_length_tag(
     length_mean: Optional[int],
     length_std: Optional[float],
     length_min: Optional[int],
-    length_max: Optional[int]
+    length_max: Optional[int],
 ) -> str:
     """Build length tag for file naming"""
     if (length_mean is not None) and (length_std is not None):
@@ -379,7 +406,7 @@ def create_multi_prefix_dataset(
     length_min: Optional[int] = None,
     length_max: Optional[int] = None,
     gsm8k_path: Optional[str] = None,
-    use_gsm8k: bool = True
+    use_gsm8k: bool = True,
 ) -> Tuple[str, str]:
     """
     Create multi-prefix dataset
@@ -406,27 +433,34 @@ def create_multi_prefix_dataset(
         (prefix_path, dataset_path) - Prefix file path and dataset file path
     """
     base_name = os.path.basename(os.path.normpath(tokenizer_path))
-    use_variable_length = (
-        (length_mean is not None and length_std is not None)
-        or (length_min is not None and length_max is not None)
+    use_variable_length = (length_mean is not None and length_std is not None) or (
+        length_min is not None and length_max is not None
     )
 
     # Data source tag for file naming
     source_tag = "GSM8K" if use_gsm8k else "Random"
 
     # Helper function to get dataset based on mode
-    def _get_dataset(length: int, count: int, prefix_flag_val: int) -> Optional[List[str]]:
+    def _get_dataset(
+        length: int, count: int, prefix_flag_val: int
+    ) -> Optional[List[str]]:
         if use_gsm8k:
-            return create_dataset(tokenizer_path, length, count, prefix_flag_val, gsm8k_path)
+            return create_dataset(
+                tokenizer_path, length, count, prefix_flag_val, gsm8k_path
+            )
         else:
-            return create_dataset_from_random_tokens(tokenizer_path, length, count, seed)
+            return create_dataset_from_random_tokens(
+                tokenizer_path, length, count, seed
+            )
 
     # ========== Normal dataset (no prefix) ==========
     if prefix_flag == 0:
         if use_variable_length:
             rng = random.Random(seed)
             real_lens = [
-                sample_target_length(rng, input_len, length_mean, length_std, length_min, length_max)
+                sample_target_length(
+                    rng, input_len, length_mean, length_std, length_min, length_max
+                )
                 for _ in range(number)
             ]
             max_len = max(real_lens)
@@ -439,7 +473,11 @@ def create_multi_prefix_dataset(
             tokenizer = _get_tokenizer(tokenizer_path)
             dataset = []
 
-            pbar = tqdm(total=number, desc="Truncating to variable lengths", unit="row") if tqdm else None
+            pbar = (
+                tqdm(total=number, desc="Truncating to variable lengths", unit="row")
+                if tqdm
+                else None
+            )
             for i, rl in enumerate(real_lens):
                 adjusted = _truncate_or_pad_text(tokenizer, long_texts[i], rl)
                 dataset.append(adjusted)
@@ -448,24 +486,42 @@ def create_multi_prefix_dataset(
             if pbar:
                 pbar.close()
 
-            length_tag = _build_length_tag(input_len, length_mean, length_std, length_min, length_max)
-            dataset_path = os.path.join(save_path, f'{source_tag}-{length_tag}-num{number}-{base_name}.jsonl')
+            length_tag = _build_length_tag(
+                input_len, length_mean, length_std, length_min, length_max
+            )
+            dataset_path = os.path.join(
+                save_path, f"{source_tag}-{length_tag}-num{number}-{base_name}.jsonl"
+            )
             write_data(dataset_path, dataset, number)
             return "", dataset_path
         else:
             dataset = _get_dataset(input_len, number, 0)
             if dataset is None:
                 return "", ""
-            dataset_path = os.path.join(save_path, f'{source_tag}-in{input_len}-num{number}-{base_name}.jsonl')
+            dataset_path = os.path.join(
+                save_path, f"{source_tag}-in{input_len}-num{number}-{base_name}.jsonl"
+            )
             write_data(dataset_path, dataset, number)
             return "", dataset_path
 
     # ========== Prefix dataset ==========
     if use_variable_length:
         return _create_prefix_dataset_variable(
-            tokenizer_path, input_len, number, save_path, base_name, dp,
-            repeat_rate, seed, prefix_num, length_mean, length_std,
-            length_min, length_max, gsm8k_path, use_gsm8k
+            tokenizer_path,
+            input_len,
+            number,
+            save_path,
+            base_name,
+            dp,
+            repeat_rate,
+            seed,
+            prefix_num,
+            length_mean,
+            length_std,
+            length_min,
+            length_max,
+            gsm8k_path,
+            use_gsm8k,
         )
 
     # -------- Fixed-length prefix dataset --------
@@ -481,11 +537,17 @@ def create_multi_prefix_dataset(
         for j in range(dp):
             prefix_dataset.append(prefix_data[i])
 
-    prefix_path = os.path.join(save_path, f'prefix-{source_tag}-in{prefix_len}-num{dp*prefix_num}-{base_name}.jsonl')
+    prefix_path = os.path.join(
+        save_path,
+        f"prefix-{source_tag}-in{prefix_len}-num{dp*prefix_num}-{base_name}.jsonl",
+    )
     write_data(prefix_path, prefix_dataset, dp * prefix_num)
 
     if repeat_rate >= 1:
-        dataset_path = os.path.join(save_path, f'{source_tag}-in{prefix_len}-num{number}-{base_name}-repeatRate{repeat_rate}.jsonl')
+        dataset_path = os.path.join(
+            save_path,
+            f"{source_tag}-in{prefix_len}-num{number}-{base_name}-repeatRate{repeat_rate}.jsonl",
+        )
         write_data(dataset_path, prefix_dataset, number)
         return prefix_path, dataset_path
 
@@ -506,14 +568,21 @@ def create_multi_prefix_dataset(
     dataset = []
     pbar = tqdm(total=number, desc="Stitching dataset", unit="row") if tqdm else None
     for data_len in range(number):
-        single_data = prefix_data[data_len % prefix_num] + uniq_token_set[data_len] + suffix_dataset[data_len]
+        single_data = (
+            prefix_data[data_len % prefix_num]
+            + uniq_token_set[data_len]
+            + suffix_dataset[data_len]
+        )
         dataset.append(single_data)
         if pbar:
             pbar.update(1)
     if pbar:
         pbar.close()
 
-    dataset_path = os.path.join(save_path, f'{source_tag}-in{input_len}-num{number}-{base_name}-repeatRate{repeat_rate}.jsonl')
+    dataset_path = os.path.join(
+        save_path,
+        f"{source_tag}-in{input_len}-num{number}-{base_name}-repeatRate{repeat_rate}.jsonl",
+    )
     write_data(dataset_path, dataset, number)
 
     return prefix_path, dataset_path
@@ -534,21 +603,29 @@ def _create_prefix_dataset_variable(
     length_min: Optional[int],
     length_max: Optional[int],
     gsm8k_path: Optional[str],
-    use_gsm8k: bool = True
+    use_gsm8k: bool = True,
 ) -> Tuple[str, str]:
     """Variable-length prefix dataset generation"""
     rng = random.Random(seed)
     source_tag = "GSM8K" if use_gsm8k else "Random"
 
     # Helper function to get dataset based on mode
-    def _get_dataset(length: int, count: int, prefix_flag_val: int) -> Optional[List[str]]:
+    def _get_dataset(
+        length: int, count: int, prefix_flag_val: int
+    ) -> Optional[List[str]]:
         if use_gsm8k:
-            return create_dataset(tokenizer_path, length, count, prefix_flag_val, gsm8k_path)
+            return create_dataset(
+                tokenizer_path, length, count, prefix_flag_val, gsm8k_path
+            )
         else:
-            return create_dataset_from_random_tokens(tokenizer_path, length, count, seed)
+            return create_dataset_from_random_tokens(
+                tokenizer_path, length, count, seed
+            )
 
     real_lens = [
-        sample_target_length(rng, input_len, length_mean, length_std, length_min, length_max)
+        sample_target_length(
+            rng, input_len, length_mean, length_std, length_min, length_max
+        )
         for _ in range(number)
     ]
     common_lens = [max(0, min(rl, int(round(rl * repeat_rate)))) for rl in real_lens]
@@ -568,11 +645,17 @@ def _create_prefix_dataset_variable(
         for j in range(dp):
             prefix_dataset.append(prefix_data[i])
 
-    prefix_path = os.path.join(save_path, f'prefix-{source_tag}-in{max_common_len}-num{dp*prefix_num}-{base_name}.jsonl')
+    prefix_path = os.path.join(
+        save_path,
+        f"prefix-{source_tag}-in{max_common_len}-num{dp*prefix_num}-{base_name}.jsonl",
+    )
     write_data(prefix_path, prefix_dataset, dp * prefix_num)
 
     if repeat_rate >= 1:
-        dataset_path = os.path.join(save_path, f'{source_tag}-in{max_common_len}-num{number}-{base_name}-repeatRate{repeat_rate}.jsonl')
+        dataset_path = os.path.join(
+            save_path,
+            f"{source_tag}-in{max_common_len}-num{number}-{base_name}-repeatRate{repeat_rate}.jsonl",
+        )
         write_data(dataset_path, prefix_dataset, number)
         return prefix_path, dataset_path
 
@@ -592,7 +675,11 @@ def _create_prefix_dataset_variable(
         return "", ""
 
     dataset = []
-    pbar = tqdm(total=number, desc="Stitching dataset (variable)", unit="row") if tqdm else None
+    pbar = (
+        tqdm(total=number, desc="Stitching dataset (variable)", unit="row")
+        if tqdm
+        else None
+    )
     for idx in range(number):
         rl = real_lens[idx]
         cl = common_lens[idx]
@@ -606,7 +693,9 @@ def _create_prefix_dataset_variable(
 
         suffix_text = suffix_pool[idx]
         if suffix_len_needed > 0 and suffix_text:
-            suffix_text = _truncate_or_pad_text(tokenizer, suffix_text, suffix_len_needed)
+            suffix_text = _truncate_or_pad_text(
+                tokenizer, suffix_text, suffix_len_needed
+            )
         else:
             suffix_text = ""
 
@@ -617,12 +706,19 @@ def _create_prefix_dataset_variable(
     if pbar:
         pbar.close()
 
-    length_tag = _build_length_tag(input_len, length_mean, length_std, length_min, length_max)
-    dataset_path = os.path.join(save_path, f'{source_tag}-{length_tag}-num{number}-{base_name}-repeatRate{repeat_rate}.jsonl')
+    length_tag = _build_length_tag(
+        input_len, length_mean, length_std, length_min, length_max
+    )
+    dataset_path = os.path.join(
+        save_path,
+        f"{source_tag}-{length_tag}-num{number}-{base_name}-repeatRate{repeat_rate}.jsonl",
+    )
     write_data(dataset_path, dataset, number)
 
     logging.info(f"  max_common_len={max_common_len}, max_suffix_len={max_suffix_len}")
-    logging.info(f"  avg_hit_ratio={sum(c / r for c, r in zip(common_lens, real_lens)) / len(real_lens):.2%}")
+    logging.info(
+        f"  avg_hit_ratio={sum(c / r for c, r in zip(common_lens, real_lens)) / len(real_lens):.2%}"
+    )
 
     return prefix_path, dataset_path
 

--- a/test/common/aisbench_utils/prefix_hit_rate.py
+++ b/test/common/aisbench_utils/prefix_hit_rate.py
@@ -1,0 +1,230 @@
+"""
+Prefix Cache hit rate calculation module
+Query vLLM metrics API to get prefix cache hit statistics
+"""
+import re
+import subprocess
+import logging
+from typing import Dict, Tuple, List
+
+logging.getLogger().setLevel(logging.INFO)
+
+
+def get_prefix_queries_total(ip_address: str, port: str) -> Tuple[Dict[int, int], Dict[int, int]]:
+    """
+    Get query token count
+
+    Args:
+        ip_address: vLLM service IP address
+        port: vLLM service port
+
+    Returns:
+        (normal_stats, external_stats) - Dict in {engine: tokens} format
+        normal_stats: HBM prefix cache query count
+        external_stats: External prefix cache query count
+    """
+    try:
+        url = f"http://{ip_address}:{port}/metrics"
+        command = f"unset http_proxy && unset https_proxy && sleep 3s && curl -s {url} | grep 'prefix_cache_queries_total' | grep 'model_name'"
+
+        result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=30)
+
+        if result.returncode != 0 or not result.stdout.strip():
+            return {}, {}
+
+        lines = result.stdout.strip().split('\n')
+        normal_stats = {}
+        external_stats = {}
+
+        for line in lines:
+            engine_match = re.search(r'engine="(\d+)"', line)
+            if not engine_match:
+                continue
+
+            engine = engine_match.group(1)
+
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+
+            value_str = parts[-1]
+            try:
+                value = float(value_str)
+                if value.is_integer():
+                    value = int(value)
+            except ValueError:
+                continue
+
+            if 'external_prefix_cache_queries_total' in line:
+                external_stats[int(engine)] = value
+            elif 'vllm:prefix_cache_queries_total' in line:
+                normal_stats[int(engine)] = value
+
+        logging.info(f"HBM queries: {normal_stats}, External queries: {external_stats}")
+        return normal_stats, external_stats
+
+    except Exception as e:
+        logging.error(f"Error getting query token count: {e}")
+        return {}, {}
+
+
+def get_prefix_hits_total(ip_address: str, port: str) -> Tuple[Dict[int, int], Dict[int, int]]:
+    """
+    Get hit token count
+
+    Args:
+        ip_address: vLLM service IP address
+        port: vLLM service port
+
+    Returns:
+        (normal_stats, external_stats) - Dict in {engine: tokens} format
+        normal_stats: HBM prefix cache hit count
+        external_stats: External prefix cache hit count
+    """
+    try:
+        url = f"http://{ip_address}:{port}/metrics"
+        command = f"unset http_proxy && unset https_proxy && sleep 3s && curl -s {url} | grep 'prefix_cache_hits_total' | grep 'model_name'"
+
+        result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=30)
+
+        if result.returncode != 0 or not result.stdout.strip():
+            return {}, {}
+
+        lines = result.stdout.strip().split('\n')
+        normal_stats = {}
+        external_stats = {}
+
+        for line in lines:
+            engine_match = re.search(r'engine="(\d+)"', line)
+            if not engine_match:
+                continue
+
+            engine = engine_match.group(1)
+
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+
+            value_str = parts[-1]
+            try:
+                value = float(value_str)
+                if value.is_integer():
+                    value = int(value)
+            except ValueError:
+                continue
+
+            if 'external_prefix_cache_hits_total' in line:
+                external_stats[int(engine)] = value
+            elif 'vllm:prefix_cache_hits_total' in line:
+                normal_stats[int(engine)] = value
+
+        logging.info(f"HBM hits: {normal_stats}, External hits: {external_stats}")
+        return normal_stats, external_stats
+
+    except Exception as e:
+        logging.error(f"Error getting hit token count: {e}")
+        return {}, {}
+
+
+def get_pod_metrics_info(pod_info: List[str]) -> Tuple[Dict, Dict, Dict, Dict]:
+    """
+    Get metrics info for all POD nodes
+
+    Args:
+        pod_info: POD list in ["ip:port", ...] format
+
+    Returns:
+        (query_tokens, query_tokens_external, hit_tokens, hit_tokens_external)
+        Each is nested dict in {pod: {engine: tokens}} format
+    """
+    query_tokens = {}
+    query_tokens_external = {}
+    hit_tokens = {}
+    hit_tokens_external = {}
+
+    for pod in pod_info:
+        ip, port = pod.split(":")
+        query_tokens[pod], query_tokens_external[pod] = get_prefix_queries_total(ip, port)
+        hit_tokens[pod], hit_tokens_external[pod] = get_prefix_hits_total(ip, port)
+
+    return query_tokens, query_tokens_external, hit_tokens, hit_tokens_external
+
+
+def cal_prefix_hit_info(query_tokens: Dict, query_tokens_external: Dict,
+                        hit_tokens: Dict, hit_tokens_external: Dict,
+                        query_tokens_new: Dict, query_tokens_external_new: Dict,
+                        hit_tokens_new: Dict, hit_tokens_external_new: Dict) -> Dict:
+    """
+    Calculate and print prefix cache hit rate info
+
+    Args:
+        Metrics data before and after test
+
+    Returns:
+        Hit rate statistics result dict
+    """
+    if not query_tokens or not query_tokens_external or not hit_tokens or not hit_tokens_external:
+        return {}
+
+    result = {}
+
+    # Define column widths
+    col1_width = 15
+    col2_width = 20
+    col3_width = 20
+    col4_width = 20
+    col5_width = 20
+
+    total_width = col1_width + col2_width + col3_width + col4_width + col5_width + 8
+
+    for pod, engines in sorted(query_tokens.items()):
+        pod_result = {
+            'pod': pod,
+            'engines': []
+        }
+
+        print("\n" + "=" * total_width)
+        print(f"POD: {pod}")
+        print("=" * total_width)
+
+        headers = ['engine_id', 'hbm_hit_rate', 'hbm(hit/query)', 'external_hit_rate', 'external(hit/query)']
+        print(f"{headers[0]:<{col1_width}} {headers[1]:<{col2_width}} {headers[2]:<{col3_width}} {headers[3]:<{col4_width}} {headers[4]:<{col5_width}}")
+        print("-" * total_width)
+
+        for engine_id, token in sorted(engines.items()):
+            query_hbm = query_tokens_new[pod][engine_id] - query_tokens[pod][engine_id]
+            hits_hbm = hit_tokens_new[pod][engine_id] - hit_tokens[pod][engine_id]
+            query_ex = query_tokens_external_new[pod][engine_id] - query_tokens_external[pod][engine_id]
+            hits_ex = hit_tokens_external_new[pod][engine_id] - hit_tokens_external[pod][engine_id]
+
+            if query_hbm == 0:
+                hit_rate_str = "0%"
+                hit_detail = "0/0"
+            else:
+                hit_rate_str = format(hits_hbm / query_hbm, '.2%')
+                hit_detail = f"{hits_hbm}/{query_hbm}"
+
+            if query_ex == 0:
+                hit_rate_ex_str = "0%"
+                hit_ex_detail = "0/0"
+            else:
+                hit_rate_ex_str = format(hits_ex / query_ex, '.2%')
+                hit_ex_detail = f"{hits_ex}/{query_ex}"
+
+            engine_result = {
+                'engine_id': str(engine_id),
+                'hbm_hit_rate': hit_rate_str,
+                'hbm_hits': hits_hbm,
+                'hbm_queries': query_hbm,
+                'external_hit_rate': hit_rate_ex_str,
+                'external_hits': hits_ex,
+                'external_queries': query_ex
+            }
+            pod_result['engines'].append(engine_result)
+
+            print(f"{engine_result['engine_id']:<{col1_width}} {hit_rate_str:<{col2_width}} {hit_detail:<{col3_width}} {hit_rate_ex_str:<{col4_width}} {hit_ex_detail:<{col5_width}}")
+
+        print("=" * total_width)
+        result[pod] = pod_result
+
+    return result

--- a/test/common/aisbench_utils/prefix_hit_rate.py
+++ b/test/common/aisbench_utils/prefix_hit_rate.py
@@ -2,15 +2,18 @@
 Prefix Cache hit rate calculation module
 Query vLLM metrics API to get prefix cache hit statistics
 """
+
+import logging
 import re
 import subprocess
-import logging
-from typing import Dict, Tuple, List
+from typing import Dict, List, Tuple
 
 logging.getLogger().setLevel(logging.INFO)
 
 
-def get_prefix_queries_total(ip_address: str, port: str) -> Tuple[Dict[int, int], Dict[int, int]]:
+def get_prefix_queries_total(
+    ip_address: str, port: str
+) -> Tuple[Dict[int, int], Dict[int, int]]:
     """
     Get query token count
 
@@ -27,12 +30,14 @@ def get_prefix_queries_total(ip_address: str, port: str) -> Tuple[Dict[int, int]
         url = f"http://{ip_address}:{port}/metrics"
         command = f"unset http_proxy && unset https_proxy && sleep 3s && curl -s {url} | grep 'prefix_cache_queries_total' | grep 'model_name'"
 
-        result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=30)
+        result = subprocess.run(
+            command, shell=True, capture_output=True, text=True, timeout=30
+        )
 
         if result.returncode != 0 or not result.stdout.strip():
             return {}, {}
 
-        lines = result.stdout.strip().split('\n')
+        lines = result.stdout.strip().split("\n")
         normal_stats = {}
         external_stats = {}
 
@@ -55,9 +60,9 @@ def get_prefix_queries_total(ip_address: str, port: str) -> Tuple[Dict[int, int]
             except ValueError:
                 continue
 
-            if 'external_prefix_cache_queries_total' in line:
+            if "external_prefix_cache_queries_total" in line:
                 external_stats[int(engine)] = value
-            elif 'vllm:prefix_cache_queries_total' in line:
+            elif "vllm:prefix_cache_queries_total" in line:
                 normal_stats[int(engine)] = value
 
         logging.info(f"HBM queries: {normal_stats}, External queries: {external_stats}")
@@ -68,7 +73,9 @@ def get_prefix_queries_total(ip_address: str, port: str) -> Tuple[Dict[int, int]
         return {}, {}
 
 
-def get_prefix_hits_total(ip_address: str, port: str) -> Tuple[Dict[int, int], Dict[int, int]]:
+def get_prefix_hits_total(
+    ip_address: str, port: str
+) -> Tuple[Dict[int, int], Dict[int, int]]:
     """
     Get hit token count
 
@@ -85,12 +92,14 @@ def get_prefix_hits_total(ip_address: str, port: str) -> Tuple[Dict[int, int], D
         url = f"http://{ip_address}:{port}/metrics"
         command = f"unset http_proxy && unset https_proxy && sleep 3s && curl -s {url} | grep 'prefix_cache_hits_total' | grep 'model_name'"
 
-        result = subprocess.run(command, shell=True, capture_output=True, text=True, timeout=30)
+        result = subprocess.run(
+            command, shell=True, capture_output=True, text=True, timeout=30
+        )
 
         if result.returncode != 0 or not result.stdout.strip():
             return {}, {}
 
-        lines = result.stdout.strip().split('\n')
+        lines = result.stdout.strip().split("\n")
         normal_stats = {}
         external_stats = {}
 
@@ -113,9 +122,9 @@ def get_prefix_hits_total(ip_address: str, port: str) -> Tuple[Dict[int, int], D
             except ValueError:
                 continue
 
-            if 'external_prefix_cache_hits_total' in line:
+            if "external_prefix_cache_hits_total" in line:
                 external_stats[int(engine)] = value
-            elif 'vllm:prefix_cache_hits_total' in line:
+            elif "vllm:prefix_cache_hits_total" in line:
                 normal_stats[int(engine)] = value
 
         logging.info(f"HBM hits: {normal_stats}, External hits: {external_stats}")
@@ -144,16 +153,24 @@ def get_pod_metrics_info(pod_info: List[str]) -> Tuple[Dict, Dict, Dict, Dict]:
 
     for pod in pod_info:
         ip, port = pod.split(":")
-        query_tokens[pod], query_tokens_external[pod] = get_prefix_queries_total(ip, port)
+        query_tokens[pod], query_tokens_external[pod] = get_prefix_queries_total(
+            ip, port
+        )
         hit_tokens[pod], hit_tokens_external[pod] = get_prefix_hits_total(ip, port)
 
     return query_tokens, query_tokens_external, hit_tokens, hit_tokens_external
 
 
-def cal_prefix_hit_info(query_tokens: Dict, query_tokens_external: Dict,
-                        hit_tokens: Dict, hit_tokens_external: Dict,
-                        query_tokens_new: Dict, query_tokens_external_new: Dict,
-                        hit_tokens_new: Dict, hit_tokens_external_new: Dict) -> Dict:
+def cal_prefix_hit_info(
+    query_tokens: Dict,
+    query_tokens_external: Dict,
+    hit_tokens: Dict,
+    hit_tokens_external: Dict,
+    query_tokens_new: Dict,
+    query_tokens_external_new: Dict,
+    hit_tokens_new: Dict,
+    hit_tokens_external_new: Dict,
+) -> Dict:
     """
     Calculate and print prefix cache hit rate info
 
@@ -163,7 +180,12 @@ def cal_prefix_hit_info(query_tokens: Dict, query_tokens_external: Dict,
     Returns:
         Hit rate statistics result dict
     """
-    if not query_tokens or not query_tokens_external or not hit_tokens or not hit_tokens_external:
+    if (
+        not query_tokens
+        or not query_tokens_external
+        or not hit_tokens
+        or not hit_tokens_external
+    ):
         return {}
 
     result = {}
@@ -178,51 +200,64 @@ def cal_prefix_hit_info(query_tokens: Dict, query_tokens_external: Dict,
     total_width = col1_width + col2_width + col3_width + col4_width + col5_width + 8
 
     for pod, engines in sorted(query_tokens.items()):
-        pod_result = {
-            'pod': pod,
-            'engines': []
-        }
+        pod_result = {"pod": pod, "engines": []}
 
         print("\n" + "=" * total_width)
         print(f"POD: {pod}")
         print("=" * total_width)
 
-        headers = ['engine_id', 'hbm_hit_rate', 'hbm(hit/query)', 'external_hit_rate', 'external(hit/query)']
-        print(f"{headers[0]:<{col1_width}} {headers[1]:<{col2_width}} {headers[2]:<{col3_width}} {headers[3]:<{col4_width}} {headers[4]:<{col5_width}}")
+        headers = [
+            "engine_id",
+            "hbm_hit_rate",
+            "hbm(hit/query)",
+            "external_hit_rate",
+            "external(hit/query)",
+        ]
+        print(
+            f"{headers[0]:<{col1_width}} {headers[1]:<{col2_width}} {headers[2]:<{col3_width}} {headers[3]:<{col4_width}} {headers[4]:<{col5_width}}"
+        )
         print("-" * total_width)
 
         for engine_id, token in sorted(engines.items()):
             query_hbm = query_tokens_new[pod][engine_id] - query_tokens[pod][engine_id]
             hits_hbm = hit_tokens_new[pod][engine_id] - hit_tokens[pod][engine_id]
-            query_ex = query_tokens_external_new[pod][engine_id] - query_tokens_external[pod][engine_id]
-            hits_ex = hit_tokens_external_new[pod][engine_id] - hit_tokens_external[pod][engine_id]
+            query_ex = (
+                query_tokens_external_new[pod][engine_id]
+                - query_tokens_external[pod][engine_id]
+            )
+            hits_ex = (
+                hit_tokens_external_new[pod][engine_id]
+                - hit_tokens_external[pod][engine_id]
+            )
 
             if query_hbm == 0:
                 hit_rate_str = "0%"
                 hit_detail = "0/0"
             else:
-                hit_rate_str = format(hits_hbm / query_hbm, '.2%')
+                hit_rate_str = format(hits_hbm / query_hbm, ".2%")
                 hit_detail = f"{hits_hbm}/{query_hbm}"
 
             if query_ex == 0:
                 hit_rate_ex_str = "0%"
                 hit_ex_detail = "0/0"
             else:
-                hit_rate_ex_str = format(hits_ex / query_ex, '.2%')
+                hit_rate_ex_str = format(hits_ex / query_ex, ".2%")
                 hit_ex_detail = f"{hits_ex}/{query_ex}"
 
             engine_result = {
-                'engine_id': str(engine_id),
-                'hbm_hit_rate': hit_rate_str,
-                'hbm_hits': hits_hbm,
-                'hbm_queries': query_hbm,
-                'external_hit_rate': hit_rate_ex_str,
-                'external_hits': hits_ex,
-                'external_queries': query_ex
+                "engine_id": str(engine_id),
+                "hbm_hit_rate": hit_rate_str,
+                "hbm_hits": hits_hbm,
+                "hbm_queries": query_hbm,
+                "external_hit_rate": hit_rate_ex_str,
+                "external_hits": hits_ex,
+                "external_queries": query_ex,
             }
-            pod_result['engines'].append(engine_result)
+            pod_result["engines"].append(engine_result)
 
-            print(f"{engine_result['engine_id']:<{col1_width}} {hit_rate_str:<{col2_width}} {hit_detail:<{col3_width}} {hit_rate_ex_str:<{col4_width}} {hit_ex_detail:<{col5_width}}")
+            print(
+                f"{engine_result['engine_id']:<{col1_width}} {hit_rate_str:<{col2_width}} {hit_detail:<{col3_width}} {hit_rate_ex_str:<{col4_width}} {hit_ex_detail:<{col5_width}}"
+            )
 
         print("=" * total_width)
         result[pod] = pod_result

--- a/test/common/aisbench_utils/result_parser.py
+++ b/test/common/aisbench_utils/result_parser.py
@@ -2,6 +2,7 @@
 AISBench result parser module
 Parse aisbench log file, extract performance metrics and save results
 """
+
 import logging
 import os
 import re
@@ -32,7 +33,7 @@ def get_data(aisbench_log: str, req_rate: str, npu_num: int) -> Tuple[List, str]
     default_values[5] = 0  # req_rate default to 0
 
     try:
-        with open(aisbench_log, 'r') as f_streaming:
+        with open(aisbench_log, "r") as f_streaming:
             txt = f_streaming.readlines()
 
             current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -61,27 +62,27 @@ def get_data(aisbench_log: str, req_rate: str, npu_num: int) -> Tuple[List, str]
 
                 if "Current exp folder" in line:
                     matches = re.findall(r"[\w']+", line)
-                    log_dir = '/'.join(matches[-3:])
+                    log_dir = "/".join(matches[-3:])
 
                 if "TTFT" in line:
-                    matches = re.findall(r'(\d+\.\d+)', line)
+                    matches = re.findall(r"(\d+\.\d+)", line)
                     if len(matches) >= 6:
                         slo_p90_first_token_time = float(matches[5])
                         AVG_first_token_time = float(matches[0])
 
                 if "TPOT" in line:
-                    matches = re.findall(r'(\d+\.\d+)', line)
+                    matches = re.findall(r"(\d+\.\d+)", line)
                     if len(matches) >= 6:
                         slo_p90_token_time = float(matches[5])
                         AVG_token_time = float(matches[0])
 
                 if "Benchmark Duration" in line:
-                    matches = re.findall(r'(\d+\.\d+)', line)
+                    matches = re.findall(r"(\d+\.\d+)", line)
                     if matches:
                         total_time = float(matches[0]) / 1000
 
                 if "Concurrency" in line:
-                    matches = re.findall(r'(\d+\.\d+)', line)
+                    matches = re.findall(r"(\d+\.\d+)", line)
                     if matches:
                         Concurrency = float(matches[0])
 
@@ -90,49 +91,49 @@ def get_data(aisbench_log: str, req_rate: str, npu_num: int) -> Tuple[List, str]
                     max_Concurrency = matches[-1]
 
                 if "Output Token Throughput" in line:
-                    matches = re.findall(r'(\d+\.\d+)', line)
+                    matches = re.findall(r"(\d+\.\d+)", line)
                     if matches:
                         GenerateSpeed = float(matches[0])
                         single_generatespeed = GenerateSpeed / npu_num
 
                 if "Input Token Throughput" in line:
-                    matches = re.findall(r'(\d+\.\d+)', line)
+                    matches = re.findall(r"(\d+\.\d+)", line)
                     if matches:
                         input_token_throughput = float(matches[0])
 
                 if "Total Token Throughput" in line:
-                    matches = re.findall(r'(\d+\.\d+)', line)
+                    matches = re.findall(r"(\d+\.\d+)", line)
                     if matches:
                         e2e_throughput = float(matches[0])
                         single_e2e_throughput = e2e_throughput / npu_num
 
                 if "InputTokens" in line:
-                    matches = re.findall(r'(\d+\.?\d*)', line)
+                    matches = re.findall(r"(\d+\.?\d*)", line)
                     if matches:
                         Total_InputTokens = float(matches[0])
 
                 if "OutputTokens" in line:
-                    matches = re.findall(r'(\d+\.?\d*)', line)
+                    matches = re.findall(r"(\d+\.?\d*)", line)
                     if matches:
                         Total_GeneratedTokens = float(matches[0])
 
                 if "Total Requests" in line:
-                    matches = re.findall(r'(\d+\.?\d*)', line)
+                    matches = re.findall(r"(\d+\.?\d*)", line)
                     if matches:
                         Total_requests = float(matches[0])
 
                 if "Request Throughput" in line:
-                    matches = re.findall(r'(\d+\.\d+)', line)
+                    matches = re.findall(r"(\d+\.\d+)", line)
                     if matches:
                         qps = float(matches[0])
                         qpm = qps * 60
 
                 if "Prefill Token Throughput" in line:
-                    matches = re.findall(r'(\d+\.\d+)', line)
+                    matches = re.findall(r"(\d+\.\d+)", line)
                     if matches:
                         prefill_throughput = float(matches[0])
 
-            ans = [
+            perf_result = [
                 current_time,
                 Total_InputTokens,
                 Total_GeneratedTokens,
@@ -152,14 +153,14 @@ def get_data(aisbench_log: str, req_rate: str, npu_num: int) -> Tuple[List, str]
                 qps,
                 qpm,
                 input_token_throughput,
-                prefill_throughput
+                prefill_throughput,
             ]
 
     except Exception as e:
         logging.warning(traceback.format_exc())
-        ans = default_values
+        perf_result = default_values
 
-    return ans, log_dir
+    return perf_result, log_dir
 
 
 def save_log(aisbench_log: str, log_dir: str):
@@ -180,10 +181,10 @@ def save_log(aisbench_log: str, log_dir: str):
     target_file = "aisbench_all.log"
 
     try:
-        with open(source_file, 'r', encoding='utf-8') as src:
+        with open(source_file, "r", encoding="utf-8") as src:
             content = src.read()
 
-        with open(target_file, 'a', encoding='utf-8') as tgt:
+        with open(target_file, "a", encoding="utf-8") as tgt:
             tgt.write(f"\n\n{'='*50}\n")
             tgt.write(f"{'='*50}\n\n")
             tgt.write(content)
@@ -199,12 +200,12 @@ def save_log(aisbench_log: str, log_dir: str):
         logging.error(f"Error occurred: {e}")
 
 
-def save_csv(ans: List, filename: str):
+def save_csv(perf_result: List, filename: str):
     """
     Save performance data to CSV file
 
     Args:
-        ans: Performance data list
+        perf_result: Performance data list
         filename: Output CSV filename
     """
     headers = [
@@ -227,7 +228,7 @@ def save_csv(ans: List, filename: str):
         "qps",
         "qpm",
         "input_token_throughput",
-        "prefill_token_throughput"
+        "prefill_token_throughput",
     ]
 
     file_exists = os.path.exists(filename)
@@ -236,12 +237,12 @@ def save_csv(ans: List, filename: str):
         if file_exists:
             df_existing = pd.read_csv(filename)
             logging.info("File exists, reading existing data")
-            new_row = pd.DataFrame([ans], columns=headers)
+            new_row = pd.DataFrame([perf_result], columns=headers)
             df_updated = pd.concat([df_existing, new_row], ignore_index=True)
             df_updated.to_csv(filename, index=False)
             logging.info("Successfully appended new row")
         else:
-            df_new = pd.DataFrame([ans], columns=headers)
+            df_new = pd.DataFrame([perf_result], columns=headers)
             df_new.to_csv(filename, index=False)
             logging.info("Created new file and wrote data")
 

--- a/test/common/aisbench_utils/result_parser.py
+++ b/test/common/aisbench_utils/result_parser.py
@@ -1,0 +1,249 @@
+"""
+AISBench result parser module
+Parse aisbench log file, extract performance metrics and save results
+"""
+import logging
+import os
+import re
+import shutil
+import traceback
+from datetime import datetime
+from typing import List, Tuple
+
+import pandas as pd
+
+logging.getLogger().setLevel(logging.INFO)
+
+
+def get_data(aisbench_log: str, req_rate: str, npu_num: int) -> Tuple[List, str]:
+    """
+    Parse performance data from aisbench log file
+
+    Args:
+        aisbench_log: aisbench log file path
+        req_rate: Request rate
+        npu_num: Number of NPU cards
+
+    Returns:
+        (performance data list, log directory)
+    """
+    log_dir = ""
+    default_values = [99999] * 20
+    default_values[5] = 0  # req_rate default to 0
+
+    try:
+        with open(aisbench_log, 'r') as f_streaming:
+            txt = f_streaming.readlines()
+
+            current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            Total_InputTokens = 99999
+            Total_GeneratedTokens = 99999
+            Total_requests = 99999
+            max_Concurrency = 99999
+            Concurrency = 99999
+            request_rate = float(req_rate) if req_rate else 0
+            AVG_first_token_time = 99999
+            slo_p90_first_token_time = 99999
+            AVG_token_time = 99999
+            slo_p90_token_time = 99999
+            total_time = 99999
+            GenerateSpeed = 99999
+            single_generatespeed = 9999
+            e2e_throughput = 9999
+            single_e2e_throughput = 9999
+            qps = 9999
+            qpm = 9999
+            input_token_throughput = 9999
+            prefill_throughput = 9999
+
+            for i in range(len(txt)):
+                line = txt[i]
+
+                if "Current exp folder" in line:
+                    matches = re.findall(r"[\w']+", line)
+                    log_dir = '/'.join(matches[-3:])
+
+                if "TTFT" in line:
+                    matches = re.findall(r'(\d+\.\d+)', line)
+                    if len(matches) >= 6:
+                        slo_p90_first_token_time = float(matches[5])
+                        AVG_first_token_time = float(matches[0])
+
+                if "TPOT" in line:
+                    matches = re.findall(r'(\d+\.\d+)', line)
+                    if len(matches) >= 6:
+                        slo_p90_token_time = float(matches[5])
+                        AVG_token_time = float(matches[0])
+
+                if "Benchmark Duration" in line:
+                    matches = re.findall(r'(\d+\.\d+)', line)
+                    if matches:
+                        total_time = float(matches[0]) / 1000
+
+                if "Concurrency" in line:
+                    matches = re.findall(r'(\d+\.\d+)', line)
+                    if matches:
+                        Concurrency = float(matches[0])
+
+                if "Max Concurrency" in line:
+                    matches = re.findall(r"[\w']+", line)
+                    max_Concurrency = matches[-1]
+
+                if "Output Token Throughput" in line:
+                    matches = re.findall(r'(\d+\.\d+)', line)
+                    if matches:
+                        GenerateSpeed = float(matches[0])
+                        single_generatespeed = GenerateSpeed / npu_num
+
+                if "Input Token Throughput" in line:
+                    matches = re.findall(r'(\d+\.\d+)', line)
+                    if matches:
+                        input_token_throughput = float(matches[0])
+
+                if "Total Token Throughput" in line:
+                    matches = re.findall(r'(\d+\.\d+)', line)
+                    if matches:
+                        e2e_throughput = float(matches[0])
+                        single_e2e_throughput = e2e_throughput / npu_num
+
+                if "InputTokens" in line:
+                    matches = re.findall(r'(\d+\.?\d*)', line)
+                    if matches:
+                        Total_InputTokens = float(matches[0])
+
+                if "OutputTokens" in line:
+                    matches = re.findall(r'(\d+\.?\d*)', line)
+                    if matches:
+                        Total_GeneratedTokens = float(matches[0])
+
+                if "Total Requests" in line:
+                    matches = re.findall(r'(\d+\.?\d*)', line)
+                    if matches:
+                        Total_requests = float(matches[0])
+
+                if "Request Throughput" in line:
+                    matches = re.findall(r'(\d+\.\d+)', line)
+                    if matches:
+                        qps = float(matches[0])
+                        qpm = qps * 60
+
+                if "Prefill Token Throughput" in line:
+                    matches = re.findall(r'(\d+\.\d+)', line)
+                    if matches:
+                        prefill_throughput = float(matches[0])
+
+            ans = [
+                current_time,
+                Total_InputTokens,
+                Total_GeneratedTokens,
+                Total_requests,
+                max_Concurrency,
+                Concurrency,
+                request_rate,
+                AVG_first_token_time,
+                slo_p90_first_token_time,
+                AVG_token_time,
+                slo_p90_token_time,
+                total_time,
+                GenerateSpeed,
+                single_generatespeed,
+                e2e_throughput,
+                single_e2e_throughput,
+                qps,
+                qpm,
+                input_token_throughput,
+                prefill_throughput
+            ]
+
+    except Exception as e:
+        logging.warning(traceback.format_exc())
+        ans = default_values
+
+    return ans, log_dir
+
+
+def save_log(aisbench_log: str, log_dir: str):
+    """
+    Save aisbench log file
+
+    Args:
+        aisbench_log: aisbench log file path
+        log_dir: Target directory
+    """
+    if not log_dir:
+        logging.warning("log_dir is empty, skipping log save")
+        return
+
+    shutil.copy2(aisbench_log, log_dir)
+
+    source_file = aisbench_log
+    target_file = "aisbench_all.log"
+
+    try:
+        with open(source_file, 'r', encoding='utf-8') as src:
+            content = src.read()
+
+        with open(target_file, 'a', encoding='utf-8') as tgt:
+            tgt.write(f"\n\n{'='*50}\n")
+            tgt.write(f"{'='*50}\n\n")
+            tgt.write(content)
+            tgt.write(f"\n\n{'='*50}\n")
+            tgt.write(f"{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}\n")
+            tgt.write(f"{'='*50}\n")
+
+        logging.info(f"Successfully appended {source_file} content to {target_file}")
+
+    except FileNotFoundError:
+        logging.error(f"Error: File not found, please check file path")
+    except Exception as e:
+        logging.error(f"Error occurred: {e}")
+
+
+def save_csv(ans: List, filename: str):
+    """
+    Save performance data to CSV file
+
+    Args:
+        ans: Performance data list
+        filename: Output CSV filename
+    """
+    headers = [
+        "current_time",
+        "input_len",
+        "output_len",
+        "total_req",
+        "max_cc",
+        "cc",
+        "rr",
+        "TTFT avg",
+        "TTFT P90",
+        "TPOT avg",
+        "TPOT SLO_P90",
+        "E2E_time",
+        "output_throughput",
+        "single_output_throughput",
+        "E2E_throughput",
+        "single_E2E_throughput",
+        "qps",
+        "qpm",
+        "input_token_throughput",
+        "prefill_token_throughput"
+    ]
+
+    file_exists = os.path.exists(filename)
+
+    try:
+        if file_exists:
+            df_existing = pd.read_csv(filename)
+            logging.info("File exists, reading existing data")
+            new_row = pd.DataFrame([ans], columns=headers)
+            df_updated = pd.concat([df_existing, new_row], ignore_index=True)
+            df_updated.to_csv(filename, index=False)
+            logging.info("Successfully appended new row")
+        else:
+            df_new = pd.DataFrame([ans], columns=headers)
+            df_new.to_csv(filename, index=False)
+            logging.info("Created new file and wrote data")
+
+    except Exception as e:
+        logging.error(f"Operation failed: {e}")

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -59,3 +59,45 @@ Env_preCheck:
   expected_fetch_bandwidth: 10
   kvCache_block_number: 1024
   storage_backends: [""]
+
+# AISBench Prefix Cache Test Configuration
+aisbench_prefix_cache:
+  # Dataset configuration
+  dataset:
+    base_path: "/mnt/host/d/Dataset/gsm"
+    gsm8k_source: "/mnt/host/d/Dataset/gsm/GSM8K.jsonl"
+    # Data source mode:
+    # - use_gsm8k: true  Use GSM8K dataset as content source
+    # - use_gsm8k: false Generate random tokens directly (no dataset dependency)
+    use_gsm8k: false
+
+  # AISBench work path configuration
+  aisbench:
+    work_path: "/benchmark"
+    output_dir: "./outputs/default"
+
+  # Model configuration
+  model:
+    name: "qwen3:0.6b"
+    path: "/mnt/host/d/Models/Qwen3-32B"
+    tokenizer_path: "/mnt/host/d/Models/Qwen3-32B"
+
+  # Server configuration
+  server:
+    url: "http://192.168.65.254:9090"
+
+  # Test configuration
+  test:
+    default_perf: "default_perf"  # or "stable_stage" for steady-state testing
+    test_type: "stream"           # stream or text
+
+  # Node info configuration (for PD separation scenario)
+  pod_info: []
+  # Example:
+  # pod_info:
+  #   - "141.xx.xx.11:8000"
+  #   - "141.xx.xx.12:8000"
+
+  # Hardware configuration
+  hardware:
+    npu_num: 1

--- a/test/suites/E2E/test_aisbench_prefix_cache.py
+++ b/test/suites/E2E/test_aisbench_prefix_cache.py
@@ -1,0 +1,436 @@
+"""
+AISBench Prefix Cache Performance Test Cases
+
+Test model performance, prefix cache performance, dataset generation, etc.
+
+Parameter passing methods:
+1. Default config: Use default test_scenarios array
+2. Environment variable: Set AISBENCH_TEST_CASE env var with JSON format test config
+3. Config file: Configure in config.yaml aisbench_prefix_cache.test_scenarios
+
+Example:
+# Pass multiple test configs via environment variable
+export AISBENCH_TEST_CASE='[
+    {"input_len": 2048, "output_len": 2048, "data_num": 160, "concurrency": 40, "test_name": "2k_perf"},
+    {"input_len": 4096, "output_len": 1024, "data_num": 80, "concurrency": 32, "dataset_type": "prefix_cache", "repeat_rate": "50%", "prefix_test": true, "test_name": "prefix_50pct"}
+]'
+pytest --feature=aisbench_prefix_cache
+"""
+import json
+import logging
+import os
+import sys
+from dataclasses import asdict
+from pathlib import Path
+from typing import List, Dict, Any
+
+import pytest
+import yaml
+
+from common.capture_utils import export_vars, set_test_info
+from common.config_utils import config_utils
+from common.aisbench_utils import (
+    create_multi_prefix_dataset,
+    parse_prefix_ratio,
+    generate_api_config,
+    symlink_force,
+    get_data,
+    save_log,
+    save_csv,
+    get_pod_metrics_info,
+    cal_prefix_hit_info,
+    DataPicker,
+    AisbenchConfig,
+    AisbenchResult,
+)
+
+
+# Get project root directory
+PRJ_ROOT = Path(__file__).resolve().parents[2]
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+
+# ========== Test Scenario Configuration ==========
+
+# Default test scenarios
+default_test_scenarios: List[Dict[str, Any]] = [
+    {
+        "input_len": 512,
+        "output_len": 512,
+        "data_num": 10,
+        "concurrency": 10,
+        "request_rate": 10,             # int: 10 req/s (also accepts "10", 0=unlimited)
+        "dataset_type": "prefix_cache",
+        "repeat_rate": 0.5,             # float: 0.5 (also accepts 50, "50%", "0.5")
+        "prefix_num": 1,
+        "prefix_test": True,
+        "dp": 1,
+        "test_name": "prefix_50pct_dp1",
+    }
+]
+
+# Load test config from environment variable
+test_scenarios = default_test_scenarios.copy()
+
+# Method 1: Environment variable AISBENCH_TEST_CASE
+env_test_case_str = os.getenv("AISBENCH_TEST_CASE")
+if env_test_case_str:
+    try:
+        parsed = json.loads(env_test_case_str)
+        if isinstance(parsed, list) and len(parsed) > 0:
+            # Validate and convert config
+            valid_configs = []
+            for item in parsed:
+                if isinstance(item, dict):
+                    try:
+                        config = AisbenchConfig(**item)
+                        valid_configs.append(config.to_dict())
+                    except TypeError as e:
+                        logging.warning(f"Invalid config item: {item}, error: {e}")
+                        continue
+
+            if valid_configs:
+                test_scenarios = valid_configs
+                logging.info(f"Loaded {len(test_scenarios)} test configs from AISBENCH_TEST_CASE env var")
+            else:
+                logging.warning("Environment variable parse failed, using default config")
+        else:
+            logging.warning("Environment variable format invalid, using default config")
+    except json.JSONDecodeError as e:
+        logging.warning(f"JSON parse failed: {e}, using default config")
+    except Exception as e:
+        logging.warning(f"Parse error: {e}, using default config")
+else:
+    logging.info("AISBENCH_TEST_CASE env var not set, using default config")
+
+# Method 2: Load from config.yaml
+config_scenarios = config_utils.get_nested_config("aisbench_prefix_cache.test_scenarios", [])
+if config_scenarios and isinstance(config_scenarios, list):
+    try:
+        valid_configs = []
+        for item in config_scenarios:
+            if isinstance(item, dict):
+                config = AisbenchConfig(**item)
+                valid_configs.append(config.to_dict())
+
+        if valid_configs:
+            test_scenarios = valid_configs
+            logging.info(f"Loaded {len(test_scenarios)} test configs from config.yaml")
+    except Exception as e:
+        logging.warning(f"Config file load failed: {e}")
+
+logging.info(f"Final test scenario count: {len(test_scenarios)}")
+for i, scenario in enumerate(test_scenarios):
+    logging.info(f"  [{i+1}] {scenario.get('test_name', 'unnamed')}: input={scenario.get('input_len')}, output={scenario.get('output_len')}, type={scenario.get('dataset_type')}")
+
+
+# Generate test IDs
+scenario_ids = [s.get('test_name', f"in_{s['input_len']}-out_{s['output_len']}-type_{s['dataset_type']}") for s in test_scenarios]
+
+
+# ========== Test Runner Class ==========
+
+class AisbenchTestRunner:
+    """AISBench test runner"""
+
+    def __init__(self, config: AisbenchConfig):
+        self.config = config
+        self.global_config = config_utils.read_config()
+
+        # Get base config from global config
+        aisbench_config = self.global_config.get('aisbench_prefix_cache', {})
+        self.model_path = aisbench_config.get('model', {}).get('path', '')
+        self.model_name = aisbench_config.get('model', {}).get('name', '')
+        self.host_ip = aisbench_config.get('server', {}).get('host_ip', '')
+        self.host_port = aisbench_config.get('server', {}).get('host_port', '')
+        self.url = aisbench_config.get('server', {}).get('url', '')  # Support custom URL for domain-based connection
+        self.work_path = aisbench_config.get('aisbench', {}).get('work_path', '/home/benchmark')
+        self.dataset_path = aisbench_config.get('dataset', {}).get('base_path', '/home/dataset')
+        self.gsm8k_path = aisbench_config.get('dataset', {}).get('gsm8k_source', str(PRJ_ROOT.parent / "GSM8K.jsonl"))
+        self.use_gsm8k = aisbench_config.get('dataset', {}).get('use_gsm8k', True)  # Data source mode
+        self.output_dir = aisbench_config.get('aisbench', {}).get('output_dir', './outputs/default')
+        self.pod_info = aisbench_config.get('pod_info', [])
+        self.default_perf = aisbench_config.get('test', {}).get('default_perf', 'default_perf')
+
+    def generate_aisbench_command(self) -> str:
+        """Generate AISBench test command"""
+        if self.config.test_accuracy:
+            return f"ais_bench --models vllm_api_chat_temp --datasets gsm8k_gen_0_shot_cot_str_perf --work-dir {self.output_dir} --dump-eval-details"
+        else:
+            base_cmd = f"ais_bench --models vllm_api_chat_temp --datasets gsm8k_gen_0_shot_cot_str_perf --mode perf --summarizer {self.default_perf} --work-dir {self.output_dir} --debug --num-warmups 0"
+            if sys.platform == "win32":
+                # Windows: redirect stdout+stderr to log file (tee not available on cmd.exe)
+                return f"{base_cmd} > aisbench.log 2>&1"
+            else:
+                # Linux: use tee to output to both terminal and log file
+                return f"{base_cmd} 2>&1 | tee aisbench.log"
+
+    def setup_dataset_dir(self) -> str:
+        """Setup dataset directory"""
+        dst_dir = os.path.normpath(os.path.join(self.work_path, "ais_bench/datasets/gsm8k"))
+        if not os.path.exists(dst_dir):
+            os.makedirs(dst_dir)
+
+        train_dataset = os.path.join(dst_dir, "train.jsonl")
+        if not os.path.exists(train_dataset):
+            with open(train_dataset, 'w') as f:
+                pass
+
+        return dst_dir
+
+    def generate_dataset(self, dst_dir: str) -> tuple:
+        """Generate test dataset"""
+        repeat_rate = parse_prefix_ratio(self.config.repeat_rate)
+        prefix_flag = 1 if self.config.dataset_type == "prefix_cache" else 0
+
+        src_file_prefix, src_file_data = create_multi_prefix_dataset(
+            tokenizer_path=self.model_path,
+            input_len=self.config.input_len,
+            number=self.config.data_num,
+            save_path=self.dataset_path,
+            prefix_flag=prefix_flag,
+            dp=self.config.dp,
+            repeat_rate=repeat_rate,
+            seed=self.config.seed,
+            prefix_num=self.config.prefix_num,
+            length_mean=self.config.length_mean,
+            length_std=self.config.length_std,
+            length_min=self.config.length_min,
+            length_max=self.config.length_max,
+            gsm8k_path=self.gsm8k_path,
+            use_gsm8k=self.use_gsm8k,
+        )
+
+        # Create symlink
+        if self.config.dataset_type == "prefix_cache" and self.config.prefix_test:
+            # Prefix warmup phase
+            prefix_dst = os.path.join(dst_dir, "test.jsonl")
+            symlink_force(src_file_prefix, prefix_dst)
+
+        # Full dataset
+        data_dst = os.path.join(dst_dir, "test.jsonl")
+        symlink_force(src_file_data, data_dst)
+
+        return src_file_prefix, src_file_data
+
+    def run_prefix_warmup(self, src_file_prefix: str, dst_dir: str, ais_bench_cmd: str) -> dict:
+        """Run prefix warmup test"""
+        # Build pod_info: prefer url if available, otherwise use host_ip:host_port
+        if self.url:
+            # Extract host from url for pod_info
+            import re
+            url_match = re.search(r'https?://([^:/]+):(\d+)', self.url)
+            if url_match:
+                pod_info = [f"{url_match.group(1)}:{url_match.group(2)}"]
+            else:
+                pod_info = [self.url]
+        else:
+            pod_info = self.pod_info if self.pod_info else [f"{self.host_ip}:{self.host_port}"]
+
+        logging.info(f"[Start] Prefix warmup test")
+
+        # Generate API config (dp concurrency, output 1 token)
+        generate_api_config(
+            model_path=self.model_path,
+            model_name=self.model_name,
+            concurrency=self.config.dp,
+            output_len=1,
+            request_rate=self.config.request_rate,
+            host_ip=self.host_ip,
+            host_port=self.host_port,
+            url=self.url,
+            test_type=self.config.test_type,
+            enable_think=self.config.enable_think,
+            test_accuracy=self.config.test_accuracy,
+            work_path=self.work_path,
+        )
+
+        # Create symlink
+        symlink_force(src_file_prefix, os.path.join(dst_dir, "test.jsonl"))
+
+        # Get metrics before test
+        query_tokens, query_tokens_external, hit_tokens, hit_tokens_external = get_pod_metrics_info(pod_info)
+
+        # Execute test
+        logging.info(f"Running prefix warmup test with command: {ais_bench_cmd}")
+        os.system(ais_bench_cmd)
+
+        # Get metrics after test
+        query_tokens_new, query_tokens_external_new, hit_tokens_new, hit_tokens_external_new = get_pod_metrics_info(pod_info)
+        hit_info = cal_prefix_hit_info(
+            query_tokens, query_tokens_external, hit_tokens, hit_tokens_external,
+            query_tokens_new, query_tokens_external_new, hit_tokens_new, hit_tokens_external_new
+        )
+
+        logging.info(f"[Done] Prefix warmup test")
+
+        return hit_info
+
+    def run_full_test(self, src_file_data: str, dst_dir: str, ais_bench_cmd: str) -> tuple:
+        """Run full dataset test"""
+        # Build pod_info: prefer url available, else use host_ip/host_port
+        if self.url:
+            # Extract host for pod_info from URL (e.g., http://api.example.com:8080 -> api.example.com:8080)
+            import re
+            url_match = re.search(r'https?://([^/:]+):(\d+)', self.url)
+            if url_match:
+                pod_info = [f"{url_match.group(1)}:{url_match.group(2)}"]
+            else:
+                pod_info = [self.url]
+        else:
+            pod_info = self.pod_info if self.pod_info else [f"{self.host_ip}:{self.host_port}"]
+
+        logging.info(f"[Start] Full dataset test")
+
+        # Get metrics before test
+        query_tokens, query_tokens_external, hit_tokens, hit_tokens_external = get_pod_metrics_info(pod_info)
+
+        # Generate API config
+        generate_api_config(
+            model_path=self.model_path,
+            model_name=self.model_name,
+            concurrency=self.config.concurrency,
+            output_len=self.config.output_len,
+            request_rate=self.config.request_rate,
+            host_ip=self.host_ip,
+            host_port=self.host_port,
+            url=self.url,
+            test_type=self.config.test_type,
+            enable_think=self.config.enable_think,
+            test_accuracy=self.config.test_accuracy,
+            work_path=self.work_path,
+        )
+
+        # Create symlink
+        symlink_force(src_file_data, os.path.join(dst_dir, "test.jsonl"))
+
+        # Execute test
+        logging.info(f"Executing AISBench command: {ais_bench_cmd}")
+        os.system(ais_bench_cmd)
+
+        # Get metrics after test
+        query_tokens_new, query_tokens_external_new, hit_tokens_new, hit_tokens_external_new = get_pod_metrics_info(pod_info)
+        hit_info = cal_prefix_hit_info(
+            query_tokens, query_tokens_external, hit_tokens, hit_tokens_external,
+            query_tokens_new, query_tokens_external_new, hit_tokens_new, hit_tokens_external_new
+        )
+
+        # Parse results
+        ans, log_dir = get_data("aisbench.log", self.config.request_rate, self.config.npu_num)
+        save_log("aisbench.log", log_dir)
+        save_csv(ans, "aisbench_result.csv")
+
+        logging.info(f"[Done] Full dataset test")
+
+        return ans, hit_info
+
+    def run(self) -> AisbenchResult:
+        """Execute full test flow"""
+        result = AisbenchResult(
+            test_name=self.config.test_name,
+            input_len=self.config.input_len,
+            output_len=self.config.output_len,
+            data_num=self.config.data_num,
+            concurrency=self.config.concurrency,
+            request_rate=self.config.request_rate,
+            dataset_type=self.config.dataset_type,
+            repeat_rate=self.config.repeat_rate,
+        )
+
+        try:
+            dst_dir = self.setup_dataset_dir()
+            ais_bench_cmd = self.generate_aisbench_command()
+
+            src_file_prefix, src_file_data = self.generate_dataset(dst_dir)
+
+            # Prefix Cache mode with warmup
+            if self.config.dataset_type == "prefix_cache" and self.config.prefix_test:
+                self.run_prefix_warmup(src_file_prefix, dst_dir, ais_bench_cmd)
+
+            # Run full test
+            ans, hit_info = self.run_full_test(src_file_data, dst_dir, ais_bench_cmd)
+
+            # Fill results
+            if ans and len(ans) >= 20:
+                result.ttft_avg = ans[7]
+                result.ttft_p90 = ans[8]
+                result.tpot_avg = ans[9]
+                result.tpot_p90 = ans[10]
+                result.total_time = ans[11]
+                result.output_throughput = ans[12]
+                result.single_output_throughput = ans[13]
+                result.e2e_throughput = ans[14]
+                result.single_e2e_throughput = ans[15]
+                result.qps = ans[16]
+                result.qpm = ans[17]
+                result.input_token_throughput = ans[18]
+                result.prefill_throughput = ans[19]
+                result.total_input_tokens = ans[1]
+                result.total_output_tokens = ans[2]
+                result.total_requests = ans[3]
+
+            # Fill hit rate info
+            if hit_info:
+                for pod, pod_data in hit_info.items():
+                    if pod_data.get('engines'):
+                        engine = pod_data['engines'][0]
+                        result.hbm_hit_rate = engine.get('hbm_hit_rate', '')
+                        result.hbm_hits = engine.get('hbm_hits', 0)
+                        result.hbm_queries = engine.get('hbm_queries', 0)
+                        result.external_hit_rate = engine.get('external_hit_rate', '')
+                        result.external_hits = engine.get('external_hits', 0)
+                        result.external_queries = engine.get('external_queries', 0)
+                        break
+
+            result.status = "pass"
+
+        except Exception as e:
+            logging.error(f"Test execution failed: {e}")
+            result.status = "failed"
+
+        return result
+
+
+# ========== Test Cases ==========
+
+@pytest.mark.stage(2)
+@pytest.mark.feature("aisbench_prefix_cache")
+@pytest.mark.platform("npu")
+@pytest.mark.parametrize("test_config", test_scenarios, ids=scenario_ids)
+@export_vars
+def test_aisbench_prefix_cache(test_config: Dict[str, Any]):
+    """
+    AISBench Prefix Cache Performance Test
+
+    Supports multiple test scenarios:
+    - Normal dataset performance test
+    - Prefix Cache performance test (with warmup)
+    - Variable-length dataset test
+    - Accuracy test
+
+    Parameter passing methods:
+    1. Default config
+    2. Environment variable AISBENCH_TEST_CASE (JSON format)
+    3. config.yaml configuration file
+
+    Args:
+        test_config: Test configuration dict containing all test parameters
+    """
+    logging.info(f"========== Start Test: {test_config.get('test_name', 'unnamed')} ========== ")
+    logging.info(f"Config params: {json.dumps(test_config, indent=2)}")
+
+    # Create config object
+    config = AisbenchConfig(**test_config)
+
+    # Execute test
+    runner = AisbenchTestRunner(config)
+    result = runner.run()
+
+    logging.info(f"========== Test Done: {result.test_name}, Status: {result.status} ========== ")
+
+    # Return results for data export
+    return {
+        "_name": "aisbench_prefix_cache_result",
+        "_data": result.to_dict()
+    }

--- a/test/suites/E2E/test_aisbench_prefix_cache.py
+++ b/test/suites/E2E/test_aisbench_prefix_cache.py
@@ -16,39 +16,40 @@ export AISBENCH_TEST_CASE='[
 ]'
 pytest --feature=aisbench_prefix_cache
 """
+
 import json
 import logging
 import os
 import sys
 from dataclasses import asdict
 from pathlib import Path
-from typing import List, Dict, Any
+from typing import Any, Dict, List
 
 import pytest
 import yaml
-
-from common.capture_utils import export_vars, set_test_info
-from common.config_utils import config_utils
 from common.aisbench_utils import (
-    create_multi_prefix_dataset,
-    parse_prefix_ratio,
-    generate_api_config,
-    symlink_force,
-    get_data,
-    save_log,
-    save_csv,
-    get_pod_metrics_info,
-    cal_prefix_hit_info,
-    DataPicker,
     AisbenchConfig,
     AisbenchResult,
+    DataPicker,
+    cal_prefix_hit_info,
+    create_multi_prefix_dataset,
+    generate_api_config,
+    get_data,
+    get_pod_metrics_info,
+    parse_prefix_ratio,
+    save_csv,
+    save_log,
+    symlink_force,
 )
-
+from common.capture_utils import export_vars, set_test_info
+from common.config_utils import config_utils
 
 # Get project root directory
 PRJ_ROOT = Path(__file__).resolve().parents[2]
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
 
 
 # ========== Test Scenario Configuration ==========
@@ -60,9 +61,9 @@ default_test_scenarios: List[Dict[str, Any]] = [
         "output_len": 512,
         "data_num": 10,
         "concurrency": 10,
-        "request_rate": 10,             # int: 10 req/s (also accepts "10", 0=unlimited)
+        "request_rate": 10,  # int: 10 req/s (also accepts "10", 0=unlimited)
         "dataset_type": "prefix_cache",
-        "repeat_rate": 0.5,             # float: 0.5 (also accepts 50, "50%", "0.5")
+        "repeat_rate": 0.5,  # float: 0.5 (also accepts 50, "50%", "0.5")
         "prefix_num": 1,
         "prefix_test": True,
         "dp": 1,
@@ -92,9 +93,13 @@ if env_test_case_str:
 
             if valid_configs:
                 test_scenarios = valid_configs
-                logging.info(f"Loaded {len(test_scenarios)} test configs from AISBENCH_TEST_CASE env var")
+                logging.info(
+                    f"Loaded {len(test_scenarios)} test configs from AISBENCH_TEST_CASE env var"
+                )
             else:
-                logging.warning("Environment variable parse failed, using default config")
+                logging.warning(
+                    "Environment variable parse failed, using default config"
+                )
         else:
             logging.warning("Environment variable format invalid, using default config")
     except json.JSONDecodeError as e:
@@ -105,7 +110,9 @@ else:
     logging.info("AISBENCH_TEST_CASE env var not set, using default config")
 
 # Method 2: Load from config.yaml
-config_scenarios = config_utils.get_nested_config("aisbench_prefix_cache.test_scenarios", [])
+config_scenarios = config_utils.get_nested_config(
+    "aisbench_prefix_cache.test_scenarios", []
+)
 if config_scenarios and isinstance(config_scenarios, list):
     try:
         valid_configs = []
@@ -122,14 +129,23 @@ if config_scenarios and isinstance(config_scenarios, list):
 
 logging.info(f"Final test scenario count: {len(test_scenarios)}")
 for i, scenario in enumerate(test_scenarios):
-    logging.info(f"  [{i+1}] {scenario.get('test_name', 'unnamed')}: input={scenario.get('input_len')}, output={scenario.get('output_len')}, type={scenario.get('dataset_type')}")
+    logging.info(
+        f"  [{i+1}] {scenario.get('test_name', 'unnamed')}: input={scenario.get('input_len')}, output={scenario.get('output_len')}, type={scenario.get('dataset_type')}"
+    )
 
 
 # Generate test IDs
-scenario_ids = [s.get('test_name', f"in_{s['input_len']}-out_{s['output_len']}-type_{s['dataset_type']}") for s in test_scenarios]
+scenario_ids = [
+    s.get(
+        "test_name",
+        f"in_{s['input_len']}-out_{s['output_len']}-type_{s['dataset_type']}",
+    )
+    for s in test_scenarios
+]
 
 
 # ========== Test Runner Class ==========
+
 
 class AisbenchTestRunner:
     """AISBench test runner"""
@@ -139,19 +155,33 @@ class AisbenchTestRunner:
         self.global_config = config_utils.read_config()
 
         # Get base config from global config
-        aisbench_config = self.global_config.get('aisbench_prefix_cache', {})
-        self.model_path = aisbench_config.get('model', {}).get('path', '')
-        self.model_name = aisbench_config.get('model', {}).get('name', '')
-        self.host_ip = aisbench_config.get('server', {}).get('host_ip', '')
-        self.host_port = aisbench_config.get('server', {}).get('host_port', '')
-        self.url = aisbench_config.get('server', {}).get('url', '')  # Support custom URL for domain-based connection
-        self.work_path = aisbench_config.get('aisbench', {}).get('work_path', '/home/benchmark')
-        self.dataset_path = aisbench_config.get('dataset', {}).get('base_path', '/home/dataset')
-        self.gsm8k_path = aisbench_config.get('dataset', {}).get('gsm8k_source', str(PRJ_ROOT.parent / "GSM8K.jsonl"))
-        self.use_gsm8k = aisbench_config.get('dataset', {}).get('use_gsm8k', True)  # Data source mode
-        self.output_dir = aisbench_config.get('aisbench', {}).get('output_dir', './outputs/default')
-        self.pod_info = aisbench_config.get('pod_info', [])
-        self.default_perf = aisbench_config.get('test', {}).get('default_perf', 'default_perf')
+        aisbench_config = self.global_config.get("aisbench_prefix_cache", {})
+        self.model_path = aisbench_config.get("model", {}).get("path", "")
+        self.model_name = aisbench_config.get("model", {}).get("name", "")
+        self.host_ip = aisbench_config.get("server", {}).get("host_ip", "")
+        self.host_port = aisbench_config.get("server", {}).get("host_port", "")
+        self.url = aisbench_config.get("server", {}).get(
+            "url", ""
+        )  # Support custom URL for domain-based connection
+        self.work_path = aisbench_config.get("aisbench", {}).get(
+            "work_path", "/home/benchmark"
+        )
+        self.dataset_path = aisbench_config.get("dataset", {}).get(
+            "base_path", "/home/dataset"
+        )
+        self.gsm8k_path = aisbench_config.get("dataset", {}).get(
+            "gsm8k_source", str(PRJ_ROOT.parent / "GSM8K.jsonl")
+        )
+        self.use_gsm8k = aisbench_config.get("dataset", {}).get(
+            "use_gsm8k", True
+        )  # Data source mode
+        self.output_dir = aisbench_config.get("aisbench", {}).get(
+            "output_dir", "./outputs/default"
+        )
+        self.pod_info = aisbench_config.get("pod_info", [])
+        self.default_perf = aisbench_config.get("test", {}).get(
+            "default_perf", "default_perf"
+        )
 
     def generate_aisbench_command(self) -> str:
         """Generate AISBench test command"""
@@ -168,13 +198,15 @@ class AisbenchTestRunner:
 
     def setup_dataset_dir(self) -> str:
         """Setup dataset directory"""
-        dst_dir = os.path.normpath(os.path.join(self.work_path, "ais_bench/datasets/gsm8k"))
+        dst_dir = os.path.normpath(
+            os.path.join(self.work_path, "ais_bench/datasets/gsm8k")
+        )
         if not os.path.exists(dst_dir):
             os.makedirs(dst_dir)
 
         train_dataset = os.path.join(dst_dir, "train.jsonl")
         if not os.path.exists(train_dataset):
-            with open(train_dataset, 'w') as f:
+            with open(train_dataset, "w") as f:
                 pass
 
         return dst_dir
@@ -214,19 +246,24 @@ class AisbenchTestRunner:
 
         return src_file_prefix, src_file_data
 
-    def run_prefix_warmup(self, src_file_prefix: str, dst_dir: str, ais_bench_cmd: str) -> dict:
+    def run_prefix_warmup(
+        self, src_file_prefix: str, dst_dir: str, ais_bench_cmd: str
+    ) -> dict:
         """Run prefix warmup test"""
         # Build pod_info: prefer url if available, otherwise use host_ip:host_port
         if self.url:
             # Extract host from url for pod_info
             import re
-            url_match = re.search(r'https?://([^:/]+):(\d+)', self.url)
+
+            url_match = re.search(r"https?://([^:/]+):(\d+)", self.url)
             if url_match:
                 pod_info = [f"{url_match.group(1)}:{url_match.group(2)}"]
             else:
                 pod_info = [self.url]
         else:
-            pod_info = self.pod_info if self.pod_info else [f"{self.host_ip}:{self.host_port}"]
+            pod_info = (
+                self.pod_info if self.pod_info else [f"{self.host_ip}:{self.host_port}"]
+            )
 
         logging.info(f"[Start] Prefix warmup test")
 
@@ -250,41 +287,61 @@ class AisbenchTestRunner:
         symlink_force(src_file_prefix, os.path.join(dst_dir, "test.jsonl"))
 
         # Get metrics before test
-        query_tokens, query_tokens_external, hit_tokens, hit_tokens_external = get_pod_metrics_info(pod_info)
+        query_tokens, query_tokens_external, hit_tokens, hit_tokens_external = (
+            get_pod_metrics_info(pod_info)
+        )
 
         # Execute test
         logging.info(f"Running prefix warmup test with command: {ais_bench_cmd}")
         os.system(ais_bench_cmd)
 
         # Get metrics after test
-        query_tokens_new, query_tokens_external_new, hit_tokens_new, hit_tokens_external_new = get_pod_metrics_info(pod_info)
+        (
+            query_tokens_new,
+            query_tokens_external_new,
+            hit_tokens_new,
+            hit_tokens_external_new,
+        ) = get_pod_metrics_info(pod_info)
         hit_info = cal_prefix_hit_info(
-            query_tokens, query_tokens_external, hit_tokens, hit_tokens_external,
-            query_tokens_new, query_tokens_external_new, hit_tokens_new, hit_tokens_external_new
+            query_tokens,
+            query_tokens_external,
+            hit_tokens,
+            hit_tokens_external,
+            query_tokens_new,
+            query_tokens_external_new,
+            hit_tokens_new,
+            hit_tokens_external_new,
         )
 
         logging.info(f"[Done] Prefix warmup test")
 
         return hit_info
 
-    def run_full_test(self, src_file_data: str, dst_dir: str, ais_bench_cmd: str) -> tuple:
+    def run_full_test(
+        self, src_file_data: str, dst_dir: str, ais_bench_cmd: str
+    ) -> tuple:
         """Run full dataset test"""
         # Build pod_info: prefer url available, else use host_ip/host_port
         if self.url:
             # Extract host for pod_info from URL (e.g., http://api.example.com:8080 -> api.example.com:8080)
             import re
-            url_match = re.search(r'https?://([^/:]+):(\d+)', self.url)
+
+            url_match = re.search(r"https?://([^/:]+):(\d+)", self.url)
             if url_match:
                 pod_info = [f"{url_match.group(1)}:{url_match.group(2)}"]
             else:
                 pod_info = [self.url]
         else:
-            pod_info = self.pod_info if self.pod_info else [f"{self.host_ip}:{self.host_port}"]
+            pod_info = (
+                self.pod_info if self.pod_info else [f"{self.host_ip}:{self.host_port}"]
+            )
 
         logging.info(f"[Start] Full dataset test")
 
         # Get metrics before test
-        query_tokens, query_tokens_external, hit_tokens, hit_tokens_external = get_pod_metrics_info(pod_info)
+        query_tokens, query_tokens_external, hit_tokens, hit_tokens_external = (
+            get_pod_metrics_info(pod_info)
+        )
 
         # Generate API config
         generate_api_config(
@@ -310,20 +367,33 @@ class AisbenchTestRunner:
         os.system(ais_bench_cmd)
 
         # Get metrics after test
-        query_tokens_new, query_tokens_external_new, hit_tokens_new, hit_tokens_external_new = get_pod_metrics_info(pod_info)
+        (
+            query_tokens_new,
+            query_tokens_external_new,
+            hit_tokens_new,
+            hit_tokens_external_new,
+        ) = get_pod_metrics_info(pod_info)
         hit_info = cal_prefix_hit_info(
-            query_tokens, query_tokens_external, hit_tokens, hit_tokens_external,
-            query_tokens_new, query_tokens_external_new, hit_tokens_new, hit_tokens_external_new
+            query_tokens,
+            query_tokens_external,
+            hit_tokens,
+            hit_tokens_external,
+            query_tokens_new,
+            query_tokens_external_new,
+            hit_tokens_new,
+            hit_tokens_external_new,
         )
 
         # Parse results
-        ans, log_dir = get_data("aisbench.log", self.config.request_rate, self.config.npu_num)
+        perf_result, log_dir = get_data(
+            "aisbench.log", self.config.request_rate, self.config.npu_num
+        )
         save_log("aisbench.log", log_dir)
-        save_csv(ans, "aisbench_result.csv")
+        save_csv(perf_result, "aisbench_result.csv")
 
         logging.info(f"[Done] Full dataset test")
 
-        return ans, hit_info
+        return perf_result, hit_info
 
     def run(self) -> AisbenchResult:
         """Execute full test flow"""
@@ -349,38 +419,40 @@ class AisbenchTestRunner:
                 self.run_prefix_warmup(src_file_prefix, dst_dir, ais_bench_cmd)
 
             # Run full test
-            ans, hit_info = self.run_full_test(src_file_data, dst_dir, ais_bench_cmd)
+            perf_result, hit_info = self.run_full_test(
+                src_file_data, dst_dir, ais_bench_cmd
+            )
 
             # Fill results
-            if ans and len(ans) >= 20:
-                result.ttft_avg = ans[7]
-                result.ttft_p90 = ans[8]
-                result.tpot_avg = ans[9]
-                result.tpot_p90 = ans[10]
-                result.total_time = ans[11]
-                result.output_throughput = ans[12]
-                result.single_output_throughput = ans[13]
-                result.e2e_throughput = ans[14]
-                result.single_e2e_throughput = ans[15]
-                result.qps = ans[16]
-                result.qpm = ans[17]
-                result.input_token_throughput = ans[18]
-                result.prefill_throughput = ans[19]
-                result.total_input_tokens = ans[1]
-                result.total_output_tokens = ans[2]
-                result.total_requests = ans[3]
+            if perf_result and len(perf_result) >= 20:
+                result.ttft_avg = perf_result[7]
+                result.ttft_p90 = perf_result[8]
+                result.tpot_avg = perf_result[9]
+                result.tpot_p90 = perf_result[10]
+                result.total_time = perf_result[11]
+                result.output_throughput = perf_result[12]
+                result.single_output_throughput = perf_result[13]
+                result.e2e_throughput = perf_result[14]
+                result.single_e2e_throughput = perf_result[15]
+                result.qps = perf_result[16]
+                result.qpm = perf_result[17]
+                result.input_token_throughput = perf_result[18]
+                result.prefill_throughput = perf_result[19]
+                result.total_input_tokens = perf_result[1]
+                result.total_output_tokens = perf_result[2]
+                result.total_requests = perf_result[3]
 
             # Fill hit rate info
             if hit_info:
                 for pod, pod_data in hit_info.items():
-                    if pod_data.get('engines'):
-                        engine = pod_data['engines'][0]
-                        result.hbm_hit_rate = engine.get('hbm_hit_rate', '')
-                        result.hbm_hits = engine.get('hbm_hits', 0)
-                        result.hbm_queries = engine.get('hbm_queries', 0)
-                        result.external_hit_rate = engine.get('external_hit_rate', '')
-                        result.external_hits = engine.get('external_hits', 0)
-                        result.external_queries = engine.get('external_queries', 0)
+                    if pod_data.get("engines"):
+                        engine = pod_data["engines"][0]
+                        result.hbm_hit_rate = engine.get("hbm_hit_rate", "")
+                        result.hbm_hits = engine.get("hbm_hits", 0)
+                        result.hbm_queries = engine.get("hbm_queries", 0)
+                        result.external_hit_rate = engine.get("external_hit_rate", "")
+                        result.external_hits = engine.get("external_hits", 0)
+                        result.external_queries = engine.get("external_queries", 0)
                         break
 
             result.status = "pass"
@@ -393,6 +465,7 @@ class AisbenchTestRunner:
 
 
 # ========== Test Cases ==========
+
 
 @pytest.mark.stage(2)
 @pytest.mark.feature("aisbench_prefix_cache")
@@ -417,7 +490,9 @@ def test_aisbench_prefix_cache(test_config: Dict[str, Any]):
     Args:
         test_config: Test configuration dict containing all test parameters
     """
-    logging.info(f"========== Start Test: {test_config.get('test_name', 'unnamed')} ========== ")
+    logging.info(
+        f"========== Start Test: {test_config.get('test_name', 'unnamed')} ========== "
+    )
     logging.info(f"Config params: {json.dumps(test_config, indent=2)}")
 
     # Create config object
@@ -427,10 +502,9 @@ def test_aisbench_prefix_cache(test_config: Dict[str, Any]):
     runner = AisbenchTestRunner(config)
     result = runner.run()
 
-    logging.info(f"========== Test Done: {result.test_name}, Status: {result.status} ========== ")
+    logging.info(
+        f"========== Test Done: {result.test_name}, Status: {result.status} ========== "
+    )
 
     # Return results for data export
-    return {
-        "_name": "aisbench_prefix_cache_result",
-        "_data": result.to_dict()
-    }
+    return {"_name": "aisbench_prefix_cache_result", "_data": result.to_dict()}


### PR DESCRIPTION
**Pull Request Description**
via: [https://github.com/rayn-zzz/aisbench_auto_tools_prefix](https://github.com/rayn-zzz/aisbench_auto_tools_prefix/tree/main)
### Summary
This PR introduces a new test tool module `aisbench_utils` to enable prefix caching performance testing for our inference service. It provides a flexible framework for generating test datasets, configuring API requests, and parsing results with hit rate metrics.

### Key Changes
- **Module structure**: Created `aisbench_utils` containing:
  - `data_selector.py` – supports GSM8K (grade-school math) dataset and random token generation modes.
  - `dataset_generator.py` – generates multi-prefix datasets with configurable variable-length patterns.
  - `api_config.py` – builds API request configurations for both streaming and non‑streaming text tests.
  - `config_dataclasses.py` – dataclasses for unified parameter management (e.g., batch size, prefix lengths, concurrency).
  - `result_parser.py` – parses test outputs and computes prefix hit rates.

- **Configuration**: Added new YAML/JSON config options under `aisbench` section, covering:
  - Dataset source (GSM8K / random)
  - Prefix length ranges
  - Number of test samples
  - API endpoint and authentication
  - Streaming on/off

- **Testing**: Included unit tests for data selection, dataset generation, and hit rate calculation (see `/tests/test_aisbench_utils.py`).

### Motivation
Prefix caching is critical for reducing latency in LLM serving. This tool allows us to systematically benchmark cache hit rates under varying prefix distributions, helping optimize our caching policies and deployment configurations.

### How to Test
1. Run the example script: `python examples/run_aisbench.py --config configs/aisbench_example.yaml`
2. Verify generated datasets and API calls succeed.
3. Check output reports for hit rate statistics.

### Additional Notes
- The module is designed to be extensible – new dataset types or test modes can be added by subclassing the base selectors/generators.
- Documentation is included in the module docstrings; a separate user guide will follow in a later PR.
<img width="2034" height="1009" alt="image" src="https://github.com/user-attachments/assets/82fd1662-4cd5-4104-8222-b7142707bbbb" />

<img width="1861" height="173" alt="image" src="https://github.com/user-attachments/assets/ed036ec8-cdfe-4bec-86b5-25dd96893d80" />