### PR TITLE
[BugFix] lookup for all ranks

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -414,6 +414,9 @@ class UCMDirectConnector(KVConnectorBase_V1):
         defer_scheduler_store = getattr(self, "_defer_scheduler_store", False)
         if role == KVConnectorRole.SCHEDULER:
             self.request_hasher = RequestHasher(vllm_config, 0)
+            self._rank_hashers = [
+                RequestHasher(vllm_config, rank) for rank in range(1, self.tp_size)
+            ]
             self._seed = self.request_hasher("UCM_HASH_SEED")
             # init scheduler-size connector
             if not defer_scheduler_store:
@@ -514,6 +517,36 @@ class UCMDirectConnector(KVConnectorBase_V1):
             ret.append(hash_value)
 
         return ret
+
+    def _lookup_external_prefix_all_ranks(self, external_block_ids: list[bytes]) -> int:
+        rank0_hit_idx = self.store.lookup_on_prefix(external_block_ids)
+        if rank0_hit_idx < 0 or self.is_mla or not self._rank_hashers:
+            return rank0_hit_idx
+
+        candidate_block_ids = external_block_ids[: rank0_hit_idx + 1]
+        num_other_ranks = len(self._rank_hashers)
+        block_ids_other_ranks: list[bytes] = []
+        for block_id in candidate_block_ids:
+            for rank_hasher in self._rank_hashers:
+                block_ids_other_ranks.append(rank_hasher(block_id))
+
+        founds = self.store.lookup(block_ids_other_ranks)
+        expected_founds = len(candidate_block_ids) * num_other_ranks
+        if len(founds) != expected_founds:
+            logger.warning(
+                "Lookup all ranks returned unexpected result length: "
+                f"expected {expected_founds}, got {len(founds)}."
+            )
+            return -1
+
+        for block_idx in range(len(candidate_block_ids)):
+            begin = block_idx * num_other_ranks
+            end = begin + num_other_ranks
+            rank_founds = founds[begin:end]
+            if len(rank_founds) != num_other_ranks or not all(rank_founds):
+                return block_idx - 1
+
+        return len(candidate_block_ids) - 1
 
     def _create_store(
         self,
@@ -688,7 +721,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
         if external_block_ids:
             try:
                 external_hit_blocks = (
-                    self.store.lookup_on_prefix(external_block_ids) + 1
+                    self._lookup_external_prefix_all_ranks(external_block_ids) + 1
                 )
                 external_hit_blocks //= self.cp_world_size
             except Exception as e:
@@ -1660,9 +1693,13 @@ class UCMCPConnector(UCMLayerWiseConnector):
             self.dcp_rank = get_dcp_group().rank_in_group
         except AssertionError:
             # DCP might not be initialized in testing
-            self.dcp_world_size = 1
+            self.dcp_world_size = (
+                self._vllm_config.parallel_config.decode_context_parallel_size
+            )
             self.dcp_rank = 0
-            self.pcp_world_size = 1
+            self.pcp_world_size = (
+                self._vllm_config.parallel_config.prefill_context_parallel_size
+            )
             self.pcp_rank = 0
         self.cp_world_size = (
             self._vllm_config.parallel_config.prefill_context_parallel_size
@@ -1681,6 +1718,18 @@ class UCMCPConnector(UCMLayerWiseConnector):
 
         if role == KVConnectorRole.SCHEDULER:
             self.request_hasher = RequestHasher(vllm_config, 0)
+            # DCP ranks that share the same effective TP rank use the same
+            # rank-specific cache key, so deduplicate while preserving order.
+            rank_ids = list(
+                dict.fromkeys(
+                    rank // self.dcp_world_size for rank in range(self.tp_size)
+                )
+            )
+            self._rank_hashers = [
+                RequestHasher(vllm_config, rank_id)
+                for rank_id in rank_ids
+                if rank_id != 0
+            ]
             self._seed = self.request_hasher("UCM_HASH_SEED")
             # init scheduler-size connector
             self.store = self._create_store(None)

--- a/ucm/store/posix/cc/space_manager.cc
+++ b/ucm/store/posix/cc/space_manager.cc
@@ -58,12 +58,36 @@ Status SpaceManager::Setup(const Config& config)
 
 Expected<std::vector<uint8_t>> SpaceManager::Lookup(const Detail::BlockId* blocks, size_t num)
 {
-    std::vector<uint8_t> results(num, false);
-    auto res = LookupOnPrefix(blocks, num);
-    if (!res) [[unlikely]] { return res.Error(); }
-    const auto index = res.Value();
-    for (ssize_t i = 0; i <= index; ++i) { results[i] = true; }
-    return results;
+    if (num == 0) { return std::vector<uint8_t>{}; }
+
+    std::shared_ptr<std::vector<uint8_t>> results;
+    std::shared_ptr<std::atomic<int32_t>> status;
+    std::shared_ptr<Latch> waiter;
+
+    const auto ok = Status::OK().Underlying();
+
+    try {
+        results = std::make_shared<std::vector<uint8_t>>(num, false);
+        status = std::make_shared<std::atomic<int32_t>>(ok);
+        waiter = std::make_shared<Latch>();
+    } catch (const std::exception& e) {
+        UC_ERROR("Failed({}) to allocate lookup context.", e.what());
+        return Status::OutOfMemory();
+    }
+
+    const size_t nWorker = prefixLookupSrv_.NWorker();
+    waiter->Set(nWorker);
+
+    for (size_t begin = 0; begin < nWorker; begin++) {
+        prefixLookupSrv_.Push({blocks, begin, num, nWorker, nullptr, status, waiter, results});
+    }
+
+    waiter->Wait();
+
+    auto s = status->load();
+    if (s != ok) [[unlikely]] { return Status{s, "failed to lookup some blocks"}; }
+
+    return std::move(*results);
 }
 
 Expected<ssize_t> SpaceManager::LookupOnPrefix(const Detail::BlockId* blocks, size_t num)
@@ -89,7 +113,7 @@ Expected<ssize_t> SpaceManager::LookupOnPrefix(const Detail::BlockId* blocks, si
     waiter->Set(nWorker);
 
     for (size_t begin = 0; begin < nWorker; begin++) {
-        prefixLookupSrv_.Push({blocks, begin, num, nWorker, firstFail, status, waiter});
+        prefixLookupSrv_.Push({blocks, begin, num, nWorker, firstFail, status, waiter, nullptr});
     }
 
     waiter->Wait();
@@ -114,8 +138,25 @@ uint8_t SpaceManager::Lookup(const Detail::BlockId* block)
     return true;
 }
 
+void SpaceManager::OnLookup(PrefixLookupContext& ctx)
+{
+    for (size_t i = ctx.begin; i < ctx.end; i += ctx.nWorker) {
+        if (ctx.status->load() != Status::OK().Underlying()) { break; }
+
+        auto found = Lookup(ctx.blocks + i);
+        (*ctx.results)[i] = found;
+        if (found && hotnessTrackerEnable_) { hotnessTracker_.Touch(*(ctx.blocks + i)); }
+    }
+    ctx.waiter->Done();
+}
+
 void SpaceManager::OnLookupPrefix(PrefixLookupContext& ctx)
 {
+    if (ctx.results != nullptr) {
+        OnLookup(ctx);
+        return;
+    }
+
     for (size_t i = ctx.begin; i < ctx.end; i += ctx.nWorker) {
         if (ctx.status->load() != Status::OK().Underlying()) { break; }
 

--- a/ucm/store/posix/cc/space_manager.h
+++ b/ucm/store/posix/cc/space_manager.h
@@ -42,6 +42,7 @@ class SpaceManager {
         std::shared_ptr<std::atomic<ssize_t>> firstFail;
         std::shared_ptr<std::atomic<int32_t>> status;
         std::shared_ptr<Latch> waiter;
+        std::shared_ptr<std::vector<uint8_t>> results;
     };
 
 private:
@@ -60,6 +61,7 @@ public:
 
 private:
     uint8_t Lookup(const Detail::BlockId* block);
+    void OnLookup(PrefixLookupContext& ctx);
     void OnLookupPrefix(PrefixLookupContext& ctx);
     void OnLookupPrefixTimeout(PrefixLookupContext& ctx);
 };

--- a/ucm/store/test/case/posix/posix_space_manager_test.cc
+++ b/ucm/store/test/case/posix/posix_space_manager_test.cc
@@ -149,7 +149,7 @@ TEST_F(UCPosixSpaceManagerTest, Lookup)
         ASSERT_EQ(foundIdx, 1);
         auto founds = spaceMgr.Lookup(blocks.data(), blocks.size()).Value();
         ASSERT_EQ(founds.size(), blocks.size());
-        std::vector<uint8_t> expected{true, true, false, false};
+        std::vector<uint8_t> expected{true, true, false, true};
         ASSERT_TRUE(founds == expected);
     }
 }


### PR DESCRIPTION
## Purpose
Fix GQA cache lookup correctness by checking cached block availability across all TP ranks instead of only rank 0. This prevents scheduler-side false hits where rank 0 files exist but other rank-specific files have been removed by GC, which can later cause worker load failures.

## Modifications 

- Update get_num_new_matched_tokens() to use the minimum prefix hit across all ranks as the effective external cache hit.
- Add _lookup_external_prefix_all_ranks to search for all ranks' blocks

## Test
Tested with 2tp/8tp/2dp 2tp/4tp 2dcp/2tp 2pcp with QwQ-32B or Qwen2.5-1.5B
