### PR TITLE
[Opt] Simplify transport task finalization helpers

### DIFF
--- a/ucm/transport/kv/asu/trans/src/transport_task_completion.cpp
+++ b/ucm/transport/kv/asu/trans/src/transport_task_completion.cpp
@@ -28,16 +28,9 @@
 
 namespace UC::ASU {
 
-namespace {
-
-bool IsSubBatchTerminal(TransportSubBatchState state)
+Status TransportTaskContext::BuildFinalStatus() const
 {
-    return state == TransportSubBatchState::COMPLETED;
-}
-
-Status BuildTaskFinalStatus(const TransportTaskContext& ctx)
-{
-    for (const auto& subBatchContext : ctx.subBatchContexts) {
+    for (const auto& subBatchContext : subBatchContexts) {
         if (!subBatchContext.status.ok()) {
             return Status::Error(StatusCode::PARTIAL_FAILED, "transport task partially failed");
         }
@@ -46,14 +39,12 @@ Status BuildTaskFinalStatus(const TransportTaskContext& ctx)
     return Status::OK();
 }
 
-}  // namespace
-
 void TransportTaskContext::InitializeTerminalSubBatchCount()
 {
     // At submit completion time, terminal sub-batches are usually submit/send failures.
     completedSubBatchCount = 0;
     for (const auto& subBatchContext : subBatchContexts) {
-        if (!IsSubBatchTerminal(subBatchContext.state)) { continue; }
+        if (subBatchContext.state != TransportSubBatchState::COMPLETED) { continue; }
 
         ++completedSubBatchCount;
     }
@@ -115,7 +106,7 @@ void TransportTaskContext::TryFinalizeFromSubBatches()
 
     if (completedSubBatchCount != static_cast<std::uint32_t>(subBatchContexts.size())) { return; }
 
-    finalStatus = BuildTaskFinalStatus(*this);
+    finalStatus = BuildFinalStatus();
     state.store(TransportTaskState::COMPLETED, std::memory_order_release);
 }
 

--- a/ucm/transport/kv/asu/trans/src/transport_task_manager.h
+++ b/ucm/transport/kv/asu/trans/src/transport_task_manager.h
@@ -113,6 +113,7 @@ struct TransportTaskContext {
     std::condition_variable cv;
 
     bool Done() const;
+    Status BuildFinalStatus() const;
     void InitializeTerminalSubBatchCount();
     void TryFinalizeFromSubBatches();
 };


### PR DESCRIPTION
## Purpose
Improve readability and ownership of transport task completion logic.
## Modifications 
- Move final status aggregation into `TransportTaskContext::BuildFinalStatus()`.
- Inline the single-use sub-batch terminal-state check with a direct `COMPLETED` comparison.
## Test
No.

