### PR TITLE
[Feat] Use fixed 8-byte CacheKey instead of std::string

### DIFF
--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -27,6 +27,7 @@
 #include <any>
 #include <cctype>
 #include <cstddef>
+#include <cstring>
 #include <functional>
 #include <memory>
 #include <numeric>
@@ -55,13 +56,11 @@ std::uint64_t HashAsuKey(const Detail::BlockId& block)
     return static_cast<std::uint64_t>(hasher(block));
 }
 
-std::string MakeAsuKey(const Detail::BlockId& block)
+UC::ASU::CacheKey MakeAsuKey(const Detail::BlockId& block)
 {
     const auto hash = HashAsuKey(block);
-    std::string key(sizeof(hash), '\0');
-    for (std::size_t i = 0; i < key.size(); ++i) {
-        key[i] = static_cast<char>((hash >> (i * 8)) & 0xff);
-    }
+    UC::ASU::CacheKey key{};
+    std::memcpy(key.data(), &hash, key.size());
     return key;
 }
 

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -78,11 +78,19 @@ std::string FirstFailedSubTaskContext(const ClientTaskContext& ctx)
     return "client_task_id=" + std::to_string(ctx.taskId) + " op=" + ClientOpTypeName(ctx.opType);
 }
 
+std::vector<UC::KV::CacheKey> ToRouterKeys(const std::vector<CacheKey>& keys)
+{
+    std::vector<UC::KV::CacheKey> routerKeys;
+    routerKeys.reserve(keys.size());
+    for (const auto& key : keys) { routerKeys.emplace_back(std::string(CacheKeyView(key))); }
+    return routerKeys;
+}
+
 std::vector<UC::KV::CacheKey> ExtractEntryKeys(const std::vector<KVBuffer>& entries)
 {
     std::vector<UC::KV::CacheKey> keys;
     keys.reserve(entries.size());
-    for (const auto& entry : entries) { keys.emplace_back(entry.key); }
+    for (const auto& entry : entries) { keys.emplace_back(std::string(CacheKeyView(entry.key))); }
     return keys;
 }
 
@@ -212,7 +220,7 @@ Status AsuClientImpl::QueryOnce(const std::vector<CacheKey>& keys, const QueryOp
         return finalStatus;
     }
 
-    auto routes = snapshot->router->RouteKeys(keys);
+    auto routes = snapshot->router->RouteKeys(ToRouterKeys(keys));
     for (const auto& route : routes) {
         auto transportIter = snapshot->transports.find(route.first);
         if (transportIter == snapshot->transports.end()) {
@@ -470,7 +478,7 @@ Status AsuClientImpl::SubmitAsyncOnce(ClientOpType opType, const std::vector<Cac
     ctx->viewSnapshot = snapshot;
     ctx->entryStatus.assign(keys.size(), Status::OK());
 
-    auto routes = snapshot->router->RouteKeys(keys);
+    auto routes = snapshot->router->RouteKeys(ToRouterKeys(keys));
     for (const auto& route : routes) {
         if (snapshot->transports.find(route.first) == snapshot->transports.end()) {
             auto status = Status::Error(StatusCode::NOT_FOUND, "routed asu transport not found");

--- a/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
@@ -4,12 +4,14 @@
 #include <chrono>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <fstream>
 #include <gtest/gtest.h>
 #include <iostream>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -17,6 +19,18 @@
 #include "kv_common/router.h"
 
 namespace UC::ASU {
+
+static CacheKey MakeCacheKey(std::string_view text)
+{
+    CacheKey key{};
+    if (text.size() <= key.size()) {
+        if (!text.empty()) { std::memcpy(key.data(), text.data(), text.size()); }
+        return key;
+    }
+    const auto hash = std::hash<std::string_view>{}(text);
+    std::memcpy(key.data(), &hash, key.size());
+    return key;
+}
 
 struct TestState {
     std::uint32_t createdTransports{0};
@@ -107,7 +121,9 @@ public:
 
         result.exists.clear();
         result.exists.reserve(keys.size());
-        for (const auto& key : keys) { result.exists.emplace_back(key == "k15" || key == "k25"); }
+        for (const auto& key : keys) {
+            result.exists.emplace_back(key == MakeCacheKey("k15") || key == MakeCacheKey("k25"));
+        }
         result.prefixHitKeys = 0;
         return Status::OK();
     }
@@ -325,10 +341,13 @@ CacheKey FindKeyForAsu(const std::vector<AsuId>& asuIds, AsuId targetAsuId)
 {
     std::vector<UC::KV::NodeId> nodeIds(asuIds.begin(), asuIds.end());
     auto router = UC::KV::CreateRouter(nodeIds, UC::KV::HashFunction{}, UC::KV::RouterConfig{});
-    for (std::size_t index = 0; index < 10000; ++index) {
-        auto key = "route-key-" + std::to_string(targetAsuId) + "-" + std::to_string(index);
-        auto routes = router->RouteKeys({key});
-        if (routes.size() == 1 && routes.begin()->first == targetAsuId) { return key; }
+    for (std::uint32_t index = 1; index < 1000000; ++index) {
+        std::uint64_t combined = (static_cast<std::uint64_t>(targetAsuId) << 32) | index;
+        CacheKey cacheKey{};
+        std::memcpy(cacheKey.data(), &combined, sizeof(combined));
+        auto routeKey = std::string(CacheKeyView(cacheKey));
+        auto routes = router->RouteKeys({routeKey});
+        if (routes.size() == 1 && routes.begin()->first == targetAsuId) { return cacheKey; }
     }
     return {};
 }
@@ -349,13 +368,13 @@ TEST(AsuClientImplTest, Lifecycle_OperationsBeforeInitReturnExpectedErrors)
     auto client = CreateAsuClient(MakeFactory(state));
 
     QueryResult queryResult;
-    auto status = client->Query({"k05"}, QueryOptions{}, queryResult);
+    auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, queryResult);
     EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
 
     TaskId taskId = kInvalidTaskId;
     status = client->StoreAsync(
         {
-            KVBuffer{"k05", {}}
+            KVBuffer{MakeCacheKey("k05"), {}}
     },
         taskId);
     EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
@@ -386,14 +405,14 @@ TEST(AsuClientImplTest, Lifecycle_ShutdownClearsTasksAndRejectsFutureOperations)
     TaskId taskId = kInvalidTaskId;
     auto status = client->StoreAsync(
         {
-            KVBuffer{"k05", {}}
+            KVBuffer{MakeCacheKey("k05"), {}}
     },
         taskId);
     ASSERT_TRUE(status.ok()) << status.message;
     ASSERT_TRUE(client->Shutdown().ok());
 
     QueryResult queryResult;
-    status = client->Query({"k05"}, QueryOptions{}, queryResult);
+    status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, queryResult);
     EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
 
     TaskResult taskResult;
@@ -519,8 +538,8 @@ TEST(AsuClientImplTest, Routing_UsesRouterConfigFromClientConfigAttrs)
 
     auto keyForAsu10 = FindKeyForAsu({10, 20}, 10);
     auto keyForAsu20 = FindKeyForAsu({10, 20}, 20);
-    ASSERT_FALSE(keyForAsu10.empty());
-    ASSERT_FALSE(keyForAsu20.empty());
+    ASSERT_NE(keyForAsu10, CacheKey{});
+    ASSERT_NE(keyForAsu20, CacheKey{});
 
     auto client = CreateAsuClient(MakeFactory(state));
     ASSERT_TRUE(client->Init(config).ok());
@@ -562,7 +581,8 @@ TEST(AsuClientImplTest, Query_PerKeyKeepsOriginalOrder)
     ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
 
     QueryResult result;
-    auto status = client->Query({"k05", "k15", "k25"}, QueryOptions{}, result);
+    auto status = client->Query({MakeCacheKey("k05"), MakeCacheKey("k15"), MakeCacheKey("k25")},
+                                QueryOptions{}, result);
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(result.exists, std::vector<std::uint8_t>({0, 1, 1}));
@@ -576,7 +596,7 @@ TEST(AsuClientImplTest, Query_PerKeyFailureIncludesAsuContext)
     ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
 
     QueryResult result;
-    auto status = client->Query({"k15"}, QueryOptions{}, result);
+    auto status = client->Query({MakeCacheKey("k15")}, QueryOptions{}, result);
 
     EXPECT_EQ(status.code, StatusCode::IO_ERROR);
     EXPECT_NE(status.message.find("asuId=20"), std::string::npos);
@@ -609,7 +629,7 @@ TEST(AsuClientImplTest, Query_PerKeyResultSizeMismatchReturnsInternalError)
     ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
 
     QueryResult result;
-    auto status = client->Query({"k05"}, QueryOptions{}, result);
+    auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
     EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_NE(status.message.find("query result size mismatch"), std::string::npos);
@@ -637,7 +657,9 @@ TEST(AsuClientImplTest, Query_PrefixBroadcastsAndMergesResults)
     QueryOptions options;
     options.mode = QueryMode::PREFIX;
     QueryResult result;
-    auto status = client->Query({"prefix-a", "prefix-b", "prefix-c"}, options, result);
+    auto status = client->Query(
+        {MakeCacheKey("prefix-a"), MakeCacheKey("prefix-b"), MakeCacheKey("prefix-c")}, options,
+        result);
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(result.exists, std::vector<std::uint8_t>({1, 1, 1}));
@@ -667,7 +689,9 @@ TEST(AsuClientImplTest, Query_PrefixPartialFailureIncludesAsuContext)
     QueryOptions options;
     options.mode = QueryMode::PREFIX;
     QueryResult result;
-    auto status = client->Query({"prefix-a", "prefix-b", "prefix-c"}, options, result);
+    auto status = client->Query(
+        {MakeCacheKey("prefix-a"), MakeCacheKey("prefix-b"), MakeCacheKey("prefix-c")}, options,
+        result);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     EXPECT_NE(status.message.find("asuId=20"), std::string::npos);
@@ -686,7 +710,8 @@ TEST(AsuClientImplTest, Query_PrefixResultSizeMismatchReturnsInternalError)
     QueryOptions options;
     options.mode = QueryMode::PREFIX;
     QueryResult result;
-    auto status = client->Query({"prefix-a", "prefix-b"}, options, result);
+    auto status =
+        client->Query({MakeCacheKey("prefix-a"), MakeCacheKey("prefix-b")}, options, result);
 
     EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_NE(status.message.find("prefix query result size mismatch"), std::string::npos);
@@ -702,11 +727,11 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryReturnsErrorWithoutRetry)
     EXPECT_EQ(state->createdTransports, std::uint32_t{2});
 
     QueryResult result;
-    auto status = client->Query({"k05"}, QueryOptions{}, result);
+    auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
     EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
 
-    status = client->Query({"k15"}, QueryOptions{}, result);
+    status = client->Query({MakeCacheKey("k15")}, QueryOptions{}, result);
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(result.exists, std::vector<std::uint8_t>({1}));
@@ -730,7 +755,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryDoesNotRefreshNonRefreshableError
     ASSERT_TRUE(client->Init(config).ok());
 
     QueryResult result;
-    auto status = client->Query({"k05"}, QueryOptions{}, result);
+    auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
     EXPECT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
     EXPECT_EQ(viewServer->FetchCount(), std::size_t{1});
@@ -755,7 +780,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryRefreshesOnIoError)
     ASSERT_TRUE(client->Init(config).ok());
 
     QueryResult result;
-    auto status = client->Query({"k05"}, QueryOptions{}, result);
+    auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
     EXPECT_EQ(status.code, StatusCode::IO_ERROR);
     ASSERT_TRUE(client->Shutdown().ok());
@@ -780,7 +805,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryRefreshesOnTimeout)
     ASSERT_TRUE(client->Init(config).ok());
 
     QueryResult result;
-    auto status = client->Query({"k05"}, QueryOptions{}, result);
+    auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
     EXPECT_EQ(status.code, StatusCode::TIMEOUT);
     ASSERT_TRUE(client->Shutdown().ok());
@@ -804,7 +829,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryKeepsOriginalErrorWhenViewFetchFa
     ASSERT_TRUE(client->Init(config).ok());
 
     QueryResult result;
-    auto status = client->Query({"k05"}, QueryOptions{}, result);
+    auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
     EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
     ASSERT_TRUE(client->Shutdown().ok());
@@ -829,7 +854,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_LoadReturnsErrorWithoutRetry)
     TaskId taskId = kInvalidTaskId;
     auto status = client->LoadAsync(
         {
-            KVBuffer{"k05", {}}
+            KVBuffer{MakeCacheKey("k05"), {}}
     },
         taskId);
 
@@ -858,7 +883,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_StoreReturnsErrorWithoutRetry)
     TaskId taskId = kInvalidTaskId;
     auto status = client->StoreAsync(
         {
-            KVBuffer{"k05", {}}
+            KVBuffer{MakeCacheKey("k05"), {}}
     },
         taskId);
 
@@ -885,7 +910,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_DeleteReturnsErrorWithoutRetry)
     ASSERT_TRUE(client->Init(config).ok());
 
     TaskId taskId = kInvalidTaskId;
-    auto status = client->DeleteAsync({"k05"}, taskId);
+    auto status = client->DeleteAsync({MakeCacheKey("k05")}, taskId);
 
     EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
     EXPECT_EQ(taskId, kInvalidTaskId);
@@ -911,7 +936,7 @@ TEST(AsuClientImplTest, ViewEpoch_DoesNotPublishSameOrOlderViewEpoch)
     ASSERT_TRUE(client->Init(config).ok());
 
     QueryResult result;
-    auto status = client->Query({"k05"}, QueryOptions{}, result);
+    auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
     EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
     ASSERT_TRUE(client->Shutdown().ok());
     EXPECT_EQ(state->createdTransports, std::uint32_t{1});
@@ -929,11 +954,11 @@ TEST(AsuClientImplTest, SnapshotRefresh_BuildFailureKeepsOldSnapshot)
     ASSERT_TRUE(client->Init(config).ok());
 
     QueryResult result;
-    auto status = client->Query({"k05"}, QueryOptions{}, result);
+    auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
     EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
     ASSERT_TRUE(WaitForFetchCount(viewServer, 2));
 
-    status = client->Query({"k05"}, QueryOptions{}, result);
+    status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(state->createdTransports, std::uint32_t{1});
@@ -1080,7 +1105,7 @@ TEST(AsuClientImplTest, MemoryRegister_BindFailureDoesNotCacheResource)
 
     state->failFirstQuery = true;
     QueryResult queryResult;
-    status = client->Query({"k05"}, QueryOptions{}, queryResult);
+    status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, queryResult);
 
     EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
     ASSERT_TRUE(client->Shutdown().ok());
@@ -1141,7 +1166,7 @@ TEST(AsuClientImplTest, MemoryRegister_UnregisterRemovesCachedResourceBeforeFutu
 
     state->failFirstQuery = true;
     QueryResult queryResult;
-    status = client->Query({"k05"}, QueryOptions{}, queryResult);
+    status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, queryResult);
 
     EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
     ASSERT_TRUE(client->Shutdown().ok());
@@ -1158,7 +1183,7 @@ TEST(AsuClientImplTest, Task_CheckRemovesTaskAfterCompletion)
     TaskId taskId = 0;
     auto status = client->StoreAsync(
         {
-            KVBuffer{"k05", {}}
+            KVBuffer{MakeCacheKey("k05"), {}}
     },
         taskId);
     ASSERT_TRUE(status.ok()) << status.message;
@@ -1181,7 +1206,7 @@ TEST(AsuClientImplTest, Task_CheckKeepsInProgressTaskUntilCompletion)
     TaskId taskId = 0;
     auto status = client->StoreAsync(
         {
-            KVBuffer{"k05", {}}
+            KVBuffer{MakeCacheKey("k05"), {}}
     },
         taskId);
     ASSERT_TRUE(status.ok()) << status.message;
@@ -1216,7 +1241,7 @@ TEST(AsuClientImplTest, Task_CheckRefreshesViewOnRefreshableChildFailure)
     TaskId taskId = 0;
     auto status = client->StoreAsync(
         {
-            KVBuffer{"k05", {}}
+            KVBuffer{MakeCacheKey("k05"), {}}
     },
         taskId);
     ASSERT_TRUE(status.ok()) << status.message;
@@ -1238,8 +1263,8 @@ TEST(AsuClientImplTest, Task_PartialDispatchFailureCancelsDispatchedSubtasks)
     ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
     auto keyForAsu10 = FindKeyForAsu({10, 20}, 10);
     auto keyForAsu20 = FindKeyForAsu({10, 20}, 20);
-    ASSERT_FALSE(keyForAsu10.empty());
-    ASSERT_FALSE(keyForAsu20.empty());
+    ASSERT_NE(keyForAsu10, CacheKey{});
+    ASSERT_NE(keyForAsu20, CacheKey{});
 
     TaskId taskId = kInvalidTaskId;
     auto status = client->StoreAsync(
@@ -1265,7 +1290,7 @@ TEST(AsuClientImplTest, Task_WaitRemovesTaskAfterCompletion)
     TaskId taskId = 0;
     auto status = client->StoreAsync(
         {
-            KVBuffer{"k05", {}}
+            KVBuffer{MakeCacheKey("k05"), {}}
     },
         taskId);
     ASSERT_TRUE(status.ok()) << status.message;
@@ -1311,7 +1336,7 @@ TEST(AsuClientImplTest, Task_WaitTimeoutKeepsTaskForLaterCompletion)
     TaskId taskId = 0;
     auto status = client->StoreAsync(
         {
-            KVBuffer{"k05", {}}
+            KVBuffer{MakeCacheKey("k05"), {}}
     },
         taskId);
     ASSERT_TRUE(status.ok()) << status.message;
@@ -1337,9 +1362,9 @@ TEST(AsuClientImplTest, Task_CheckKeepsEntryStatusInOriginalOrderAcrossAsus)
     ASSERT_TRUE(client->Init(MakeConfig({10, 20, 30})).ok());
     auto entries = BuildRoutedEntries({30, 10, 20});
     ASSERT_EQ(entries.size(), std::size_t{3});
-    ASSERT_FALSE(entries[0].key.empty());
-    ASSERT_FALSE(entries[1].key.empty());
-    ASSERT_FALSE(entries[2].key.empty());
+    ASSERT_NE(entries[0].key, CacheKey{});
+    ASSERT_NE(entries[1].key, CacheKey{});
+    ASSERT_NE(entries[2].key, CacheKey{});
 
     TaskId taskId = 0;
     auto status = client->StoreAsync(entries, taskId);
@@ -1365,9 +1390,9 @@ TEST(AsuClientImplTest, Task_LoadKeepsEntryStatusInOriginalOrderAcrossAsus)
     ASSERT_TRUE(client->Init(MakeConfig({10, 20, 30})).ok());
     auto entries = BuildRoutedEntries({30, 10, 20});
     ASSERT_EQ(entries.size(), std::size_t{3});
-    ASSERT_FALSE(entries[0].key.empty());
-    ASSERT_FALSE(entries[1].key.empty());
-    ASSERT_FALSE(entries[2].key.empty());
+    ASSERT_NE(entries[0].key, CacheKey{});
+    ASSERT_NE(entries[1].key, CacheKey{});
+    ASSERT_NE(entries[2].key, CacheKey{});
 
     TaskId taskId = kInvalidTaskId;
     auto status = client->LoadAsync(entries, taskId);
@@ -1393,9 +1418,9 @@ TEST(AsuClientImplTest, Task_DeleteKeepsEntryStatusInOriginalOrderAcrossAsus)
     ASSERT_TRUE(client->Init(MakeConfig({10, 20, 30})).ok());
     auto entries = BuildRoutedEntries({30, 10, 20});
     ASSERT_EQ(entries.size(), std::size_t{3});
-    ASSERT_FALSE(entries[0].key.empty());
-    ASSERT_FALSE(entries[1].key.empty());
-    ASSERT_FALSE(entries[2].key.empty());
+    ASSERT_NE(entries[0].key, CacheKey{});
+    ASSERT_NE(entries[1].key, CacheKey{});
+    ASSERT_NE(entries[2].key, CacheKey{});
     std::vector<CacheKey> keys;
     keys.reserve(entries.size());
     for (const auto& entry : entries) { keys.emplace_back(entry.key); }
@@ -1432,7 +1457,7 @@ TEST(AsuClientImplTest, SnapshotRefresh_ReusesExistingTransportAndBindsResources
     state->failFirstQuery = true;
 
     QueryResult result;
-    status = client->Query({"k05"}, QueryOptions{}, result);
+    status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
     EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
     ASSERT_TRUE(client->Shutdown().ok());
@@ -1458,7 +1483,7 @@ TEST(AsuClientImplTest,
     TaskId taskId = 0;
     auto status = client->StoreAsync(
         {
-            KVBuffer{"k15", {}}
+            KVBuffer{MakeCacheKey("k15"), {}}
     },
         taskId);
     ASSERT_TRUE(status.ok()) << status.message;
@@ -1466,7 +1491,7 @@ TEST(AsuClientImplTest,
 
     state->failFirstQuery = true;
     QueryResult queryResult;
-    status = client->Query({"k05"}, QueryOptions{}, queryResult);
+    status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, queryResult);
     ASSERT_EQ(status.code, StatusCode::CONNECTION_ERROR);
     ASSERT_TRUE(WaitForFetchCount(viewServer, 2));
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -1478,7 +1503,7 @@ TEST(AsuClientImplTest,
 
     status = client->StoreAsync(
         {
-            KVBuffer{"k15", {}}
+            KVBuffer{MakeCacheKey("k15"), {}}
     },
         taskId);
     EXPECT_TRUE(status.ok()) << status.message;

--- a/ucm/transport/kv/asu/test/case/asu_client_e2e_metrics_test.cc
+++ b/ucm/transport/kv/asu/test/case/asu_client_e2e_metrics_test.cc
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
+#include <cstring>
 #include <ctime>
 #include <functional>
 #include <gtest/gtest.h>
@@ -31,6 +32,7 @@
 #include <mutex>
 #include <numeric>
 #include <string>
+#include <string_view>
 #include <thread>
 #include <unordered_map>
 #include <unordered_set>
@@ -40,6 +42,30 @@
 
 namespace UC::ASU {
 namespace {
+
+CacheKey MakeCacheKey(std::string_view text)
+{
+    CacheKey key{};
+    if (text.size() <= key.size()) {
+        if (!text.empty()) { std::memcpy(key.data(), text.data(), text.size()); }
+        return key;
+    }
+    const auto hash = std::hash<std::string_view>{}(text);
+    std::memcpy(key.data(), &hash, key.size());
+    return key;
+}
+
+struct CacheKeyHasher {
+    std::size_t operator()(const CacheKey& key) const
+    {
+        std::uint64_t hash = 1469598103934665603ULL;
+        for (auto byte : key) {
+            hash ^= static_cast<std::uint64_t>(std::to_integer<unsigned char>(byte));
+            hash *= 1099511628211ULL;
+        }
+        return static_cast<std::size_t>(hash);
+    }
+};
 
 enum class OperationKind {
     QUERY,
@@ -167,10 +193,20 @@ struct ResourceSnapshot {
     std::clock_t cpuTicks{0};
 };
 
+bool CacheKeyStartsWith(const CacheKey& key, const CacheKey& prefix)
+{
+    auto prefixLength = prefix.size();
+    while (prefixLength > 0 && prefix[prefixLength - 1] == std::byte{0}) { --prefixLength; }
+    if (prefixLength == 0) { return false; }
+    return std::equal(prefix.begin(), prefix.begin() + prefixLength, key.begin());
+}
+
 struct ClusterState {
     mutable std::mutex mutex;
     std::unordered_set<AsuId> activeAsus;
-    std::unordered_map<AsuId, std::unordered_map<CacheKey, std::vector<std::uint8_t>>> stores;
+    std::unordered_map<AsuId,
+                       std::unordered_map<CacheKey, std::vector<std::uint8_t>, CacheKeyHasher>>
+        stores;
     std::unordered_map<TaskId, TaskResult> tasks;
     std::unordered_map<AsuId, std::size_t> queryCalls;
     std::unordered_map<AsuId, std::size_t> loadCalls;
@@ -318,7 +354,7 @@ public:
         for (std::size_t index = 0; index < keys.size(); ++index) {
             if (options.mode == QueryMode::PREFIX) {
                 const bool hit = std::any_of(store.begin(), store.end(), [&](const auto& item) {
-                    return item.first.rfind(keys[index], 0) == 0;
+                    return CacheKeyStartsWith(item.first, keys[index]);
                 });
                 result.exists[index] = hit ? 1 : 0;
                 if (hit) { ++result.prefixHitKeys; }
@@ -596,7 +632,8 @@ std::vector<KVBuffer> MakeStoreEntries(const std::string& prefix, std::size_t co
     for (std::size_t index = 0; index < count; ++index) {
         payloads.emplace_back(
             MakePayload(baseSize + (index % 5U) * 17U, static_cast<std::uint8_t>(index + 1U)));
-        entries.emplace_back(MakeBuffer(prefix + std::to_string(index), payloads.back()));
+        entries.emplace_back(
+            MakeBuffer(MakeCacheKey(prefix + std::to_string(index)), payloads.back()));
     }
     return entries;
 }
@@ -716,7 +753,7 @@ std::vector<CacheKey> MakeProbeKeys(std::size_t count)
     std::vector<CacheKey> keys;
     keys.reserve(count);
     for (std::size_t index = 0; index < count; ++index) {
-        keys.emplace_back("refresh-probe-" + std::to_string(index));
+        keys.emplace_back(MakeCacheKey("refresh-probe-" + std::to_string(index)));
     }
     return keys;
 }
@@ -814,7 +851,8 @@ TEST(AsuClientE2EMetricsTest, DiskMembershipChangesRefreshAndContinueWorkload)
     viewServer->Publish({1, 2, 3});
     state->ForceNextQueryFailure();
     QueryResult ignoredResult;
-    auto status = client->Query({"membership-refresh-add"}, QueryOptions{}, ignoredResult);
+    auto status =
+        client->Query({MakeCacheKey("membership-refresh-add")}, QueryOptions{}, ignoredResult);
     EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
     ASSERT_TRUE(WaitUntil(
         [&] { return viewServer->FetchCount() >= 2 && state->Snapshot().createdTransports >= 3; }));
@@ -868,7 +906,8 @@ TEST(AsuClientE2EMetricsTest, NoDiskAndEmptyRequestsReturnStableStatuses)
         ASSERT_TRUE(client->Init(MakeClientConfig({})).ok());
 
         QueryResult queryResult;
-        auto status = client->Query({"missing-on-empty-view"}, QueryOptions{}, queryResult);
+        auto status =
+            client->Query({MakeCacheKey("missing-on-empty-view")}, QueryOptions{}, queryResult);
         ASSERT_TRUE(status.ok()) << status.message;
         ASSERT_EQ(queryResult.exists, std::vector<std::uint8_t>{0});
 

--- a/ucm/transport/kv/asu/test/case/asu_smoke_test.cc
+++ b/ucm/transport/kv/asu/test/case/asu_smoke_test.cc
@@ -21,12 +21,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  * */
+#include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <gtest/gtest.h>
+#include <string_view>
 #include "asu_client_impl.h"
 
 namespace UC::ASU {
 namespace {
+
+CacheKey MakeCacheKey(std::string_view text)
+{
+    CacheKey key{};
+    const auto size = std::min(text.size(), key.size());
+    if (size > 0) { std::memcpy(key.data(), text.data(), size); }
+    return key;
+}
 
 class StubTransport : public AsuTransport {
 public:
@@ -162,10 +173,10 @@ std::vector<KVBuffer> MakeEntries(std::vector<std::uint8_t>& payload)
     buffer.region = region;
 
     return {
-        KVBuffer{"alpha", buffer},
-        KVBuffer{"beta",  buffer},
-        KVBuffer{"gamma", buffer},
-        KVBuffer{"delta", buffer},
+        KVBuffer{MakeCacheKey("alpha"), buffer},
+        KVBuffer{MakeCacheKey("beta"),  buffer},
+        KVBuffer{MakeCacheKey("gamma"), buffer},
+        KVBuffer{MakeCacheKey("delta"), buffer},
     };
 }
 
@@ -210,7 +221,8 @@ TEST(AsuSmokeTest, ClientAsyncTasksCompleteEndToEnd)
     ASSERT_NE(storeTaskId, kInvalidTaskId);
     ExpectCompleted(*client, storeTaskId, entries.size());
 
-    std::vector<CacheKey> keys{"alpha", "beta", "gamma", "delta"};
+    std::vector<CacheKey> keys{MakeCacheKey("alpha"), MakeCacheKey("beta"), MakeCacheKey("gamma"),
+                               MakeCacheKey("delta")};
     QueryOptions queryOptions;
     queryOptions.timeoutMs = 500;
     QueryResult queryResult;

--- a/ucm/transport/kv/asu/test/case/kv_protocol_test.cc
+++ b/ucm/transport/kv/asu/test/case/kv_protocol_test.cc
@@ -22,12 +22,29 @@
  * SOFTWARE.
  * */
 #include "kv_protocol.h"
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <gtest/gtest.h>
+#include <string_view>
 
 namespace UC::ASU {
 namespace {
+
+CacheKey MakeCacheKey(std::string_view text)
+{
+    CacheKey key{};
+    const auto size = std::min(text.size(), key.size());
+    if (size > 0) { std::memcpy(key.data(), text.data(), size); }
+    return key;
+}
+
+CacheKey MakeCacheKey(std::uint64_t value)
+{
+    CacheKey key{};
+    std::memcpy(key.data(), &value, key.size());
+    return key;
+}
 
 class KvProtocolPackTest : public ::testing::Test {
 protected:
@@ -47,7 +64,7 @@ TEST_F(KvProtocolPackTest, StoreProtocolPackMatchesProtocol)
     constexpr std::uint32_t kOffset = 0x00001000;
     constexpr bool kLr = true;
     constexpr std::uint32_t kLength = 0x00000002;
-    const std::string kKey = "tk_02";
+    const std::string kKey = "test_key_01";
 
     KvStoreRequest req;
     req.cid = kCid;
@@ -60,7 +77,7 @@ TEST_F(KvProtocolPackTest, StoreProtocolPackMatchesProtocol)
     req.offset = kOffset;
     req.lr = kLr;
     req.length = kLength;
-    req.key = kKey;
+    req.key = MakeCacheKey(kKey);
 
     KvStoreProtocol proto;
     std::vector<std::uint32_t> packed(16, 0);
@@ -77,7 +94,7 @@ TEST_F(KvProtocolPackTest, StoreProtocolPackMatchesProtocol)
     expected[9] = (0x40 << 24) | ((kMrKey >> 8) & 0xFFFFFF);
     expected[10] = kOffset;
     expected[11] = (kLr ? (1U << 31) : 0) | (kLength & 0xFFFFFF);
-    std::size_t key_len = std::min(kKey.size(), static_cast<std::size_t>(8));
+    std::size_t key_len = std::min(kKey.size(), kCacheKeySizeBytes);
     if (key_len > 0) { std::memcpy(&expected[12], kKey.data(), key_len); }
 
     ASSERT_EQ(packed.size(), expected.size());
@@ -97,7 +114,7 @@ TEST_F(KvProtocolPackTest, RetrieveProtocolPackMatchesProtocol)
     constexpr std::uint32_t kOffset = 0x00002000;
     constexpr bool kLr = false;
     constexpr std::uint32_t kLength = 0x00000003;
-    const std::string kKey = "retkez";
+    const std::string kKey = "retrieve_key";
 
     KvRetrieveRequest req;
     req.cid = kCid;
@@ -108,7 +125,7 @@ TEST_F(KvProtocolPackTest, RetrieveProtocolPackMatchesProtocol)
     req.offset = kOffset;
     req.lr = kLr;
     req.length = kLength;
-    req.key = kKey;
+    req.key = MakeCacheKey(kKey);
 
     KvRetrieveProtocol proto;
     std::vector<std::uint32_t> packed(proto.PackedSize(req) / sizeof(std::uint32_t), 0);
@@ -124,7 +141,7 @@ TEST_F(KvProtocolPackTest, RetrieveProtocolPackMatchesProtocol)
     expected[9] = (0x40 << 24) | ((kMrKey >> 8) & 0xFFFFFF);
     expected[10] = kOffset;
     expected[11] = (kLr ? (1U << 31) : 0) | (kLength & 0xFFFFFF);
-    std::memcpy(&expected[12], kKey.data(), std::min(kKey.size(), static_cast<std::size_t>(8)));
+    std::memcpy(&expected[12], kKey.data(), std::min(kKey.size(), kCacheKeySizeBytes));
 
     ASSERT_EQ(packed.size(), expected.size());
     for (std::size_t i = 0; i < expected.size(); ++i) {
@@ -145,14 +162,14 @@ TEST_F(KvProtocolPackTest, BatchStoreProtocolPackMatchesProtocol)
 
     KvBatchStoreEntry entry1;
     entry1.offset = 0x1000;
-    entry1.key = "bk_1";
+    entry1.key = MakeCacheKey("batch_key_1");
     entry1.buffer_addr = 0x0000AAAABBBBCCCCULL;
     entry1.mr_key = 0x11111111;
     entry1.length = 0x2000;
 
     KvBatchStoreEntry entry2;
     entry2.offset = 0x2000;
-    entry2.key = "bk_2";
+    entry2.key = MakeCacheKey("batch_key_2");
     entry2.buffer_addr = 0x0000DDDDEEEEFFFFULL;
     entry2.mr_key = 0x22222222;
     entry2.length = 0x3000;
@@ -187,16 +204,14 @@ TEST_F(KvProtocolPackTest, BatchStoreProtocolPackMatchesProtocol)
     expected[11] = kLr ? (1U << 31) : 0;
 
     expected[16] = entry1.offset;
-    std::memcpy(&expected[17], entry1.key.data(),
-                std::min(entry1.key.size(), static_cast<std::size_t>(8)));
+    std::memcpy(&expected[17], entry1.key.data(), std::min(entry1.key.size(), kCacheKeySizeBytes));
     expected[21] = entry1.buffer_addr & 0xFFFFFFFFULL;
     expected[22] = (entry1.buffer_addr >> 32) & 0xFFFFFFFFULL;
     expected[23] = ((entry1.mr_key & 0xFF) << 24) | (entry1.length & 0xFFFFFF);
     expected[24] = (0x40 << 24) | ((entry1.mr_key >> 8) & 0xFFFFFF);
 
     expected[25] = entry2.offset;
-    std::memcpy(&expected[26], entry2.key.data(),
-                std::min(entry2.key.size(), static_cast<std::size_t>(8)));
+    std::memcpy(&expected[26], entry2.key.data(), std::min(entry2.key.size(), kCacheKeySizeBytes));
     expected[30] = entry2.buffer_addr & 0xFFFFFFFFULL;
     expected[31] = (entry2.buffer_addr >> 32) & 0xFFFFFFFFULL;
     expected[32] = ((entry2.mr_key & 0xFF) << 24) | (entry2.length & 0xFFFFFF);
@@ -219,7 +234,7 @@ TEST_F(KvProtocolPackTest, BatchRetrieveProtocolPackMatchesProtocol)
 
     KvBatchRetrieveEntry entry;
     entry.offset = 0x3000;
-    entry.key = "br_key";
+    entry.key = MakeCacheKey("batch_ret_key");
     entry.buffer_addr = 0x0000777788889999ULL;
     entry.mr_key = 0x33333333;
     entry.length = 0x4000;
@@ -249,8 +264,7 @@ TEST_F(KvProtocolPackTest, BatchRetrieveProtocolPackMatchesProtocol)
     expected[9] = 0x01 << 24;
     expected[10] = 1;
     expected[16] = entry.offset;
-    std::memcpy(&expected[17], entry.key.data(),
-                std::min(entry.key.size(), static_cast<std::size_t>(8)));
+    std::memcpy(&expected[17], entry.key.data(), std::min(entry.key.size(), kCacheKeySizeBytes));
     expected[21] = entry.buffer_addr & 0xFFFFFFFFULL;
     expected[22] = (entry.buffer_addr >> 32) & 0xFFFFFFFFULL;
     expected[23] = ((entry.mr_key & 0xFF) << 24) | (entry.length & 0xFFFFFF);
@@ -277,7 +291,7 @@ TEST_F(KvProtocolPackTest, DeleteProtocolPackMatchesProtocol)
     req.response_mr_key = kRespMrKey;
     req.rflag = kRflag;
     req.batch_number = 2;
-    req.keys = {"dk_1", "dk_2"};
+    req.keys = {MakeCacheKey("delete_key_1"), MakeCacheKey("delete_key_2")};
 
     KvDeleteProtocol proto;
     std::vector<std::uint32_t> packed(proto.PackedSize(req) / sizeof(std::uint32_t), 0);
@@ -294,9 +308,9 @@ TEST_F(KvProtocolPackTest, DeleteProtocolPackMatchesProtocol)
     expected[9] = 0x01 << 24;
     expected[10] = 2;
     std::memcpy(&expected[16], req.keys[0].data(),
-                std::min(req.keys[0].size(), static_cast<std::size_t>(8)));
+                std::min(req.keys[0].size(), kCacheKeySizeBytes));
     std::memcpy(&expected[20], req.keys[1].data(),
-                std::min(req.keys[1].size(), static_cast<std::size_t>(8)));
+                std::min(req.keys[1].size(), kCacheKeySizeBytes));
 
     ASSERT_EQ(packed.size(), expected.size());
     for (std::size_t i = 0; i < expected.size(); ++i) {
@@ -321,7 +335,7 @@ TEST_F(KvProtocolPackTest, ExistProtocolPackMatchesProtocol)
     req.rflag = kRflag;
     req.sc = kSc;
     req.batch_number = 1;
-    req.keys = {"exkey"};
+    req.keys = {MakeCacheKey("exist_key")};
 
     KvExistProtocol proto;
     std::vector<std::uint32_t> packed(proto.PackedSize(req) / sizeof(std::uint32_t), 0);
@@ -338,7 +352,7 @@ TEST_F(KvProtocolPackTest, ExistProtocolPackMatchesProtocol)
     expected[9] = 0x01 << 24;
     expected[10] = 1 | (kSc ? (1U << 16) : 0);
     std::memcpy(&expected[16], req.keys[0].data(),
-                std::min(req.keys[0].size(), static_cast<std::size_t>(8)));
+                std::min(req.keys[0].size(), kCacheKeySizeBytes));
 
     ASSERT_EQ(packed.size(), expected.size());
     for (std::size_t i = 0; i < expected.size(); ++i) {
@@ -422,7 +436,7 @@ TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsZeroBufferAddr)
     req.buffer_length = 512;
     req.offset = 0;
     req.length = 1;
-    req.key = "key";
+    req.key = MakeCacheKey("key");
 
     KvStoreProtocol proto;
     std::vector<std::uint32_t> target(16, 0);
@@ -438,7 +452,7 @@ TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsZeroBufferLength)
     req.buffer_length = 0;
     req.offset = 0;
     req.length = 1;
-    req.key = "key";
+    req.key = MakeCacheKey("key");
 
     KvStoreProtocol proto;
     std::vector<std::uint32_t> target(16, 0);
@@ -454,7 +468,7 @@ TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsUnalignedBufferLength)
     req.buffer_length = 100;
     req.offset = 0;
     req.length = 1;
-    req.key = "key";
+    req.key = MakeCacheKey("key");
 
     KvStoreProtocol proto;
     std::vector<std::uint32_t> target(16, 0);
@@ -463,37 +477,20 @@ TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsUnalignedBufferLength)
     EXPECT_NE(status.message.find("512B aligned"), std::string::npos);
 }
 
-TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsEmptyKey)
+TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsAllZeroKey)
 {
     KvStoreRequest req;
     req.buffer_addr = 0x1000;
     req.buffer_length = 512;
     req.offset = 0;
     req.length = 1;
-    req.key = "";
+    req.key = CacheKey{};
 
     KvStoreProtocol proto;
     std::vector<std::uint32_t> target(16, 0);
     auto status = proto.PackSqe(req, target.data());
     EXPECT_FALSE(status.ok());
-    EXPECT_NE(status.message.find("key is empty"), std::string::npos);
-}
-
-TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsKeyTooLong)
-{
-    KvStoreRequest req;
-    req.buffer_addr = 0x1000;
-    req.buffer_length = 512;
-    req.offset = 0;
-    req.length = 1;
-    req.key = "this_key_is_way_too_long_for_16_bytes";
-
-    KvStoreProtocol proto;
-    std::vector<std::uint32_t> target(16, 0);
-    auto status = proto.PackSqe(req, target.data());
-    EXPECT_FALSE(status.ok());
-    EXPECT_NE(status.message.find("key size("), std::string::npos);
-    EXPECT_NE(status.message.find("exceeds 8 bytes"), std::string::npos);
+    EXPECT_NE(status.message.find("all zeros"), std::string::npos);
 }
 
 TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsDtypeOverflow)
@@ -503,7 +500,7 @@ TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsDtypeOverflow)
     req.buffer_length = 512;
     req.offset = 0;
     req.length = 1;
-    req.key = "key";
+    req.key = MakeCacheKey("key");
     req.dtype = 8;
 
     KvStoreProtocol proto;
@@ -521,7 +518,7 @@ TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsDspecOverflow)
     req.buffer_length = 512;
     req.offset = 0;
     req.length = 1;
-    req.key = "key";
+    req.key = MakeCacheKey("key");
     req.dspec = 32;
 
     KvStoreProtocol proto;
@@ -539,7 +536,7 @@ TEST_F(KvProtocolPackTest, StoreValidateRequestAcceptsValidRequest)
     req.buffer_length = 512;
     req.offset = 0;
     req.length = 1;
-    req.key = "vkey";
+    req.key = MakeCacheKey("valid_key");
     req.dtype = 1;
     req.dspec = 5;
 
@@ -569,7 +566,7 @@ TEST_F(KvProtocolPackTest, BatchStoreValidateRequestRejectsRflagWithZeroResponse
     req.rflag = true;
     req.response_buffer_addr = 0;
     req.entries.resize(1);
-    req.entries[0].key = "key";
+    req.entries[0].key = MakeCacheKey("key");
 
     KvBatchStoreProtocol proto;
     std::vector<std::uint32_t> target(64, 0);
@@ -583,7 +580,7 @@ TEST_F(KvProtocolPackTest, BatchStoreValidateRequestRejectsUnalignedLength)
     KvBatchStoreRequest req;
     req.batch_number = 1;
     req.entries.resize(1);
-    req.entries[0].key = "key";
+    req.entries[0].key = MakeCacheKey("key");
     req.entries[0].offset = 0;
     req.entries[0].buffer_addr = 0x1000;
     req.entries[0].length = 100;
@@ -595,12 +592,12 @@ TEST_F(KvProtocolPackTest, BatchStoreValidateRequestRejectsUnalignedLength)
     EXPECT_NE(status.message.find("512B aligned"), std::string::npos);
 }
 
-TEST_F(KvProtocolPackTest, BatchStoreValidateRequestRejectsKeyTooLong)
+TEST_F(KvProtocolPackTest, BatchStoreValidateRequestRejectsAllZeroKey)
 {
     KvBatchStoreRequest req;
     req.batch_number = 1;
     req.entries.resize(1);
-    req.entries[0].key = "toolongkey9";
+    req.entries[0].key = CacheKey{};
     req.entries[0].offset = 0;
     req.entries[0].buffer_addr = 0x1000;
     req.entries[0].length = 512;
@@ -609,8 +606,7 @@ TEST_F(KvProtocolPackTest, BatchStoreValidateRequestRejectsKeyTooLong)
     std::vector<std::uint32_t> target(64, 0);
     auto status = proto.PackSqe(req, target.data());
     EXPECT_FALSE(status.ok());
-    EXPECT_NE(status.message.find("key size("), std::string::npos);
-    EXPECT_NE(status.message.find("exceeds 8 bytes"), std::string::npos);
+    EXPECT_NE(status.message.find("all zeros"), std::string::npos);
 }
 
 TEST_F(KvProtocolPackTest, KeepAliveValidateRequestRejectsRflagWithZeroResponseAddr)
@@ -747,7 +743,7 @@ TEST_F(KvProtocolPackTest, RetrieveValidateRequestAcceptsValid)
     req.buffer_length = 1024;
     req.offset = 512;
     req.length = 512;
-    req.key = "retkey";
+    req.key = MakeCacheKey("retrieve_key");
 
     KvRetrieveProtocol proto;
     std::vector<std::uint32_t> target(16, 0);
@@ -762,7 +758,7 @@ TEST_F(KvProtocolPackTest, RetrieveValidateRequestRejectsZeroBufferAddr)
     req.buffer_length = 1024;
     req.offset = 0;
     req.length = 1;
-    req.key = "key";
+    req.key = MakeCacheKey("key");
 
     KvRetrieveProtocol proto;
     std::vector<std::uint32_t> target(16, 0);
@@ -778,7 +774,7 @@ TEST_F(KvProtocolPackTest, RetrieveValidateRequestRejectsUnalignedBufferLength)
     req.buffer_length = 100;
     req.offset = 512;
     req.length = 512;
-    req.key = "retkey";
+    req.key = MakeCacheKey("retrieve_key");
 
     KvRetrieveProtocol proto;
     std::vector<std::uint32_t> target(16, 0);
@@ -787,21 +783,20 @@ TEST_F(KvProtocolPackTest, RetrieveValidateRequestRejectsUnalignedBufferLength)
     EXPECT_NE(status.message.find("512B aligned"), std::string::npos);
 }
 
-TEST_F(KvProtocolPackTest, RetrieveValidateRequestRejectsKeyTooLong)
+TEST_F(KvProtocolPackTest, RetrieveValidateRequestRejectsAllZeroKey)
 {
     KvRetrieveRequest req;
     req.buffer_addr = 0x2000;
     req.buffer_length = 1024;
     req.offset = 512;
     req.length = 512;
-    req.key = "toolongkey9";
+    req.key = CacheKey{};
 
     KvRetrieveProtocol proto;
     std::vector<std::uint32_t> target(16, 0);
     auto status = proto.PackSqe(req, target.data());
     EXPECT_FALSE(status.ok());
-    EXPECT_NE(status.message.find("key size("), std::string::npos);
-    EXPECT_NE(status.message.find("exceeds 8 bytes"), std::string::npos);
+    EXPECT_NE(status.message.find("all zeros"), std::string::npos);
 }
 
 TEST_F(KvProtocolPackTest, BatchRetrieveValidateRequestAcceptsValid)
@@ -809,11 +804,11 @@ TEST_F(KvProtocolPackTest, BatchRetrieveValidateRequestAcceptsValid)
     KvBatchRetrieveRequest req;
     req.batch_number = 2;
     req.entries.resize(2);
-    req.entries[0].key = "key1";
+    req.entries[0].key = MakeCacheKey("key1");
     req.entries[0].offset = 0;
     req.entries[0].buffer_addr = 0x1000;
     req.entries[0].length = 512;
-    req.entries[1].key = "key2";
+    req.entries[1].key = MakeCacheKey("key2");
     req.entries[1].offset = 512;
     req.entries[1].buffer_addr = 0x2000;
     req.entries[1].length = 512;
@@ -842,7 +837,7 @@ TEST_F(KvProtocolPackTest, BatchRetrieveValidateRequestRejectsUnalignedLength)
     KvBatchRetrieveRequest req;
     req.batch_number = 1;
     req.entries.resize(1);
-    req.entries[0].key = "key";
+    req.entries[0].key = MakeCacheKey("key");
     req.entries[0].offset = 0;
     req.entries[0].buffer_addr = 0x1000;
     req.entries[0].length = 100;
@@ -854,12 +849,12 @@ TEST_F(KvProtocolPackTest, BatchRetrieveValidateRequestRejectsUnalignedLength)
     EXPECT_NE(status.message.find("512B aligned"), std::string::npos);
 }
 
-TEST_F(KvProtocolPackTest, BatchRetrieveValidateRequestRejectsKeyTooLong)
+TEST_F(KvProtocolPackTest, BatchRetrieveValidateRequestRejectsAllZeroKey)
 {
     KvBatchRetrieveRequest req;
     req.batch_number = 1;
     req.entries.resize(1);
-    req.entries[0].key = "toolongkey9";
+    req.entries[0].key = CacheKey{};
     req.entries[0].offset = 0;
     req.entries[0].buffer_addr = 0x1000;
     req.entries[0].length = 512;
@@ -868,15 +863,14 @@ TEST_F(KvProtocolPackTest, BatchRetrieveValidateRequestRejectsKeyTooLong)
     std::vector<std::uint32_t> target(64, 0);
     auto status = proto.PackSqe(req, target.data());
     EXPECT_FALSE(status.ok());
-    EXPECT_NE(status.message.find("key size("), std::string::npos);
-    EXPECT_NE(status.message.find("exceeds 8 bytes"), std::string::npos);
+    EXPECT_NE(status.message.find("all zeros"), std::string::npos);
 }
 
 TEST_F(KvProtocolPackTest, DeleteValidateRequestAcceptsValid)
 {
     KvDeleteRequest req;
     req.batch_number = 2;
-    req.keys = {"key1", "key2"};
+    req.keys = {MakeCacheKey("key1"), MakeCacheKey("key2")};
 
     KvDeleteProtocol proto;
     std::vector<std::uint32_t> target(32, 0);
@@ -884,38 +878,24 @@ TEST_F(KvProtocolPackTest, DeleteValidateRequestAcceptsValid)
     EXPECT_TRUE(status.ok()) << status.message;
 }
 
-TEST_F(KvProtocolPackTest, DeleteValidateRequestRejectsEmptyKey)
+TEST_F(KvProtocolPackTest, DeleteValidateRequestRejectsAllZeroKey)
 {
     KvDeleteRequest req;
     req.batch_number = 2;
-    req.keys = {"key1", ""};
+    req.keys = {MakeCacheKey("key1"), CacheKey{}};
 
     KvDeleteProtocol proto;
     std::vector<std::uint32_t> target(32, 0);
     auto status = proto.PackSqe(req, target.data());
     EXPECT_FALSE(status.ok());
-    EXPECT_NE(status.message.find("is empty"), std::string::npos);
-}
-
-TEST_F(KvProtocolPackTest, DeleteValidateRequestRejectsKeyTooLong)
-{
-    KvDeleteRequest req;
-    req.batch_number = 2;
-    req.keys = {"key1", "toolongkey9"};
-
-    KvDeleteProtocol proto;
-    std::vector<std::uint32_t> target(32, 0);
-    auto status = proto.PackSqe(req, target.data());
-    EXPECT_FALSE(status.ok());
-    EXPECT_NE(status.message.find("size("), std::string::npos);
-    EXPECT_NE(status.message.find("exceeds 8 bytes"), std::string::npos);
+    EXPECT_NE(status.message.find("all zeros"), std::string::npos);
 }
 
 TEST_F(KvProtocolPackTest, ExistValidateRequestAcceptsValid)
 {
     KvExistRequest req;
     req.batch_number = 1;
-    req.keys = {"exkey"};
+    req.keys = {MakeCacheKey("exist_key")};
 
     KvExistProtocol proto;
     std::vector<std::uint32_t> target(32, 0);
@@ -927,7 +907,7 @@ TEST_F(KvProtocolPackTest, ExistValidateRequestRejectsBatchNumberOverflow)
 {
     KvExistRequest req;
     req.batch_number = 300;
-    req.keys.resize(300, "key");
+    req.keys.resize(300, MakeCacheKey("key"));
 
     KvExistProtocol proto;
     std::vector<std::uint32_t> target(16, 0);
@@ -936,18 +916,17 @@ TEST_F(KvProtocolPackTest, ExistValidateRequestRejectsBatchNumberOverflow)
     EXPECT_NE(status.message.find("must be in range"), std::string::npos);
 }
 
-TEST_F(KvProtocolPackTest, ExistValidateRequestRejectsKeyTooLong)
+TEST_F(KvProtocolPackTest, ExistValidateRequestRejectsAllZeroKey)
 {
     KvExistRequest req;
     req.batch_number = 1;
-    req.keys = {"toolongkey9"};
+    req.keys = {CacheKey{}};
 
     KvExistProtocol proto;
     std::vector<std::uint32_t> target(32, 0);
     auto status = proto.PackSqe(req, target.data());
     EXPECT_FALSE(status.ok());
-    EXPECT_NE(status.message.find("size("), std::string::npos);
-    EXPECT_NE(status.message.find("exceeds 8 bytes"), std::string::npos);
+    EXPECT_NE(status.message.find("all zeros"), std::string::npos);
 }
 
 TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsZeroLength)
@@ -957,7 +936,7 @@ TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsZeroLength)
     req.buffer_length = 512;
     req.offset = 0;
     req.length = 0;
-    req.key = "key";
+    req.key = MakeCacheKey("key");
 
     KvStoreProtocol proto;
     std::vector<std::uint32_t> target(16, 0);
@@ -973,7 +952,7 @@ TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsUnalignedOffset)
     req.buffer_length = 512;
     req.offset = 100;
     req.length = 1;
-    req.key = "key";
+    req.key = MakeCacheKey("key");
 
     KvStoreProtocol proto;
     std::vector<std::uint32_t> target(16, 0);
@@ -1001,7 +980,7 @@ TEST_F(ProtocolManagerTest, PackStoreRequest)
     req.mr_key = 0xABCD;
     req.offset = 0;
     req.length = 1;
-    req.key = "test_key";
+    req.key = MakeCacheKey("test_key");
 
     std::vector<std::uint32_t> target(16, 0);
     auto status = mgr_->PackRequest(target.data(), KvOpcode::Store, req);
@@ -1024,11 +1003,11 @@ TEST_F(ProtocolManagerTest, PackBatchStoreRequest)
     req.rflag = true;
     req.batch_number = 2;
     req.entries.resize(2);
-    req.entries[0].key = "key1";
+    req.entries[0].key = MakeCacheKey("key1");
     req.entries[0].offset = 0;
     req.entries[0].buffer_addr = 0x3000;
     req.entries[0].length = 512;
-    req.entries[1].key = "key2";
+    req.entries[1].key = MakeCacheKey("key2");
     req.entries[1].offset = 512;
     req.entries[1].buffer_addr = 0x4000;
     req.entries[1].length = 512;
@@ -1065,7 +1044,7 @@ TEST_F(ProtocolManagerTest, PackRequestRejectsInvalidRequest)
     req.buffer_length = 512;
     req.offset = 0;
     req.length = 1;
-    req.key = "key";
+    req.key = MakeCacheKey("key");
 
     std::vector<std::uint32_t> target(16, 0);
     auto status = mgr_->PackRequest(target.data(), KvOpcode::Store, req);
@@ -1148,7 +1127,7 @@ TEST_F(ProtocolManagerTest, UnpackStoreReturnsUnsupported)
 TEST_F(ProtocolManagerTest, GetPackedSizeReturnsCorrectValue)
 {
     KvStoreRequest store_req;
-    store_req.key = "key";
+    store_req.key = MakeCacheKey("key");
     EXPECT_EQ(mgr_->GetPackedSize(KvOpcode::Store, store_req), 64);
 
     KvBatchStoreRequest batch_req;
@@ -1167,11 +1146,11 @@ TEST_F(ProtocolManagerTest, EndToEndPackAndUnpack)
     req.response_mr_key = 0x3333;
     req.rflag = true;
     req.entries.resize(2);
-    req.entries[0].key = "key_a";
+    req.entries[0].key = MakeCacheKey("key_a");
     req.entries[0].offset = 0;
     req.entries[0].buffer_addr = 0x9000;
     req.entries[0].length = 512;
-    req.entries[1].key = "key_b";
+    req.entries[1].key = MakeCacheKey("key_b");
     req.entries[1].offset = 512;
     req.entries[1].buffer_addr = 0xA000;
     req.entries[1].length = 512;
@@ -1223,7 +1202,7 @@ protected:
         req.offset = 0x1000;
         req.lr = true;
         req.length = 2;
-        req.key = "tk_01";
+        req.key = MakeCacheKey("test_key_01");
         KvStoreProtocol proto;
         std::vector<std::uint32_t> buf(16, 0);
         auto s = proto.PackSqe(req, buf.data());
@@ -1242,7 +1221,7 @@ protected:
         req.offset = 0x2000;
         req.lr = false;
         req.length = 3;
-        req.key = "retkey";
+        req.key = MakeCacheKey("retrieve_key");
         KvRetrieveProtocol proto;
         std::vector<std::uint32_t> buf(16, 0);
         auto s = proto.PackSqe(req, buf.data());
@@ -1265,7 +1244,7 @@ protected:
         for (std::uint16_t i = 0; i < batch_n; ++i) {
             KvBatchStoreEntry e;
             e.offset = (i + 1) * 512;
-            e.key = "bs_key_" + std::to_string(i);
+            e.key = MakeCacheKey(static_cast<std::uint64_t>(0xB500 + i));
             e.buffer_addr = 0xBBBB0000ULL + i * 0x1000;
             e.mr_key = 0x2222 + i;
             e.length = 512;
@@ -1293,7 +1272,7 @@ protected:
         for (std::uint16_t i = 0; i < batch_n; ++i) {
             KvBatchRetrieveEntry e;
             e.offset = (i + 1) * 512;
-            e.key = "br_key_" + std::to_string(i);
+            e.key = MakeCacheKey(static_cast<std::uint64_t>(0xB600 + i));
             e.buffer_addr = 0xDDDD0000ULL + i * 0x1000;
             e.mr_key = 0x4444 + i;
             e.length = 512;
@@ -1317,7 +1296,7 @@ protected:
         req.rflag = rflag;
         req.batch_number = batch_n;
         for (std::uint16_t i = 0; i < batch_n; ++i) {
-            req.keys.push_back("dk_" + std::to_string(i));
+            req.keys.push_back(MakeCacheKey(static_cast<std::uint64_t>(0xD000 + i)));
         }
         KvDeleteProtocol proto;
         std::size_t sz = proto.PackedSize(req) / sizeof(std::uint32_t);
@@ -1339,7 +1318,7 @@ protected:
         req.sc = sc;
         req.batch_number = batch_n;
         for (std::uint16_t i = 0; i < batch_n; ++i) {
-            req.keys.push_back("ex_key_" + std::to_string(i));
+            req.keys.push_back(MakeCacheKey(static_cast<std::uint64_t>(0xE000 + i)));
         }
         KvExistProtocol proto;
         std::size_t sz = proto.PackedSize(req) / sizeof(std::uint32_t);

--- a/ucm/transport/kv/asu/trans/include/asu_transport/types.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/types.h
@@ -23,9 +23,12 @@
  * */
 #pragma once
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -33,8 +36,27 @@ namespace UC::ASU {
 
 using TaskId = std::uint64_t;
 using MRHandle = std::uint64_t;
-using CacheKey = std::string;
+constexpr std::size_t kCacheKeySizeBytes = 8;
+using CacheKey = std::array<std::byte, kCacheKeySizeBytes>;
 using AsuId = std::uint64_t;
+
+inline std::string_view CacheKeyView(const CacheKey& key)
+{
+    return {reinterpret_cast<const char*>(key.data()), key.size()};
+}
+
+inline std::string CacheKeyToHex(const CacheKey& key)
+{
+    static constexpr char kHex[] = "0123456789abcdef";
+    std::string text;
+    text.reserve(key.size() * 2);
+    for (auto byte : key) {
+        const auto value = static_cast<unsigned char>(std::to_integer<unsigned char>(byte));
+        text.push_back(kHex[value >> 4]);
+        text.push_back(kHex[value & 0x0F]);
+    }
+    return text;
+}
 
 enum class TransProviderType { AICPU, FAKE, AIV, UNSUPPORTED };
 

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
@@ -25,6 +25,7 @@
 #include <acl/acl.h>
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
@@ -62,18 +63,18 @@ KvOpcode RequestOpcode(const std::uint32_t* request)
     return static_cast<KvOpcode>(request[0] & 0xFF);
 }
 
-std::string ReadKey(const std::uint32_t* data)
+CacheKey ReadKey(const std::uint32_t* data)
 {
-    char key[17] = {};
-    std::memcpy(key, data, 16);
-    const auto keyLen = std::find(key, key + 16, '\0') - key;
-    return std::string(key, static_cast<std::size_t>(keyLen));
+    CacheKey key{};
+    std::memcpy(key.data(), data, kCacheKeySizeBytes);
+    return key;
 }
 
-std::string KeyFileName(const std::string& key)
+std::string KeyFileName(const CacheKey& key)
 {
     std::uint64_t hash = 1469598103934665603ULL;
-    for (unsigned char ch : key) {
+    for (auto byte : key) {
+        const auto ch = std::to_integer<unsigned char>(byte);
         hash ^= ch;
         hash *= 1099511628211ULL;
     }
@@ -89,12 +90,12 @@ std::filesystem::path AsuRoot(const FakeTransProviderConfig& config, AsuId asuId
 }
 
 std::filesystem::path KeyPath(const FakeTransProviderConfig& config, AsuId asuId,
-                              const std::string& key)
+                              const CacheKey& key)
 {
     return AsuRoot(config, asuId) / KeyFileName(key);
 }
 
-bool StoreBytes(const FakeTransProviderConfig& config, AsuId asuId, const std::string& key,
+bool StoreBytes(const FakeTransProviderConfig& config, AsuId asuId, const CacheKey& key,
                 std::uint64_t addr, std::uint32_t length)
 {
     std::vector<char> buffer(length);
@@ -104,28 +105,28 @@ bool StoreBytes(const FakeTransProviderConfig& config, AsuId asuId, const std::s
         UC_ERROR(
             "ASU fake backend device-to-host copy failed asuId={} key={} addr={} length={} "
             "ret={}.",
-            asuId, key, addr, length, ret);
+            asuId, CacheKeyToHex(key), addr, length, ret);
         return false;
     }
 
     std::filesystem::create_directories(AsuRoot(config, asuId));
     std::ofstream output(KeyPath(config, asuId, key), std::ios::binary | std::ios::trunc);
     if (!output) {
-        UC_ERROR("ASU fake backend failed to open store file asuId={} key={} path={}.", asuId, key,
-                 KeyPath(config, asuId, key).string());
+        UC_ERROR("ASU fake backend failed to open store file asuId={} key={} path={}.", asuId,
+                 CacheKeyToHex(key), KeyPath(config, asuId, key).string());
         return false;
     }
     output.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
     return output.good();
 }
 
-bool LoadBytes(const FakeTransProviderConfig& config, AsuId asuId, const std::string& key,
+bool LoadBytes(const FakeTransProviderConfig& config, AsuId asuId, const CacheKey& key,
                std::uint64_t addr, std::uint32_t length)
 {
     std::ifstream input(KeyPath(config, asuId, key), std::ios::binary);
     if (!input) {
-        UC_ERROR("ASU fake backend failed to open load file asuId={} key={} path={}.", asuId, key,
-                 KeyPath(config, asuId, key).string());
+        UC_ERROR("ASU fake backend failed to open load file asuId={} key={} path={}.", asuId,
+                 CacheKeyToHex(key), KeyPath(config, asuId, key).string());
         return false;
     }
     std::vector<char> buffer(length, 0);
@@ -140,20 +141,20 @@ bool LoadBytes(const FakeTransProviderConfig& config, AsuId asuId, const std::st
         UC_ERROR(
             "ASU fake backend host-to-device copy failed asuId={} key={} addr={} length={} "
             "ret={}.",
-            asuId, key, addr, length, ret);
+            asuId, CacheKeyToHex(key), addr, length, ret);
         return false;
     }
     return true;
 }
 
-bool DeleteKey(const FakeTransProviderConfig& config, AsuId asuId, const std::string& key)
+bool DeleteKey(const FakeTransProviderConfig& config, AsuId asuId, const CacheKey& key)
 {
     std::error_code errorCode;
     std::filesystem::remove(KeyPath(config, asuId, key), errorCode);
     return !errorCode;
 }
 
-bool ExistsKey(const FakeTransProviderConfig& config, AsuId asuId, const std::string& key)
+bool ExistsKey(const FakeTransProviderConfig& config, AsuId asuId, const CacheKey& key)
 {
     std::error_code errorCode;
     return std::filesystem::exists(KeyPath(config, asuId, key), errorCode);
@@ -187,7 +188,7 @@ void PackResultBuffer1Bit(std::uint32_t* resultData, const std::vector<std::uint
 }
 
 struct BatchEntry {
-    std::string key;
+    CacheKey key{};
     std::uint64_t bufferAddr{0};
     std::uint32_t length{0};
 };
@@ -207,9 +208,9 @@ std::vector<BatchEntry> ReadBatchEntries(const std::uint32_t* request, std::uint
     return entries;
 }
 
-std::vector<std::string> ReadKeyEntries(const std::uint32_t* request, std::uint16_t batchNumber)
+std::vector<CacheKey> ReadKeyEntries(const std::uint32_t* request, std::uint16_t batchNumber)
 {
-    std::vector<std::string> keys;
+    std::vector<CacheKey> keys;
     keys.reserve(batchNumber);
     for (std::uint16_t index = 0; index < batchNumber; ++index) {
         const auto* entry = request + kSqeDwordCount + index * kKeyEntryDwordCount;

--- a/ucm/transport/kv/asu/trans/src/kv_protocol.cpp
+++ b/ucm/transport/kv/asu/trans/src/kv_protocol.cpp
@@ -96,12 +96,27 @@ static Status VerifyRflagConsistency(const std::uint32_t* data, const char* log_
     return Status::OK();
 }
 
-static Status VerifyKeyNotAllZero(const std::uint32_t* key_dwords, const std::string& log_prefix)
+static Status VerifyCacheKeyEntry(const std::uint32_t* key_dwords, const std::string& log_prefix)
 {
-    if (key_dwords[0] == 0 && key_dwords[1] == 0 && key_dwords[2] == 0 && key_dwords[3] == 0) {
+    const auto* bytes = reinterpret_cast<const std::byte*>(key_dwords);
+    const auto keyAllZero = std::all_of(bytes, bytes + kCacheKeySizeBytes,
+                                        [](std::byte value) { return value == std::byte{0}; });
+    if (keyAllZero) {
         return Status::Error(StatusCode::INVALID_ARGUMENT, log_prefix + ": key is all zeros");
     }
+    const auto tailAllZero = std::all_of(bytes + kCacheKeySizeBytes, bytes + kKeyEntrySizeBytes,
+                                         [](std::byte value) { return value == std::byte{0}; });
+    if (!tailAllZero) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             log_prefix + ": reserved key bytes are non-zero");
+    }
     return Status::OK();
+}
+
+static bool IsCacheKeyAllZero(const CacheKey& key)
+{
+    return std::all_of(key.begin(), key.end(),
+                       [](std::byte value) { return value == std::byte{0}; });
 }
 
 static Status VerifyBatchEntry(const std::uint32_t* base, const std::string& log_prefix,
@@ -114,7 +129,7 @@ static Status VerifyBatchEntry(const std::uint32_t* base, const std::string& log
     }
 
     auto key_status =
-        VerifyKeyNotAllZero(&base[1], log_prefix + ": entry[" + std::to_string(i) + "]");
+        VerifyCacheKeyEntry(&base[1], log_prefix + ": entry[" + std::to_string(i) + "]");
     if (!key_status.ok()) { return key_status; }
 
     std::uint64_t entry_addr =
@@ -161,8 +176,7 @@ Status KvStoreProtocol::PackSqe(const SqeRequest& req, std::uint32_t* target)
     target[10] = r.offset;
     target[11] = (r.lr ? (1U << 31) : 0) | (r.length & 0xFFFFFF);
 
-    std::size_t key_len = std::min(r.key.size(), static_cast<std::size_t>(8));
-    if (key_len > 0) { std::memcpy(&target[12], r.key.data(), key_len); }
+    std::memcpy(&target[12], r.key.data(), kCacheKeySizeBytes);
     return Status::OK();
 }
 
@@ -199,13 +213,8 @@ Status KvStoreProtocol::ValidateRequest(const KvStoreRequest& r) const
             StatusCode::INVALID_ARGUMENT,
             "length(" + std::to_string(r.length) + ") exceeds 24-bit limit in Store request");
     }
-    if (r.key.empty()) [[unlikely]] {
-        return Status::Error(StatusCode::INVALID_ARGUMENT, "key is empty in Store request");
-    }
-    if (r.key.size() > 8) [[unlikely]] {
-        return Status::Error(
-            StatusCode::INVALID_ARGUMENT,
-            "key size(" + std::to_string(r.key.size()) + ") exceeds 8 bytes in Store request");
+    if (IsCacheKeyAllZero(r.key)) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "key is all zeros in Store request");
     }
     if (r.dtype > 0x7) [[unlikely]] {
         return Status::Error(
@@ -278,7 +287,7 @@ Status KvStoreProtocol::VerifyPackedBuffer(const std::uint32_t* data, std::size_
                              "Store: reserved bits non-zero in data[11] bit24-30");
     }
 
-    status = VerifyKeyNotAllZero(&data[12], "Store");
+    status = VerifyCacheKeyEntry(&data[12], "Store");
     if (!status.ok()) { return status; }
 
     return Status::OK();
@@ -300,8 +309,7 @@ Status KvRetrieveProtocol::PackSqe(const SqeRequest& req, std::uint32_t* target)
     target[10] = r.offset;
     target[11] = (r.lr ? (1U << 31) : 0) | (r.length & 0xFFFFFF);
 
-    std::size_t key_len = std::min(r.key.size(), static_cast<std::size_t>(8));
-    if (key_len > 0) { std::memcpy(&target[12], r.key.data(), key_len); }
+    std::memcpy(&target[12], r.key.data(), kCacheKeySizeBytes);
     return Status::OK();
 }
 
@@ -339,13 +347,8 @@ Status KvRetrieveProtocol::ValidateRequest(const KvRetrieveRequest& r) const
             StatusCode::INVALID_ARGUMENT,
             "length(" + std::to_string(r.length) + ") exceeds 24-bit limit in Retrieve request");
     }
-    if (r.key.empty()) [[unlikely]] {
-        return Status::Error(StatusCode::INVALID_ARGUMENT, "key is empty in Retrieve request");
-    }
-    if (r.key.size() > 8) [[unlikely]] {
-        return Status::Error(
-            StatusCode::INVALID_ARGUMENT,
-            "key size(" + std::to_string(r.key.size()) + ") exceeds 8 bytes in Retrieve request");
+    if (IsCacheKeyAllZero(r.key)) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "key is all zeros in Retrieve request");
     }
     return Status::OK();
 }
@@ -409,7 +412,7 @@ Status KvRetrieveProtocol::VerifyPackedBuffer(const std::uint32_t* data, std::si
                              "Retrieve: reserved bits non-zero in data[11] bit24-30");
     }
 
-    status = VerifyKeyNotAllZero(&data[12], "Retrieve");
+    status = VerifyCacheKeyEntry(&data[12], "Retrieve");
     if (!status.ok()) { return status; }
 
     return Status::OK();
@@ -498,16 +501,10 @@ Status KvBatchStoreProtocol::ValidateRequest(const KvBatchStoreRequest& r) const
                                      std::to_string(entry.offset) +
                                      ") must be 512B aligned in BatchStore request");
         }
-        if (entry.key.empty()) [[unlikely]] {
+        if (IsCacheKeyAllZero(entry.key)) [[unlikely]] {
             return Status::Error(
                 StatusCode::INVALID_ARGUMENT,
-                "entry[" + std::to_string(i) + "] key is empty in BatchStore request");
-        }
-        if (entry.key.size() > 8) [[unlikely]] {
-            return Status::Error(StatusCode::INVALID_ARGUMENT,
-                                 "entry[" + std::to_string(i) + "] key size(" +
-                                     std::to_string(entry.key.size()) +
-                                     ") exceeds 8 bytes in BatchStore request");
+                "entry[" + std::to_string(i) + "] key is all zeros in BatchStore request");
         }
         if (entry.buffer_addr == 0) [[unlikely]] {
             return Status::Error(
@@ -539,8 +536,7 @@ void KvBatchStoreProtocol::PackEntry(const KvBatchStoreEntry& entry, std::uint32
 {
     base[0] = entry.offset;
 
-    std::size_t key_len = std::min(entry.key.size(), static_cast<std::size_t>(8));
-    if (key_len > 0) { std::memcpy(&base[1], entry.key.data(), key_len); }
+    std::memcpy(&base[1], entry.key.data(), kCacheKeySizeBytes);
 
     base[5] = entry.buffer_addr & 0xFFFFFFFFULL;
     base[6] = (entry.buffer_addr >> 32) & 0xFFFFFFFFULL;
@@ -695,16 +691,10 @@ Status KvBatchRetrieveProtocol::ValidateRequest(const KvBatchRetrieveRequest& r)
                                      std::to_string(entry.offset) +
                                      ") must be 512B aligned in BatchRetrieve request");
         }
-        if (entry.key.empty()) [[unlikely]] {
+        if (IsCacheKeyAllZero(entry.key)) [[unlikely]] {
             return Status::Error(
                 StatusCode::INVALID_ARGUMENT,
-                "entry[" + std::to_string(i) + "] key is empty in BatchRetrieve request");
-        }
-        if (entry.key.size() > 8) [[unlikely]] {
-            return Status::Error(StatusCode::INVALID_ARGUMENT,
-                                 "entry[" + std::to_string(i) + "] key size(" +
-                                     std::to_string(entry.key.size()) +
-                                     ") exceeds 8 bytes in BatchRetrieve request");
+                "entry[" + std::to_string(i) + "] key is all zeros in BatchRetrieve request");
         }
         if (entry.buffer_addr == 0) [[unlikely]] {
             return Status::Error(
@@ -736,8 +726,7 @@ void KvBatchRetrieveProtocol::PackEntry(const KvBatchRetrieveEntry& entry, std::
 {
     base[0] = entry.offset;
 
-    std::size_t key_len = std::min(entry.key.size(), static_cast<std::size_t>(8));
-    if (key_len > 0) { std::memcpy(&base[1], entry.key.data(), key_len); }
+    std::memcpy(&base[1], entry.key.data(), kCacheKeySizeBytes);
 
     base[5] = entry.buffer_addr & 0xFFFFFFFFULL;
     base[6] = (entry.buffer_addr >> 32) & 0xFFFFFFFFULL;
@@ -884,24 +873,17 @@ Status KvDeleteProtocol::ValidateRequest(const KvDeleteRequest& r) const
         }
     }
     for (std::size_t i = 0; i < r.batch_number; ++i) {
-        if (r.keys[i].empty()) [[unlikely]] {
+        if (IsCacheKeyAllZero(r.keys[i])) [[unlikely]] {
             return Status::Error(StatusCode::INVALID_ARGUMENT,
-                                 "key[" + std::to_string(i) + "] is empty in Delete request");
-        }
-        if (r.keys[i].size() > 8) [[unlikely]] {
-            return Status::Error(StatusCode::INVALID_ARGUMENT,
-                                 "key[" + std::to_string(i) + "] size(" +
-                                     std::to_string(r.keys[i].size()) +
-                                     ") exceeds 8 bytes in Delete request");
+                                 "key[" + std::to_string(i) + "] is all zeros in Delete request");
         }
     }
     return Status::OK();
 }
 
-void KvDeleteProtocol::PackEntry(const std::string& key, std::uint32_t* base)
+void KvDeleteProtocol::PackEntry(const CacheKey& key, std::uint32_t* base)
 {
-    std::size_t key_len = std::min(key.size(), static_cast<std::size_t>(8));
-    if (key_len > 0) { std::memcpy(&base[0], key.data(), key_len); }
+    std::memcpy(&base[0], key.data(), kCacheKeySizeBytes);
 }
 
 Status KvDeleteProtocol::UnpackCqe(const std::uint32_t* data, std::uint16_t batch_number,
@@ -971,7 +953,7 @@ Status KvDeleteProtocol::VerifyPackedBuffer(const std::uint32_t* data, std::size
 
     for (std::uint16_t i = 0; i < batch_number; ++i) {
         const std::uint32_t* base = data + kSqeDwordCount + i * kKeyEntryDwordCount;
-        auto key_status = VerifyKeyNotAllZero(base, "Delete: entry[" + std::to_string(i) + "]");
+        auto key_status = VerifyCacheKeyEntry(base, "Delete: entry[" + std::to_string(i) + "]");
         if (!key_status.ok()) { return key_status; }
     }
 
@@ -1042,24 +1024,17 @@ Status KvExistProtocol::ValidateRequest(const KvExistRequest& r) const
         }
     }
     for (std::size_t i = 0; i < r.batch_number; ++i) {
-        if (r.keys[i].empty()) [[unlikely]] {
+        if (IsCacheKeyAllZero(r.keys[i])) [[unlikely]] {
             return Status::Error(StatusCode::INVALID_ARGUMENT,
-                                 "key[" + std::to_string(i) + "] is empty in Exist request");
-        }
-        if (r.keys[i].size() > 8) [[unlikely]] {
-            return Status::Error(StatusCode::INVALID_ARGUMENT,
-                                 "key[" + std::to_string(i) + "] size(" +
-                                     std::to_string(r.keys[i].size()) +
-                                     ") exceeds 8 bytes in Exist request");
+                                 "key[" + std::to_string(i) + "] is all zeros in Exist request");
         }
     }
     return Status::OK();
 }
 
-void KvExistProtocol::PackEntry(const std::string& key, std::uint32_t* base)
+void KvExistProtocol::PackEntry(const CacheKey& key, std::uint32_t* base)
 {
-    std::size_t key_len = std::min(key.size(), static_cast<std::size_t>(8));
-    if (key_len > 0) { std::memcpy(&base[0], key.data(), key_len); }
+    std::memcpy(&base[0], key.data(), kCacheKeySizeBytes);
 }
 
 Status KvExistProtocol::UnpackCqe(const std::uint32_t* data, std::uint16_t batch_number,
@@ -1130,7 +1105,7 @@ Status KvExistProtocol::VerifyPackedBuffer(const std::uint32_t* data, std::size_
 
     for (std::uint16_t i = 0; i < batch_number; ++i) {
         const std::uint32_t* base = data + kSqeDwordCount + i * kKeyEntryDwordCount;
-        auto key_status = VerifyKeyNotAllZero(base, "Exist: entry[" + std::to_string(i) + "]");
+        auto key_status = VerifyCacheKeyEntry(base, "Exist: entry[" + std::to_string(i) + "]");
         if (!key_status.ok()) { return key_status; }
     }
 

--- a/ucm/transport/kv/asu/trans/src/kv_protocol.h
+++ b/ucm/transport/kv/asu/trans/src/kv_protocol.h
@@ -74,7 +74,7 @@ public:
     std::uint32_t offset{0};
     bool lr{false};
     std::uint32_t length{0};
-    std::string key;
+    CacheKey key{};
 };
 
 class KvRetrieveRequest : public SqeRequest {
@@ -87,13 +87,13 @@ public:
     std::uint32_t offset{0};
     bool lr{false};
     std::uint32_t length{0};
-    std::string key;
+    CacheKey key{};
 };
 
 class KvBatchStoreEntry {
 public:
     std::uint32_t offset{0};
-    std::string key;
+    CacheKey key{};
     std::uint64_t buffer_addr{0};
     std::uint32_t mr_key{0};
     std::uint32_t length{0};
@@ -116,7 +116,7 @@ public:
 class KvBatchRetrieveEntry {
 public:
     std::uint32_t offset{0};
-    std::string key;
+    CacheKey key{};
     std::uint64_t buffer_addr{0};
     std::uint32_t mr_key{0};
     std::uint32_t length{0};
@@ -142,7 +142,7 @@ public:
     std::uint32_t response_mr_key{0};
     bool rflag{false};
     std::uint16_t batch_number{0};
-    std::vector<std::string> keys;
+    std::vector<CacheKey> keys;
 };
 
 class KvExistRequest : public SqeRequest {
@@ -154,7 +154,7 @@ public:
     bool rflag{false};
     bool sc{false};
     std::uint16_t batch_number{0};
-    std::vector<std::string> keys;
+    std::vector<CacheKey> keys;
 };
 
 class KvKeepAliveRequest : public SqeRequest {
@@ -252,7 +252,7 @@ public:
 
 private:
     Status ValidateRequest(const KvDeleteRequest& r) const;
-    static void PackEntry(const std::string& key, std::uint32_t* base);
+    static void PackEntry(const CacheKey& key, std::uint32_t* base);
 };
 
 class KvExistProtocol : public KvProtocol {
@@ -265,7 +265,7 @@ public:
 
 private:
     Status ValidateRequest(const KvExistRequest& r) const;
-    static void PackEntry(const std::string& key, std::uint32_t* base);
+    static void PackEntry(const CacheKey& key, std::uint32_t* base);
 };
 
 class KvKeepAliveProtocol : public KvProtocol {

--- a/ucm/transport/kv/asu/trans/src/sqe_request.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.cpp
@@ -230,9 +230,9 @@ KvBatchRetrieveRequest BuildBatchRetrieveRequest(
     return request;
 }
 
-std::vector<std::string> CopyKeys(const BatchView<CacheKey>& keys)
+std::vector<CacheKey> CopyKeys(const BatchView<CacheKey>& keys)
 {
-    std::vector<std::string> requestKeys;
+    std::vector<CacheKey> requestKeys;
     requestKeys.reserve(keys.size);
     for (std::size_t index = 0; index < keys.size; ++index) {
         requestKeys.emplace_back(keys[index]);

--- a/ucm/transport/kv/asu/trans/test/io_scheduler_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/io_scheduler_test.cpp
@@ -22,6 +22,8 @@
  * SOFTWARE.
  * */
 #include "io_scheduler.h"
+#include <algorithm>
+#include <cstring>
 #include <gtest/gtest.h>
 #include <string>
 #include <vector>
@@ -29,11 +31,19 @@
 namespace UC::ASU {
 namespace {
 
+CacheKey MakeCacheKey(const std::string& text)
+{
+    CacheKey key{};
+    const auto size = std::min(text.size(), key.size());
+    if (size > 0) { std::memcpy(key.data(), text.data(), size); }
+    return key;
+}
+
 TEST(IoSchedulerTest, SplitEntryBatchPreservesOrderAndUsesViews)
 {
     std::vector<KVBuffer> entries(5);
     for (std::size_t index = 0; index < entries.size(); ++index) {
-        entries[index].key = "key_" + std::to_string(index);
+        entries[index].key = MakeCacheKey("key_" + std::to_string(index));
     }
 
     TransportConfig config;
@@ -49,7 +59,7 @@ TEST(IoSchedulerTest, SplitEntryBatchPreservesOrderAndUsesViews)
     EXPECT_EQ(&batches[0].entries[0], &entries[0]);
     EXPECT_EQ(&batches[1].entries[0], &entries[2]);
     EXPECT_EQ(&batches[2].entries[0], &entries[4]);
-    EXPECT_EQ(batches[1].entries[1].key, "key_3");
+    EXPECT_EQ(batches[1].entries[1].key, MakeCacheKey("key_3"));
 }
 
 TEST(IoSchedulerTest, GetSqeIoNumMatchesOperationKind)

--- a/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
@@ -22,10 +22,13 @@
  * SOFTWARE.
  * */
 #include <acl/acl.h>
+#include <algorithm>
 #include <cstdint>
+#include <cstring>
 #include <gtest/gtest.h>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <vector>
 #define private public
@@ -39,6 +42,14 @@
 namespace UC::ASU {
 
 namespace {
+
+CacheKey MakeCacheKey(std::string_view text)
+{
+    CacheKey key{};
+    const auto size = std::min(text.size(), key.size());
+    if (size > 0) { std::memcpy(key.data(), text.data(), size); }
+    return key;
+}
 
 class StubTransProvider : public TransProvider {
 public:
@@ -101,7 +112,7 @@ std::vector<KVBuffer> MakeEntries(std::size_t count)
 {
     std::vector<KVBuffer> entries(count);
     for (std::size_t index = 0; index < count; ++index) {
-        entries[index].key = "key_" + std::to_string(index);
+        entries[index].key = MakeCacheKey("key_" + std::to_string(index));
         entries[index].buffer.region.addr = 0x100000 + index * 0x1000;
         entries[index].buffer.region.size = 4096;
         entries[index].buffer.handle = 0x20 + index;
@@ -270,7 +281,9 @@ TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
 
 TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)
 {
-    std::vector<CacheKey> keys = {"k0", "k1", "k2", "k3", "k4", "k5", "k6", "k7", "k8"};
+    std::vector<CacheKey> keys = {MakeCacheKey("k0"), MakeCacheKey("k1"), MakeCacheKey("k2"),
+                                  MakeCacheKey("k3"), MakeCacheKey("k4"), MakeCacheKey("k5"),
+                                  MakeCacheKey("k6"), MakeCacheKey("k7"), MakeCacheKey("k8")};
     IoScheduler::ScheduledKeyBatch subBatch{
         BatchView<CacheKey>{keys.data(), keys.size()}
     };
@@ -293,7 +306,9 @@ TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)
 
 TEST_F(SqeRequestTest, SubmitExistReadsScAttribute)
 {
-    std::vector<CacheKey> keys = {"k0", "k1", "k2", "k3", "k4", "k5", "k6", "k7", "k8"};
+    std::vector<CacheKey> keys = {MakeCacheKey("k0"), MakeCacheKey("k1"), MakeCacheKey("k2"),
+                                  MakeCacheKey("k3"), MakeCacheKey("k4"), MakeCacheKey("k5"),
+                                  MakeCacheKey("k6"), MakeCacheKey("k7"), MakeCacheKey("k8")};
     IoScheduler::ScheduledKeyBatch subBatch{
         BatchView<CacheKey>{keys.data(), keys.size()}
     };
@@ -319,7 +334,7 @@ TEST_F(SqeRequestTest, SubmitExistDisablesSeekControlWhenScDisabled)
     transport_->config_.attrs = attrs;
     transport_->nextRequestCid_.store(13, std::memory_order_relaxed);
 
-    std::vector<CacheKey> keys = {"k0"};
+    std::vector<CacheKey> keys = {MakeCacheKey("k0")};
     IoScheduler::ScheduledKeyBatch subBatch{
         BatchView<CacheKey>{keys.data(), keys.size()}
     };

--- a/ucm/transport/kv/common/include/kv_common/router.h
+++ b/ucm/transport/kv/common/include/kv_common/router.h
@@ -171,7 +171,7 @@ private:
     // Returns the owner selected from all active nodes.
     NodeId RouteKey(const CacheKey& key) const override;
     // Selects the TopK candidates for one batch fingerprint.
-    std::vector<NodeId> SelectCandidates(const CacheKey& batchKey) const;
+    std::vector<NodeId> SelectCandidates(const std::string& batchKey) const;
 
     RouterConfig config_;
     std::vector<NodeId> nodeIds_;

--- a/ucm/transport/kv/common/src/router.cpp
+++ b/ucm/transport/kv/common/src/router.cpp
@@ -24,6 +24,7 @@
 #include "kv_common/router.h"
 #include <algorithm>
 #include <array>
+#include <string>
 #include <unordered_set>
 #include <utility>
 
@@ -34,7 +35,7 @@ using RingData = std::vector<RingNode>;
 
 constexpr std::uint64_t kMaxVirtualNodeSaltAttempts = 4096;
 
-std::uint64_t Crc32IEEE(const std::string& data)
+std::uint64_t Crc32IEEE(std::string_view data)
 {
     static const auto table = [] {
         std::array<std::uint32_t, 256> values{};
@@ -296,7 +297,7 @@ NodeId BatchTopKAffinityRouter::RouteKey(const CacheKey& key) const
     return nodeIds_[hash_(key) % nodeIds_.size()];
 }
 
-std::vector<NodeId> BatchTopKAffinityRouter::SelectCandidates(const CacheKey& batchKey) const
+std::vector<NodeId> BatchTopKAffinityRouter::SelectCandidates(const std::string& batchKey) const
 {
     if (nodeIds_.empty()) { return {}; }
 

--- a/ucm/transport/kv/kv-test/asu_kv_test.conf
+++ b/ucm/transport/kv/kv-test/asu_kv_test.conf
@@ -38,7 +38,7 @@ asu_info.2=protocol=TCP,local.comm_id=127.0.0.1,port=19002,local.phy_device_id=0
 asu_info.3=protocol=TCP,local.comm_id=127.0.0.1,port=19003,local.phy_device_id=0
 
 # kv-test data generation defaults.
-kv.key_prefix=kv-test-key-
+kv.key_prefix=k
 kv.seed=20260530
 kv.value_size=4096
 kv.count=16

--- a/ucm/transport/kv/kv-test/scripts/fake_backend_common.sh
+++ b/ucm/transport/kv/kv-test/scripts/fake_backend_common.sh
@@ -95,7 +95,7 @@ write_fake_backend_config() {
             echo "asu_info.${id}=protocol=TCP,local.comm_id=127.0.0.1,port=$((19000 + id)),local.phy_device_id=0"
         done
         echo
-        echo "kv.key_prefix=kv-test-fake-key-"
+        echo "kv.key_prefix=k"
         echo "kv.seed=20260530"
         echo "kv.value_size=4096"
         echo "kv.count=16"

--- a/ucm/transport/kv/kv-test/scripts/test_fake_backend_multi_asu.sh
+++ b/ucm/transport/kv/kv-test/scripts/test_fake_backend_multi_asu.sh
@@ -15,8 +15,8 @@ LOG="${WORK_DIR}/command.log"
 
 write_fake_backend_config "${CONFIG}" "${STORE}" "${OUTPUT}" "1,2"
 
-run_success "${LOG}" "${KV_TEST}" store --configpath "${CONFIG}" --prefix fb-multi- --key-start 0 --key-end 63 --check
-run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --prefix fb-multi- --key-start 0 --key-end 63
+run_success "${LOG}" "${KV_TEST}" store --configpath "${CONFIG}" --prefix m --key-start 0 --key-end 63 --check
+run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --prefix m --key-start 0 --key-end 63
 assert_contains "${LOG}" "total=64"
 assert_contains "${LOG}" "exists=64"
 assert_contains "${LOG}" "missing=0"

--- a/ucm/transport/kv/kv-test/scripts/test_fake_backend_protocol_results.sh
+++ b/ucm/transport/kv/kv-test/scripts/test_fake_backend_protocol_results.sh
@@ -17,17 +17,17 @@ TRACE="${WORK_DIR}/fake-backend.trace"
 write_fake_backend_config "${CONFIG}" "${STORE}" "${OUTPUT}" "1"
 export KV_TEST_FAKE_BACKEND_TRACE="${TRACE}"
 
-run_success "${LOG}" "${KV_TEST}" store --configpath "${CONFIG}" --key proto-existing
+run_success "${LOG}" "${KV_TEST}" store --configpath "${CONFIG}" --key pexist
 
 >"${TRACE}"
-run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --key proto-existing
+run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --key pexist
 assert_contains "${LOG}" "result=exists"
 assert_contains "${TRACE}" "opcode=Exist"
 assert_contains "${TRACE}" "status=0x000"
 assert_contains "${TRACE}" "result_buffer=0"
 
 >"${TRACE}"
-run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --keys proto-existing,proto-missing
+run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --keys pexist,pmiss
 assert_contains "${LOG}" "total=2"
 assert_contains "${LOG}" "exists=1"
 assert_contains "${LOG}" "missing=1"
@@ -36,13 +36,13 @@ assert_contains "${TRACE}" "status=0x732"
 assert_contains "${TRACE}" "result_buffer=1"
 
 >"${TRACE}"
-run_failure "${LOG}" "${KV_TEST}" batch-retrieve --configpath "${CONFIG}" --keys proto-existing,proto-missing --batch-size 2
+run_failure "${LOG}" "${KV_TEST}" batch-retrieve --configpath "${CONFIG}" --keys pexist,pmiss --batch-size 2
 assert_contains "${TRACE}" "opcode=BatchRetrieve"
 assert_contains "${TRACE}" "status=0x732"
 assert_contains "${TRACE}" "result_buffer=1"
 
 >"${TRACE}"
-run_success "${LOG}" "${KV_TEST}" delete --configpath "${CONFIG}" --keys proto-existing,proto-missing
+run_success "${LOG}" "${KV_TEST}" delete --configpath "${CONFIG}" --keys pexist,pmiss
 assert_contains "${TRACE}" "opcode=Delete"
 assert_contains "${TRACE}" "status=0x000"
 assert_contains "${TRACE}" "result_buffer=0"

--- a/ucm/transport/kv/kv-test/scripts/test_fake_backend_single_asu.sh
+++ b/ucm/transport/kv/kv-test/scripts/test_fake_backend_single_asu.sh
@@ -15,14 +15,14 @@ LOG="${WORK_DIR}/command.log"
 
 write_fake_backend_config "${CONFIG}" "${STORE}" "${OUTPUT}" "1"
 
-run_success "${LOG}" "${KV_TEST}" store --configpath "${CONFIG}" --key fb-single --check
-run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --key fb-single
+run_success "${LOG}" "${KV_TEST}" store --configpath "${CONFIG}" --key fb1 --check
+run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --key fb1
 assert_contains "${LOG}" "result=exists"
 
-run_success "${LOG}" "${KV_TEST}" retrieve --configpath "${CONFIG}" --key fb-single --check
-run_success "${LOG}" "${KV_TEST}" delete --configpath "${CONFIG}" --key fb-single --check
+run_success "${LOG}" "${KV_TEST}" retrieve --configpath "${CONFIG}" --key fb1 --check
+run_success "${LOG}" "${KV_TEST}" delete --configpath "${CONFIG}" --key fb1 --check
 
-run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --key fb-single
+run_success "${LOG}" "${KV_TEST}" exist --configpath "${CONFIG}" --key fb1
 assert_contains "${LOG}" "result=missing"
 
 print_success "fake_backend single ASU flow passed"

--- a/ucm/transport/kv/kv-test/src/bench_runner.cpp
+++ b/ucm/transport/kv/kv-test/src/bench_runner.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstring>
 #include <future>
 #include <iomanip>
 #include <iostream>
@@ -14,6 +15,19 @@ namespace UC::KVTest {
 namespace {
 
 constexpr int kExitInvalidArgument = 1;
+
+Status StringToCacheKey(const std::string& value, UC::ASU::CacheKey& key)
+{
+    if (value.size() > key.size()) {
+        return Status::Error(kExitInvalidArgument,
+                             "bench key length exceeds " + std::to_string(key.size()) +
+                                 " bytes: length=" + std::to_string(value.size()) +
+                                 ", key=" + value);
+    }
+    key = UC::ASU::CacheKey{};
+    if (!value.empty()) { std::memcpy(key.data(), value.data(), value.size()); }
+    return Status::Success();
+}
 
 struct BenchBufferSlot {
     BufferSet buffers;
@@ -187,8 +201,8 @@ bool IsBenchReadOperation(BenchOpType op, std::uint64_t operationIndex, const Be
     return operationIndex % ratioTotal < bench.readRatio;
 }
 
-void PrepareBenchBuffers(BenchBufferSlot& slot, std::uint64_t begin, std::size_t entryCount,
-                         const std::string& keyPrefix)
+Status PrepareBenchBuffers(BenchBufferSlot& slot, std::uint64_t begin, std::size_t entryCount,
+                           const std::string& keyPrefix)
 {
     auto& buffers = slot.buffers;
     buffers.regions.clear();
@@ -202,8 +216,12 @@ void PrepareBenchBuffers(BenchBufferSlot& slot, std::uint64_t begin, std::size_t
         auto& value = buffers.ownedBuffers[index];
         auto region = MakeHostRegion(value);
         buffers.regions.emplace_back(region);
-        buffers.entries.emplace_back(MakeKvBuffer(keyPrefix + std::to_string(keyIndex), region));
+        UC::ASU::CacheKey key{};
+        auto status = StringToCacheKey(keyPrefix + std::to_string(keyIndex), key);
+        if (!status.Ok()) { return status; }
+        buffers.entries.emplace_back(MakeKvBuffer(key, region));
     }
+    return Status::Success();
 }
 
 Status ExecuteBenchOperation(BenchOpType requestedOp, const BenchConfig& bench,
@@ -215,10 +233,11 @@ Status ExecuteBenchOperation(BenchOpType requestedOp, const BenchConfig& bench,
     const bool isRead = IsBenchReadOperation(requestedOp, operationIndex, bench);
     const auto submitMode =
         entryCount > 1 ? SubmitMode::ALL_ENTRIES_IN_ONE_CALL : SubmitMode::SINGLE_ENTRY_PER_CALL;
-    PrepareBenchBuffers(slot, begin, entryCount, keyPrefix);
+    auto status = PrepareBenchBuffers(slot, begin, entryCount, keyPrefix);
+    if (!status.Ok()) { return status; }
     auto& buffers = slot.buffers;
 
-    auto status = clientRunner.RegisterBuffers(buffers);
+    status = clientRunner.RegisterBuffers(buffers);
     if (!status.Ok()) { return status; }
 
     status = isRead ? clientRunner.Retrieve(buffers, submitMode, timeoutMs, operationResult)
@@ -268,7 +287,7 @@ Status BenchRunner::Run(const CommandOptions& options, const KvTestConfig& confi
     auto status = ValidateBenchBufferConfig(bench, poolEntryCount, config.memoryMaxBytes);
     if (!status.Ok()) { return status; }
 
-    const std::string keyPrefix = config.keyPrefix.empty() ? "bench-key-" : config.keyPrefix;
+    const std::string keyPrefix = config.keyPrefix.empty() ? "b" : config.keyPrefix;
     auto bufferPool = BuildBenchBufferPool(bench, entryCountPerOperation, config.seed);
 
     using Clock = std::chrono::steady_clock;

--- a/ucm/transport/kv/kv-test/src/consistency_checker.cpp
+++ b/ucm/transport/kv/kv-test/src/consistency_checker.cpp
@@ -1,8 +1,10 @@
 ﻿#include "kv_test/consistency_checker.h"
+#include <string>
 #include "kv_test/key_value_generator.h"
 
 namespace UC::KVTest {
 
+using UC::ASU::CacheKeyToHex;
 namespace {
 
 constexpr int kExitInvalidArgument = 1;
@@ -43,9 +45,9 @@ std::string AsuStatusCodeToString(UC::ASU::StatusCode code)
 Status ConsistencyError(const std::string& operation, const UC::ASU::CacheKey& key,
                         const std::string& reason)
 {
-    return Status::Error(
-        kExitConsistencyFailed,
-        "consistency check failed: operation=" + operation + " key=" + key + " reason=" + reason);
+    return Status::Error(kExitConsistencyFailed,
+                         "consistency check failed: operation=" + operation +
+                             " key=" + CacheKeyToHex(key) + " reason=" + reason);
 }
 
 Status ValidateTaskForConsistency(const CommandResult& result, const std::string& operation,
@@ -99,7 +101,7 @@ Status DigestValue(const std::vector<std::uint8_t>& value, std::string& digest)
 void SetValueComparison(ConsistencySummary& summary, const UC::ASU::CacheKey& key,
                         const std::string& expectedDigest, const std::string& actualDigest)
 {
-    summary.key = key;
+    summary.key = CacheKeyToHex(key);
     summary.expected = "digest=" + expectedDigest;
     summary.actual = "digest=" + actualDigest;
 }
@@ -107,7 +109,7 @@ void SetValueComparison(ConsistencySummary& summary, const UC::ASU::CacheKey& ke
 void SetExistComparison(ConsistencySummary& summary, const UC::ASU::CacheKey& key,
                         bool expectedExists, bool actualExists)
 {
-    summary.key = key;
+    summary.key = CacheKeyToHex(key);
     summary.expected = expectedExists ? "exists=true" : "exists=false";
     summary.actual = actualExists ? "exists=true" : "exists=false";
 }

--- a/ucm/transport/kv/kv-test/src/key_value_generator.cpp
+++ b/ucm/transport/kv/kv-test/src/key_value_generator.cpp
@@ -1,5 +1,6 @@
 ﻿#include "kv_test/key_value_generator.h"
 #include <algorithm>
+#include <cstring>
 #include <fstream>
 #include <iomanip>
 #include <limits>
@@ -31,10 +32,23 @@ std::uint64_t HashUint64(std::uint64_t hash, std::uint64_t value)
     return hash;
 }
 
-std::uint64_t HashString(std::uint64_t hash, const std::string& value)
+std::uint64_t HashString(std::uint64_t hash, std::string_view value)
 {
     for (const char byte : value) { hash = HashByte(hash, static_cast<std::uint8_t>(byte)); }
     return hash;
+}
+
+Status StringToCacheKey(const std::string& value, const std::string& source, UC::ASU::CacheKey& key)
+{
+    if (value.size() > key.size()) {
+        return Status::Error(kExitInvalidArgument,
+                             source + " key length exceeds " + std::to_string(key.size()) +
+                                 " bytes: length=" + std::to_string(value.size()) +
+                                 ", key=" + value);
+    }
+    key = UC::ASU::CacheKey{};
+    if (!value.empty()) { std::memcpy(key.data(), value.data(), value.size()); }
+    return Status::Success();
 }
 
 std::uint64_t SplitMix64Next(std::uint64_t& state)
@@ -50,7 +64,8 @@ std::vector<std::uint8_t> GenerateValueBytes(const UC::ASU::CacheKey& key, std::
                                              std::uint64_t valueSize)
 {
     std::vector<std::uint8_t> value(static_cast<std::size_t>(valueSize));
-    std::uint64_t state = HashString(HashUint64(kFnvOffsetBasis64, seed), key);
+    std::uint64_t state =
+        HashString(HashUint64(kFnvOffsetBasis64, seed), UC::ASU::CacheKeyView(key));
     for (std::size_t offset = 0; offset < value.size();) {
         const std::uint64_t random = SplitMix64Next(state);
         for (std::uint32_t byteIndex = 0; byteIndex < 8 && offset < value.size();
@@ -83,7 +98,10 @@ Status AddCommaSeparatedKeys(const std::string& value, const std::string& source
         if (item.empty()) {
             return Status::Error(kExitInvalidArgument, source + " contains an empty key");
         }
-        keys.push_back(item);
+        UC::ASU::CacheKey key{};
+        auto status = StringToCacheKey(item, source, key);
+        if (!status.Ok()) { return status; }
+        keys.push_back(key);
     }
 
     return Status::Success();
@@ -119,7 +137,11 @@ Status GenerateRangeKeys(const CommandOptions& options, std::vector<UC::ASU::Cac
 
     keys.reserve(static_cast<std::size_t>(rangeCount));
     for (std::uint64_t index = options.keyStart; index <= options.keyEnd; ++index) {
-        keys.push_back(options.keyPrefix + std::to_string(index));
+        UC::ASU::CacheKey key{};
+        auto status =
+            StringToCacheKey(options.keyPrefix + std::to_string(index), "generated range", key);
+        if (!status.Ok()) { return status; }
+        keys.push_back(key);
         if (index == std::numeric_limits<std::uint64_t>::max()) { break; }
     }
     return Status::Success();
@@ -167,7 +189,10 @@ Status KeyValueGenerator::Generate(const CommandOptions& options, const KvTestCo
         data.keys.reserve(options.keys.size());
         for (const auto& key : options.keys) {
             if (key.empty()) { return Status::Error(kExitInvalidArgument, "key cannot be empty"); }
-            data.keys.push_back(key);
+            UC::ASU::CacheKey cacheKey{};
+            auto status = StringToCacheKey(key, "--key/--keys", cacheKey);
+            if (!status.Ok()) { return status; }
+            data.keys.push_back(cacheKey);
         }
     } else if (!options.keysFile.empty()) {
         auto status = LoadKeysFile(options.keysFile, data.keys);
@@ -181,7 +206,11 @@ Status KeyValueGenerator::Generate(const CommandOptions& options, const KvTestCo
         }
         data.keys.reserve(static_cast<std::size_t>(count));
         for (std::uint64_t index = 0; index < count; ++index) {
-            data.keys.push_back(config.keyPrefix + std::to_string(index));
+            UC::ASU::CacheKey key{};
+            auto status =
+                StringToCacheKey(config.keyPrefix + std::to_string(index), "generated config", key);
+            if (!status.Ok()) { return status; }
+            data.keys.push_back(key);
         }
     }
 

--- a/ucm/transport/kv/kv-test/src/local_asu_transport.cpp
+++ b/ucm/transport/kv/kv-test/src/local_asu_transport.cpp
@@ -8,6 +8,7 @@
 #include <utility>
 
 namespace UC::KVTest {
+using UC::ASU::CacheKeyToHex;
 namespace {
 
 class LocalAsuTransport final : public UC::ASU::AsuTransport {
@@ -58,7 +59,7 @@ public:
 
         result = UC::ASU::QueryResult{};
         if (options.mode == UC::ASU::QueryMode::PREFIX) {
-            result.prefixHitKeys = CountPrefixHits(keys.empty() ? "" : keys.front());
+            result.prefixHitKeys = keys.empty() ? 0 : CountPrefixHits(keys.front());
             return UC::ASU::Status::OK();
         }
 
@@ -122,9 +123,10 @@ public:
             std::error_code errorCode;
             (void)std::filesystem::remove(KeyPath(key), errorCode);
             if (errorCode) {
-                result.entryStatus.emplace_back(UC::ASU::Status::Error(
-                    UC::ASU::StatusCode::IO_ERROR,
-                    "failed to delete local key=" + key + " error=" + errorCode.message()));
+                result.entryStatus.emplace_back(
+                    UC::ASU::Status::Error(UC::ASU::StatusCode::IO_ERROR,
+                                           "failed to delete local key=" + CacheKeyToHex(key) +
+                                               " error=" + errorCode.message()));
             } else {
                 result.entryStatus.emplace_back(UC::ASU::Status::OK());
             }
@@ -237,18 +239,6 @@ private:
         }
     }
 
-    static std::string HexEncode(const std::string& value)
-    {
-        constexpr char kHex[] = "0123456789abcdef";
-        std::string output;
-        output.reserve(value.size() * 2);
-        for (unsigned char ch : value) {
-            output.push_back(kHex[ch >> 4]);
-            output.push_back(kHex[ch & 0x0F]);
-        }
-        return output;
-    }
-
     std::filesystem::path AsuRoot() const
     {
         return std::filesystem::path(storeRoot_) / ("asu-" + std::to_string(config_.asuId));
@@ -256,21 +246,22 @@ private:
 
     std::filesystem::path KeyPath(const UC::ASU::CacheKey& key) const
     {
-        return AsuRoot() / (HexEncode(key) + ".bin");
+        return AsuRoot() / (CacheKeyToHex(key) + ".bin");
     }
 
     UC::ASU::Status StoreEntry(const UC::ASU::KVBuffer& entry)
     {
         std::ofstream file{KeyPath(entry.key), std::ios::binary | std::ios::trunc};
         if (!file.is_open()) {
-            return UC::ASU::Status::Error(UC::ASU::StatusCode::IO_ERROR,
-                                          "failed to open local key for store=" + entry.key);
+            return UC::ASU::Status::Error(
+                UC::ASU::StatusCode::IO_ERROR,
+                "failed to open local key for store=" + CacheKeyToHex(entry.key));
         }
         const auto* data = reinterpret_cast<const char*>(entry.buffer.region.addr);
         file.write(data, static_cast<std::streamsize>(entry.buffer.region.size));
         if (!file.good()) {
             return UC::ASU::Status::Error(UC::ASU::StatusCode::IO_ERROR,
-                                          "failed to write local key=" + entry.key);
+                                          "failed to write local key=" + CacheKeyToHex(entry.key));
         }
         return UC::ASU::Status::OK();
     }
@@ -280,7 +271,7 @@ private:
         std::ifstream file{KeyPath(entry.key), std::ios::binary};
         if (!file.is_open()) {
             return UC::ASU::Status::Error(UC::ASU::StatusCode::NOT_FOUND,
-                                          "local key not found=" + entry.key);
+                                          "local key not found=" + CacheKeyToHex(entry.key));
         }
 
         file.seekg(0, std::ios::end);
@@ -288,26 +279,29 @@ private:
         file.seekg(0, std::ios::beg);
         if (size < 0 || static_cast<std::uint64_t>(size) >
                             static_cast<std::uint64_t>(entry.buffer.region.size)) {
-            return UC::ASU::Status::Error(UC::ASU::StatusCode::BUFFER_NOT_SUPPORTED,
-                                          "local value does not fit destination key=" + entry.key);
+            return UC::ASU::Status::Error(
+                UC::ASU::StatusCode::BUFFER_NOT_SUPPORTED,
+                "local value does not fit destination key=" + CacheKeyToHex(entry.key));
         }
 
         auto* data = reinterpret_cast<char*>(entry.buffer.region.addr);
         file.read(data, size);
         if (!file.good() && !file.eof()) {
             return UC::ASU::Status::Error(UC::ASU::StatusCode::IO_ERROR,
-                                          "failed to read local key=" + entry.key);
+                                          "failed to read local key=" + CacheKeyToHex(entry.key));
         }
         return UC::ASU::Status::OK();
     }
 
-    std::uint32_t CountPrefixHits(const std::string& prefix) const
+    std::uint32_t CountPrefixHits(const UC::ASU::CacheKey& prefixKey) const
     {
         std::uint32_t hits = 0;
         std::error_code errorCode;
         for (const auto& entry : std::filesystem::directory_iterator(AsuRoot(), errorCode)) {
             if (errorCode) { break; }
-            if (entry.path().filename().string().rfind(HexEncode(prefix), 0) == 0) { ++hits; }
+            if (entry.path().filename().string().rfind(CacheKeyToHex(prefixKey), 0) == 0) {
+                ++hits;
+            }
         }
         return hits;
     }


### PR DESCRIPTION
## Purpose
Replace variable-length string keys with a fixed 8-byte byte array (std::array<std::byte, 8>) to simplify packing and eliminate runtime size checks in the KV protocol path.

## Modifications
1. types.h: redefine CacheKey as std::array<std::byte, 8>; add CacheKeyView() helper for string_view interop.
2. kv_protocol: replace empty/size key validation with all-zero check; simplify all PackEntry/PackSqe to fixed memcpy.
3. router: switch HashFunction to string_view; use CacheKeyView for hash inputs in all router implementations.
4. asu_store: build CacheKey via memcpy from hash.
5. Tests: adapt key construction and assertions to fixed-size keys.

## Test
All test passed.