### PR TITLE
[Fix] add patch fixing SWA block double free && Add fawa metric

### DIFF
--- a/examples/metrics/metrics_configs.yaml
+++ b/examples/metrics/metrics_configs.yaml
@@ -251,3 +251,28 @@ histogram:
   - name: "layerwise_save_tail_total_ms"
     documentation: "Legacy metric; LayerWise no longer waits for dump completion in wait_for_save"
     buckets: [0.1, 0.5, 1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000]
+
+  # =========================================================================
+  # FAWA Connector
+  # =========================================================================
+  # visualize major time span for TTFT
+
+  - name: "fawa_scheduler_lookup_external_hit_blocks_ms"
+    documentation: "store lookup latency"
+    buckets: [1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 30, 40, 50]
+
+  - name: "fawa_scheduler_get_num_new_matched_tokens_ms"
+    documentation: "store lookup latency + generate block hash latency"
+    buckets: [1, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 30, 40, 50]
+
+  - name: "fawa_worker_wait_wait_all_load_task_ms"
+    documentation: "store load latency"
+    buckets: [1, 5, 10, 20, 30, 40, 50, 60, 70, 80, 100, 150, 200, 250, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 800, 850, 900, 950, 1000, 1250, 1500, 1750, 2000]
+
+  - name: "fawa_worker_start_load_kv_ms"
+    documentation: "store load task latency + generate task latency"
+    buckets: [1, 5, 10, 20, 30, 40, 50, 60, 70, 80, 100]
+
+  - name: "fawa_worker_wait_for_save_ms"
+    documentation: "store dump task latency"
+    buckets: [1, 5, 10, 20, 30, 40, 50, 60, 70, 80, 100, 150, 200, 250, 300, 350, 400, 450, 500]

--- a/examples/metrics/metrics_configs.yaml
+++ b/examples/metrics/metrics_configs.yaml
@@ -271,8 +271,9 @@ histogram:
 
   - name: "fawa_worker_start_load_kv_ms"
     documentation: "store load task latency + generate task latency"
-    buckets: [1, 5, 10, 20, 30, 40, 50, 60, 70, 80, 100]
+    buckets: [1, 5, 10, 20, 30, 40, 50, 60, 70, 80, 100, 150, 200, 250, 300, 350, 400, 450, 500, 550, 600, 650, 700, 750, 800, 850, 900, 950, 1000, 1250, 1500, 1750, 2000]
 
   - name: "fawa_worker_wait_for_save_ms"
     documentation: "store dump task latency"
     buckets: [1, 5, 10, 20, 30, 40, 50, 60, 70, 80, 100, 150, 200, 250, 300, 350, 400, 450, 500]
+     

--- a/examples/ucm_config_example.yaml
+++ b/examples/ucm_config_example.yaml
@@ -27,7 +27,7 @@ ucm_connectors:
 # When you use UcmNfsStore, you should set enable_event_sync to false.
 enable_event_sync: true
 # Enable UCM metrics so they can be monitored online via Grafana and Prometheus.
-# metrics_config_path: "/workspace/unified-cache-management/examples/metrics/metrics_configs.yaml"
+metrics_config_path: "/workspace/unified-cache-management/examples/metrics/metrics_configs.yaml"
 
 # Sparse attention configuration
 # ucm_sparse_config:
@@ -56,5 +56,5 @@ use_lite: false
 persist_token_threshold: 0
 
 # Minimum block threshold for loading KV cache.
-# Only when hit blocks num > load_threshold_blocks, kv cache loading behavior can be triggered
-load_threshold_blocks: 1
+# Only when hit blocks num > load_blocks_threshold, kv cache loading behavior can be triggered
+load_blocks_threshold: 1

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -1,8 +1,8 @@
 import copy
 import math
 import os
-from dataclasses import dataclass, field
 import time
+from dataclasses import dataclass, field
 from functools import wraps
 from typing import TYPE_CHECKING, Optional, Sequence, Tuple
 
@@ -19,10 +19,10 @@ from vllm.v1.core.sched.output import SchedulerOutput
 from ucm.integration.vllm.device import create_device
 from ucm.integration.vllm.ucm_connector import UCMDirectConnector
 from ucm.logger import init_logger
+from ucm.shared.metrics import ucmmetrics
 from ucm.sparse.utils import round_up
 from ucm.store.factory_v1 import UcmConnectorFactoryV1
 from ucm.store.ucmstore_v1 import Task, UcmKVStoreBaseV1
-from ucm.shared.metrics import ucmmetrics
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 
 logger = init_logger(__name__)
+
 
 def fawa_latency_metric(metric_name: str, *, ms_threshold: int = 1):
     def decorator(func):
@@ -50,9 +51,11 @@ def fawa_latency_metric(metric_name: str, *, ms_threshold: int = 1):
                             metric_name: duration_ms,
                         }
                     )
+
         return wrapper
 
     return decorator
+
 
 @dataclass(frozen=True)
 class KVCacheGroupMeta:

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
-def fawa_latency_metric(metric_name: str, *, ms_threshold: int):
+def fawa_latency_metric(metric_name: str, *, ms_threshold: int = 1):
     def decorator(func):
         @wraps(func)
         def wrapper(self, *args, **kwargs):

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -2,6 +2,8 @@ import copy
 import math
 import os
 from dataclasses import dataclass, field
+import time
+from functools import wraps
 from typing import TYPE_CHECKING, Optional, Sequence, Tuple
 
 import numpy as np
@@ -20,6 +22,7 @@ from ucm.logger import init_logger
 from ucm.sparse.utils import round_up
 from ucm.store.factory_v1 import UcmConnectorFactoryV1
 from ucm.store.ucmstore_v1 import Task, UcmKVStoreBaseV1
+from ucm.shared.metrics import ucmmetrics
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
@@ -30,6 +33,26 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+def fawa_latency_metric(metric_name: str, *, ms_threshold: int):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(self, *args, **kwargs):
+            if not getattr(self, "_fawa_stats_enabled", True):
+                return func(self, *args, **kwargs)
+            start = time.perf_counter()
+            try:
+                return func(self, *args, **kwargs)
+            finally:
+                duration_ms = (time.perf_counter() - start) * 1e3
+                if duration_ms >= ms_threshold:
+                    ucmmetrics.update_stats(
+                        {
+                            metric_name: duration_ms,
+                        }
+                    )
+        return wrapper
+
+    return decorator
 
 @dataclass(frozen=True)
 class KVCacheGroupMeta:
@@ -308,7 +331,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         # If the number of external hit blocks is small, it's possible that the load overhead is larger than the compute of a few blocks.
         # In that case, we can skip loading and directly compute the missed blocks, which can be faster.
         # This threshold can be tuned based on the performance characteristics of the system.
-        self.load_threshold_blocks = self.launch_config.get("load_threshold_blocks", 0)
+        self.load_blocks_threshold = self.launch_config.get("load_blocks_threshold", 0)
 
         if role == KVConnectorRole.SCHEDULER:
             self.store = self._create_fa_store(None)
@@ -683,6 +706,9 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
             raise RuntimeError(f"Worker FAWA {group_label} layout is empty.")
         return tensor_size_list
 
+    @fawa_latency_metric(
+        "fawa_scheduler_lookup_external_hit_blocks_ms",
+    )
     def _lookup_external_hit_blocks(self, external_keys: list[bytes]) -> int:
         """Find the longest reusable prefix present in both FA and WA stores."""
 
@@ -705,6 +731,9 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                 return hit_blocks
         return 0
 
+    @fawa_latency_metric(
+        "fawa_scheduler_get_num_new_matched_tokens_ms",
+    )
     def get_num_new_matched_tokens(
         self,
         request: "Request",
@@ -743,7 +772,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         if num_total_hit_tokens == request.num_tokens:
             external_hit_tokens -= 1
 
-        if external_hit_blocks <= self.load_threshold_blocks:
+        if external_hit_blocks <= self.load_blocks_threshold:
             external_hit_tokens = 0
             num_total_hit_tokens = num_computed_tokens
             # let wa_hbm_hit_block_num equal to total_hit_block_num,so no need to load external blocks
@@ -1094,6 +1123,9 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         }
         return all_group_vllm_block_ids
 
+    @fawa_latency_metric(
+        "fawa_worker_start_load_kv_ms",
+    )
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
         metadata = self._get_connector_metadata()
         if not isinstance(metadata, UCMFAWAConnectorMetadata):
@@ -1149,9 +1181,18 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                 )
                 self._handle_load_err(request_id)
 
+        self._wait_all_load_task(tasks)
+
+    @fawa_latency_metric(
+        "fawa_worker_wait_wait_all_load_task_ms",
+    )
+    def _wait_all_load_task(self, tasks: list[FAWALoadTask]):
         for load_task in tasks:
             self._wait_load_task(load_task)
 
+    @fawa_latency_metric(
+        "fawa_worker_wait_for_save_ms",
+    )
     def wait_for_save(self) -> None:
         metadata = self._get_connector_metadata()
         if not isinstance(metadata, UCMFAWAConnectorMetadata):

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -970,6 +970,14 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
             key_count=len(keys),
         )
 
+    def _handle_load_err(self, request_id: str):
+        affected_block_ids = self._get_request_all_block_ids(request_id)
+        self._record_load_error(
+            "connector_load_wait_errors_total",
+            affected_block_ids,
+        )
+        self._connector_worker_meta.mark_failed(request_id)
+
     def _wait_load_task(
         self,
         load_task: FAWALoadTask,
@@ -983,12 +991,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                 f"request {load_task.request_id} wait FAWA load "
                 f"task label={load_task.label} error. {type(e).__name__}: {e}"
             )
-            affected_block_ids = self._get_request_all_block_ids(load_task.request_id)
-            self._record_load_error(
-                "connector_load_wait_errors_total",
-                affected_block_ids,
-            )
-            self._connector_worker_meta.mark_failed(load_task.request_id)
+            self._handle_load_err(load_task.request_id)
 
     def get_block_ids_with_load_errors(self) -> set[int]:
         res = self._invalid_block_ids
@@ -1144,11 +1147,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                     f"request {request_id} submit FAWA load task "
                     f"error. {type(e).__name__}: {e}"
                 )
-                affected_block_ids = self._get_request_all_block_ids(request_id)
-                self._record_load_error(
-                    "connector_load_submit_errors_total",
-                    affected_block_ids,
-                )
+                self._handle_load_err(request_id)
 
         for load_task in tasks:
             self._wait_load_task(load_task)

--- a/ucm/integration/vllm/patch/v0202/vllm/load_failure_patch.py
+++ b/ucm/integration/vllm/patch/v0202/vllm/load_failure_patch.py
@@ -16,12 +16,15 @@ def patch_core_sched_scheduler(mod):
         scheduler.Scheduler._update_requests_with_invalid_blocks,
     )
 
+
 # double free patch
 @when_imported("vllm.v1.core.single_type_kv_cache_manager")
 def patch_core_single_type_kv_cache_manager(mod):
     logger.debug(f"Patched {mod} called")
 
-    from ucm.integration.vllm.patch.v0202.vllm.v1.core import single_type_kv_cache_manager
+    from ucm.integration.vllm.patch.v0202.vllm.v1.core import (
+        single_type_kv_cache_manager,
+    )
 
     patch_or_inject(
         mod.SingleTypeKVCacheManager,

--- a/ucm/integration/vllm/patch/v0202/vllm/load_failure_patch.py
+++ b/ucm/integration/vllm/patch/v0202/vllm/load_failure_patch.py
@@ -15,3 +15,16 @@ def patch_core_sched_scheduler(mod):
         "_update_requests_with_invalid_blocks",
         scheduler.Scheduler._update_requests_with_invalid_blocks,
     )
+
+# double free patch
+@when_imported("vllm.v1.core.single_type_kv_cache_manager")
+def patch_core_single_type_kv_cache_manager(mod):
+    logger.debug(f"Patched {mod} called")
+
+    from ucm.integration.vllm.patch.v0202.vllm.v1.core import single_type_kv_cache_manager
+
+    patch_or_inject(
+        mod.Scheduler,
+        "remove_skipped_blocks",
+        single_type_kv_cache_manager.SingleTypeKVCacheManager.remove_skipped_blocks,
+    )

--- a/ucm/integration/vllm/patch/v0202/vllm/load_failure_patch.py
+++ b/ucm/integration/vllm/patch/v0202/vllm/load_failure_patch.py
@@ -24,7 +24,7 @@ def patch_core_single_type_kv_cache_manager(mod):
     from ucm.integration.vllm.patch.v0202.vllm.v1.core import single_type_kv_cache_manager
 
     patch_or_inject(
-        mod.Scheduler,
+        mod.SingleTypeKVCacheManager,
         "remove_skipped_blocks",
         single_type_kv_cache_manager.SingleTypeKVCacheManager.remove_skipped_blocks,
     )

--- a/ucm/integration/vllm/patch/v0202/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/ucm/integration/vllm/patch/v0202/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1,0 +1,69 @@
+from ucm.logger import init_logger
+
+logger = init_logger(__name__)
+
+class SingleTypeKVCacheManager():
+    def remove_skipped_blocks(
+            self, request_id: str, total_computed_tokens: int
+        ) -> None:
+            """
+            Remove and free the blocks that are no longer needed for attention computation.
+            The removed blocks should be replaced by null_block.
+
+            This function depends on `get_num_skipped_tokens`, which need to be implemented
+            differently for each attention type.
+
+            Args:
+                request_id: The request ID.
+                total_computed_tokens: The total number of computed tokens, including
+                    local computed tokens and external computed tokens.
+            """
+            # Remove the blocks that will be skipped during attention computation.
+            num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+            if num_skipped_tokens <= 0:
+                # This indicates that ALL tokens are inside attention window.
+                # Thus we do not need to free any blocks outside attention window.
+                # A typical case is full attention that we never free any token
+                # before the request is finished.
+                return
+            blocks = self.req_to_blocks[request_id]
+            num_skipped_blocks = num_skipped_tokens // self.block_size
+            # `num_skipped_tokens` may include tokens that haven't been allocated yet
+            # (e.g., when the attention window moves into the external computed tokens
+            # range), so we must cap to the number of blocks that currently exist for
+            # this request.
+            num_skipped_blocks = min(num_skipped_blocks, len(blocks))
+            removed_blocks = []
+            # Because the block starts from index 0, the num_skipped_block-th block
+            # corresponds to index num_skipped_blocks - 1.
+            removed_block_ids: set[int] = set()
+            duplicate_removed_block_ids: set[int] = set()
+
+            for i in range(num_skipped_blocks - 1, -1, -1):
+                block = blocks[i]
+                if block == self._null_block:
+                    break
+
+                blocks[i] = self._null_block
+                if block.block_id in removed_block_ids:
+                    duplicate_removed_block_ids.add(block.block_id)
+                    continue
+
+                removed_block_ids.add(block.block_id)
+                removed_blocks.append(block)
+
+            if duplicate_removed_block_ids:
+                logger.warning(
+                    "Duplicate physical KV blocks found in remove_skipped_blocks: "
+                    "request_id=%s, total_computed_tokens=%d, "
+                    "num_skipped_tokens=%d, num_skipped_blocks=%d, "
+                    "duplicate_block_ids=%s",
+                    request_id,
+                    total_computed_tokens,
+                    num_skipped_tokens,
+                    num_skipped_blocks,
+                    sorted(duplicate_removed_block_ids),
+                )
+
+            if removed_blocks:
+                self.block_pool.free_blocks(removed_blocks)

--- a/ucm/integration/vllm/patch/v0202/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/ucm/integration/vllm/patch/v0202/vllm/v1/core/single_type_kv_cache_manager.py
@@ -2,68 +2,69 @@ from ucm.logger import init_logger
 
 logger = init_logger(__name__)
 
-class SingleTypeKVCacheManager():
+
+class SingleTypeKVCacheManager:
     def remove_skipped_blocks(
-            self, request_id: str, total_computed_tokens: int
-        ) -> None:
-            """
-            Remove and free the blocks that are no longer needed for attention computation.
-            The removed blocks should be replaced by null_block.
+        self, request_id: str, total_computed_tokens: int
+    ) -> None:
+        """
+        Remove and free the blocks that are no longer needed for attention computation.
+        The removed blocks should be replaced by null_block.
 
-            This function depends on `get_num_skipped_tokens`, which need to be implemented
-            differently for each attention type.
+        This function depends on `get_num_skipped_tokens`, which need to be implemented
+        differently for each attention type.
 
-            Args:
-                request_id: The request ID.
-                total_computed_tokens: The total number of computed tokens, including
-                    local computed tokens and external computed tokens.
-            """
-            # Remove the blocks that will be skipped during attention computation.
-            num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
-            if num_skipped_tokens <= 0:
-                # This indicates that ALL tokens are inside attention window.
-                # Thus we do not need to free any blocks outside attention window.
-                # A typical case is full attention that we never free any token
-                # before the request is finished.
-                return
-            blocks = self.req_to_blocks[request_id]
-            num_skipped_blocks = num_skipped_tokens // self.block_size
-            # `num_skipped_tokens` may include tokens that haven't been allocated yet
-            # (e.g., when the attention window moves into the external computed tokens
-            # range), so we must cap to the number of blocks that currently exist for
-            # this request.
-            num_skipped_blocks = min(num_skipped_blocks, len(blocks))
-            removed_blocks = []
-            # Because the block starts from index 0, the num_skipped_block-th block
-            # corresponds to index num_skipped_blocks - 1.
-            removed_block_ids: set[int] = set()
-            duplicate_removed_block_ids: set[int] = set()
+        Args:
+            request_id: The request ID.
+            total_computed_tokens: The total number of computed tokens, including
+                local computed tokens and external computed tokens.
+        """
+        # Remove the blocks that will be skipped during attention computation.
+        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        if num_skipped_tokens <= 0:
+            # This indicates that ALL tokens are inside attention window.
+            # Thus we do not need to free any blocks outside attention window.
+            # A typical case is full attention that we never free any token
+            # before the request is finished.
+            return
+        blocks = self.req_to_blocks[request_id]
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        # `num_skipped_tokens` may include tokens that haven't been allocated yet
+        # (e.g., when the attention window moves into the external computed tokens
+        # range), so we must cap to the number of blocks that currently exist for
+        # this request.
+        num_skipped_blocks = min(num_skipped_blocks, len(blocks))
+        removed_blocks = []
+        # Because the block starts from index 0, the num_skipped_block-th block
+        # corresponds to index num_skipped_blocks - 1.
+        removed_block_ids: set[int] = set()
+        duplicate_removed_block_ids: set[int] = set()
 
-            for i in range(num_skipped_blocks - 1, -1, -1):
-                block = blocks[i]
-                if block == self._null_block:
-                    break
+        for i in range(num_skipped_blocks - 1, -1, -1):
+            block = blocks[i]
+            if block == self._null_block:
+                break
 
-                blocks[i] = self._null_block
-                if block.block_id in removed_block_ids:
-                    duplicate_removed_block_ids.add(block.block_id)
-                    continue
+            blocks[i] = self._null_block
+            if block.block_id in removed_block_ids:
+                duplicate_removed_block_ids.add(block.block_id)
+                continue
 
-                removed_block_ids.add(block.block_id)
-                removed_blocks.append(block)
+            removed_block_ids.add(block.block_id)
+            removed_blocks.append(block)
 
-            if duplicate_removed_block_ids:
-                logger.warning(
-                    "Duplicate physical KV blocks found in remove_skipped_blocks: "
-                    "request_id=%s, total_computed_tokens=%d, "
-                    "num_skipped_tokens=%d, num_skipped_blocks=%d, "
-                    "duplicate_block_ids=%s",
-                    request_id,
-                    total_computed_tokens,
-                    num_skipped_tokens,
-                    num_skipped_blocks,
-                    sorted(duplicate_removed_block_ids),
-                )
+        if duplicate_removed_block_ids:
+            logger.warning(
+                "Duplicate physical KV blocks found in remove_skipped_blocks: "
+                "request_id=%s, total_computed_tokens=%d, "
+                "num_skipped_tokens=%d, num_skipped_blocks=%d, "
+                "duplicate_block_ids=%s",
+                request_id,
+                total_computed_tokens,
+                num_skipped_tokens,
+                num_skipped_blocks,
+                sorted(duplicate_removed_block_ids),
+            )
 
-            if removed_blocks:
-                self.block_pool.free_blocks(removed_blocks)
+        if removed_blocks:
+            self.block_pool.free_blocks(removed_blocks)


### PR DESCRIPTION
 ## Purpose

  Improve FAWA/HMA observability and stability in vLLM integration, especially around KV load latency tracking, load-threshold control, and SWA skipped-block cleanup.

  ## Modifications

  - Add FAWA latency metrics for scheduler external-hit lookup, matched-token calculation, worker load start, load-task wait, and save wait.
  - Add corresponding FAWA histogram metric configs in examples/metrics/metrics_configs.yaml.
  - Enable metrics_config_path in the example UCM config.
  - Rename FAWA load threshold config to load_blocks_threshold and use it to skip low-value external KV-cache loads.
  - Centralize FAWA load-error handling so failed requests are marked for recovery.
  - Patch vLLM SingleTypeKVCacheManager.remove_skipped_blocks to avoid double-freeing duplicated physical KV blocks in SWA scenarios.

  ## Test