### PR TITLE
[Feat] Add DRAM pool KV protocol with unified pack/unpack

### DIFF
--- a/ucm/transport/kv/dramstore/src/kv_protocol.cpp
+++ b/ucm/transport/kv/dramstore/src/kv_protocol.cpp
@@ -1,0 +1,392 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "kv_protocol.h"
+#include <cstring>
+#include <string>
+
+namespace UC::DRAMPOOL {
+
+// ---------------------------------------------------------------------------
+// Free helpers
+// ---------------------------------------------------------------------------
+
+KvOpcode PeekOpcode(const void* data)
+{
+    return static_cast<KvOpcode>(static_cast<const std::uint8_t*>(data)[kOpcodeOffset]);
+}
+
+bool IsAllZeroKey(const std::uint8_t* key)
+{
+    for (std::size_t i = 0; i < kKvKeySize; ++i) {
+        if (key[i] != 0) { return false; }
+    }
+    return true;
+}
+
+const char* ProtocolName(KvOpcode opcode)
+{
+    switch (opcode) {
+        case KvOpcode::None: return "Unknown";
+        case KvOpcode::Dump: return "Dump";
+        case KvOpcode::Load: return "Load";
+        case KvOpcode::Lookup: return "Lookup";
+    }
+    return "Unknown";
+}
+
+void PackHeader(std::uint8_t* out, KvOpcode opcode, std::uint64_t resp_addr,
+                std::uint16_t batch_size)
+{
+    out[kOpcodeOffset] = static_cast<std::uint8_t>(opcode);
+    std::memcpy(out + kRespAddrOffset, &resp_addr, sizeof(resp_addr));
+    std::memcpy(out + kBatchSizeOffset, &batch_size, sizeof(batch_size));
+}
+
+// ===========================================================================
+// KvDumpLoadProtocol
+// ===========================================================================
+
+// ---- Client side ----
+
+std::size_t KvDumpLoadProtocol::PackedSize(const KvRequest& req) const
+{
+    const auto& r = static_cast<const KvDumpLoadRequest&>(req);
+    return kKvHeaderSize + static_cast<std::size_t>(r.batch_size) * kKvDumpLoadEntrySize;
+}
+
+Status KvDumpLoadProtocol::PackRequest(const KvRequest& req, void* target)
+{
+    const auto& r = static_cast<const KvDumpLoadRequest&>(req);
+    auto status = ValidateRequest(r);
+    if (!status.ok()) { return status; }
+
+    auto* out = static_cast<std::uint8_t*>(target);
+    PackHeader(out, r.opcode, r.resp_addr, r.batch_size);
+
+    for (std::size_t i = 0; i < r.entries.size(); ++i) {
+        const auto& entry = r.entries[i];
+        std::uint8_t* base = out + kKvHeaderSize + i * kKvDumpLoadEntrySize;
+        std::memcpy(base + kDumpLoadEntryKeyOffset, entry.key.data(), kKvKeySize);
+        std::memcpy(base + kDumpLoadEntryAddrOffset, &entry.addr, sizeof(entry.addr));
+        std::memcpy(base + kDumpLoadEntryLenOffset, &entry.len, sizeof(entry.len));
+        std::memcpy(base + kDumpLoadEntryIdxOffset, &entry.idx, sizeof(entry.idx));
+    }
+    return Status::OK();
+}
+
+Status KvDumpLoadProtocol::UnpackResponse(const void* data, std::uint16_t result_count,
+                                          KvResponse& out) const
+{
+    if (!data) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "DumpLoad: UnpackResponse data is null");
+    }
+    out.results.resize(result_count);
+    std::memcpy(out.results.data(), data,
+                static_cast<std::size_t>(result_count) * sizeof(std::uint32_t));
+    return Status::OK();
+}
+
+Status KvDumpLoadProtocol::ValidateRequest(const KvDumpLoadRequest& req) const
+{
+    if (req.opcode != KvOpcode::Dump && req.opcode != KvOpcode::Load) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "DumpLoad: opcode must be Dump or Load");
+    }
+    auto header_status = ValidateRequestHeader(req);
+    if (!header_status.ok()) { return header_status; }
+
+    for (std::size_t i = 0; i < req.entries.size(); ++i) {
+        const auto& entry = req.entries[i];
+        if (IsAllZeroKey(entry.key.data())) {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "DumpLoad: entry[" + std::to_string(i) + "] key is all zero");
+        }
+        if (entry.addr == 0) {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "DumpLoad: entry[" + std::to_string(i) + "] addr is zero");
+        }
+        if (entry.len == 0) {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "DumpLoad: entry[" + std::to_string(i) + "] len is zero");
+        }
+    }
+    return Status::OK();
+}
+
+// ---- Server side ----
+
+Status KvDumpLoadProtocol::UnpackRequest(const void* data, std::size_t size,
+                                         std::unique_ptr<KvRequest>& out) const
+{
+    auto* bytes = static_cast<const std::uint8_t*>(data);
+    auto req = std::make_unique<KvDumpLoadRequest>();
+
+    req->opcode = PeekOpcode(data);
+    if (req->opcode != KvOpcode::Dump && req->opcode != KvOpcode::Load) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "DumpLoad: opcode mismatch");
+    }
+
+    std::memcpy(&req->resp_addr, bytes + kRespAddrOffset, sizeof(req->resp_addr));
+    if (req->resp_addr == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "DumpLoad: resp_addr is zero");
+    }
+
+    std::memcpy(&req->batch_size, bytes + kBatchSizeOffset, sizeof(req->batch_size));
+    if (req->batch_size == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "DumpLoad: batch_size is zero");
+    }
+
+    std::size_t expected_size =
+        kKvHeaderSize + static_cast<std::size_t>(req->batch_size) * kKvDumpLoadEntrySize;
+    if (size != expected_size) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "DumpLoad: size(" + std::to_string(size) + ") != expected(" +
+                                 std::to_string(expected_size) + ")");
+    }
+
+    req->entries.resize(req->batch_size);
+    for (std::size_t i = 0; i < req->batch_size; ++i) {
+        const std::uint8_t* base = bytes + kKvHeaderSize + i * kKvDumpLoadEntrySize;
+        std::memcpy(req->entries[i].key.data(), base + kDumpLoadEntryKeyOffset, kKvKeySize);
+        if (IsAllZeroKey(req->entries[i].key.data())) {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "DumpLoad: entry[" + std::to_string(i) + "] key is all zero");
+        }
+        std::memcpy(&req->entries[i].addr, base + kDumpLoadEntryAddrOffset, sizeof(std::uint64_t));
+        if (req->entries[i].addr == 0) {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "DumpLoad: entry[" + std::to_string(i) + "] addr is zero");
+        }
+        std::memcpy(&req->entries[i].len, base + kDumpLoadEntryLenOffset, sizeof(std::uint32_t));
+        if (req->entries[i].len == 0) {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "DumpLoad: entry[" + std::to_string(i) + "] len is zero");
+        }
+        std::memcpy(&req->entries[i].idx, base + kDumpLoadEntryIdxOffset, sizeof(std::uint32_t));
+    }
+    out = std::move(req);
+    return Status::OK();
+}
+
+Status KvDumpLoadProtocol::PackResponse(void* data, const KvResponse& resp) const
+{
+    if (!data) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "DumpLoad: PackResponse data is null");
+    }
+    std::memcpy(data, resp.results.data(), resp.results.size() * sizeof(std::uint32_t));
+    return Status::OK();
+}
+
+// ===========================================================================
+// KvLookupProtocol
+// ===========================================================================
+
+// ---- Client side ----
+
+std::size_t KvLookupProtocol::PackedSize(const KvRequest& req) const
+{
+    const auto& r = static_cast<const KvLookupRequest&>(req);
+    return kKvHeaderSize + static_cast<std::size_t>(r.batch_size) * kKvLookupEntrySize;
+}
+
+Status KvLookupProtocol::PackRequest(const KvRequest& req, void* target)
+{
+    const auto& r = static_cast<const KvLookupRequest&>(req);
+    auto status = ValidateRequest(r);
+    if (!status.ok()) { return status; }
+
+    auto* out = static_cast<std::uint8_t*>(target);
+    PackHeader(out, r.opcode, r.resp_addr, r.batch_size);
+
+    for (std::size_t i = 0; i < r.entries.size(); ++i) {
+        const auto& entry = r.entries[i];
+        std::uint8_t* base = out + kKvHeaderSize + i * kKvLookupEntrySize;
+        std::memcpy(base + kLookupEntryKeyOffset, entry.key.data(), kKvKeySize);
+    }
+    return Status::OK();
+}
+
+Status KvLookupProtocol::UnpackResponse(const void* data, std::uint16_t result_count,
+                                        KvResponse& out) const
+{
+    if (result_count != 1) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Lookup: result_count must be 1, got " + std::to_string(result_count));
+    }
+    if (!data) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Lookup: UnpackResponse data is null");
+    }
+    out.results.resize(result_count);
+    std::memcpy(out.results.data(), data, result_count * sizeof(std::uint32_t));
+    return Status::OK();
+}
+
+Status KvLookupProtocol::ValidateRequest(const KvLookupRequest& req) const
+{
+    if (req.opcode != KvOpcode::Lookup) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Lookup: opcode must be Lookup");
+    }
+    auto header_status = ValidateRequestHeader(req);
+    if (!header_status.ok()) { return header_status; }
+
+    for (std::size_t i = 0; i < req.entries.size(); ++i) {
+        if (IsAllZeroKey(req.entries[i].key.data())) {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "Lookup: entry[" + std::to_string(i) + "] key is all zero");
+        }
+    }
+    return Status::OK();
+}
+
+// ---- Server side ----
+
+Status KvLookupProtocol::UnpackRequest(const void* data, std::size_t size,
+                                       std::unique_ptr<KvRequest>& out) const
+{
+    auto* bytes = static_cast<const std::uint8_t*>(data);
+    auto req = std::make_unique<KvLookupRequest>();
+
+    req->opcode = PeekOpcode(data);
+    if (req->opcode != KvOpcode::Lookup) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Lookup: opcode mismatch");
+    }
+
+    std::memcpy(&req->resp_addr, bytes + kRespAddrOffset, sizeof(req->resp_addr));
+    if (req->resp_addr == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Lookup: resp_addr is zero");
+    }
+
+    std::memcpy(&req->batch_size, bytes + kBatchSizeOffset, sizeof(req->batch_size));
+    if (req->batch_size == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Lookup: batch_size is zero");
+    }
+
+    std::size_t expected_size =
+        kKvHeaderSize + static_cast<std::size_t>(req->batch_size) * kKvLookupEntrySize;
+    if (size != expected_size) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Lookup: size(" + std::to_string(size) +
+                                                               ") != expected(" +
+                                                               std::to_string(expected_size) + ")");
+    }
+
+    req->entries.resize(req->batch_size);
+    for (std::size_t i = 0; i < req->batch_size; ++i) {
+        const std::uint8_t* base = bytes + kKvHeaderSize + i * kKvLookupEntrySize;
+        std::memcpy(req->entries[i].key.data(), base + kLookupEntryKeyOffset, kKvKeySize);
+        if (IsAllZeroKey(req->entries[i].key.data())) {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "Lookup: entry[" + std::to_string(i) + "] key is all zero");
+        }
+    }
+    out = std::move(req);
+    return Status::OK();
+}
+
+Status KvLookupProtocol::PackResponse(void* data, const KvResponse& resp) const
+{
+    if (!data) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Lookup: PackResponse data is null");
+    }
+    if (resp.results.size() != 1) {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            "Lookup: results.size()(" + std::to_string(resp.results.size()) + ") must be 1");
+    }
+    std::memcpy(data, resp.results.data(), sizeof(std::uint32_t));
+    return Status::OK();
+}
+
+// ===========================================================================
+// ProtocolManager
+// ===========================================================================
+
+ProtocolManager::ProtocolManager()
+{
+    protocols_[KvOpcode::Dump] = std::make_unique<KvDumpLoadProtocol>();
+    protocols_[KvOpcode::Load] = std::make_unique<KvDumpLoadProtocol>();
+    protocols_[KvOpcode::Lookup] = std::make_unique<KvLookupProtocol>();
+}
+
+KvProtocol* ProtocolManager::GetProtocol(KvOpcode opcode) const
+{
+    auto it = protocols_.find(opcode);
+    return it != protocols_.end() ? it->second.get() : nullptr;
+}
+
+// ---- Client side ----
+
+std::size_t ProtocolManager::GetPackedSize(KvOpcode opcode, const KvRequest& req) const
+{
+    KvProtocol* proto = GetProtocol(opcode);
+    if (!proto) { return 0; }
+    return proto->PackedSize(req);
+}
+
+Status ProtocolManager::PackRequest(void* data, KvOpcode opcode, const KvRequest& req)
+{
+    KvProtocol* proto = GetProtocol(opcode);
+    if (!proto) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "unknown opcode in PackRequest");
+    }
+    return proto->PackRequest(req, data);
+}
+
+Status ProtocolManager::UnpackResponse(const void* data, KvOpcode opcode,
+                                       std::uint16_t result_count, KvResponse& out)
+{
+    KvProtocol* proto = GetProtocol(opcode);
+    if (!proto) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "unknown opcode in UnpackResponse");
+    }
+    return proto->UnpackResponse(data, result_count, out);
+}
+
+// ---- Server side ----
+
+Status ProtocolManager::UnpackRequest(const void* data, std::size_t size,
+                                      std::unique_ptr<KvRequest>& out)
+{
+    if (!data || size < kKvHeaderSize) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "UnpackRequest: invalid data or size smaller than header");
+    }
+    KvOpcode opcode = PeekOpcode(data);
+    KvProtocol* proto = GetProtocol(opcode);
+    if (!proto) {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            "UnpackRequest: unknown opcode " + std::to_string(static_cast<std::uint8_t>(opcode)));
+    }
+    return proto->UnpackRequest(data, size, out);
+}
+
+Status ProtocolManager::PackResponse(void* data, KvOpcode opcode, const KvResponse& resp)
+{
+    KvProtocol* proto = GetProtocol(opcode);
+    if (!proto) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "unknown opcode in PackResponse");
+    }
+    return proto->PackResponse(data, resp);
+}
+
+}  // namespace UC::DRAMPOOL

--- a/ucm/transport/kv/dramstore/src/kv_protocol.h
+++ b/ucm/transport/kv/dramstore/src/kv_protocol.h
@@ -1,0 +1,215 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "../../asu/trans/include/asu_transport/types.h"
+
+namespace UC::DRAMPOOL {
+
+using Status = UC::ASU::Status;
+using StatusCode = UC::ASU::StatusCode;
+
+enum class KvOpcode : std::uint8_t {
+    None = 0x0,
+    Dump = 0x1,
+    Load = 0x2,
+    Lookup = 0x3,
+};
+
+constexpr std::size_t kKvKeySize = 16;
+constexpr std::size_t kKvHeaderSize =
+    sizeof(std::uint8_t) + sizeof(std::uint64_t) + sizeof(std::uint16_t);
+constexpr std::size_t kKvDumpLoadEntrySize =
+    kKvKeySize + sizeof(std::uint64_t) + sizeof(std::uint32_t) + sizeof(std::uint32_t);
+constexpr std::size_t kKvLookupEntrySize = kKvKeySize;
+constexpr std::size_t kKvFlagEntrySize = sizeof(std::uint32_t);
+
+// Wire offsets shared by the client (pack) and server (unpack) sides.
+constexpr std::size_t kOpcodeOffset = 0;
+constexpr std::size_t kRespAddrOffset = 1;
+constexpr std::size_t kBatchSizeOffset = 9;
+
+constexpr std::size_t kDumpLoadEntryKeyOffset = 0;
+constexpr std::size_t kDumpLoadEntryAddrOffset = 16;
+constexpr std::size_t kDumpLoadEntryLenOffset = 24;
+constexpr std::size_t kDumpLoadEntryIdxOffset = 28;
+
+constexpr std::size_t kLookupEntryKeyOffset = 0;
+
+class KvDumpLoadEntry {
+public:
+    std::array<std::uint8_t, kKvKeySize> key{};
+    std::uint64_t addr{0};
+    std::uint32_t len{0};
+    std::uint32_t idx{0};
+};
+
+class KvLookupEntry {
+public:
+    std::array<std::uint8_t, kKvKeySize> key{};
+};
+
+class KvRequest {
+public:
+    virtual ~KvRequest() = default;
+};
+
+class KvDumpLoadRequest : public KvRequest {
+public:
+    KvOpcode opcode{KvOpcode::None};
+    std::uint64_t resp_addr{0};
+    std::uint16_t batch_size{0};
+    std::vector<KvDumpLoadEntry> entries;
+};
+
+class KvLookupRequest : public KvRequest {
+public:
+    KvOpcode opcode{KvOpcode::None};
+    std::uint64_t resp_addr{0};
+    std::uint16_t batch_size{0};
+    std::vector<KvLookupEntry> entries;
+};
+
+class KvResponse {
+public:
+    std::vector<std::uint32_t> results;
+};
+
+// ---------------------------------------------------------------------------
+// Free helpers (shared by pack / unpack paths)
+// ---------------------------------------------------------------------------
+
+// Peek the opcode byte from a packed request buffer (byte 0).
+KvOpcode PeekOpcode(const void* data);
+
+// True if every byte of the 16-byte key is zero.
+bool IsAllZeroKey(const std::uint8_t* key);
+
+// Human-readable protocol name for log prefixes (Dump/Load/Lookup, "Unknown" otherwise).
+const char* ProtocolName(KvOpcode opcode);
+
+// Write the 11-byte header (opcode + resp_addr + batch_size) into out.
+void PackHeader(std::uint8_t* out, KvOpcode opcode, std::uint64_t resp_addr,
+                std::uint16_t batch_size);
+
+// Validate resp_addr != 0 and batch_size == entries.size() (and non-zero).
+template <typename Req>
+Status ValidateRequestHeader(const Req& req)
+{
+    const std::string name = ProtocolName(req.opcode);
+    if (req.resp_addr == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, name + ": resp_addr is zero");
+    }
+    if (req.batch_size == 0 || req.batch_size != req.entries.size()) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             name + ": batch_size(" + std::to_string(req.batch_size) +
+                                 ") must be non-zero and equal to entries.size()(" +
+                                 std::to_string(req.entries.size()) + ")");
+    }
+    return Status::OK();
+}
+
+// ---------------------------------------------------------------------------
+// Protocol classes
+// ---------------------------------------------------------------------------
+
+class KvProtocol {
+public:
+    virtual ~KvProtocol() = default;
+
+    // Client side: pack request struct -> wire; unpack response wire -> struct.
+    virtual std::size_t PackedSize(const KvRequest& req) const = 0;
+    virtual Status PackRequest(const KvRequest& req, void* target) = 0;
+    virtual Status UnpackResponse(const void* data, std::uint16_t result_count,
+                                  KvResponse& out) const = 0;
+
+    // Server side: unpack request wire -> struct; pack response struct -> wire.
+    virtual Status UnpackRequest(const void* data, std::size_t size,
+                                 std::unique_ptr<KvRequest>& out) const = 0;
+    virtual Status PackResponse(void* data, const KvResponse& resp) const = 0;
+};
+
+class KvDumpLoadProtocol : public KvProtocol {
+public:
+    // Client side
+    std::size_t PackedSize(const KvRequest& req) const override;
+    Status PackRequest(const KvRequest& req, void* target) override;
+    Status UnpackResponse(const void* data, std::uint16_t result_count,
+                          KvResponse& out) const override;
+    // Server side
+    Status UnpackRequest(const void* data, std::size_t size,
+                         std::unique_ptr<KvRequest>& out) const override;
+    Status PackResponse(void* data, const KvResponse& resp) const override;
+
+private:
+    Status ValidateRequest(const KvDumpLoadRequest& req) const;
+};
+
+class KvLookupProtocol : public KvProtocol {
+public:
+    // Client side
+    std::size_t PackedSize(const KvRequest& req) const override;
+    Status PackRequest(const KvRequest& req, void* target) override;
+    Status UnpackResponse(const void* data, std::uint16_t result_count,
+                          KvResponse& out) const override;
+    // Server side
+    Status UnpackRequest(const void* data, std::size_t size,
+                         std::unique_ptr<KvRequest>& out) const override;
+    Status PackResponse(void* data, const KvResponse& resp) const override;
+
+private:
+    Status ValidateRequest(const KvLookupRequest& req) const;
+};
+
+class ProtocolManager {
+public:
+    ProtocolManager();
+    ~ProtocolManager() = default;
+
+    ProtocolManager(const ProtocolManager&) = delete;
+    ProtocolManager& operator=(const ProtocolManager&) = delete;
+
+    // Client side
+    std::size_t GetPackedSize(KvOpcode opcode, const KvRequest& req) const;
+    Status PackRequest(void* data, KvOpcode opcode, const KvRequest& req);
+    Status UnpackResponse(const void* data, KvOpcode opcode, std::uint16_t result_count,
+                          KvResponse& out);
+    // Server side
+    Status UnpackRequest(const void* data, std::size_t size, std::unique_ptr<KvRequest>& out);
+    Status PackResponse(void* data, KvOpcode opcode, const KvResponse& resp);
+
+private:
+    std::unordered_map<KvOpcode, std::unique_ptr<KvProtocol>> protocols_;
+
+    KvProtocol* GetProtocol(KvOpcode opcode) const;
+};
+
+}  // namespace UC::DRAMPOOL

--- a/ucm/transport/kv/dramstore/test/kv_protocol_test.cpp
+++ b/ucm/transport/kv/dramstore/test/kv_protocol_test.cpp
@@ -1,0 +1,652 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "kv_protocol.h"
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+namespace UC::DRAMPOOL {
+namespace {
+
+std::array<std::uint8_t, kKvKeySize> MakeKey(std::uint8_t seed)
+{
+    std::array<std::uint8_t, kKvKeySize> key{};
+    for (std::size_t i = 0; i < key.size(); ++i) { key[i] = static_cast<std::uint8_t>(seed + i); }
+    return key;
+}
+
+void ExpectLe16(const std::vector<std::uint8_t>& buf, std::size_t offset, std::uint16_t value)
+{
+    EXPECT_EQ(buf[offset], static_cast<std::uint8_t>(value & 0xFF));
+    EXPECT_EQ(buf[offset + 1], static_cast<std::uint8_t>((value >> 8) & 0xFF));
+}
+
+void ExpectLe32(const std::vector<std::uint8_t>& buf, std::size_t offset, std::uint32_t value)
+{
+    for (std::size_t i = 0; i < sizeof(value); ++i) {
+        EXPECT_EQ(buf[offset + i], static_cast<std::uint8_t>((value >> (i * 8)) & 0xFF));
+    }
+}
+
+void ExpectLe64(const std::vector<std::uint8_t>& buf, std::size_t offset, std::uint64_t value)
+{
+    for (std::size_t i = 0; i < sizeof(value); ++i) {
+        EXPECT_EQ(buf[offset + i], static_cast<std::uint8_t>((value >> (i * 8)) & 0xFF));
+    }
+}
+
+class KvProtocolTest : public ::testing::Test {
+protected:
+    ProtocolManager mgr_;
+};
+
+TEST_F(KvProtocolTest, PackDumpRequestMatchesLayout)
+{
+    KvDumpLoadEntry entry;
+    entry.key = MakeKey(0x10);
+    entry.addr = 0x1122334455667788ULL;
+    entry.len = 0xAABBCCDD;
+    entry.idx = 0x12345678;
+
+    KvDumpLoadRequest req;
+    req.opcode = KvOpcode::Dump;
+    req.resp_addr = 0x0102030405060708ULL;
+    req.batch_size = 1;
+    req.entries = {entry};
+
+    std::vector<std::uint8_t> packed(mgr_.GetPackedSize(req.opcode, req), 0);
+    auto status = mgr_.PackRequest(packed.data(), req.opcode, req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    EXPECT_EQ(packed[0], static_cast<std::uint8_t>(KvOpcode::Dump));
+    ExpectLe64(packed, 1, req.resp_addr);
+    ExpectLe16(packed, 9, req.batch_size);
+    EXPECT_EQ(std::memcmp(packed.data() + kKvHeaderSize, entry.key.data(), kKvKeySize), 0);
+    ExpectLe64(packed, kKvHeaderSize + 16, entry.addr);
+    ExpectLe32(packed, kKvHeaderSize + 24, entry.len);
+    ExpectLe32(packed, kKvHeaderSize + 28, entry.idx);
+}
+
+TEST_F(KvProtocolTest, PackLoadRequestMatchesLayout)
+{
+    KvDumpLoadEntry entry;
+    entry.key = MakeKey(0x20);
+    entry.addr = 0x8877665544332211ULL;
+    entry.len = 0x1000;
+    entry.idx = 7;
+
+    KvDumpLoadRequest req;
+    req.opcode = KvOpcode::Load;
+    req.resp_addr = 0x1111222233334444ULL;
+    req.batch_size = 1;
+    req.entries = {entry};
+
+    std::vector<std::uint8_t> packed(mgr_.GetPackedSize(req.opcode, req), 0);
+    auto status = mgr_.PackRequest(packed.data(), req.opcode, req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    EXPECT_EQ(packed[0], static_cast<std::uint8_t>(KvOpcode::Load));
+    ExpectLe64(packed, 1, req.resp_addr);
+    ExpectLe16(packed, 9, req.batch_size);
+    EXPECT_EQ(std::memcmp(packed.data() + kKvHeaderSize, entry.key.data(), kKvKeySize), 0);
+}
+
+TEST_F(KvProtocolTest, PackLookupRequestMatchesLayout)
+{
+    KvLookupEntry entry0;
+    entry0.key = MakeKey(0x30);
+    KvLookupEntry entry1;
+    entry1.key = MakeKey(0x40);
+
+    KvLookupRequest req;
+    req.opcode = KvOpcode::Lookup;
+    req.resp_addr = 0x1234000056780000ULL;
+    req.batch_size = 2;
+    req.entries = {entry0, entry1};
+
+    std::vector<std::uint8_t> packed(mgr_.GetPackedSize(req.opcode, req), 0);
+    auto status = mgr_.PackRequest(packed.data(), req.opcode, req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    EXPECT_EQ(packed[0], static_cast<std::uint8_t>(KvOpcode::Lookup));
+    ExpectLe64(packed, 1, req.resp_addr);
+    ExpectLe16(packed, 9, req.batch_size);
+    EXPECT_EQ(std::memcmp(packed.data() + kKvHeaderSize, entry0.key.data(), kKvKeySize), 0);
+    EXPECT_EQ(std::memcmp(packed.data() + kKvHeaderSize + kKvLookupEntrySize, entry1.key.data(),
+                          kKvKeySize),
+              0);
+}
+
+TEST_F(KvProtocolTest, RejectsBatchSizeMismatch)
+{
+    KvLookupEntry entry;
+    entry.key = MakeKey(0x50);
+
+    KvLookupRequest req;
+    req.opcode = KvOpcode::Lookup;
+    req.resp_addr = 0x1000;
+    req.batch_size = 2;
+    req.entries = {entry};
+
+    std::vector<std::uint8_t> packed(kKvHeaderSize + 2 * kKvLookupEntrySize, 0);
+    auto status = mgr_.PackRequest(packed.data(), req.opcode, req);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("batch_size"), std::string::npos);
+}
+
+TEST_F(KvProtocolTest, RejectsAllZeroKey)
+{
+    KvLookupEntry entry;
+
+    KvLookupRequest req;
+    req.opcode = KvOpcode::Lookup;
+    req.resp_addr = 0x1000;
+    req.batch_size = 1;
+    req.entries = {entry};
+
+    std::vector<std::uint8_t> packed(mgr_.GetPackedSize(req.opcode, req), 0);
+    auto status = mgr_.PackRequest(packed.data(), req.opcode, req);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("key"), std::string::npos);
+}
+
+TEST_F(KvProtocolTest, RejectsZeroDumpLoadAddrAndLen)
+{
+    KvDumpLoadEntry entry;
+    entry.key = MakeKey(0x60);
+    entry.addr = 0;
+    entry.len = 1;
+
+    KvDumpLoadRequest req;
+    req.opcode = KvOpcode::Dump;
+    req.resp_addr = 0x1000;
+    req.batch_size = 1;
+    req.entries = {entry};
+
+    std::vector<std::uint8_t> packed(mgr_.GetPackedSize(req.opcode, req), 0);
+    auto status = mgr_.PackRequest(packed.data(), req.opcode, req);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("addr"), std::string::npos);
+
+    req.entries[0].addr = 0x2000;
+    req.entries[0].len = 0;
+    status = mgr_.PackRequest(packed.data(), req.opcode, req);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("len"), std::string::npos);
+}
+
+TEST_F(KvProtocolTest, UnpackRequestRejectsWrongSize)
+{
+    KvLookupEntry entry;
+    entry.key = MakeKey(0x70);
+
+    KvLookupRequest req;
+    req.opcode = KvOpcode::Lookup;
+    req.resp_addr = 0x1000;
+    req.batch_size = 1;
+    req.entries = {entry};
+
+    std::vector<std::uint8_t> packed(mgr_.GetPackedSize(req.opcode, req), 0);
+    auto status = mgr_.PackRequest(packed.data(), req.opcode, req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::unique_ptr<KvRequest> parsed;
+    status = mgr_.UnpackRequest(packed.data(), packed.size() - 1, parsed);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("size"), std::string::npos);
+}
+
+TEST_F(KvProtocolTest, UnpackResponseReadsFlagEntry)
+{
+    // Lookup: single idx
+    std::uint8_t flag[kKvFlagEntrySize] = {0x78, 0x56, 0x34, 0x12};
+    KvResponse resp;
+    auto status = mgr_.UnpackResponse(flag, KvOpcode::Lookup, 1, resp);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(resp.results.size(), 1u);
+    EXPECT_EQ(resp.results[0], 0x12345678U);
+
+    // Dump/Load: batch_size errcodes (one per entry)
+    std::uint8_t flag2[2 * kKvFlagEntrySize] = {0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00};
+    resp.results.clear();
+    status = mgr_.UnpackResponse(flag2, KvOpcode::Dump, 2, resp);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(resp.results.size(), 2u);
+    EXPECT_EQ(resp.results[0], 0x12345678U);
+    EXPECT_EQ(resp.results[1], 0x00000000U);
+}
+
+TEST_F(KvProtocolTest, ServerRoundTripDumpLoad)
+{
+    KvDumpLoadEntry entry;
+    entry.key = MakeKey(0x80);
+    entry.addr = 0xAABBCCDDEEFF0011ULL;
+    entry.len = 0x2000;
+    entry.idx = 0x55;
+
+    KvDumpLoadRequest req;
+    req.opcode = KvOpcode::Load;
+    req.resp_addr = 0x9988776655443322ULL;
+    req.batch_size = 1;
+    req.entries = {entry};
+
+    // client packs
+    std::vector<std::uint8_t> packed(mgr_.GetPackedSize(req.opcode, req), 0);
+    ASSERT_TRUE(mgr_.PackRequest(packed.data(), req.opcode, req).ok());
+
+    // server unpacks (validation merged into UnpackRequest)
+    std::unique_ptr<KvRequest> parsed;
+    ASSERT_TRUE(mgr_.UnpackRequest(packed.data(), packed.size(), parsed).ok());
+    auto& dl = static_cast<KvDumpLoadRequest&>(*parsed);
+    EXPECT_EQ(dl.opcode, req.opcode);
+    EXPECT_EQ(dl.resp_addr, req.resp_addr);
+    EXPECT_EQ(dl.batch_size, req.batch_size);
+    EXPECT_EQ(std::memcmp(dl.entries[0].key.data(), entry.key.data(), kKvKeySize), 0);
+    EXPECT_EQ(dl.entries[0].addr, entry.addr);
+    EXPECT_EQ(dl.entries[0].len, entry.len);
+    EXPECT_EQ(dl.entries[0].idx, entry.idx);
+
+    // server packs response, client unpacks it
+    KvResponse resp;
+    resp.results = {0x0};  // batch_size == 1 errcode
+    std::uint8_t flag[kKvFlagEntrySize] = {0};
+    ASSERT_TRUE(mgr_.PackResponse(flag, req.opcode, resp).ok());
+    KvResponse resp2;
+    ASSERT_TRUE(mgr_.UnpackResponse(flag, req.opcode, req.batch_size, resp2).ok());
+    ASSERT_EQ(resp2.results.size(), 1u);
+    EXPECT_EQ(resp2.results[0], 0x0U);
+}
+
+TEST_F(KvProtocolTest, ServerRoundTripLookup)
+{
+    KvLookupEntry e0;
+    e0.key = MakeKey(0x90);
+    KvLookupEntry e1;
+    e1.key = MakeKey(0xA0);
+    KvLookupRequest req;
+    req.opcode = KvOpcode::Lookup;
+    req.resp_addr = 0x0E0E0E0E0E0E0E0EULL;
+    req.batch_size = 2;
+    req.entries = {e0, e1};
+
+    // client packs
+    std::vector<std::uint8_t> packed(mgr_.GetPackedSize(req.opcode, req), 0);
+    ASSERT_TRUE(mgr_.PackRequest(packed.data(), req.opcode, req).ok());
+
+    // server verifies + unpacks
+    std::unique_ptr<KvRequest> parsed;
+    ASSERT_TRUE(mgr_.UnpackRequest(packed.data(), packed.size(), parsed).ok());
+    auto& lk = static_cast<KvLookupRequest&>(*parsed);
+    EXPECT_EQ(lk.opcode, req.opcode);
+    EXPECT_EQ(lk.resp_addr, req.resp_addr);
+    EXPECT_EQ(lk.batch_size, req.batch_size);
+    EXPECT_EQ(std::memcmp(lk.entries[0].key.data(), e0.key.data(), kKvKeySize), 0);
+    EXPECT_EQ(std::memcmp(lk.entries[1].key.data(), e1.key.data(), kKvKeySize), 0);
+
+    // server packs the single idx response, client unpacks it
+    KvResponse resp;
+    resp.results = {0xCAFEBABEU};
+    std::uint8_t flag[kKvFlagEntrySize] = {0};
+    ASSERT_TRUE(mgr_.PackResponse(flag, req.opcode, resp).ok());
+    KvResponse resp2;
+    ASSERT_TRUE(mgr_.UnpackResponse(flag, req.opcode, 1, resp2).ok());
+    ASSERT_EQ(resp2.results.size(), 1u);
+    EXPECT_EQ(resp2.results[0], 0xCAFEBABEU);
+}
+
+// ---------------------------------------------------------------------------
+// Boundary values: every field set to max
+// ---------------------------------------------------------------------------
+
+TEST_F(KvProtocolTest, DumpLoadMaxFieldValuesRoundTrip)
+{
+    KvDumpLoadEntry entry;
+    entry.key.fill(0xFF);
+    entry.addr = 0xFFFFFFFFFFFFFFFFULL;
+    entry.len = 0xFFFFFFFFU;
+    entry.idx = 0xFFFFFFFFU;
+
+    KvDumpLoadRequest req;
+    req.opcode = KvOpcode::Load;
+    req.resp_addr = 0xFFFFFFFFFFFFFFFFULL;
+    req.batch_size = 1;
+    req.entries = {entry};
+
+    std::vector<std::uint8_t> packed(mgr_.GetPackedSize(req.opcode, req), 0);
+    ASSERT_TRUE(mgr_.PackRequest(packed.data(), req.opcode, req).ok());
+
+    std::unique_ptr<KvRequest> parsed;
+    ASSERT_TRUE(mgr_.UnpackRequest(packed.data(), packed.size(), parsed).ok());
+    auto& dl = static_cast<KvDumpLoadRequest&>(*parsed);
+    EXPECT_EQ(dl.resp_addr, 0xFFFFFFFFFFFFFFFFULL);
+    EXPECT_EQ(dl.entries[0].addr, 0xFFFFFFFFFFFFFFFFULL);
+    EXPECT_EQ(dl.entries[0].len, 0xFFFFFFFFU);
+    EXPECT_EQ(dl.entries[0].idx, 0xFFFFFFFFU);
+    EXPECT_EQ(std::memcmp(dl.entries[0].key.data(), entry.key.data(), kKvKeySize), 0);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-entry: batch_size > 1, verify every entry survives the round-trip
+// ---------------------------------------------------------------------------
+
+TEST_F(KvProtocolTest, DumpLoadMultiEntryRoundTrip)
+{
+    constexpr std::uint16_t kBatch = 5;
+    KvDumpLoadRequest req;
+    req.opcode = KvOpcode::Dump;
+    req.resp_addr = 0xA5A5A5A5A5A5A5A5ULL;
+    req.batch_size = kBatch;
+    for (std::uint16_t i = 0; i < kBatch; ++i) {
+        KvDumpLoadEntry e;
+        e.key = MakeKey(static_cast<std::uint8_t>(i * 0x10));
+        e.addr = 0x1000ULL * (i + 1);
+        e.len = 0x200U * (i + 1);
+        e.idx = i;
+        req.entries.push_back(e);
+    }
+
+    std::vector<std::uint8_t> packed(mgr_.GetPackedSize(req.opcode, req), 0);
+    ASSERT_TRUE(mgr_.PackRequest(packed.data(), req.opcode, req).ok());
+
+    std::unique_ptr<KvRequest> parsed;
+    ASSERT_TRUE(mgr_.UnpackRequest(packed.data(), packed.size(), parsed).ok());
+    auto& dl = static_cast<KvDumpLoadRequest&>(*parsed);
+    ASSERT_EQ(dl.entries.size(), kBatch);
+    for (std::uint16_t i = 0; i < kBatch; ++i) {
+        EXPECT_EQ(std::memcmp(dl.entries[i].key.data(), req.entries[i].key.data(), kKvKeySize), 0)
+            << "entry " << i;
+        EXPECT_EQ(dl.entries[i].addr, req.entries[i].addr) << "entry " << i;
+        EXPECT_EQ(dl.entries[i].len, req.entries[i].len) << "entry " << i;
+        EXPECT_EQ(dl.entries[i].idx, req.entries[i].idx) << "entry " << i;
+    }
+}
+
+TEST_F(KvProtocolTest, LookupMultiEntryRoundTrip)
+{
+    constexpr std::uint16_t kBatch = 4;
+    KvLookupRequest req;
+    req.opcode = KvOpcode::Lookup;
+    req.resp_addr = 0xB0B0B0B0B0B0B0B0ULL;
+    req.batch_size = kBatch;
+    for (std::uint16_t i = 0; i < kBatch; ++i) {
+        KvLookupEntry e;
+        e.key = MakeKey(static_cast<std::uint8_t>(0x50 + i));
+        req.entries.push_back(e);
+    }
+
+    std::vector<std::uint8_t> packed(mgr_.GetPackedSize(req.opcode, req), 0);
+    ASSERT_TRUE(mgr_.PackRequest(packed.data(), req.opcode, req).ok());
+
+    std::unique_ptr<KvRequest> parsed;
+    ASSERT_TRUE(mgr_.UnpackRequest(packed.data(), packed.size(), parsed).ok());
+    auto& lk = static_cast<KvLookupRequest&>(*parsed);
+    ASSERT_EQ(lk.entries.size(), kBatch);
+    for (std::uint16_t i = 0; i < kBatch; ++i) {
+        EXPECT_EQ(std::memcmp(lk.entries[i].key.data(), req.entries[i].key.data(), kKvKeySize), 0)
+            << "entry " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// opcode validation
+// ---------------------------------------------------------------------------
+
+TEST_F(KvProtocolTest, RejectsNoneOpcodeOnDumpLoad)
+{
+    KvDumpLoadRequest req;  // opcode defaults to None
+    req.resp_addr = 0x1000;
+    req.batch_size = 1;
+    req.entries = {
+        KvDumpLoadEntry{MakeKey(0x10), 0x2000, 0x100, 0}
+    };
+
+    std::vector<std::uint8_t> buf(mgr_.GetPackedSize(KvOpcode::Dump, req), 0);
+    auto status = mgr_.PackRequest(buf.data(), KvOpcode::None, req);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("opcode"), std::string::npos);
+}
+
+TEST_F(KvProtocolTest, RejectsOpcodeMismatch)
+{
+    KvDumpLoadRequest req;
+    req.opcode = KvOpcode::Lookup;  // wrong opcode for a DumpLoad request
+    req.resp_addr = 0x1000;
+    req.batch_size = 1;
+    req.entries = {
+        KvDumpLoadEntry{MakeKey(0x10), 0x2000, 0x100, 0}
+    };
+
+    std::vector<std::uint8_t> buf(mgr_.GetPackedSize(KvOpcode::Dump, req), 0);
+    auto status = mgr_.PackRequest(buf.data(), KvOpcode::Dump, req);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("opcode"), std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// Server UnpackRequest edge cases (validation is now merged into UnpackRequest)
+// ---------------------------------------------------------------------------
+
+TEST_F(KvProtocolTest, UnpackRequestRejectsUnknownOpcode)
+{
+    std::vector<std::uint8_t> buf(kKvHeaderSize + kKvLookupEntrySize, 0);
+    buf[0] = 0xEE;  // unknown opcode
+    std::unique_ptr<KvRequest> parsed;
+    auto status = mgr_.UnpackRequest(buf.data(), buf.size(), parsed);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("unknown opcode"), std::string::npos);
+}
+
+TEST_F(KvProtocolTest, UnpackRequestRejectsExtraBytes)
+{
+    KvLookupRequest req;
+    req.opcode = KvOpcode::Lookup;
+    req.resp_addr = 0x1000;
+    req.batch_size = 1;
+    req.entries = {KvLookupEntry{MakeKey(0x70)}};
+
+    std::vector<std::uint8_t> packed(mgr_.GetPackedSize(req.opcode, req), 0);
+    ASSERT_TRUE(mgr_.PackRequest(packed.data(), req.opcode, req).ok());
+    packed.push_back(0x00);  // one extra byte
+    std::unique_ptr<KvRequest> parsed;
+    auto status = mgr_.UnpackRequest(packed.data(), packed.size(), parsed);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("size"), std::string::npos);
+}
+
+TEST_F(KvProtocolTest, UnpackRequestRejectsNull)
+{
+    std::unique_ptr<KvRequest> out;
+    auto status = mgr_.UnpackRequest(nullptr, kKvHeaderSize, out);
+    EXPECT_FALSE(status.ok());
+}
+
+TEST_F(KvProtocolTest, UnpackRequestRejectsTooSmall)
+{
+    std::vector<std::uint8_t> buf(kKvHeaderSize - 1, 0);
+    buf[0] = static_cast<std::uint8_t>(KvOpcode::Dump);
+    std::unique_ptr<KvRequest> out;
+    auto status = mgr_.UnpackRequest(buf.data(), buf.size(), out);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("header"), std::string::npos);
+}
+
+TEST_F(KvProtocolTest, UnpackRequestRejectsSizeMismatch)
+{
+    KvDumpLoadRequest req;
+    req.opcode = KvOpcode::Dump;
+    req.resp_addr = 0x1000;
+    req.batch_size = 2;
+    req.entries = {
+        KvDumpLoadEntry{MakeKey(0x10), 0x2000, 0x100, 0},
+        KvDumpLoadEntry{MakeKey(0x20), 0x3000, 0x200, 1}
+    };
+
+    std::vector<std::uint8_t> packed(mgr_.GetPackedSize(req.opcode, req), 0);
+    ASSERT_TRUE(mgr_.PackRequest(packed.data(), req.opcode, req).ok());
+    std::unique_ptr<KvRequest> out;
+    // truncated by 1 byte
+    auto status = mgr_.UnpackRequest(packed.data(), packed.size() - 1, out);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("size"), std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// PackResponse edge cases
+// ---------------------------------------------------------------------------
+
+TEST_F(KvProtocolTest, PackResponseRejectsNullData)
+{
+    KvResponse resp;
+    resp.results = {0x0};
+    auto status = mgr_.PackResponse(nullptr, KvOpcode::Dump, resp);
+    EXPECT_FALSE(status.ok());
+}
+
+TEST_F(KvProtocolTest, PackResponseLookupRejectsWrongCount)
+{
+    KvResponse resp;
+    resp.results = {0x0, 0x1};  // size 2, but Lookup must return exactly 1
+    std::uint8_t flag[2 * kKvFlagEntrySize] = {0};
+    auto status = mgr_.PackResponse(flag, KvOpcode::Lookup, resp);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("must be 1"), std::string::npos);
+}
+
+TEST_F(KvProtocolTest, PackResponseLookupRejectsZeroCount)
+{
+    KvResponse resp;  // empty results
+    std::uint8_t flag[kKvFlagEntrySize] = {0};
+    auto status = mgr_.PackResponse(flag, KvOpcode::Lookup, resp);
+    EXPECT_FALSE(status.ok());
+}
+
+TEST_F(KvProtocolTest, PackResponseDumpLoadZeroErrcodes)
+{
+    KvResponse resp;  // empty, result_count=0
+    std::uint8_t flag[1] = {0xFF};
+    auto status = mgr_.PackResponse(flag, KvOpcode::Dump, resp);
+    EXPECT_TRUE(status.ok());  // 0 errcodes is valid (memcpy 0 bytes)
+}
+
+// ---------------------------------------------------------------------------
+// UnpackResponse edge cases
+// ---------------------------------------------------------------------------
+
+TEST_F(KvProtocolTest, UnpackResponseRejectsNullData)
+{
+    KvResponse resp;
+    auto status = mgr_.UnpackResponse(nullptr, KvOpcode::Dump, 1, resp);
+    EXPECT_FALSE(status.ok());
+}
+
+TEST_F(KvProtocolTest, UnpackResponseLookupRejectsWrongCount)
+{
+    std::uint8_t flag[2 * kKvFlagEntrySize] = {0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00};
+    KvResponse resp;
+    auto status = mgr_.UnpackResponse(flag, KvOpcode::Lookup, 2, resp);
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("result_count"), std::string::npos);
+}
+
+// ---------------------------------------------------------------------------
+// Full response symmetry: PackResponse -> UnpackResponse exact match
+// ---------------------------------------------------------------------------
+
+TEST_F(KvProtocolTest, ResponseSymmetryMultipleErrcodes)
+{
+    KvResponse resp;
+    resp.results = {0x0, 0x1, 0x2, 0xDEADBEEF, 0xFFFFFFFF};
+    constexpr std::uint16_t kCount = 5;
+    std::vector<std::uint8_t> flag(kCount * kKvFlagEntrySize, 0);
+
+    ASSERT_TRUE(mgr_.PackResponse(flag.data(), KvOpcode::Dump, resp).ok());
+    KvResponse resp2;
+    ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), KvOpcode::Dump, kCount, resp2).ok());
+    ASSERT_EQ(resp2.results.size(), kCount);
+    for (std::uint16_t i = 0; i < kCount; ++i) {
+        EXPECT_EQ(resp2.results[i], resp.results[i]) << "result " << i;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Multi-round: same manager handles many sequential operations
+// ---------------------------------------------------------------------------
+
+TEST_F(KvProtocolTest, MultiRoundSequentialPacks)
+{
+    for (std::uint8_t round = 0; round < 10; ++round) {
+        KvDumpLoadRequest req;
+        req.opcode = (round % 2 == 0) ? KvOpcode::Dump : KvOpcode::Load;
+        req.resp_addr = 0x1000ULL * (round + 1);
+        req.batch_size = 1;
+        req.entries = {
+            KvDumpLoadEntry{MakeKey(round), 0x2000ULL * (round + 1), 0x100U * (round + 1), round}
+        };
+
+        std::vector<std::uint8_t> packed(mgr_.GetPackedSize(req.opcode, req), 0);
+        ASSERT_TRUE(mgr_.PackRequest(packed.data(), req.opcode, req).ok()) << "round " << round;
+
+        std::unique_ptr<KvRequest> parsed;
+        ASSERT_TRUE(mgr_.UnpackRequest(packed.data(), packed.size(), parsed).ok())
+            << "round " << round;
+        auto& dl = static_cast<KvDumpLoadRequest&>(*parsed);
+        EXPECT_EQ(dl.opcode, req.opcode) << "round " << round;
+        EXPECT_EQ(dl.resp_addr, req.resp_addr) << "round " << round;
+        EXPECT_EQ(dl.entries[0].idx, round) << "round " << round;
+
+        // response round-trip each iteration
+        KvResponse resp;
+        resp.results = {static_cast<std::uint32_t>(round)};
+        std::uint8_t flag[kKvFlagEntrySize] = {0};
+        ASSERT_TRUE(mgr_.PackResponse(flag, req.opcode, resp).ok()) << "round " << round;
+        KvResponse resp2;
+        ASSERT_TRUE(mgr_.UnpackResponse(flag, req.opcode, 1, resp2).ok()) << "round " << round;
+        EXPECT_EQ(resp2.results[0], static_cast<std::uint32_t>(round)) << "round " << round;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Full client-server round-trip with response values spanning the range
+// ---------------------------------------------------------------------------
+
+TEST_F(KvProtocolTest, LookupIdxFullRangeSymmetry)
+{
+    const std::uint32_t kValues[] = {0x0, 0x1, 0x7FFFFFFF, 0x80000000, 0xDEADBEEF, 0xFFFFFFFF};
+    for (std::uint32_t v : kValues) {
+        KvResponse resp;
+        resp.results = {v};
+        std::uint8_t flag[kKvFlagEntrySize] = {0};
+        ASSERT_TRUE(mgr_.PackResponse(flag, KvOpcode::Lookup, resp).ok());
+        KvResponse resp2;
+        ASSERT_TRUE(mgr_.UnpackResponse(flag, KvOpcode::Lookup, 1, resp2).ok());
+        ASSERT_EQ(resp2.results.size(), 1u);
+        EXPECT_EQ(resp2.results[0], v);
+    }
+}
+
+}  // namespace
+}  // namespace UC::DRAMPOOL


### PR DESCRIPTION
## Purpose
Implement pack/unpack for the DRAM pool KV transport (send + flag buffer), mirroring the ASU architecture.

## Modifications
1. common: shared types, constants, and helpers (PeekOpcode, VerifyHeader, PackHeader, ValidateRequestHeader).
2. client: KvDumpLoadProtocol/KvLookupProtocol + ProtocolManager for PackRequest and UnpackResponse.
3. server: KvDumpLoadServerProtocol/KvLookupServerProtocol + ServerProtocolManager for UnpackRequest (with inline validation) and PackResponse.
4. CMakeLists: drampool_kv_common/client/server lib targets.
5. Tests: 29 cases covering pack/unpack round-trips, boundary values, multi-entry, opcode validation, and edge cases.

## Test
- drampool.test: 29 gtests passing on x64 (MSVC) and aarch64 (GCC 12.3.1).