### PR TITLE
[Feat] Adapt ASU client transport registration

### DIFF
--- a/ucm/transport/kv/asu/CMakeLists.txt
+++ b/ucm/transport/kv/asu/CMakeLists.txt
@@ -41,6 +41,10 @@ endif()
 message(STATUS "ASU ASCEND include: ${ASU_ASCEND_INCLUDE_DIR}")
 message(STATUS "ASU ASCENDCL lib: ${ASU_ASCENDCL_LIB}")
 
+option(BUILD_UCM_ASU_PROVIDER_AICPU "Build ASU AICPU trans provider" OFF)
+option(BUILD_UCM_ASU_PROVIDER_FAKE "Build ASU fake trans provider" ON)
+option(BUILD_UCM_ASU_PROVIDER_AIV "Build ASU AIV trans provider (requires external libumc.a)" OFF)
+
 add_library(asu_ascend_deps INTERFACE)
 target_include_directories(asu_ascend_deps INTERFACE ${ASU_ASCEND_INCLUDE_DIR})
 target_link_libraries(asu_ascend_deps INTERFACE ${ASU_ASCENDCL_LIB})
@@ -75,9 +79,15 @@ target_link_libraries(asu_transport
         asu_ascend_deps
 )
 
-option(BUILD_UCM_ASU_AIV "Enable AIV transport backend (requires external libumc.a)" OFF)
+if(BUILD_UCM_ASU_PROVIDER_AICPU)
+    target_compile_definitions(asu_transport PRIVATE UCM_ASU_ENABLE_AICPU_PROVIDER=1)
+endif()
 
-if(BUILD_UCM_ASU_AIV)
+if(BUILD_UCM_ASU_PROVIDER_FAKE)
+    target_compile_definitions(asu_transport PRIVATE UCM_ASU_ENABLE_FAKE_PROVIDER=1)
+endif()
+
+if(BUILD_UCM_ASU_PROVIDER_AIV)
     if(NOT DEFINED ASU_AIV_PROVIDER_ROOT)
         if(DEFINED ENV{ASU_AIV_PROVIDER_ROOT})
             set(ASU_AIV_PROVIDER_ROOT "$ENV{ASU_AIV_PROVIDER_ROOT}" CACHE PATH "Install prefix of libumc.a")
@@ -98,8 +108,8 @@ if(BUILD_UCM_ASU_AIV)
     endif()
 
     message(STATUS "ASU AIV provider lib: ${ASU_AIV_PROVIDER_LIB}")
-    target_link_libraries(asu_transport PRIVATE ${ASU_AIV_PROVIDER_LIB} dl)
-    target_compile_definitions(asu_transport PRIVATE UCM_ASU_ENABLE_AIV)
+    target_link_libraries(asu_transport PRIVATE ${ASU_AIV_PROVIDER_LIB} ${CMAKE_DL_LIBS})
+    target_compile_definitions(asu_transport PRIVATE UCM_ASU_ENABLE_AIV_PROVIDER=1)
 endif()
 
 file(GLOB ASU_CLIENT_SOURCES CONFIGURE_DEPENDS client/src/*.cpp)

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -342,7 +342,12 @@ Status AsuClientImpl::RegisterRegionsOnce(const std::vector<MemoryRegion>& regio
     for (std::size_t index = 0; index < regions.size(); ++index) {
         RegisteredMemory registeredRegion;
         registeredRegion.region = regions[index];
-        if (index < results.size()) { registeredRegion.handle = results[index].handle; }
+        if (index < results.size()) {
+            registeredRegion.handle = results[index].handle;
+            registeredRegion.lkey = results[index].lkey;
+            registeredRegion.rkey = results[index].rkey;
+            registeredRegion.tokenId = results[index].tokenId;
+        }
         registeredRegions.emplace_back(registeredRegion);
     }
 
@@ -899,6 +904,9 @@ Status AsuClientImpl::BindRegisteredResources(AsuId asuId,
         RegisteredMemory registeredRegion;
         registeredRegion.region = resource.region;
         registeredRegion.handle = resource.result.handle;
+        registeredRegion.lkey = resource.result.lkey;
+        registeredRegion.rkey = resource.result.rkey;
+        registeredRegion.tokenId = resource.result.tokenId;
         registeredRegions.emplace_back(registeredRegion);
     }
 

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -336,18 +336,23 @@ Status AsuClientImpl::RegisterRegionsOnce(const std::vector<MemoryRegion>& regio
         return WithContext(status, "asuIndex=0 asuId=" + std::to_string(snapshot->asuIds.front()) +
                                        " region_count=" + std::to_string(regions.size()));
     }
+    if (results.size() != regions.size()) {
+        return WithContext(Status::Error(StatusCode::INTERNAL_ERROR,
+                                         "register result count does not match region count"),
+                           "asuIndex=0 asuId=" + std::to_string(snapshot->asuIds.front()) +
+                               " region_count=" + std::to_string(regions.size()) +
+                               " result_count=" + std::to_string(results.size()));
+    }
 
     std::vector<RegisteredMemory> registeredRegions;
     registeredRegions.reserve(regions.size());
     for (std::size_t index = 0; index < regions.size(); ++index) {
         RegisteredMemory registeredRegion;
         registeredRegion.region = regions[index];
-        if (index < results.size()) {
-            registeredRegion.handle = results[index].handle;
-            registeredRegion.lkey = results[index].lkey;
-            registeredRegion.rkey = results[index].rkey;
-            registeredRegion.tokenId = results[index].tokenId;
-        }
+        registeredRegion.handle = results[index].handle;
+        registeredRegion.lkey = results[index].lkey;
+        registeredRegion.rkey = results[index].rkey;
+        registeredRegion.tokenId = results[index].tokenId;
         registeredRegions.emplace_back(registeredRegion);
     }
 
@@ -372,12 +377,20 @@ Status AsuClientImpl::RegisterRegionsOnce(const std::vector<MemoryRegion>& regio
                             "asuIndex=" + std::to_string(asuIndex) +
                                 " asuId=" + std::to_string(snapshot->asuIds[asuIndex]) +
                                 " region_count=" + std::to_string(registeredRegions.size()));
+        } else if (status.ok() && childResults.size() != registeredRegions.size() &&
+                   finalStatus.ok()) {
+            finalStatus =
+                WithContext(PartialFailed("one or more asu region bindings failed"),
+                            "asuIndex=" + std::to_string(asuIndex) +
+                                " asuId=" + std::to_string(snapshot->asuIds[asuIndex]) +
+                                " region_count=" + std::to_string(registeredRegions.size()) +
+                                " result_count=" + std::to_string(childResults.size()));
         }
     }
 
     if (finalStatus.ok()) {
         std::lock_guard<std::mutex> lock{mutex_};
-        for (std::size_t index = 0; index < regions.size() && index < results.size(); ++index) {
+        for (std::size_t index = 0; index < regions.size(); ++index) {
             registeredResources_.emplace_back(RegisteredResource{regions[index], results[index]});
         }
     }

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -1076,4 +1076,20 @@ std::unique_ptr<AsuClient> CreateAsuClient(TransportFactory transportFactory)
     return std::make_unique<AsuClientImpl>(std::move(transportFactory), nullptr);
 }
 
+extern "C" std::unique_ptr<AsuClient> UcmAsuCreateAsuClient(
+    const TransportFactory* transportFactory)
+{
+    if (transportFactory == nullptr) { return CreateAsuClient(); }
+    return CreateAsuClient(*transportFactory);
+}
+
+extern "C" Status UcmAsuLoadAsuClientConfig(const char* configPath, AsuClientConfig* config)
+{
+    if (configPath == nullptr || config == nullptr) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "UcmAsuLoadAsuClientConfig received null argument");
+    }
+    return LoadAsuClientConfig(configPath, *config);
+}
+
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
@@ -56,6 +56,7 @@ struct TestState {
     std::unordered_map<AsuId, QueryResult> prefixQueryResults;
     std::vector<AsuId> registerCalls;
     std::vector<AsuId> bindCalls;
+    std::unordered_map<AsuId, std::vector<RegisteredMemory>> boundRegions;
     std::vector<AsuId> unregisterCalls;
     std::vector<AsuId> queryCalls;
     std::unordered_map<AsuId, std::size_t> queryKeyCounts;
@@ -217,7 +218,8 @@ public:
         state_->registerCalls.emplace_back(config_.asuId);
         results.clear();
         for (std::size_t index = 0; index < regions.size(); ++index) {
-            results.emplace_back(RegisterResult{Status::OK(), 500 + index});
+            results.emplace_back(RegisterResult{Status::OK(), 500 + index, 0, 0,
+                                                900 + static_cast<std::uint32_t>(index)});
         }
         return Status::OK();
     }
@@ -226,9 +228,11 @@ public:
                                  std::vector<RegisterResult>& results) override
     {
         state_->bindCalls.emplace_back(config_.asuId);
+        state_->boundRegions[config_.asuId] = regions;
         results.clear();
         for (const auto& region : regions) {
-            results.emplace_back(RegisterResult{Status::OK(), region.handle});
+            results.emplace_back(RegisterResult{Status::OK(), region.handle, region.lkey,
+                                                region.rkey, region.tokenId});
         }
         return Status::OK();
     }
@@ -981,6 +985,15 @@ TEST(AsuClientImplTest, MemoryRegister_RegisterRegionsRegistersFirstTransportAnd
     ASSERT_EQ(results.size(), std::size_t{2});
     EXPECT_EQ(results[0].handle, MRHandle{500});
     EXPECT_EQ(results[1].handle, MRHandle{501});
+    EXPECT_EQ(results[0].tokenId, std::uint32_t{900});
+    EXPECT_EQ(results[1].tokenId, std::uint32_t{901});
+    ASSERT_EQ(state->boundRegions[20].size(), std::size_t{2});
+    EXPECT_EQ(state->boundRegions[20][0].handle, MRHandle{500});
+    EXPECT_EQ(state->boundRegions[20][0].tokenId, std::uint32_t{900});
+    EXPECT_EQ(state->boundRegions[20][1].handle, MRHandle{501});
+    EXPECT_EQ(state->boundRegions[20][1].tokenId, std::uint32_t{901});
+    ASSERT_EQ(state->boundRegions[30].size(), std::size_t{2});
+    EXPECT_EQ(state->boundRegions[30][0].tokenId, std::uint32_t{900});
 }
 
 TEST(AsuClientImplTest, MemoryRegister_FirstRegisterFailureIncludesAsuContext)
@@ -1464,6 +1477,9 @@ TEST(AsuClientImplTest, SnapshotRefresh_ReusesExistingTransportAndBindsResources
     ASSERT_TRUE(client->Shutdown().ok());
     EXPECT_EQ(state->createdTransports, std::uint32_t{2});
     EXPECT_EQ(state->bindCalls, std::vector<AsuId>({20}));
+    ASSERT_EQ(state->boundRegions[20].size(), std::size_t{1});
+    EXPECT_EQ(state->boundRegions[20][0].handle, MRHandle{500});
+    EXPECT_EQ(state->boundRegions[20][0].tokenId, std::uint32_t{900});
 }
 
 TEST(AsuClientImplTest,

--- a/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
@@ -1093,6 +1093,40 @@ TEST(AsuClientImplTest, MemoryRegister_FirstRegisterFailureIncludesAsuContext)
     EXPECT_EQ(state->createdTransports, std::uint32_t{2});
 }
 
+TEST(AsuClientImplTest, MemoryRegister_SuccessWithMismatchedResultCountReturnsInternalError)
+{
+    class MismatchedRegisterTransport final : public FakeTransport {
+    public:
+        explicit MismatchedRegisterTransport(std::shared_ptr<TestState> state)
+            : FakeTransport(std::move(state))
+        {
+        }
+
+        Status RegisterRegions(const std::vector<MemoryRegion>&,
+                               std::vector<RegisterResult>& results) override
+        {
+            results.clear();
+            return Status::OK();
+        }
+    };
+
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient([state] {
+        ++state->createdTransports;
+        return std::unique_ptr<AsuTransport>(new MismatchedRegisterTransport(state));
+    });
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
+
+    std::vector<RegisterResult> results;
+    auto status = client->RegisterRegions({MemoryRegion{}}, results);
+
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("asuIndex=0"), std::string::npos);
+    EXPECT_NE(status.message.find("region_count=1"), std::string::npos);
+    EXPECT_NE(status.message.find("result_count=0"), std::string::npos);
+    EXPECT_TRUE(state->bindCalls.empty());
+}
+
 TEST(AsuClientImplTest, MemoryRegister_BindFailureIncludesAsuContext)
 {
     class FailingBindTransport final : public FakeTransport {
@@ -1126,6 +1160,42 @@ TEST(AsuClientImplTest, MemoryRegister_BindFailureIncludesAsuContext)
     EXPECT_NE(status.message.find("asuIndex=1"), std::string::npos);
     EXPECT_NE(status.message.find("asuId=20"), std::string::npos);
     EXPECT_NE(status.message.find("region_count=1"), std::string::npos);
+}
+
+TEST(AsuClientImplTest, MemoryRegister_SuccessfulBindWithMismatchedResultCountFails)
+{
+    class MismatchedBindTransport final : public FakeTransport {
+    public:
+        explicit MismatchedBindTransport(std::shared_ptr<TestState> state)
+            : FakeTransport(std::move(state))
+        {
+        }
+
+        Status BindRegisteredRegions(const std::vector<RegisteredMemory>&,
+                                     std::vector<RegisterResult>& results) override
+        {
+            results.clear();
+            return Status::OK();
+        }
+    };
+
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient([state] {
+        ++state->createdTransports;
+        if (state->createdTransports == 2) {
+            return std::unique_ptr<AsuTransport>(new MismatchedBindTransport(state));
+        }
+        return std::unique_ptr<AsuTransport>(new FakeTransport(state));
+    });
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
+
+    std::vector<RegisterResult> results;
+    auto status = client->RegisterRegions({MemoryRegion{}}, results);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_NE(status.message.find("asuIndex=1"), std::string::npos);
+    EXPECT_NE(status.message.find("region_count=1"), std::string::npos);
+    EXPECT_NE(status.message.find("result_count=0"), std::string::npos);
 }
 
 TEST(AsuClientImplTest, MemoryRegister_BindFailureDoesNotCacheResource)

--- a/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
@@ -996,6 +996,60 @@ TEST(AsuClientImplTest, MemoryRegister_RegisterRegionsRegistersFirstTransportAnd
     EXPECT_EQ(state->boundRegions[30][0].tokenId, std::uint32_t{900});
 }
 
+TEST(AsuClientImplTest, MemoryRegister_PartialRegisterFailureDoesNotBindFollowers)
+{
+    class PartialRegisterTransport final : public FakeTransport {
+    public:
+        explicit PartialRegisterTransport(std::shared_ptr<TestState> state)
+            : FakeTransport(state), state_(std::move(state))
+        {
+        }
+
+        Status RegisterRegions(const std::vector<MemoryRegion>& regions,
+                               std::vector<RegisterResult>& results) override
+        {
+            state_->registerCalls.emplace_back(10);
+            results.clear();
+            results.reserve(regions.size());
+            if (!regions.empty()) {
+                results.emplace_back(RegisterResult{Status::OK(), 500, 0, 0, 900});
+            }
+            if (regions.size() > 1) {
+                results.emplace_back(RegisterResult{
+                    Status::Error(StatusCode::INTERNAL_ERROR, "fake region register failure"),
+                    kInvalidMRHandle});
+            }
+            return Status::Error(StatusCode::PARTIAL_FAILED,
+                                 "one or more memory regions failed to register");
+        }
+
+    private:
+        std::shared_ptr<TestState> state_;
+    };
+
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient([state] {
+        ++state->createdTransports;
+        if (state->createdTransports == 1) {
+            return std::unique_ptr<AsuTransport>(new PartialRegisterTransport(state));
+        }
+        return std::unique_ptr<AsuTransport>(new FakeTransport(state));
+    });
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
+
+    std::vector<RegisterResult> results;
+    auto status = client->RegisterRegions({MemoryRegion{}, MemoryRegion{}}, results);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_NE(status.message.find("asuIndex=0"), std::string::npos);
+    EXPECT_NE(status.message.find("asuId=10"), std::string::npos);
+    EXPECT_EQ(state->registerCalls, std::vector<AsuId>({10}));
+    EXPECT_TRUE(state->bindCalls.empty());
+    ASSERT_EQ(results.size(), std::size_t{2});
+    EXPECT_TRUE(results[0].status.ok()) << results[0].status.message;
+    EXPECT_EQ(results[1].status.code, StatusCode::INTERNAL_ERROR);
+}
+
 TEST(AsuClientImplTest, MemoryRegister_FirstRegisterFailureIncludesAsuContext)
 {
     class FailingRegisterTransport final : public FakeTransport {

--- a/ucm/transport/kv/asu/common/config_parser_common.cpp
+++ b/ucm/transport/kv/asu/common/config_parser_common.cpp
@@ -173,7 +173,8 @@ bool ApplyTransportProviderConfigField(TransportConfig& config, const std::strin
                                        const std::string& value)
 {
     if (key == "providerBackend" || key == "provider_backend" || key == "transProviderBackend" ||
-        key == "trans_provider_backend") {
+        key == "trans_provider_backend" || key == "providerType" || key == "provider_type" ||
+        key == "transProviderType" || key == "trans_provider_type") {
         config.providerType = ParseConfigTransProviderType(value);
     } else {
         return false;

--- a/ucm/transport/kv/asu/test/case/buffer_manager_test.cc
+++ b/ucm/transport/kv/asu/test/case/buffer_manager_test.cc
@@ -399,6 +399,7 @@ public:
     bool failGetToken = false;
     MemType lastMemType = MemType::MEM_HOST;
     uintptr_t lastAddr = 0;
+    uintptr_t lastLocalAddr = 0;
     size_t lastSize = 0;
 
     Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t, uint32_t,
@@ -421,6 +422,7 @@ public:
         if (!descs.empty()) {
             lastMemType = descs[0].memoryType;
             lastAddr = descs[0].addr;
+            lastLocalAddr = descs[0].localAddr;
             lastSize = descs[0].size;
         }
         if (failRegister) {
@@ -459,6 +461,7 @@ TEST_F(BufferManagerTest, InitWithProviderRegistersMemory)
     ASSERT_EQ(provider.registerCount, 1);
     ASSERT_EQ(provider.lastMemType, TransProvider::MemType::MEM_HOST);
     ASSERT_NE(provider.lastAddr, 0);
+    ASSERT_EQ(provider.lastLocalAddr, provider.lastAddr);
     ASSERT_EQ(provider.lastSize, 1024 * 10);
     ASSERT_EQ(mgr.GetTokenId(), 42);
 
@@ -484,6 +487,7 @@ TEST_F(BufferManagerTest, HostPinnedRegistersDeviceAddress)
     ASSERT_NE(sge.local_addr, sge.device_addr);
     ASSERT_EQ(sge.local_addr % 4096, 0);
     ASSERT_EQ(provider.lastAddr, sge.device_addr);
+    ASSERT_EQ(provider.lastLocalAddr, sge.local_addr);
 
     // The CPU writes through addr while HCOMM and remote RDMA use device_addr.
     std::memset(reinterpret_cast<void*>(sge.local_addr), 0x5A, sge.length);

--- a/ucm/transport/kv/asu/trans/include/asu_transport/types.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/types.h
@@ -170,6 +170,7 @@ struct RegisteredMemory {  // 用于绑定已注册的内存
     MRHandle handle{kInvalidMRHandle};
     std::uint32_t lkey{0};
     std::uint32_t rkey{0};
+    std::uint32_t tokenId{0};
 };
 
 struct TaskResult {

--- a/ucm/transport/kv/asu/trans/include/asu_transport/types.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/types.h
@@ -163,6 +163,9 @@ struct KVBuffer {
 struct RegisterResult {
     Status status;
     MRHandle handle{kInvalidMRHandle};
+    std::uint32_t lkey{0};
+    std::uint32_t rkey{0};
+    std::uint32_t tokenId{0};
 };
 
 struct RegisteredMemory {  // 用于绑定已注册的内存

--- a/ucm/transport/kv/asu/trans/src/aiv_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/aiv_trans_provider.h
@@ -29,9 +29,9 @@
 
 namespace UC::ASU {
 
-class AIVTransProvider : public TransProvider {
+class AIVTransProviderAdapter : public TransProvider {
 public:
-    AIVTransProvider() : impl_(CreateAIVTransProvider()) {}
+    AIVTransProviderAdapter() : impl_(CreateAIVTransProvider()) {}
 
     Status CreateConnection(const std::string& localIp, const std::string& remoteIp, uint32_t port,
                             uint32_t qpNum, uint32_t timeout,

--- a/ucm/transport/kv/asu/trans/src/aiv_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/aiv_trans_provider.h
@@ -98,16 +98,16 @@ public:
     }
 
 private:
-    static Status FromImpl(const Status& s)
+    static Status FromImpl(const Status& status)
     {
-        return s.ok() ? Status::OK() : Status::Error(s.code, s.message);
+        return status.ok() ? Status::OK() : Status::Error(status.code, status.message);
     }
 
-    static std::vector<Status> FromImpl(const std::vector<Status>& vec)
+    static std::vector<Status> FromImpl(const std::vector<Status>& statuses)
     {
         std::vector<Status> out;
-        out.reserve(vec.size());
-        for (const auto& s : vec) { out.push_back(FromImpl(s)); }
+        out.reserve(statuses.size());
+        for (const auto& status : statuses) { out.push_back(FromImpl(status)); }
         return out;
     }
 

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -352,7 +352,7 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
         regMem.handle = handle;
         regMem.tokenId = tokenId;  // Only UB is supported for the current version.
         registeredRegions_[handle] = regMem;
-        results.emplace_back(RegisterResult{Status::OK(), handle});
+        results.emplace_back(RegisterResult{Status::OK(), handle, 0, 0, tokenId});
     }
     return Status::OK();
 }
@@ -366,7 +366,8 @@ Status AsuTransportImpl::BindRegisteredRegions(const std::vector<RegisteredMemor
     std::lock_guard<std::mutex> lock(registeredRegionsMu_);
     for (const auto& region : regions) {
         registeredRegions_[region.handle] = region;
-        results.emplace_back(RegisterResult{Status::OK(), region.handle});
+        results.emplace_back(
+            RegisterResult{Status::OK(), region.handle, region.lkey, region.rkey, region.tokenId});
     }
     return Status::OK();
 }

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -321,11 +321,37 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
 
     std::lock_guard<std::mutex> lock(registeredRegionsMu_);
     for (const auto& region : regions) {
-        auto handle = nextMrHandle_.fetch_add(1, std::memory_order_relaxed);
-        if (handle == kInvalidMRHandle) {
-            handle = nextMrHandle_.fetch_add(1, std::memory_order_relaxed);
+        const auto memType = region.memoryType == MemoryType::ASCEND_DEVICE
+                                 ? TransProvider::MemType::MEM_DEVICE
+                                 : TransProvider::MemType::MEM_HOST;
+        std::vector<TransProvider::RegisterMemoryDesc> descs{
+            {memType, static_cast<std::uintptr_t>(region.addr),
+             static_cast<std::size_t>(region.size)}
+        };
+        std::vector<TransProvider::MemHandle> memHandles;
+        auto status = transProvider_->RegisterMemory(nullptr, descs, memHandles);
+        if (!status.ok() || memHandles.empty()) {
+            results.emplace_back(RegisterResult{
+                status.ok() ? Status::Error(StatusCode::INTERNAL_ERROR,
+                                            "transport register memory returned no handle")
+                            : status,
+                kInvalidMRHandle});
+            continue;
         }
-        registeredRegions_[handle] = region;
+
+        auto handle = static_cast<MRHandle>(reinterpret_cast<std::uintptr_t>(memHandles[0]));
+        uint32_t tokenId{0};
+        status = transProvider_->GetMemTokenId(memHandles[0], tokenId);
+        if (!status.ok()) {
+            results.emplace_back(RegisterResult{status, kInvalidMRHandle});
+            continue;
+        }
+
+        RegisteredMemory regMem;
+        regMem.region = region;
+        regMem.handle = handle;
+        regMem.tokenId = tokenId;  // Only UB is supported for the current version.
+        registeredRegions_[handle] = regMem;
         results.emplace_back(RegisterResult{Status::OK(), handle});
     }
     return Status::OK();
@@ -339,7 +365,7 @@ Status AsuTransportImpl::BindRegisteredRegions(const std::vector<RegisteredMemor
 
     std::lock_guard<std::mutex> lock(registeredRegionsMu_);
     for (const auto& region : regions) {
-        registeredRegions_[region.handle] = region.region;
+        registeredRegions_[region.handle] = region;
         results.emplace_back(RegisterResult{Status::OK(), region.handle});
     }
     return Status::OK();

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -325,6 +325,11 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
     results.reserve(regions.size());
 
     std::lock_guard<std::mutex> lock(registeredRegionsMu_);
+    bool hasFailure = false;
+    std::vector<MRHandle> registeredHandles;
+    std::vector<TransProvider::UnregisterMemoryDesc> registeredDescs;
+    registeredHandles.reserve(regions.size());
+    registeredDescs.reserve(regions.size());
     for (const auto& region : regions) {
         const auto memType = region.memoryType == MemoryType::ASCEND_DEVICE
                                  ? TransProvider::MemType::MEM_DEVICE
@@ -341,6 +346,7 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
         const auto connectionHandle =
             connectionChannel == nullptr ? nullptr : connectionChannel->GetConnection();
         if (memType == TransProvider::MemType::MEM_DEVICE && connectionHandle == nullptr) {
+            hasFailure = true;
             results.emplace_back(RegisterResult{
                 Status::Error(StatusCode::CONNECTION_ERROR,
                               "transport register device memory requires an active connection"),
@@ -350,6 +356,7 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
 
         auto status = transProvider_->RegisterMemory(connectionHandle, descs, memHandles);
         if (!status.ok() || memHandles.empty()) {
+            hasFailure = true;
             results.emplace_back(RegisterResult{
                 status.ok() ? Status::Error(StatusCode::INTERNAL_ERROR,
                                             "transport register memory returned no handle")
@@ -376,7 +383,19 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
         registeredRegions_[handle] = regMem;
         registeredRegionStates_[handle] =
             RegisteredRegionState{connectionHandle, memHandles[0], std::move(connectionChannel)};
+        registeredHandles.emplace_back(handle);
+        registeredDescs.push_back(
+            TransProvider::UnregisterMemoryDesc{connectionHandle, memHandles[0]});
         results.emplace_back(RegisterResult{Status::OK(), handle, 0, 0, tokenId});
+    }
+    if (hasFailure) {
+        if (!registeredDescs.empty()) { (void)transProvider_->UnregisterMemory(registeredDescs); }
+        for (auto handle : registeredHandles) {
+            registeredRegions_.erase(handle);
+            registeredRegionStates_.erase(handle);
+        }
+        return Status::Error(StatusCode::PARTIAL_FAILED,
+                             "one or more memory regions failed to register");
     }
     return Status::OK();
 }

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -215,6 +215,7 @@ Status AsuTransportImpl::Shutdown()
         }
         registeredRegions_.clear();
         registeredRegionStates_.clear();
+        registeredRegionConnectionLeases_.clear();
     }
     if (connManager_) {
         auto status = connManager_->Shutdown();
@@ -396,8 +397,10 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
         regMem.handle = handle;
         regMem.tokenId = tokenId;  // Only UB is supported for the current version.
         registeredRegions_[handle] = regMem;
-        registeredRegionStates_[handle] =
-            RegisteredRegionState{connectionHandle, memHandles[0], std::move(connectionChannel)};
+        registeredRegionStates_[handle] = RegisteredRegionState{connectionHandle, memHandles[0]};
+        if (connectionChannel != nullptr) {
+            registeredRegionConnectionLeases_[handle] = std::move(connectionChannel);
+        }
         registeredHandles.emplace_back(handle);
         registeredDescs.push_back(
             TransProvider::UnregisterMemoryDesc{connectionHandle, memHandles[0]});
@@ -408,6 +411,7 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
         for (auto handle : registeredHandles) {
             registeredRegions_.erase(handle);
             registeredRegionStates_.erase(handle);
+            registeredRegionConnectionLeases_.erase(handle);
         }
         return Status::Error(StatusCode::PARTIAL_FAILED,
                              "one or more memory regions failed to register");
@@ -452,6 +456,7 @@ Status AsuTransportImpl::UnregisterRegions(const std::vector<MRHandle>& handles)
 
     for (auto handle : handles) { registeredRegions_.erase(handle); }
     for (auto handle : handles) { registeredRegionStates_.erase(handle); }
+    for (auto handle : handles) { registeredRegionConnectionLeases_.erase(handle); }
     return Status::OK();
 }
 

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -112,7 +112,7 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
 #endif
             case TransProviderType::AIV:
 #ifdef UCM_ASU_ENABLE_AIV_PROVIDER
-                transProvider_ = std::make_unique<AIVTransProvider>();
+                transProvider_ = std::make_unique<AIVTransProviderAdapter>();
                 break;
 #else
                 return Status::Error(

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -178,6 +178,7 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
 
 Status AsuTransportImpl::Shutdown()
 {
+    Status finalStatus = Status::OK();
     for (const auto& ctx : taskManager_.GetAll()) {
         if (ctx == nullptr) { continue; }
         std::lock_guard<std::mutex> lock(ctx->waitMu);
@@ -199,16 +200,30 @@ Status AsuTransportImpl::Shutdown()
     }
     {
         std::lock_guard<std::mutex> lock(registeredRegionsMu_);
+        std::vector<TransProvider::UnregisterMemoryDesc> descs;
+        descs.reserve(registeredRegionStates_.size());
+        for (const auto& item : registeredRegionStates_) {
+            const auto& state = item.second;
+            descs.push_back(
+                TransProvider::UnregisterMemoryDesc{state.connectionHandle, state.memHandle});
+        }
+        if (!descs.empty() && transProvider_) {
+            const auto statuses = transProvider_->UnregisterMemory(descs);
+            for (const auto& status : statuses) {
+                if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+            }
+        }
         registeredRegions_.clear();
         registeredRegionStates_.clear();
     }
     if (connManager_) {
-        connManager_->Shutdown();
+        auto status = connManager_->Shutdown();
+        if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
         connManager_.reset();
     }
 
     UC_DEBUG("AsuTransportImpl::Shutdown OK");
-    return Status::OK();
+    return finalStatus;
 }
 
 Status AsuTransportImpl::CheckHealth()

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -329,7 +329,19 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
              static_cast<std::size_t>(region.size)}
         };
         std::vector<TransProvider::MemHandle> memHandles;
-        auto status = transProvider_->RegisterMemory(nullptr, descs, memHandles);
+        const auto connectionHandle =
+            memType == TransProvider::MemType::MEM_DEVICE && connManager_ != nullptr
+                ? connManager_->GetActiveConnectionHandle()
+                : nullptr;
+        if (memType == TransProvider::MemType::MEM_DEVICE && connectionHandle == nullptr) {
+            results.emplace_back(RegisterResult{
+                Status::Error(StatusCode::CONNECTION_ERROR,
+                              "transport register device memory requires an active connection"),
+                kInvalidMRHandle});
+            continue;
+        }
+
+        auto status = transProvider_->RegisterMemory(connectionHandle, descs, memHandles);
         if (!status.ok() || memHandles.empty()) {
             results.emplace_back(RegisterResult{
                 status.ok() ? Status::Error(StatusCode::INTERNAL_ERROR,
@@ -375,6 +387,22 @@ Status AsuTransportImpl::BindRegisteredRegions(const std::vector<RegisteredMemor
 Status AsuTransportImpl::UnregisterRegions(const std::vector<MRHandle>& handles)
 {
     std::lock_guard<std::mutex> lock(registeredRegionsMu_);
+    std::vector<TransProvider::UnregisterMemoryDesc> descs;
+    descs.reserve(handles.size());
+    for (auto handle : handles) {
+        if (handle == kInvalidMRHandle) { continue; }
+        descs.push_back(TransProvider::UnregisterMemoryDesc{
+            nullptr,
+            reinterpret_cast<TransProvider::MemHandle>(static_cast<std::uintptr_t>(handle))});
+    }
+
+    if (!descs.empty()) {
+        const auto statuses = transProvider_->UnregisterMemory(descs);
+        for (const auto& status : statuses) {
+            if (!status.ok()) { return status; }
+        }
+    }
+
     for (auto handle : handles) { registeredRegions_.erase(handle); }
     return Status::OK();
 }

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -197,6 +197,11 @@ Status AsuTransportImpl::Shutdown()
     for (const auto& ctx : taskManager_.GetAll()) {
         if (ctx != nullptr) { (void)taskManager_.Remove(ctx->taskId); }
     }
+    {
+        std::lock_guard<std::mutex> lock(registeredRegionsMu_);
+        registeredRegions_.clear();
+        registeredRegionStates_.clear();
+    }
     if (connManager_) {
         connManager_->Shutdown();
         connManager_.reset();
@@ -329,10 +334,12 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
              static_cast<std::size_t>(region.size)}
         };
         std::vector<TransProvider::MemHandle> memHandles;
-        const auto connectionHandle =
+        auto connectionChannel =
             memType == TransProvider::MemType::MEM_DEVICE && connManager_ != nullptr
-                ? connManager_->GetActiveConnectionHandle()
+                ? connManager_->GetActiveConnection()
                 : nullptr;
+        const auto connectionHandle =
+            connectionChannel == nullptr ? nullptr : connectionChannel->GetConnection();
         if (memType == TransProvider::MemType::MEM_DEVICE && connectionHandle == nullptr) {
             results.emplace_back(RegisterResult{
                 Status::Error(StatusCode::CONNECTION_ERROR,
@@ -355,6 +362,9 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
         uint32_t tokenId{0};
         status = transProvider_->GetMemTokenId(memHandles[0], tokenId);
         if (!status.ok()) {
+            (void)transProvider_->UnregisterMemory({
+                TransProvider::UnregisterMemoryDesc{connectionHandle, memHandles[0]}
+            });
             results.emplace_back(RegisterResult{status, kInvalidMRHandle});
             continue;
         }
@@ -364,6 +374,8 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
         regMem.handle = handle;
         regMem.tokenId = tokenId;  // Only UB is supported for the current version.
         registeredRegions_[handle] = regMem;
+        registeredRegionStates_[handle] =
+            RegisteredRegionState{connectionHandle, memHandles[0], std::move(connectionChannel)};
         results.emplace_back(RegisterResult{Status::OK(), handle, 0, 0, tokenId});
     }
     return Status::OK();
@@ -391,9 +403,10 @@ Status AsuTransportImpl::UnregisterRegions(const std::vector<MRHandle>& handles)
     descs.reserve(handles.size());
     for (auto handle : handles) {
         if (handle == kInvalidMRHandle) { continue; }
-        descs.push_back(TransProvider::UnregisterMemoryDesc{
-            nullptr,
-            reinterpret_cast<TransProvider::MemHandle>(static_cast<std::uintptr_t>(handle))});
+        auto stateIter = registeredRegionStates_.find(handle);
+        if (stateIter == registeredRegionStates_.end()) { continue; }
+        descs.push_back(TransProvider::UnregisterMemoryDesc{stateIter->second.connectionHandle,
+                                                            stateIter->second.memHandle});
     }
 
     if (!descs.empty()) {
@@ -404,6 +417,7 @@ Status AsuTransportImpl::UnregisterRegions(const std::vector<MRHandle>& handles)
     }
 
     for (auto handle : handles) { registeredRegions_.erase(handle); }
+    for (auto handle : handles) { registeredRegionStates_.erase(handle); }
     return Status::OK();
 }
 

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -31,15 +31,19 @@
 #include <string>
 #include <thread>
 #include <utility>
+#ifdef UCM_ASU_ENABLE_AICPU_PROVIDER
 #include "aicpu_trans_provider.h"
-#ifdef UCM_ASU_ENABLE_AIV
+#endif
+#ifdef UCM_ASU_ENABLE_AIV_PROVIDER
 #include "aiv_trans_provider.h"
 #endif
 #include "asu_response_status.h"
 #include "asu_transport/asu_transport.h"
 #include "connection_internal.h"
 #include "connection_manager.h"
+#ifdef UCM_ASU_ENABLE_FAKE_PROVIDER
 #include "fake_trans_provider.h"
+#endif
 #include "logger.h"
 #include "transport_config_parser.h"
 
@@ -88,19 +92,34 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
     if (!transProvider_) {
         switch (config_.providerType) {
             case TransProviderType::AICPU:
+#ifdef UCM_ASU_ENABLE_AICPU_PROVIDER
                 transProvider_ = std::make_unique<AICPUTransProvider>();
                 break;
+#else
+                return Status::Error(
+                    StatusCode::UNSUPPORTED,
+                    "AICPU trans provider is not built; enable BUILD_UCM_ASU_PROVIDER_AICPU");
+#endif
             case TransProviderType::FAKE:
+#ifdef UCM_ASU_ENABLE_FAKE_PROVIDER
                 transProvider_ =
                     std::make_unique<FakeTransProvider>(MakeFakeTransProviderConfig(config_));
                 break;
-            case TransProviderType::AIV:
-#ifdef UCM_ASU_ENABLE_AIV
-                transProvider_ = std::make_unique<AIVTransProvider>();
 #else
-                return Status::Error(StatusCode::UNSUPPORTED, "AIV backend not enabled");
+                return Status::Error(
+                    StatusCode::UNSUPPORTED,
+                    "FAKE trans provider is not built; enable BUILD_UCM_ASU_PROVIDER_FAKE");
 #endif
+            case TransProviderType::AIV:
+#ifdef UCM_ASU_ENABLE_AIV_PROVIDER
+                transProvider_ = std::make_unique<AIVTransProvider>();
                 break;
+#else
+                return Status::Error(
+                    StatusCode::UNSUPPORTED,
+                    "AIV trans provider is not built; enable BUILD_UCM_ASU_PROVIDER_AIV and set "
+                    "ASU_AIV_PROVIDER_ROOT");
+#endif
             case TransProviderType::UNSUPPORTED:
                 return Status::Error(StatusCode::UNSUPPORTED,
                                      "ASU trans provider backend is not supported");

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -587,4 +587,6 @@ void AsuTransportImpl::SetTransProvider(std::unique_ptr<TransProvider> provider)
 
 std::unique_ptr<AsuTransport> CreateAsuTransport() { return std::make_unique<AsuTransportImpl>(); }
 
+extern "C" std::unique_ptr<AsuTransport> UcmAsuCreateAsuTransport() { return CreateAsuTransport(); }
+
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
@@ -140,7 +140,7 @@ private:
 
     std::mutex registeredRegionsMu_;
     std::atomic<MRHandle> nextMrHandle_{1};
-    std::unordered_map<MRHandle, MemoryRegion> registeredRegions_;
+    std::unordered_map<MRHandle, RegisteredMemory> registeredRegions_;
 };
 
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
@@ -121,6 +121,12 @@ private:
 
     void SetTransProvider(std::unique_ptr<TransProvider> provider);
 
+    struct RegisteredRegionState {
+        TransProvider::ConnectionHandle connectionHandle{nullptr};
+        TransProvider::MemHandle memHandle{nullptr};
+        std::shared_ptr<ConnectionChannel> channel;
+    };
+
     TransportConfig config_;
     IoScheduler ioScheduler_;
     std::unique_ptr<TransProvider> transProvider_;
@@ -141,6 +147,7 @@ private:
     std::mutex registeredRegionsMu_;
     std::atomic<MRHandle> nextMrHandle_{1};
     std::unordered_map<MRHandle, RegisteredMemory> registeredRegions_;
+    std::unordered_map<MRHandle, RegisteredRegionState> registeredRegionStates_;
 };
 
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
@@ -124,7 +124,6 @@ private:
     struct RegisteredRegionState {
         TransProvider::ConnectionHandle connectionHandle{nullptr};
         TransProvider::MemHandle memHandle{nullptr};
-        std::shared_ptr<ConnectionChannel> channel;
     };
 
     TransportConfig config_;
@@ -148,6 +147,8 @@ private:
     std::atomic<MRHandle> nextMrHandle_{1};
     std::unordered_map<MRHandle, RegisteredMemory> registeredRegions_;
     std::unordered_map<MRHandle, RegisteredRegionState> registeredRegionStates_;
+    std::unordered_map<MRHandle, std::shared_ptr<ConnectionChannel>>
+        registeredRegionConnectionLeases_;
 };
 
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/buffer_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/buffer_manager.cpp
@@ -169,7 +169,8 @@ Status BufferManager::RegisterMemory()
 {
     std::size_t total = slot_stride_ * slot_num_;
     std::vector<TransProvider::RegisterMemoryDesc> descs{
-        {region_.providerMemType, reinterpret_cast<uintptr_t>(region_.deviceAddr), total}
+        {region_.providerMemType, reinterpret_cast<uintptr_t>(region_.deviceAddr), total,
+         reinterpret_cast<uintptr_t>(region_.localAddr)}
     };
     std::vector<TransProvider::MemHandle> memHandles;
     auto regStatus = provider_->RegisterMemory(nullptr, descs, memHandles);

--- a/ucm/transport/kv/asu/trans/src/connection_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/connection_manager.cpp
@@ -112,7 +112,7 @@ std::shared_ptr<ConnectionChannel> ConnectionManager::SelectConnection()
     return channel;
 }
 
-TransProvider::ConnectionHandle ConnectionManager::GetActiveConnectionHandle()
+std::shared_ptr<ConnectionChannel> ConnectionManager::GetActiveConnection()
 {
     if (shuttingDown_.load(std::memory_order_acquire)) { return nullptr; }
 
@@ -120,7 +120,7 @@ TransProvider::ConnectionHandle ConnectionManager::GetActiveConnectionHandle()
     if (cacheDirty_.load(std::memory_order_acquire)) { RebuildChannelCache(); }
 
     for (const auto& channel : channelCache_) {
-        if (channel->GetState() == ChannelState::ACTIVE) { return channel->GetConnection(); }
+        if (channel->GetState() == ChannelState::ACTIVE) { return channel; }
     }
     return nullptr;
 }

--- a/ucm/transport/kv/asu/trans/src/connection_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/connection_manager.cpp
@@ -112,6 +112,19 @@ std::shared_ptr<ConnectionChannel> ConnectionManager::SelectConnection()
     return channel;
 }
 
+TransProvider::ConnectionHandle ConnectionManager::GetActiveConnectionHandle()
+{
+    if (shuttingDown_.load(std::memory_order_acquire)) { return nullptr; }
+
+    std::lock_guard<std::mutex> cacheLock(channelCacheMu_);
+    if (cacheDirty_.load(std::memory_order_acquire)) { RebuildChannelCache(); }
+
+    for (const auto& channel : channelCache_) {
+        if (channel->GetState() == ChannelState::ACTIVE) { return channel->GetConnection(); }
+    }
+    return nullptr;
+}
+
 void ConnectionManager::SetRoutingPolicy(RoutingPolicy policy) { routingPolicy_ = policy; }
 
 void ConnectionManager::ReportFailure(const std::shared_ptr<ConnectionChannel>& channel)

--- a/ucm/transport/kv/asu/trans/src/connection_manager.h
+++ b/ucm/transport/kv/asu/trans/src/connection_manager.h
@@ -59,6 +59,7 @@ public:
     Status Shutdown();
 
     std::shared_ptr<ConnectionChannel> SelectConnection();
+    TransProvider::ConnectionHandle GetActiveConnectionHandle();
     void SetRoutingPolicy(RoutingPolicy policy);
     void ReportFailure(const std::shared_ptr<ConnectionChannel>& channel);
 

--- a/ucm/transport/kv/asu/trans/src/connection_manager.h
+++ b/ucm/transport/kv/asu/trans/src/connection_manager.h
@@ -59,7 +59,7 @@ public:
     Status Shutdown();
 
     std::shared_ptr<ConnectionChannel> SelectConnection();
-    TransProvider::ConnectionHandle GetActiveConnectionHandle();
+    std::shared_ptr<ConnectionChannel> GetActiveConnection();
     void SetRoutingPolicy(RoutingPolicy policy);
     void ReportFailure(const std::shared_ptr<ConnectionChannel>& channel);
 

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
@@ -31,6 +31,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <limits>
 #include <sstream>
 #include <thread>
 #include <utility>
@@ -221,12 +222,10 @@ std::vector<CacheKey> ReadKeyEntries(const std::uint32_t* request, std::uint16_t
 }
 
 Status CompleteBatchStore(const FakeTransProviderConfig& config, AsuId asuId,
-                          const std::uint32_t* request)
+                          const std::uint32_t* request, std::uint32_t* flagBuffer)
 {
     const auto cid = static_cast<std::uint16_t>(RequestCid(request));
-    const auto responseBufferAddr = ReadU64(request[3], request[4]);
     const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
-    auto* flagBuffer = reinterpret_cast<std::uint32_t*>(responseBufferAddr);
     std::vector<std::uint8_t> results(batchNumber, kBatchEntryOk);
 
     const auto entries = ReadBatchEntries(request, batchNumber);
@@ -246,12 +245,10 @@ Status CompleteBatchStore(const FakeTransProviderConfig& config, AsuId asuId,
 }
 
 Status CompleteBatchRetrieve(const FakeTransProviderConfig& config, AsuId asuId,
-                             const std::uint32_t* request)
+                             const std::uint32_t* request, std::uint32_t* flagBuffer)
 {
     const auto cid = static_cast<std::uint16_t>(RequestCid(request));
-    const auto responseBufferAddr = ReadU64(request[3], request[4]);
     const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
-    auto* flagBuffer = reinterpret_cast<std::uint32_t*>(responseBufferAddr);
     std::vector<std::uint8_t> results(batchNumber, kBatchEntryOk);
 
     const auto entries = ReadBatchEntries(request, batchNumber);
@@ -271,12 +268,10 @@ Status CompleteBatchRetrieve(const FakeTransProviderConfig& config, AsuId asuId,
 }
 
 Status CompleteDelete(const FakeTransProviderConfig& config, AsuId asuId,
-                      const std::uint32_t* request)
+                      const std::uint32_t* request, std::uint32_t* flagBuffer)
 {
     const auto cid = static_cast<std::uint16_t>(RequestCid(request));
-    const auto responseBufferAddr = ReadU64(request[3], request[4]);
     const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
-    auto* flagBuffer = reinterpret_cast<std::uint32_t*>(responseBufferAddr);
     std::vector<std::uint8_t> results(batchNumber, kDeleteEntryOk);
 
     const auto keys = ReadKeyEntries(request, batchNumber);
@@ -293,12 +288,10 @@ Status CompleteDelete(const FakeTransProviderConfig& config, AsuId asuId,
 }
 
 Status CompleteExist(const FakeTransProviderConfig& config, AsuId asuId,
-                     const std::uint32_t* request)
+                     const std::uint32_t* request, std::uint32_t* flagBuffer)
 {
     const auto cid = static_cast<std::uint16_t>(RequestCid(request));
-    const auto responseBufferAddr = ReadU64(request[3], request[4]);
     const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
-    auto* flagBuffer = reinterpret_cast<std::uint32_t*>(responseBufferAddr);
     std::vector<std::uint8_t> results(batchNumber, kExistEntryNotExist);
     std::uint16_t existingKeyNumber = 0;
 
@@ -318,26 +311,41 @@ Status CompleteExist(const FakeTransProviderConfig& config, AsuId asuId,
     return Status::OK();
 }
 
+std::size_t CompletionDwordCount(const std::uint32_t* request)
+{
+    const auto opcode = RequestOpcode(request);
+    if (opcode == KvOpcode::KeepAlive) { return kCqeDwordCount; }
+
+    const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
+    const auto resultDwordCount =
+        opcode == KvOpcode::BatchStore || opcode == KvOpcode::BatchRetrieve
+            ? (static_cast<std::size_t>(batchNumber) + 7) / 8
+            : (static_cast<std::size_t>(batchNumber) + 31) / 32;
+    return kCqeDwordCount + resultDwordCount;
+}
+
 Status CompleteFakeBackendRequest(const FakeTransProviderConfig& config, const void* sendBuffer,
-                                  std::uint64_t len)
+                                  std::uint64_t len, std::vector<std::uint32_t>& completion)
 {
     if (config.latencyMs > 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(config.latencyMs));
     }
 
-    if (sendBuffer == nullptr || len < sizeof(std::uint32_t)) {
+    if (sendBuffer == nullptr || len < kSqeDwordCount * sizeof(std::uint32_t)) {
         return Status::Error(StatusCode::INVALID_ARGUMENT, "fake backend send buffer is empty");
     }
 
     const auto* request = reinterpret_cast<const std::uint32_t*>(sendBuffer);
+    completion.assign(CompletionDwordCount(request), 0);
+    auto* flagBuffer = completion.data();
     const auto asuId = RequestAsuId(request);
     switch (RequestOpcode(request)) {
-        case KvOpcode::BatchStore: return CompleteBatchStore(config, asuId, request);
-        case KvOpcode::BatchRetrieve: return CompleteBatchRetrieve(config, asuId, request);
-        case KvOpcode::Delete: return CompleteDelete(config, asuId, request);
-        case KvOpcode::Exist: return CompleteExist(config, asuId, request);
+        case KvOpcode::BatchStore: return CompleteBatchStore(config, asuId, request, flagBuffer);
+        case KvOpcode::BatchRetrieve:
+            return CompleteBatchRetrieve(config, asuId, request, flagBuffer);
+        case KvOpcode::Delete: return CompleteDelete(config, asuId, request, flagBuffer);
+        case KvOpcode::Exist: return CompleteExist(config, asuId, request, flagBuffer);
         case KvOpcode::KeepAlive: {
-            auto* flagBuffer = reinterpret_cast<std::uint32_t*>(ReadU64(request[3], request[4]));
             PackCqeHeader(flagBuffer, static_cast<std::uint16_t>(RequestCid(request)), kCqeSuccess);
             return Status::OK();
         }
@@ -392,6 +400,24 @@ Status FakeTransProvider::SetUpAclRuntime()
     return Status::OK();
 }
 
+Status FakeTransProvider::ResolveLocalAddress(const void* providerAddr, std::size_t size,
+                                              void*& localAddr)
+{
+    const auto address = reinterpret_cast<std::uintptr_t>(providerAddr);
+    std::lock_guard<std::mutex> lock(registeredMemoryMu_);
+    for (const auto& item : registeredMemories_) {
+        const auto& memory = item.second;
+        if (address < memory.providerAddr) { continue; }
+        const auto offset = address - memory.providerAddr;
+        if (offset > memory.size || size > memory.size - offset) { continue; }
+        localAddr = reinterpret_cast<void*>(memory.localAddr + offset);
+        return Status::OK();
+    }
+    localAddr = nullptr;
+    return Status::Error(StatusCode::BUFFER_NOT_REGISTERED,
+                         "fake backend IO buffer is not registered");
+}
+
 Status FakeTransProvider::CreateConnection(const std::string&, const std::string&, uint32_t,
                                            uint32_t qpNum, uint32_t,
                                            std::vector<ConnectionHandle>& handles)
@@ -424,7 +450,37 @@ std::vector<Status> FakeTransProvider::Send(const std::vector<SendIoBatch>& ioBa
     std::vector<Status> statuses;
     statuses.reserve(ioBatches.size());
     for (const auto& ioBatch : ioBatches) {
-        statuses.emplace_back(CompleteFakeBackendRequest(config_, ioBatch.sendBuffer, ioBatch.len));
+        if (ioBatch.sendBuffer == nullptr || ioBatch.flagBuffer == nullptr ||
+            ioBatch.len > std::numeric_limits<std::size_t>::max()) {
+            statuses.emplace_back(
+                Status::Error(StatusCode::INVALID_ARGUMENT, "fake backend IO buffer is invalid"));
+            continue;
+        }
+
+        void* localSendBuffer = nullptr;
+        auto status = ResolveLocalAddress(ioBatch.sendBuffer, static_cast<std::size_t>(ioBatch.len),
+                                          localSendBuffer);
+        if (!status.ok()) {
+            statuses.emplace_back(std::move(status));
+            continue;
+        }
+
+        std::vector<std::uint32_t> completion;
+        status = CompleteFakeBackendRequest(config_, localSendBuffer, ioBatch.len, completion);
+        if (!status.ok()) {
+            statuses.emplace_back(std::move(status));
+            continue;
+        }
+
+        const auto completionSize = completion.size() * sizeof(std::uint32_t);
+        void* localFlagBuffer = nullptr;
+        status = ResolveLocalAddress(ioBatch.flagBuffer, completionSize, localFlagBuffer);
+        if (!status.ok()) {
+            statuses.emplace_back(std::move(status));
+            continue;
+        }
+        std::memcpy(localFlagBuffer, completion.data(), completionSize);
+        statuses.emplace_back(Status::OK());
     }
     return statuses;
 }
@@ -435,10 +491,16 @@ Status FakeTransProvider::RegisterMemory(ConnectionHandle,
 {
     memoryHandles.clear();
     memoryHandles.reserve(memoryDescs.size());
-    for (std::size_t index = 0; index < memoryDescs.size(); ++index) {
+    std::lock_guard<std::mutex> lock(registeredMemoryMu_);
+    for (const auto& desc : memoryDescs) {
         auto handle = nextMemoryHandle_.fetch_add(1, std::memory_order_relaxed);
         if (handle == 0) { handle = nextMemoryHandle_.fetch_add(1, std::memory_order_relaxed); }
-        memoryHandles.push_back(reinterpret_cast<MemHandle>(handle));
+        auto memoryHandle = reinterpret_cast<MemHandle>(handle);
+        if (desc.localAddr != 0) {
+            registeredMemories_[memoryHandle] =
+                RegisteredMemory{desc.addr, desc.localAddr, desc.size};
+        }
+        memoryHandles.push_back(memoryHandle);
     }
     return Status::OK();
 }
@@ -446,6 +508,8 @@ Status FakeTransProvider::RegisterMemory(ConnectionHandle,
 std::vector<Status> FakeTransProvider::UnregisterMemory(
     const std::vector<UnregisterMemoryDesc>& handles)
 {
+    std::lock_guard<std::mutex> lock(registeredMemoryMu_);
+    for (const auto& desc : handles) { registeredMemories_.erase(desc.memoryHandle); }
     return std::vector<Status>(handles.size(), Status::OK());
 }
 

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
@@ -436,8 +436,9 @@ Status FakeTransProvider::RegisterMemory(ConnectionHandle,
     memoryHandles.clear();
     memoryHandles.reserve(memoryDescs.size());
     for (std::size_t index = 0; index < memoryDescs.size(); ++index) {
-        memoryHandles.push_back(reinterpret_cast<MemHandle>(static_cast<std::uintptr_t>(index) +
-                                                            static_cast<std::uintptr_t>(1)));
+        auto handle = nextMemoryHandle_.fetch_add(1, std::memory_order_relaxed);
+        if (handle == 0) { handle = nextMemoryHandle_.fetch_add(1, std::memory_order_relaxed); }
+        memoryHandles.push_back(reinterpret_cast<MemHandle>(handle));
     }
     return Status::OK();
 }

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -371,21 +372,23 @@ FakeTransProvider::FakeTransProvider(FakeTransProviderConfig config) : config_(s
 
 Status FakeTransProvider::SetUpAclRuntime()
 {
-    if (aclReady_) { return Status::OK(); }
+    const auto deviceId = config_.deviceId < 0 ? 0 : config_.deviceId;
+    thread_local std::int32_t readyDeviceId = -1;
+    if (readyDeviceId == deviceId) { return Status::OK(); }
+
     auto ret = aclInit(nullptr);
     if (ret != ACL_SUCCESS && ret != ACL_ERROR_REPEAT_INITIALIZE) {
         return Status::Error(StatusCode::INTERNAL_ERROR,
                              "ASU fake backend aclInit failed: " + std::to_string(ret));
     }
 
-    const auto deviceId = config_.deviceId < 0 ? 0 : config_.deviceId;
     ret = aclrtSetDevice(deviceId);
     if (ret != ACL_SUCCESS) {
         return Status::Error(StatusCode::INTERNAL_ERROR,
                              "ASU fake backend aclrtSetDevice failed: device_id=" +
                                  std::to_string(deviceId) + " ret=" + std::to_string(ret));
     }
-    aclReady_ = true;
+    readyDeviceId = deviceId;
     return Status::OK();
 }
 
@@ -415,6 +418,9 @@ std::vector<Status> FakeTransProvider::Send(const std::vector<SendIoBatch>& ioBa
 {
     (void)kernelCount;
     (void)quietCount;
+    auto runtimeStatus = SetUpAclRuntime();
+    if (!runtimeStatus.ok()) { return std::vector<Status>(ioBatches.size(), runtimeStatus); }
+
     std::vector<Status> statuses;
     statuses.reserve(ioBatches.size());
     for (const auto& ioBatch : ioBatches) {

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
@@ -25,6 +25,8 @@
 
 #include <atomic>
 #include <cstdint>
+#include <mutex>
+#include <unordered_map>
 #include "asu_transport/asu_transport.h"
 #include "trans_provider.h"
 
@@ -60,10 +62,19 @@ public:
     Status GetMemTokenId(MemHandle, uint32_t& tokenId) override;
 
 private:
+    struct RegisteredMemory {
+        std::uintptr_t providerAddr{0};
+        std::uintptr_t localAddr{0};
+        std::size_t size{0};
+    };
+
     Status SetUpAclRuntime();
+    Status ResolveLocalAddress(const void* providerAddr, std::size_t size, void*& localAddr);
 
     FakeTransProviderConfig config_;
     std::atomic<std::uintptr_t> nextMemoryHandle_{1};
+    std::mutex registeredMemoryMu_;
+    std::unordered_map<MemHandle, RegisteredMemory> registeredMemories_;
 };
 
 FakeTransProviderConfig MakeFakeTransProviderConfig(const TransportConfig& config);

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
@@ -23,6 +23,8 @@
  * */
 #pragma once
 
+#include <atomic>
+#include <cstdint>
 #include "asu_transport/asu_transport.h"
 #include "trans_provider.h"
 
@@ -61,6 +63,7 @@ private:
     Status SetUpAclRuntime();
 
     FakeTransProviderConfig config_;
+    std::atomic<std::uintptr_t> nextMemoryHandle_{1};
 };
 
 FakeTransProviderConfig MakeFakeTransProviderConfig(const TransportConfig& config);

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
@@ -61,7 +61,6 @@ private:
     Status SetUpAclRuntime();
 
     FakeTransProviderConfig config_;
-    bool aclReady_{false};
 };
 
 FakeTransProviderConfig MakeFakeTransProviderConfig(const TransportConfig& config);

--- a/ucm/transport/kv/asu/trans/src/sqe_request.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.cpp
@@ -26,6 +26,7 @@
 #include <cctype>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -42,10 +43,22 @@ namespace {
 
 constexpr std::size_t kFlagBufferHeaderSize = 16;
 
-std::uint32_t ToSqeMrKey(MRHandle handle)
+Status ResolveSqeMrKeys(const BatchView<KVBuffer>& entries,
+                        const std::unordered_map<MRHandle, RegisteredMemory>& registeredRegions,
+                        std::vector<std::uint32_t>& mrKeys)
 {
-    // TODO: 每个mrhandle对应的mrkey
-    return static_cast<std::uint32_t>(handle);
+    mrKeys.clear();
+    mrKeys.reserve(entries.size);
+    for (std::size_t index = 0; index < entries.size; ++index) {
+        const auto handle = entries[index].buffer.handle;
+        auto iter = registeredRegions.find(handle);
+        if (iter == registeredRegions.end()) {
+            return Status::Error(StatusCode::BUFFER_NOT_REGISTERED,
+                                 "entry buffer is not registered");
+        }
+        mrKeys.emplace_back(iter->second.tokenId);
+    }
+    return Status::OK();
 }
 
 std::string ToLower(std::string value)
@@ -180,7 +193,8 @@ Status PackSubBatchRequest(ProtocolManager& protocolManager, BufferManager& send
 
 KvBatchStoreRequest BuildBatchStoreRequest(
     const BatchView<KVBuffer>& entries, const std::unordered_map<std::string, std::string>& attrs,
-    std::uint16_t cid, const ScatterGatherEntry& flagBuffer)
+    std::uint16_t cid, const ScatterGatherEntry& flagBuffer,
+    const std::vector<std::uint32_t>& mrKeys)
 {
     KvBatchStoreRequest request;
     request.cid = cid;
@@ -198,7 +212,7 @@ KvBatchStoreRequest BuildBatchStoreRequest(
         entry.key = entries[index].key;
         entry.offset = entries[index].offset;
         entry.buffer_addr = entries[index].buffer.region.addr;
-        entry.mr_key = ToSqeMrKey(entries[index].buffer.handle);
+        entry.mr_key = mrKeys[index];
         entry.length = static_cast<std::uint32_t>(entries[index].buffer.region.size);
         request.entries.emplace_back(std::move(entry));
     }
@@ -207,7 +221,8 @@ KvBatchStoreRequest BuildBatchStoreRequest(
 
 KvBatchRetrieveRequest BuildBatchRetrieveRequest(
     const BatchView<KVBuffer>& entries, const std::unordered_map<std::string, std::string>& attrs,
-    std::uint16_t cid, const ScatterGatherEntry& flagBuffer)
+    std::uint16_t cid, const ScatterGatherEntry& flagBuffer,
+    const std::vector<std::uint32_t>& mrKeys)
 {
     KvBatchRetrieveRequest request;
     request.cid = cid;
@@ -223,7 +238,7 @@ KvBatchRetrieveRequest BuildBatchRetrieveRequest(
         entry.key = entries[index].key;
         entry.offset = entries[index].offset;
         entry.buffer_addr = entries[index].buffer.region.addr;
-        entry.mr_key = ToSqeMrKey(entries[index].buffer.handle);
+        entry.mr_key = mrKeys[index];
         entry.length = static_cast<std::uint32_t>(entries[index].buffer.region.size);
         request.entries.emplace_back(std::move(entry));
     }
@@ -284,17 +299,18 @@ KvKeepAliveRequest BuildKeepAliveRequest(std::uint16_t cid, const ScatterGatherE
 std::unique_ptr<SqeRequest> BuildSqeRequest(
     KvOpcode opcode, const SubBatchRequestSource& source,
     const std::unordered_map<std::string, std::string>& attrs, std::uint16_t cid,
-    const ScatterGatherEntry& flagBuffer, TransportSubBatchContext& subBatchContext)
+    const ScatterGatherEntry& flagBuffer, const std::vector<std::uint32_t>* mrKeys,
+    TransportSubBatchContext& subBatchContext)
 {
     switch (opcode) {
         case KvOpcode::BatchRetrieve:
-            if (source.entries == nullptr) { return nullptr; }
+            if (source.entries == nullptr || mrKeys == nullptr) { return nullptr; }
             return std::make_unique<KvBatchRetrieveRequest>(
-                BuildBatchRetrieveRequest(*source.entries, attrs, cid, flagBuffer));
+                BuildBatchRetrieveRequest(*source.entries, attrs, cid, flagBuffer, *mrKeys));
         case KvOpcode::BatchStore:
-            if (source.entries == nullptr) { return nullptr; }
+            if (source.entries == nullptr || mrKeys == nullptr) { return nullptr; }
             return std::make_unique<KvBatchStoreRequest>(
-                BuildBatchStoreRequest(*source.entries, attrs, cid, flagBuffer));
+                BuildBatchStoreRequest(*source.entries, attrs, cid, flagBuffer, *mrKeys));
         case KvOpcode::Delete:
             if (source.keys == nullptr) { return nullptr; }
             return std::make_unique<KvDeleteRequest>(
@@ -323,14 +339,23 @@ Status AsuTransportImpl::SubmitEntrySubBatchRequest(TransportOpType opType,
     const auto source = SubBatchRequestSource::FromEntries(subBatch.entries);
     subBatchContext.entryStatus.assign(subBatch.entries.size, Status::OK());
     const auto opcode = ToKvOpcode(opType);
+    const auto cid = AllocateRequestCid();
+    subBatchContext.opType = opType;
+    subBatchContext.cid = cid;
 
-    auto status =
-        PrepareSubBatchRequest(opType, opcode, AllocateRequestCid(), subBatch.entries.size,
-                               flagBufferManager_, subBatchContext);
+    std::vector<std::uint32_t> mrKeys;
+    {
+        std::lock_guard<std::mutex> lock(registeredRegionsMu_);
+        auto resolveStatus = ResolveSqeMrKeys(subBatch.entries, registeredRegions_, mrKeys);
+        if (!resolveStatus.ok()) { return SetSubBatchBuildFailed(subBatchContext, resolveStatus); }
+    }
+
+    auto status = PrepareSubBatchRequest(opType, opcode, cid, subBatch.entries.size,
+                                         flagBufferManager_, subBatchContext);
     if (!status.ok()) { return status; }
 
     auto request = BuildSqeRequest(opcode, source, config_.attrs, subBatchContext.cid,
-                                   subBatchContext.flagBuffer, subBatchContext);
+                                   subBatchContext.flagBuffer, &mrKeys, subBatchContext);
     return PackSubBatchRequest(*protocolManager_, sendBufferManager_, opcode, *request,
                                subBatchContext);
 }
@@ -348,7 +373,7 @@ Status AsuTransportImpl::SubmitKeySubBatchRequest(TransportOpType opType,
     if (!status.ok()) { return status; }
 
     auto request = BuildSqeRequest(opcode, source, config_.attrs, subBatchContext.cid,
-                                   subBatchContext.flagBuffer, subBatchContext);
+                                   subBatchContext.flagBuffer, nullptr, subBatchContext);
     return PackSubBatchRequest(*protocolManager_, sendBufferManager_, opcode, *request,
                                subBatchContext);
 }
@@ -365,7 +390,7 @@ Status AsuTransportImpl::SubmitKeepAliveRequest(TransportSubBatchContext& subBat
     if (!status.ok()) { return status; }
 
     auto request = BuildSqeRequest(opcode, source, config_.attrs, subBatchContext.cid,
-                                   subBatchContext.flagBuffer, subBatchContext);
+                                   subBatchContext.flagBuffer, nullptr, subBatchContext);
     return PackSubBatchRequest(*protocolManager_, sendBufferManager_, opcode, *request,
                                subBatchContext);
 }

--- a/ucm/transport/kv/asu/trans/src/trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/trans_provider.h
@@ -39,6 +39,7 @@ public:
         MemType memoryType;
         uintptr_t addr;
         size_t size;
+        uintptr_t localAddr{0};
     };
 
     virtual Status RegisterMemory(ConnectionHandle connectionHandle,

--- a/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
@@ -23,6 +23,7 @@
  * */
 #include <acl/acl.h>
 #include <cstdint>
+#include <functional>
 #include <gtest/gtest.h>
 #include <unordered_map>
 #include <vector>
@@ -45,6 +46,7 @@ public:
     std::uint32_t registerCount{0};
     std::uint32_t unregisterCount{0};
     std::uint32_t failRegisterAt{0};
+    std::function<void()> onUnregister;
 
     Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t qpNum,
                             uint32_t, std::vector<ConnectionHandle>& handles) override
@@ -81,6 +83,7 @@ public:
 
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& descs) override
     {
+        if (onUnregister) { onUnregister(); }
         unregisterCount += static_cast<std::uint32_t>(descs.size());
         return std::vector<Status>(descs.size(), Status::OK());
     }
@@ -182,6 +185,7 @@ TEST(AsuTransportRegisterTest, RegisterRegionsReturnsPartialFailedAndRollsBackSu
     EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
     EXPECT_TRUE(transport.registeredRegions_.empty());
     EXPECT_TRUE(transport.registeredRegionStates_.empty());
+    EXPECT_TRUE(transport.registeredRegionConnectionLeases_.empty());
 }
 
 TEST(AsuTransportRegisterTest, ShutdownUnregistersRegisteredRegions)
@@ -210,6 +214,33 @@ TEST(AsuTransportRegisterTest, ShutdownUnregistersRegisteredRegions)
     EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{2});
     EXPECT_TRUE(transport.registeredRegions_.empty());
     EXPECT_TRUE(transport.registeredRegionStates_.empty());
+    EXPECT_TRUE(transport.registeredRegionConnectionLeases_.empty());
+}
+
+TEST(AsuTransportRegisterTest, UnregisterRegionReleasesConnectionLeaseAfterProviderCall)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    constexpr MRHandle handle{7};
+    auto connection = std::make_shared<ConnectionChannel>(
+        0, nullptr, reinterpret_cast<TransProvider::ConnectionHandle>(1), providerPtr);
+    std::weak_ptr<ConnectionChannel> weakConnection = connection;
+    transport.registeredRegionStates_[handle] = AsuTransportImpl::RegisteredRegionState{
+        connection->GetConnection(), reinterpret_cast<TransProvider::MemHandle>(handle)};
+    transport.registeredRegionConnectionLeases_[handle] = std::move(connection);
+    providerPtr->onUnregister = [&weakConnection]() { EXPECT_FALSE(weakConnection.expired()); };
+
+    const auto status = transport.UnregisterRegions({handle});
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
+    EXPECT_TRUE(transport.registeredRegionStates_.empty());
+    EXPECT_TRUE(transport.registeredRegionConnectionLeases_.empty());
+    EXPECT_TRUE(weakConnection.expired());
 }
 
 TEST(AsuSubmitFlowTest, SendSubBatchBuffersReportsSendFailures)

--- a/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
@@ -185,6 +185,34 @@ TEST(AsuTransportRegisterTest, RegisterRegionsReturnsPartialFailedAndRollsBackSu
     EXPECT_TRUE(transport.registeredRegionStates_.empty());
 }
 
+TEST(AsuTransportRegisterTest, ShutdownUnregistersRegisteredRegions)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    std::vector<MemoryRegion> regions(2);
+    regions[0].addr = 0x1000;
+    regions[0].size = 4096;
+    regions[1].addr = 0x2000;
+    regions[1].size = 4096;
+
+    std::vector<RegisterResult> results;
+    auto status = transport.RegisterRegions(regions, results);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(results.size(), std::size_t{2});
+    ASSERT_EQ(transport.registeredRegions_.size(), std::size_t{2});
+
+    status = transport.Shutdown();
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{2});
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_TRUE(transport.registeredRegionStates_.empty());
+}
+
 TEST(AsuSubmitFlowTest, SendSubBatchBuffersReportsSendFailures)
 {
     g_sendStatuses = {

--- a/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
@@ -75,8 +75,7 @@ public:
         if (failRegisterAt != 0 && registerCount == failRegisterAt) {
             return Status::Error(StatusCode::INTERNAL_ERROR, "stub register failed");
         }
-        handles.push_back(
-            reinterpret_cast<MemHandle>(static_cast<uintptr_t>(registerCount)));
+        handles.push_back(reinterpret_cast<MemHandle>(static_cast<uintptr_t>(registerCount)));
         return Status::OK();
     }
 

--- a/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
@@ -42,6 +42,10 @@ std::vector<Status> g_sendStatuses;
 
 class StubTransProvider : public TransProvider {
 public:
+    std::uint32_t registerCount{0};
+    std::uint32_t unregisterCount{0};
+    std::uint32_t failRegisterAt{0};
+
     Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t qpNum,
                             uint32_t, std::vector<ConnectionHandle>& handles) override
     {
@@ -67,13 +71,19 @@ public:
     Status RegisterMemory(ConnectionHandle, const std::vector<RegisterMemoryDesc>&,
                           std::vector<MemHandle>& handles) override
     {
-        handles.push_back(reinterpret_cast<MemHandle>(static_cast<uintptr_t>(1)));
+        ++registerCount;
+        if (failRegisterAt != 0 && registerCount == failRegisterAt) {
+            return Status::Error(StatusCode::INTERNAL_ERROR, "stub register failed");
+        }
+        handles.push_back(
+            reinterpret_cast<MemHandle>(static_cast<uintptr_t>(registerCount)));
         return Status::OK();
     }
 
-    std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>&) override
+    std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& descs) override
     {
-        return {};
+        unregisterCount += static_cast<std::uint32_t>(descs.size());
+        return std::vector<Status>(descs.size(), Status::OK());
     }
 
     Status AllocThread(uint32_t, const std::vector<uint32_t>&, std::vector<ThreadHandle>&) override
@@ -144,6 +154,35 @@ TEST(AsuSubmitFlowTest, SendSubBatchBuffersReadsSendCountsFromAttrs)
     EXPECT_EQ(g_quietCount, std::uint32_t{7});
     EXPECT_EQ(subBatchContexts[0].state, TransportSubBatchState::PENDING);
     EXPECT_TRUE(subBatchContexts[0].status.ok());
+}
+
+TEST(AsuTransportRegisterTest, RegisterRegionsReturnsPartialFailedAndRollsBackSuccessfulRegions)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+    providerPtr->failRegisterAt = 2;
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    std::vector<MemoryRegion> regions(2);
+    regions[0].addr = 0x1000;
+    regions[0].size = 4096;
+    regions[1].addr = 0x2000;
+    regions[1].size = 4096;
+
+    std::vector<RegisterResult> results;
+    auto status = transport.RegisterRegions(regions, results);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_EQ(results.size(), std::size_t{2});
+    EXPECT_TRUE(results[0].status.ok()) << results[0].status.message;
+    EXPECT_EQ(results[0].handle, MRHandle{1});
+    EXPECT_EQ(results[1].status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(results[1].handle, kInvalidMRHandle);
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_TRUE(transport.registeredRegionStates_.empty());
 }
 
 TEST(AsuSubmitFlowTest, SendSubBatchBuffersReportsSendFailures)

--- a/ucm/transport/kv/asu/trans/test/fake_trans_provider_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/fake_trans_provider_test.cpp
@@ -1,0 +1,29 @@
+#include "fake_trans_provider.h"
+#include <gtest/gtest.h>
+#include <unordered_set>
+
+namespace UC::ASU {
+namespace {
+
+TEST(FakeTransProviderTest, RegisterMemoryReturnsUniqueHandlesAcrossCalls)
+{
+    FakeTransProvider provider(FakeTransProviderConfig{});
+    const std::vector<TransProvider::RegisterMemoryDesc> descs{
+        {TransProvider::MemType::MEM_DEVICE, 0x1000, 4096},
+        {TransProvider::MemType::MEM_DEVICE, 0x2000, 4096}
+    };
+
+    std::vector<TransProvider::MemHandle> firstHandles;
+    ASSERT_TRUE(provider.RegisterMemory(nullptr, descs, firstHandles).ok());
+    std::vector<TransProvider::MemHandle> secondHandles;
+    ASSERT_TRUE(provider.RegisterMemory(nullptr, descs, secondHandles).ok());
+
+    std::unordered_set<TransProvider::MemHandle> uniqueHandles;
+    uniqueHandles.insert(firstHandles.begin(), firstHandles.end());
+    uniqueHandles.insert(secondHandles.begin(), secondHandles.end());
+    EXPECT_EQ(uniqueHandles.size(), firstHandles.size() + secondHandles.size());
+    EXPECT_EQ(uniqueHandles.count(nullptr), 0);
+}
+
+}  // namespace
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
@@ -120,6 +120,24 @@ std::vector<KVBuffer> MakeEntries(std::size_t count)
     return entries;
 }
 
+void BindEntries(AsuTransportImpl& transport, const std::vector<KVBuffer>& entries,
+                 std::uint32_t tokenBase)
+{
+    for (std::size_t index = 0; index < entries.size(); ++index) {
+        RegisteredMemory memory;
+        memory.region = entries[index].buffer.region;
+        memory.handle = entries[index].buffer.handle;
+        memory.tokenId = tokenBase + static_cast<std::uint32_t>(index);
+        transport.registeredRegions_[memory.handle] = memory;
+    }
+}
+
+std::uint32_t PackedBatchEntryMrKey(const std::uint32_t* sqe, std::size_t entryIndex)
+{
+    const auto base = kSqeDwordCount + entryIndex * kBatchEntryDwordCount;
+    return ((sqe[base + 7] >> 24) & 0xFF) | ((sqe[base + 8] & 0xFFFFFF) << 8);
+}
+
 }  // namespace
 
 class SqeRequestTest : public ::testing::Test {
@@ -189,6 +207,7 @@ TEST_F(SqeRequestTest, SubmitBatchStoreAllocatesFlagBufferAndBuildsRequest)
     };
     TransportSubBatchContext subBatchContext;
     transport_->nextRequestCid_.store(41, std::memory_order_relaxed);
+    BindEntries(*transport_, entries, 0xABCD0000);
 
     const auto status = transport_->SubmitEntrySubBatchRequest(TransportOpType::BATCH_STORE,
                                                                subBatch, subBatchContext);
@@ -214,6 +233,9 @@ TEST_F(SqeRequestTest, SubmitBatchStoreAllocatesFlagBufferAndBuildsRequest)
     EXPECT_EQ(sqe[kSqeDwordCount], entries[0].offset);
     EXPECT_EQ(sqe[kSqeDwordCount + kBatchEntryDwordCount], entries[1].offset);
     EXPECT_EQ(sqe[kSqeDwordCount + 2 * kBatchEntryDwordCount], entries[2].offset);
+    EXPECT_EQ(PackedBatchEntryMrKey(sqe, 0), std::uint32_t{0xABCD0000});
+    EXPECT_EQ(PackedBatchEntryMrKey(sqe, 1), std::uint32_t{0xABCD0001});
+    EXPECT_EQ(PackedBatchEntryMrKey(sqe, 2), std::uint32_t{0xABCD0002});
 }
 
 TEST_F(SqeRequestTest, SubmitBatchStorePacksSqeIntoDeviceSendBuffer)
@@ -234,6 +256,7 @@ TEST_F(SqeRequestTest, SubmitBatchStorePacksSqeIntoDeviceSendBuffer)
     deviceTransport.protocolManager_ = std::make_unique<ProtocolManager>();
 
     auto entries = MakeEntries(3);
+    BindEntries(deviceTransport, entries, 0x12340000);
     IoScheduler::ScheduledIoBatch subBatch{
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
@@ -264,6 +287,7 @@ TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
     };
     TransportSubBatchContext subBatchContext;
     transport_->nextRequestCid_.store(9, std::memory_order_relaxed);
+    BindEntries(*transport_, entries, 0x76540000);
 
     const auto status = transport_->SubmitEntrySubBatchRequest(TransportOpType::BATCH_LOAD,
                                                                subBatch, subBatchContext);
@@ -277,6 +301,25 @@ TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
     const auto* sqe = reinterpret_cast<const std::uint32_t*>(subBatchContext.sendSge.local_addr);
     EXPECT_EQ(sqe[kSqeDwordCount], entries[0].offset);
     EXPECT_EQ(sqe[kSqeDwordCount + kBatchEntryDwordCount], entries[1].offset);
+    EXPECT_EQ(PackedBatchEntryMrKey(sqe, 0), std::uint32_t{0x76540000});
+    EXPECT_EQ(PackedBatchEntryMrKey(sqe, 1), std::uint32_t{0x76540001});
+}
+
+TEST_F(SqeRequestTest, SubmitBatchStoreRejectsUnregisteredEntryBuffer)
+{
+    auto entries = MakeEntries(1);
+    IoScheduler::ScheduledIoBatch subBatch{
+        BatchView<KVBuffer>{entries.data(), entries.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+
+    const auto status = transport_->SubmitEntrySubBatchRequest(TransportOpType::BATCH_STORE,
+                                                               subBatch, subBatchContext);
+
+    EXPECT_EQ(status.code, StatusCode::BUFFER_NOT_REGISTERED);
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
+    ASSERT_EQ(subBatchContext.entryStatus.size(), entries.size());
+    EXPECT_EQ(subBatchContext.entryStatus[0].code, StatusCode::BUFFER_NOT_REGISTERED);
 }
 
 TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)
@@ -363,6 +406,7 @@ TEST_F(SqeRequestTest, AllocationFailureMarksWholeSubBatchFailed)
                           kTestSendBufferSlotNum)
                     .ok());
     uninitializedFlagTransport.protocolManager_ = std::make_unique<ProtocolManager>();
+    BindEntries(uninitializedFlagTransport, entries, 0x45670000);
 
     const auto status = uninitializedFlagTransport.SubmitEntrySubBatchRequest(
         TransportOpType::BATCH_STORE, subBatch, subBatchContext);


### PR DESCRIPTION
## Purpose
Adapt AsuClient to AIV transport provider.

## Modifications 
1. Add C ABI entry points for creating ASU client / transport instances and loading client config, so kv-test can load them through the runtime proxy.
2. Support selecting AICPU / FAKE / AIV transport providers through build options.
3. Extend transport provider config field parsing.
4. Update RegisterRegions / BindRegisteredRegions to preserve and pass tokenId.
5. Use the real active connection handle when registering device memory, and keep the connection alive until unregister.
6. Clean up provider memory handles during unregister.
7. Fix SQE request building to resolve MR keys from the registered handle map.
8. Update related AsuClient and SQE tests.
