### PR TITLE
[Bugfix] Select SDMA direct launch granularity by connector mode

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -480,7 +480,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
         if "cache_sdma_direct_launch_granularity" in config:
             return
         config["cache_sdma_direct_launch_granularity"] = (
-            "task" if self.launch_config.get("use_layerwise", False) else "shard"
+            "task" if self.use_layerwise else "shard"
         )
 
     def _record_load_error(self, metric_name: str, block_ids: Any) -> None:


### PR DESCRIPTION
Follow-up to #1039.
This PR fixes the default SDMA Direct launch granularity selection for HMA/FAWA connectors. HMA/FAWA uses whole-object store access rather than layerwise store access, so its default SDMA Direct launch granularity should be shard.
Without this fix, the default could be derived from the user-level use_layerwise config instead of the actual connector mode, causing HMA/FAWA to use task-level launch and potentially aggregate too many FFTS contexts in one launch.
Modifications
Change SDMA Direct launch granularity default selection to use the actual connector mode.
self.use_layerwise == true: default to task.
self.use_layerwise == false: default to shard.

Keep explicit user config priority unchanged.
If cache_sdma_direct_launch_granularity is already set by the user, the connector does not override it.

Preserve existing behavior for normal connectors.
Layerwise connector still defaults to task.
Direct connector still defaults to shard.
HMA/FAWA inherits the direct connector mode and defaults to shard.

Test
Ran git diff --check.
Verified the follow-up branch is based on latest upstream/develop.
Verified the branch contains exactly one commit.
Verified the diff only changes SDMA Direct launch granularity default selection in the vLLM connector.