### PR TITLE
[Feat] Adapt AsuStore to layerwise load/dump.

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -337,6 +337,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
             backends = [path for path in config["storage_backends"].split(":")]
             config["storage_backends"] = backends
         config["unique_id"] = f"{self.engine_id}"
+        config["asu_tensor_layout"] = "mla" if self.is_mla else "gqa"
         if self._role == KVConnectorRole.WORKER:
             config["device_id"] = self.local_rank
             config["tensor_size_list"] = (

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -46,6 +46,11 @@ namespace {
 using AsuStatus = UC::ASU::Status;
 using AsuStatusCode = UC::ASU::StatusCode;
 
+std::size_t AlignUp(std::size_t value, std::size_t alignment)
+{
+    return ((value + alignment - 1) / alignment) * alignment;
+}
+
 std::uint64_t HashAsuKey(const Detail::BlockId& block)
 {
     static Detail::BlockIdHasher hasher;
@@ -347,6 +352,7 @@ public:
     Status Setup(const Detail::Dictionary& inConfig) override
     {
         auto config = ParseConfig(inConfig);
+        NormalizeAsuShardConfig(config);
         auto status = CheckConfig(config);
         if (status.Failure()) { return status; }
 
@@ -473,6 +479,7 @@ private:
         inConfig.GetNumber("block_size", config.blockSize);
         inConfig.GetNumber("device_id", config.deviceId);
         inConfig.Get("asu_memory_type", config.memoryType);
+        inConfig.Get("asu_tensor_layout", config.tensorLayout);
         std::string providerBackend;
         if (TryGetStringLike(inConfig, "asu_trans_provider_backend", providerBackend)) {
             config.transProviderType = ParseTransProviderBackend(providerBackend);
@@ -506,6 +513,23 @@ private:
         return config;
     }
 
+    void NormalizeAsuShardConfig(Config& config)
+    {
+        if (config.tensorSizes.empty() || config.shardSize == 0 || config.blockSize == 0) {
+            return;
+        }
+        if (config.blockSize % config.shardSize != 0) { return; }
+
+        const auto shardsPerBlock = config.blockSize / config.shardSize;
+        std::size_t alignedShardSize = 0;
+        for (auto& tensorSize : config.tensorSizes) {
+            tensorSize = AlignUp(tensorSize, UC::ASU::kAsuAlignmentBytes);
+            alignedShardSize += tensorSize;
+        }
+        config.shardSize = alignedShardSize;
+        config.blockSize = alignedShardSize * shardsPerBlock;
+    }
+
     Status CheckConfig(const Config& config)
     {
         if (config.mode != "client" && config.mode != "transport") {
@@ -533,16 +557,33 @@ private:
             return Status::InvalidParam(
                 "asu_trans_provider_backend=fake does not support asu_config_path");
         }
+        if (!config.tensorLayout.empty() && config.tensorLayout != "mla" &&
+            config.tensorLayout != "gqa") {
+            return Status::InvalidParam("invalid asu_tensor_layout({})", config.tensorLayout);
+        }
         if (config.tensorSizes.empty()) { return Status::InvalidParam("invalid tensor size"); }
+        if (config.tensorLayout == "gqa" &&
+            (config.tensorSizes.size() < 2 || config.tensorSizes.size() % 2 != 0)) {
+            return Status::InvalidParam("invalid tensor size count({})", config.tensorSizes.size());
+        }
         if (config.shardSize == 0) { return Status::InvalidParam("invalid shard size"); }
         if (config.blockSize == 0) { return Status::InvalidParam("invalid block size"); }
         const auto tensorSum =
             std::accumulate(config.tensorSizes.begin(), config.tensorSizes.end(), std::size_t{0});
-        if (tensorSum != config.shardSize) {
+        if (tensorSum == 0 || tensorSum > config.shardSize) {
             return Status::InvalidParam("invalid shard size({})", config.shardSize);
         }
         if (config.blockSize % config.shardSize != 0) {
             return Status::InvalidParam("invalid block size({})", config.blockSize);
+        }
+        const auto shardsPerBlock = config.blockSize / config.shardSize;
+        if (shardsPerBlock > 1 && config.tensorLayout == "gqa" && config.tensorSizes.size() != 2) {
+            return Status::InvalidParam("invalid layerwise gqa tensor size count({})",
+                                        config.tensorSizes.size());
+        }
+        if (shardsPerBlock > 1 && config.tensorLayout == "mla" && config.tensorSizes.size() != 1) {
+            return Status::InvalidParam("invalid layerwise mla tensor size count({})",
+                                        config.tensorSizes.size());
         }
         return Status::OK();
     }
@@ -557,6 +598,52 @@ private:
     }
 
     std::size_t ShardsPerBlock() const { return config_.blockSize / config_.shardSize; }
+
+    std::vector<std::size_t> BuildMlaTensorOffsets(std::size_t shardIndex) const
+    {
+        std::vector<std::size_t> offsets(config_.tensorSizes.size());
+        auto offset = shardIndex * config_.shardSize;
+        for (std::size_t index = 0; index < config_.tensorSizes.size(); ++index) {
+            offsets[index] = offset;
+            offset += config_.tensorSizes[index];
+        }
+        return offsets;
+    }
+
+    std::vector<std::size_t> BuildGqaTensorOffsets(std::size_t shardIndex) const
+    {
+        std::vector<std::size_t> offsets(config_.tensorSizes.size());
+        const auto tensorCount = config_.tensorSizes.size();
+        if (ShardsPerBlock() > 1) {  // layerwise case
+            const auto numLayers = ShardsPerBlock();
+            offsets[0] = shardIndex * config_.tensorSizes[0];
+            offsets[1] = numLayers * config_.tensorSizes[0] + shardIndex * config_.tensorSizes[1];
+            return offsets;
+        }
+
+        std::size_t keyBase = 0;  // non-layerwise case
+        std::size_t keyPrefix = 0;
+        std::size_t valuePrefix = 0;
+        for (std::size_t index = 0; index < tensorCount; ++index) {
+            if (index % 2 == 0) { keyBase += config_.tensorSizes[index]; }
+        }
+        for (std::size_t index = 0; index < tensorCount; ++index) {
+            if (index % 2 == 0) {
+                offsets[index] = keyPrefix;
+                keyPrefix += config_.tensorSizes[index];
+            } else {
+                offsets[index] = keyBase + valuePrefix;
+                valuePrefix += config_.tensorSizes[index];
+            }
+        }
+        return offsets;
+    }
+
+    std::vector<std::size_t> BuildTensorOffsets(std::size_t shardIndex) const
+    {
+        if (config_.tensorLayout == "gqa") { return BuildGqaTensorOffsets(shardIndex); }
+        return BuildMlaTensorOffsets(shardIndex);
+    }
 
     Expected<std::vector<uint8_t>> QueryBlocks(const Detail::BlockId* blocks, std::size_t num,
                                                const UC::ASU::QueryOptions& options) const
@@ -620,6 +707,7 @@ private:
             if (shard.addrs.size() != config_.tensorSizes.size()) {
                 return Status::InvalidParam("invalid tensor addr count({})", shard.addrs.size());
             }
+            const auto tensorOffsets = BuildTensorOffsets(shard.index);
             for (std::size_t tensorIndex = 0; tensorIndex < shard.addrs.size(); ++tensorIndex) {
                 UC::ASU::KVBuffer entry;
                 entry.key = MakeAsuKey(shard.owner);
@@ -629,6 +717,7 @@ private:
                 entry.buffer.region.size = config_.tensorSizes[tensorIndex];
                 entry.buffer.region.deviceId = config_.deviceId;
                 entry.buffer.handle = UC::ASU::kInvalidMRHandle;
+                entry.offset = static_cast<std::uint32_t>(tensorOffsets[tensorIndex]);
                 entries.emplace_back(std::move(entry));
             }
         }
@@ -646,6 +735,7 @@ private:
         UC_INFO("Set AsuStore::ShardSize to {}.", config.shardSize);
         UC_INFO("Set AsuStore::BlockSize to {}.", config.blockSize);
         UC_INFO("Set AsuStore::TensorSizes to {}.", config.tensorSizes);
+        UC_INFO("Set AsuStore::TensorLayout to {}.", config.tensorLayout);
         UC_INFO("Set AsuStore::DeviceId to {}.", config.deviceId);
         UC_INFO("Set AsuStore::TransProviderBackend to {}.",
                 TransProviderBackendName(config.transProviderType));

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -29,6 +29,7 @@ struct Config {
     std::size_t blockSize{0};
     std::int32_t deviceId{-1};
     std::string memoryType;
+    std::string tensorLayout;
     UC::ASU::TransProviderType transProviderType{UC::ASU::TransProviderType::AICPU};
     std::string fakeBackendPath;
     std::uint64_t fakeBackendLatencyMs{1};

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -40,6 +40,9 @@ namespace {
 
 struct FakeAsuBackendState {
     std::vector<UC::ASU::QueryMode> queryModes;
+    std::vector<UC::AsuStore::Config> initConfigs;
+    std::vector<UC::ASU::KVBuffer> lastLoadEntries;
+    std::vector<UC::ASU::KVBuffer> lastStoreEntries;
 };
 
 class FakeAsuBackend final : public UC::AsuStore::AsuBackend {
@@ -51,6 +54,7 @@ public:
     UC::ASU::Status Init(const UC::AsuStore::Config& config) override
     {
         config_ = config;
+        state_->initConfigs.emplace_back(config);
         initialized_ = true;
         return UC::ASU::Status::OK();
     }
@@ -91,12 +95,14 @@ public:
     UC::ASU::Status LoadAsync(const std::vector<UC::ASU::KVBuffer>& entries,
                               UC::ASU::TaskId& taskId) override
     {
+        state_->lastLoadEntries = entries;
         return Submit(entries, taskId);
     }
 
     UC::ASU::Status StoreAsync(const std::vector<UC::ASU::KVBuffer>& entries,
                                UC::ASU::TaskId& taskId) override
     {
+        state_->lastStoreEntries = entries;
         for (const auto& entry : entries) { storedKeys_.emplace(entry.key); }
         return Submit(entries, taskId);
     }
@@ -338,18 +344,133 @@ TEST(UCAsuStoreTest, TransportModeConfigPathSmoke)
     ExpectLoadDumpSmoke(store, block);
 }
 
-TEST(UCAsuStoreTest, RejectsInvalidTensorLayout)
+TEST(UCAsuStoreTest, RejectsOddMultiTensorLayout)
 {
     UC::AsuStore::AsuStore store;
     auto config = MakeBaseConfig();
     config.Set("asu_mode", std::string{"transport"});
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
     config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("asu_tensor_layout", std::string{"gqa"});
     config.SetNumber("tensor_size", std::size_t{0});
-    config.Set("tensor_size_list", std::vector<ssize_t>{32, 16});
+    config.Set("tensor_size_list", std::vector<ssize_t>{16, 16, 16});
+    config.SetNumber("shard_size", std::size_t{48});
+    config.SetNumber("block_size", std::size_t{48});
 
     auto status = store.Setup(config);
     ASSERT_TRUE(status.Failure());
+}
+
+TEST(UCAsuStoreTest, UsesNonLayerwiseMlaTensorOffsets)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeBackend(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_mode", std::string{"transport"});
+    config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("asu_tensor_layout", std::string{"mla"});
+    config.SetNumber("tensor_size", std::size_t{0});
+    config.Set("tensor_size_list", std::vector<ssize_t>{100, 120, 140});
+    config.SetNumber("shard_size", std::size_t{360});
+    config.SetNumber("block_size", std::size_t{360});
+
+    auto status = store.Setup(config);
+    ASSERT_TRUE(status.Success()) << status.ToString();
+    ASSERT_FALSE(state->initConfigs.empty());
+    ASSERT_EQ(state->initConfigs.back().tensorSizes.size(), std::size_t{3});
+    EXPECT_EQ(state->initConfigs.back().tensorSizes[0], std::size_t{512});
+    EXPECT_EQ(state->initConfigs.back().tensorSizes[1], std::size_t{512});
+    EXPECT_EQ(state->initConfigs.back().tensorSizes[2], std::size_t{512});
+
+    std::array<std::byte, 140> first{};
+    std::array<std::byte, 140> second{};
+    std::array<std::byte, 140> third{};
+    auto block = UC::Test::Detail::TypesHelper::MakeBlockId("d1b2c3d4e5f6789012345678901234ab");
+    UC::Detail::TaskDesc task;
+    task.brief = "asu-store-test";
+    task.push_back(UC::Detail::Shard{
+        block, 0, {first.data(), second.data(), third.data()}
+    });
+
+    auto dump = store.Dump(task);
+    ASSERT_TRUE(dump.HasValue()) << dump.Error().ToString();
+    ASSERT_EQ(state->lastStoreEntries.size(), 3);
+    EXPECT_EQ(state->lastStoreEntries[0].buffer.region.size, std::size_t{512});
+    EXPECT_EQ(state->lastStoreEntries[0].offset, std::uint32_t{0});
+    EXPECT_EQ(state->lastStoreEntries[1].buffer.region.size, std::size_t{512});
+    EXPECT_EQ(state->lastStoreEntries[1].offset, std::uint32_t{512});
+    EXPECT_EQ(state->lastStoreEntries[2].buffer.region.size, std::size_t{512});
+    EXPECT_EQ(state->lastStoreEntries[2].offset, std::uint32_t{1024});
+}
+
+TEST(UCAsuStoreTest, UsesLayerwiseMlaTensorOffsets)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeBackend(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_mode", std::string{"transport"});
+    config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("asu_tensor_layout", std::string{"mla"});
+    config.SetNumber("tensor_size", std::size_t{0});
+    config.Set("tensor_size_list", std::vector<ssize_t>{128});
+    config.SetNumber("shard_size", std::size_t{128});
+    config.SetNumber("block_size", std::size_t{384});
+
+    auto status = store.Setup(config);
+    ASSERT_TRUE(status.Success()) << status.ToString();
+
+    std::array<std::byte, 128> buffer{};
+    auto block = UC::Test::Detail::TypesHelper::MakeBlockId("e1b2c3d4e5f6789012345678901234ab");
+    UC::Detail::TaskDesc task;
+    task.brief = "asu-store-test";
+    task.push_back(UC::Detail::Shard{block, 2, {buffer.data()}});
+
+    auto dump = store.Dump(task);
+    ASSERT_TRUE(dump.HasValue()) << dump.Error().ToString();
+    ASSERT_EQ(state->lastStoreEntries.size(), 1);
+    EXPECT_EQ(state->lastStoreEntries[0].buffer.region.addr,
+              reinterpret_cast<std::uint64_t>(buffer.data()));
+    EXPECT_EQ(state->lastStoreEntries[0].buffer.region.size, std::size_t{512});
+    EXPECT_EQ(state->lastStoreEntries[0].offset, std::uint32_t{1024});
+}
+
+TEST(UCAsuStoreTest, AlignsTensorSizeAndDerivesShardBlockSize)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeBackend(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_mode", std::string{"transport"});
+    config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.SetNumber("tensor_size", std::size_t{100});
+    config.SetNumber("shard_size", std::size_t{100});
+    config.SetNumber("block_size", std::size_t{300});
+
+    auto status = store.Setup(config);
+    ASSERT_TRUE(status.Success()) << status.ToString();
+    ASSERT_FALSE(state->initConfigs.empty());
+    ASSERT_EQ(state->initConfigs.back().tensorSizes.size(), std::size_t{1});
+    EXPECT_EQ(state->initConfigs.back().tensorSizes[0],
+              static_cast<std::size_t>(UC::ASU::kAsuAlignmentBytes));
+    EXPECT_EQ(state->initConfigs.back().shardSize,
+              static_cast<std::size_t>(UC::ASU::kAsuAlignmentBytes));
+    EXPECT_EQ(state->initConfigs.back().blockSize,
+              static_cast<std::size_t>(UC::ASU::kAsuAlignmentBytes) * 3);
+
+    std::array<std::byte, 100> buffer{};
+    auto block = UC::Test::Detail::TypesHelper::MakeBlockId("abb2c3d4e5f6789012345678901234ab");
+    UC::Detail::TaskDesc task;
+    task.brief = "asu-store-test";
+    task.push_back(UC::Detail::Shard{block, 2, {buffer.data()}});
+
+    auto dump = store.Dump(task);
+    ASSERT_TRUE(dump.HasValue()) << dump.Error().ToString();
+    ASSERT_FALSE(state->lastStoreEntries.empty());
+    EXPECT_EQ(state->lastStoreEntries[0].buffer.region.size,
+              static_cast<std::size_t>(UC::ASU::kAsuAlignmentBytes));
+    EXPECT_EQ(state->lastStoreEntries[0].offset, UC::ASU::kAsuAlignmentBytes * 2);
 }
 
 TEST(UCAsuStoreTest, AllowsMultipleShardsPerBlock)
@@ -366,29 +487,81 @@ TEST(UCAsuStoreTest, AllowsMultipleShardsPerBlock)
     ASSERT_TRUE(status.Success()) << status.ToString();
 }
 
-TEST(UCAsuStoreTest, AllowsMultipleTensorBuffersPerShard)
+TEST(UCAsuStoreTest, UsesLayerwiseGqaKeyValueOffsets)
 {
     UC::AsuStore::AsuStore store;
-    UseFakeBackend(store);
+    auto state = UseFakeBackend(store);
     auto config = MakeBaseConfig();
     config.Set("asu_mode", std::string{"transport"});
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
     config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("asu_tensor_layout", std::string{"gqa"});
     config.SetNumber("tensor_size", std::size_t{0});
-    config.Set("tensor_size_list", std::vector<ssize_t>{32, 32});
+    config.Set("tensor_size_list", std::vector<ssize_t>{100, 200});
+    config.SetNumber("shard_size", std::size_t{300});
+    config.SetNumber("block_size", std::size_t{900});
 
     auto status = store.Setup(config);
     ASSERT_TRUE(status.Success()) << status.ToString();
 
-    std::array<std::byte, 32> first{};
-    std::array<std::byte, 32> second{};
-    auto block = UC::Test::Detail::TypesHelper::MakeBlockId("aab2c3d4e5f6789012345678901234ab");
+    std::array<std::byte, 100> key{};
+    std::array<std::byte, 200> value{};
+    auto block = UC::Test::Detail::TypesHelper::MakeBlockId("b1b2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
     task.push_back(UC::Detail::Shard{
-        block, 0, {first.data(), second.data()}
+        block, 2, {key.data(), value.data()}
     });
+
     auto dump = store.Dump(task);
     ASSERT_TRUE(dump.HasValue()) << dump.Error().ToString();
-    ASSERT_TRUE(store.Wait(dump.Value()).Success());
+    ASSERT_EQ(state->lastStoreEntries.size(), 2);
+    EXPECT_EQ(state->lastStoreEntries[0].buffer.region.addr,
+              reinterpret_cast<std::uint64_t>(key.data()));
+    EXPECT_EQ(state->lastStoreEntries[0].buffer.region.size, std::size_t{512});
+    EXPECT_EQ(state->lastStoreEntries[0].offset, std::uint32_t{1024});
+    EXPECT_EQ(state->lastStoreEntries[1].buffer.region.addr,
+              reinterpret_cast<std::uint64_t>(value.data()));
+    EXPECT_EQ(state->lastStoreEntries[1].buffer.region.size, std::size_t{512});
+    EXPECT_EQ(state->lastStoreEntries[1].offset, std::uint32_t{2560});
+}
+
+TEST(UCAsuStoreTest, UsesNonLayerwiseGqaKeyValueOffsets)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeBackend(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_mode", std::string{"transport"});
+    config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("asu_tensor_layout", std::string{"gqa"});
+    config.SetNumber("tensor_size", std::size_t{0});
+    config.Set("tensor_size_list", std::vector<ssize_t>{100, 200, 100, 200, 100, 200});
+    config.SetNumber("shard_size", std::size_t{900});
+    config.SetNumber("block_size", std::size_t{900});
+
+    auto status = store.Setup(config);
+    ASSERT_TRUE(status.Success()) << status.ToString();
+
+    std::array<std::array<std::byte, 200>, 6> buffers{};
+    auto block = UC::Test::Detail::TypesHelper::MakeBlockId("c1b2c3d4e5f6789012345678901234ab");
+    UC::Detail::TaskDesc task;
+    task.brief = "asu-store-test";
+    task.push_back(UC::Detail::Shard{
+        block,
+        0,
+        {buffers[0].data(), buffers[1].data(), buffers[2].data(), buffers[3].data(),
+          buffers[4].data(), buffers[5].data()}
+    });
+
+    auto dump = store.Dump(task);
+    ASSERT_TRUE(dump.HasValue()) << dump.Error().ToString();
+    ASSERT_EQ(state->lastStoreEntries.size(), 6);
+    const std::array<std::uint32_t, 6> expectedOffsets{0, 1536, 512, 2048, 1024, 2560};
+    for (std::size_t index = 0; index < expectedOffsets.size(); ++index) {
+        EXPECT_EQ(state->lastStoreEntries[index].buffer.region.addr,
+                  reinterpret_cast<std::uint64_t>(buffers[index].data()));
+        EXPECT_EQ(state->lastStoreEntries[index].buffer.region.size, std::size_t{512});
+        EXPECT_EQ(state->lastStoreEntries[index].offset, expectedOffsets[index]);
+    }
 }

--- a/ucm/transport/kv/asu/test/case/kv_protocol_test.cc
+++ b/ucm/transport/kv/asu/test/case/kv_protocol_test.cc
@@ -578,6 +578,23 @@ TEST_F(KvProtocolPackTest, BatchStoreValidateRequestRejectsRflagWithZeroResponse
     EXPECT_NE(status.message.find("response_buffer_addr is zero"), std::string::npos);
 }
 
+TEST_F(KvProtocolPackTest, BatchStoreValidateRequestRejectsUnalignedLength)
+{
+    KvBatchStoreRequest req;
+    req.batch_number = 1;
+    req.entries.resize(1);
+    req.entries[0].key = "key";
+    req.entries[0].offset = 0;
+    req.entries[0].buffer_addr = 0x1000;
+    req.entries[0].length = 100;
+
+    KvBatchStoreProtocol proto;
+    std::vector<std::uint32_t> target(64, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("512B aligned"), std::string::npos);
+}
+
 TEST_F(KvProtocolPackTest, KeepAliveValidateRequestRejectsRflagWithZeroResponseAddr)
 {
     KvKeepAliveRequest req;
@@ -736,6 +753,22 @@ TEST_F(KvProtocolPackTest, RetrieveValidateRequestRejectsZeroBufferAddr)
     EXPECT_NE(status.message.find("buffer_addr is zero"), std::string::npos);
 }
 
+TEST_F(KvProtocolPackTest, RetrieveValidateRequestRejectsUnalignedBufferLength)
+{
+    KvRetrieveRequest req;
+    req.buffer_addr = 0x2000;
+    req.buffer_length = 100;
+    req.offset = 512;
+    req.length = 512;
+    req.key = "retrieve_key";
+
+    KvRetrieveProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("512B aligned"), std::string::npos);
+}
+
 TEST_F(KvProtocolPackTest, BatchRetrieveValidateRequestAcceptsValid)
 {
     KvBatchRetrieveRequest req;
@@ -767,6 +800,23 @@ TEST_F(KvProtocolPackTest, BatchRetrieveValidateRequestRejectsMismatch)
     auto status = proto.PackSqe(req, target.data());
     EXPECT_FALSE(status.ok());
     EXPECT_NE(status.message.find("must equal entries.size()"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, BatchRetrieveValidateRequestRejectsUnalignedLength)
+{
+    KvBatchRetrieveRequest req;
+    req.batch_number = 1;
+    req.entries.resize(1);
+    req.entries[0].key = "key";
+    req.entries[0].offset = 0;
+    req.entries[0].buffer_addr = 0x1000;
+    req.entries[0].length = 100;
+
+    KvBatchRetrieveProtocol proto;
+    std::vector<std::uint32_t> target(64, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("512B aligned"), std::string::npos);
 }
 
 TEST_F(KvProtocolPackTest, DeleteValidateRequestAcceptsValid)

--- a/ucm/transport/kv/asu/trans/include/asu_transport/types.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/types.h
@@ -40,6 +40,7 @@ enum class TransProviderType { AICPU, FAKE, AIV, UNSUPPORTED };
 
 constexpr TaskId kInvalidTaskId = 0;
 constexpr MRHandle kInvalidMRHandle = 0;
+constexpr std::uint32_t kAsuAlignmentBytes = 512;  // KV protocol requires 512B alignment
 
 enum class StatusCode {
     OK = 0,
@@ -134,6 +135,7 @@ struct Buffer {  // 单个IO
 struct KVBuffer {
     CacheKey key;
     Buffer buffer;
+    std::uint32_t offset{0};  // target buffer offset
 };
 
 struct RegisterResult {

--- a/ucm/transport/kv/asu/trans/src/kv_protocol.h
+++ b/ucm/transport/kv/asu/trans/src/kv_protocol.h
@@ -47,7 +47,7 @@ enum class DptrType : std::uint8_t { Standard = 0x40, Batch = 0x1 };
 
 constexpr std::size_t kSqeDwordCount = 16;
 constexpr std::uint32_t kFixedBits = 0x3;
-constexpr std::uint32_t kAlignmentBytes = 512;
+constexpr std::uint32_t kAlignmentBytes = kAsuAlignmentBytes;
 constexpr std::size_t kBatchEntrySizeBytes = 36;
 constexpr std::size_t kBatchEntryDwordCount = 9;
 constexpr std::size_t kKeyEntrySizeBytes = 16;

--- a/ucm/transport/kv/asu/trans/src/sqe_request.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.cpp
@@ -196,7 +196,7 @@ KvBatchStoreRequest BuildBatchStoreRequest(
     for (std::size_t index = 0; index < entries.size; ++index) {
         KvBatchStoreEntry entry;
         entry.key = entries[index].key;
-        entry.offset = 0;
+        entry.offset = entries[index].offset;
         entry.buffer_addr = entries[index].buffer.region.addr;
         entry.mr_key = ToSqeMrKey(entries[index].buffer.handle);
         entry.length = static_cast<std::uint32_t>(entries[index].buffer.region.size);
@@ -221,7 +221,7 @@ KvBatchRetrieveRequest BuildBatchRetrieveRequest(
     for (std::size_t index = 0; index < entries.size; ++index) {
         KvBatchRetrieveEntry entry;
         entry.key = entries[index].key;
-        entry.offset = 0;
+        entry.offset = entries[index].offset;
         entry.buffer_addr = entries[index].buffer.region.addr;
         entry.mr_key = ToSqeMrKey(entries[index].buffer.handle);
         entry.length = static_cast<std::uint32_t>(entries[index].buffer.region.size);

--- a/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
@@ -170,6 +170,9 @@ TEST_F(SqeRequestTest, ValidateSqeRequestAttrsRejectsMalformedValues)
 TEST_F(SqeRequestTest, SubmitBatchStoreAllocatesFlagBufferAndBuildsRequest)
 {
     auto entries = MakeEntries(3);
+    entries[0].offset = kAlignmentBytes;
+    entries[1].offset = kAlignmentBytes * 2;
+    entries[2].offset = kAlignmentBytes * 3;
     IoScheduler::ScheduledIoBatch subBatch{
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
@@ -196,6 +199,10 @@ TEST_F(SqeRequestTest, SubmitBatchStoreAllocatesFlagBufferAndBuildsRequest)
     EXPECT_EQ(packedResponseAddr, subBatchContext.flagBuffer.device_addr);
     ASSERT_EQ(subBatchContext.entryStatus.size(), entries.size());
     for (const auto& entryStatus : subBatchContext.entryStatus) { EXPECT_TRUE(entryStatus.ok()); }
+    const auto* sqe = reinterpret_cast<const std::uint32_t*>(subBatchContext.sendSge.addr);
+    EXPECT_EQ(sqe[kSqeDwordCount], entries[0].offset);
+    EXPECT_EQ(sqe[kSqeDwordCount + kBatchEntryDwordCount], entries[1].offset);
+    EXPECT_EQ(sqe[kSqeDwordCount + 2 * kBatchEntryDwordCount], entries[2].offset);
 }
 
 TEST_F(SqeRequestTest, SubmitBatchStorePacksSqeIntoDeviceSendBuffer)
@@ -239,6 +246,8 @@ TEST_F(SqeRequestTest, SubmitBatchStorePacksSqeIntoDeviceSendBuffer)
 TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
 {
     auto entries = MakeEntries(2);
+    entries[0].offset = kAlignmentBytes * 4;
+    entries[1].offset = kAlignmentBytes * 5;
     IoScheduler::ScheduledIoBatch subBatch{
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
@@ -254,6 +263,9 @@ TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
     EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
     EXPECT_TRUE(subBatchContext.status.ok());
     EXPECT_NE(subBatchContext.sendSge.local_addr, std::uint64_t{0});
+    const auto* sqe = reinterpret_cast<const std::uint32_t*>(subBatchContext.sendSge.local_addr);
+    EXPECT_EQ(sqe[kSqeDwordCount], entries[0].offset);
+    EXPECT_EQ(sqe[kSqeDwordCount + kBatchEntryDwordCount], entries[1].offset);
 }
 
 TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)


### PR DESCRIPTION
## Purpose
Adapt AsuStore to layerwise case I/O.

## Modifications 
1. Move offset align size to types.h and keeps its value to be 512 (bytes). Add the logic of up-alignment to 512 of shardsize in AsuStore. Remove the validation of length in kv_protocol.cpp.
2. KVBuffer adds component *offset*, which stands for the offset of target tensor on ASU. The offset value in sqe is computed in different cases of GQA/MLA and layerwise/non-layerwise. Fill up KvBatchRetrieveEntry.offset and KvBatchStoreEntry.offset by this *offset*.
<img width="1222" height="260" alt="image" src="https://github.com/user-attachments/assets/5d10013d-3d6c-4e2b-b849-47138c24dfb2" />
(*blocks_per_chunk* is used for aggregation of vllm blocks. E.g. blocks_per_chunk = 4 means that UCM aggregates 4 vllm-blocks into 1 UCM-block.)

3. Add a new config key "asu_tensor_layout" which takes the value "mla" or "gqa" to explicitly tell whether I/O comes from MLA or GQA.

4. Adapt tests to changes above. Remove length alignment checks in unit tests.

