### PR TITLE
[Opt] change load_blocks_threshold to load_tokens_threshold  and fix duplicated block free

### DIFF
--- a/examples/ucm_config_example.yaml
+++ b/examples/ucm_config_example.yaml
@@ -55,6 +55,6 @@ use_lite: false
 # Requests with fewer tokens skip KV load and dump operations.
 persist_token_threshold: 0
 
-# Minimum block threshold for loading KV cache.
-# Only when hit blocks num > load_blocks_threshold, kv cache loading behavior can be triggered
-load_blocks_threshold: 1
+# Minimum token threshold for loading KV cache.
+# Only when external hit tokens num > load_tokens_threshold, kv cache loading behavior can be triggered
+load_tokens_threshold: 2048

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -334,7 +334,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         # If the number of external hit blocks is small, it's possible that the load overhead is larger than the compute of a few blocks.
         # In that case, we can skip loading and directly compute the missed blocks, which can be faster.
         # This threshold can be tuned based on the performance characteristics of the system.
-        self.load_blocks_threshold = self.launch_config.get("load_blocks_threshold", 0)
+        self.load_tokens_threshold = self.launch_config.get("load_tokens_threshold", 0)
 
         if role == KVConnectorRole.SCHEDULER:
             self.store = self._create_fa_store(None)
@@ -745,12 +745,14 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         wa_hbm_hit_block_num = num_computed_tokens // self.hash_block_size
         wa_computed_tokens = wa_hbm_hit_block_num * self.hash_block_size
 
+        if (
+            request.num_tokens <= self.persist_token_threshold
+            or request.num_tokens <= (wa_computed_tokens + self.load_tokens_threshold)
+        ):
+            return 0, False
         canonical_hashes = self.generate_hash(
             self.hash_block_size, request.all_token_ids, self._seed
         )
-
-        if self.persist_token_threshold > request.num_tokens:
-            return 0, False
 
         external_keys = canonical_hashes[wa_hbm_hit_block_num:]
         if not external_keys:
@@ -775,7 +777,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         if num_total_hit_tokens == request.num_tokens:
             external_hit_tokens -= 1
 
-        if external_hit_blocks <= self.load_blocks_threshold:
+        if external_hit_blocks * self.hash_block_size <= self.load_tokens_threshold:
             external_hit_tokens = 0
             num_total_hit_tokens = num_computed_tokens
             # let wa_hbm_hit_block_num equal to total_hit_block_num,so no need to load external blocks

--- a/ucm/integration/vllm/patch/v0202/vllm/load_failure_patch.py
+++ b/ucm/integration/vllm/patch/v0202/vllm/load_failure_patch.py
@@ -31,3 +31,9 @@ def patch_core_single_type_kv_cache_manager(mod):
         "remove_skipped_blocks",
         single_type_kv_cache_manager.SingleTypeKVCacheManager.remove_skipped_blocks,
     )
+
+    patch_or_inject(
+        mod.SingleTypeKVCacheManager,
+        "free",
+        single_type_kv_cache_manager.SingleTypeKVCacheManager.free,
+    )

--- a/ucm/integration/vllm/patch/v0202/vllm/v1/core/sched/scheduler.py
+++ b/ucm/integration/vllm/patch/v0202/vllm/v1/core/sched/scheduler.py
@@ -103,7 +103,7 @@ class Scheduler:
                         request.num_computed_tokens - req_num_computed_tokens
                     )
                     request.num_computed_tokens = req_num_computed_tokens
-                
+
                 affected_req_ids.add(request.request_id)
 
         return affected_req_ids, total_affected_tokens, blocks_to_evict

--- a/ucm/integration/vllm/patch/v0202/vllm/v1/core/sched/scheduler.py
+++ b/ucm/integration/vllm/patch/v0202/vllm/v1/core/sched/scheduler.py
@@ -103,10 +103,7 @@ class Scheduler:
                         request.num_computed_tokens - req_num_computed_tokens
                     )
                     request.num_computed_tokens = req_num_computed_tokens
-                """UCM patch for HMA start"""
-                # reset num_output_placeholders to 0 for affected requests, so that they can be properly rescheduled and avoid hanging due to KV load failure
-                request.num_output_placeholders = 0
-                """UCM patch for HMA end"""
+                
                 affected_req_ids.add(request.request_id)
 
         return affected_req_ids, total_affected_tokens, blocks_to_evict

--- a/ucm/integration/vllm/patch/v0202/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/ucm/integration/vllm/patch/v0202/vllm/v1/core/single_type_kv_cache_manager.py
@@ -21,7 +21,7 @@ class SingleTypeKVCacheManager:
 
         for block in reversed(req_blocks):
             if block in seen_blocks:
-                logger.warning(
+                logger.warning_once(
                     f"request_id {request_id} free duplicate physical KV blocks in self.kv_cache_group_id {self.kv_cache_group_id}"
                 )
                 continue

--- a/ucm/integration/vllm/patch/v0202/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/ucm/integration/vllm/patch/v0202/vllm/v1/core/single_type_kv_cache_manager.py
@@ -20,12 +20,12 @@ class SingleTypeKVCacheManager:
         ordered_blocks = []
 
         for block in reversed(req_blocks):
-            if block in seen_blocks:
+            if block.block_id in seen_blocks:
                 logger.warning_once(
                     f"request_id {request_id} free duplicate physical KV blocks in self.kv_cache_group_id {self.kv_cache_group_id}"
                 )
                 continue
-            seen_blocks.add(block)
+            seen_blocks.add(block.block_id)
             ordered_blocks.append(block)
 
         self.block_pool.free_blocks(ordered_blocks)

--- a/ucm/integration/vllm/patch/v0202/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/ucm/integration/vllm/patch/v0202/vllm/v1/core/single_type_kv_cache_manager.py
@@ -4,6 +4,30 @@ logger = init_logger(__name__)
 
 
 class SingleTypeKVCacheManager:
+    def free(self, request_id: str) -> None:
+        """
+        Free the blocks for the request.
+
+        Args:
+            request_id: The request ID.
+        """
+        # Default to [] in case a request is freed (aborted) before alloc.
+        req_blocks = self.req_to_blocks.pop(request_id, [])
+
+        # Free blocks in reverse order so that the tail blocks are freed first.
+        # Deduplicate while preserving reverse order.
+        seen_blocks = set()
+        ordered_blocks = []
+
+        for block in reversed(req_blocks):
+            if block in seen_blocks:
+                continue
+            seen_blocks.add(block)
+            ordered_blocks.append(block)
+
+        self.block_pool.free_blocks(ordered_blocks)
+        self.num_cached_block.pop(request_id, None)
+
     def remove_skipped_blocks(
         self, request_id: str, total_computed_tokens: int
     ) -> None:

--- a/ucm/integration/vllm/patch/v0202/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/ucm/integration/vllm/patch/v0202/vllm/v1/core/single_type_kv_cache_manager.py
@@ -21,6 +21,9 @@ class SingleTypeKVCacheManager:
 
         for block in reversed(req_blocks):
             if block in seen_blocks:
+                logger.warning(
+                    f"request_id {request_id} free duplicate physical KV blocks in self.kv_cache_group_id {self.kv_cache_group_id}"
+                )
                 continue
             seen_blocks.add(block)
             ordered_blocks.append(block)


### PR DESCRIPTION
## Purpose

  Improve FAWA KV-cache load decision logic and fix duplicated block free handling in the vLLM 0.20.2 SingleTypeKVCacheManager patch.

  ## Modifications

  - Replace load_blocks_threshold with token-based load_tokens_threshold.
  - Update the example config to use load_tokens_threshold: 2048.
  - Skip external KV-cache lookup/load when the request does not exceed the configured token threshold.
  - Compare external hit size by tokens instead of block count before deciding whether to load KV cache.
  - Patch SingleTypeKVCacheManager.free() to deduplicate request blocks before freeing them.
  - Keep the existing remove_skipped_blocks() patch and extend the import hook to inject the new free() implementation.