### PR TITLE
[fix]Add UCMConnectorV1 in factory

### DIFF
--- a/ucm/integration/vllm/patch/apply_patch.py
+++ b/ucm/integration/vllm/patch/apply_patch.py
@@ -149,9 +149,7 @@ def apply_all_patches() -> None:
         # UCM PATCH: vllm-ascend registers UCMConnector as an alias for the
         # concrete UCMConnectorV1 class used by MultiConnector metrics.
         if ascend_version in {"0.18.0", "0.19.1", "0.20.2", "0.22.1"}:
-            logger.info(
-                "UCM patching vllm-ascend UCM connector metrics alias..."
-            )
+            logger.info("UCM patching vllm-ascend UCM connector metrics alias...")
             import ucm.integration.vllm.patch.ucm_connector_registration_patch
 
         # Apply vllm/vllm-ascend version-specific patches

--- a/ucm/integration/vllm/patch/apply_patch.py
+++ b/ucm/integration/vllm/patch/apply_patch.py
@@ -114,7 +114,15 @@ def get_vllm_version() -> Optional[str]:
 
 def get_supported_versions() -> list[str]:
     """Get patch-required vLLM versions."""
-    return ["0.11.0", "0.17.0", "0.18.0", "0.19.1", "0.20.2", "0.21.0"]
+    return [
+        "0.11.0",
+        "0.17.0",
+        "0.18.0",
+        "0.19.1",
+        "0.20.2",
+        "0.21.0",
+        "0.22.1",
+    ]
 
 
 def apply_all_patches() -> None:
@@ -136,6 +144,15 @@ def apply_all_patches() -> None:
                 f"No version-specific vLLM patches available for vLLM {version}. "
                 f"Versions applicable for UCM patches: {', '.join(supported_versions)}."
             )
+
+        ascend_version = get_vllm_ascend_version()
+        # UCM PATCH: vllm-ascend registers UCMConnector as an alias for the
+        # concrete UCMConnectorV1 class used by MultiConnector metrics.
+        if ascend_version in {"0.18.0", "0.19.1", "0.20.2", "0.22.1"}:
+            logger.info(
+                "UCM patching vllm-ascend UCM connector metrics alias..."
+            )
+            import ucm.integration.vllm.patch.ucm_connector_registration_patch
 
         # Apply vllm/vllm-ascend version-specific patches
         # vllm patches
@@ -168,7 +185,6 @@ def apply_all_patches() -> None:
             import ucm.integration.vllm.patch.load_failure_patch
 
         # vllm_ascend patches
-        ascend_version = get_vllm_ascend_version()
         match ascend_version:
             case "0.11.0":
                 logger.info("UCM patching vllm-ascend for pc...")

--- a/ucm/integration/vllm/patch/ucm_connector_registration_patch.py
+++ b/ucm/integration/vllm/patch/ucm_connector_registration_patch.py
@@ -1,0 +1,48 @@
+"""Register the concrete vllm-ascend UCM class name used by metrics."""
+
+from typing import Any
+
+from ucm.integration.vllm.patch.utils import when_imported
+from ucm.logger import init_logger
+
+logger = init_logger(__name__)
+
+UCM_CONNECTOR_MODULE = (
+    "vllm_ascend.distributed.kv_transfer.kv_pool.ucm_connector"
+)
+
+
+def _register_ucm_connector_class_alias(factory: type) -> None:
+    if "UCMConnector" not in factory._registry:
+        return
+    if "UCMConnectorV1" in factory._registry:
+        return
+
+    # UCM PATCH: MultiConnector serializes stats with the concrete class name
+    # UCMConnectorV1, while vllm-ascend registers only UCMConnector.
+    factory.register_connector(
+        "UCMConnectorV1", UCM_CONNECTOR_MODULE, "UCMConnectorV1"
+    )
+
+
+def patch_ucm_connector_registration(mod: Any) -> None:
+    if getattr(mod, "_ucm_connector_metrics_alias_patch", False):
+        return
+
+    original = mod.register_connector
+
+    def register_connector() -> None:
+        original()
+        _register_ucm_connector_class_alias(mod.KVConnectorFactory)
+
+    mod.register_connector = register_connector
+    mod._ucm_connector_metrics_alias_patch = True
+
+    # Handle the case where vllm-ascend registration ran before this hook.
+    _register_ucm_connector_class_alias(mod.KVConnectorFactory)
+    logger.debug("Patched vllm-ascend UCMConnectorV1 metrics alias registration")
+
+
+when_imported("vllm_ascend.distributed.kv_transfer")(
+    patch_ucm_connector_registration
+)

--- a/ucm/integration/vllm/patch/ucm_connector_registration_patch.py
+++ b/ucm/integration/vllm/patch/ucm_connector_registration_patch.py
@@ -7,9 +7,7 @@ from ucm.logger import init_logger
 
 logger = init_logger(__name__)
 
-UCM_CONNECTOR_MODULE = (
-    "vllm_ascend.distributed.kv_transfer.kv_pool.ucm_connector"
-)
+UCM_CONNECTOR_MODULE = "vllm_ascend.distributed.kv_transfer.kv_pool.ucm_connector"
 
 
 def _register_ucm_connector_class_alias(factory: type) -> None:
@@ -20,9 +18,7 @@ def _register_ucm_connector_class_alias(factory: type) -> None:
 
     # UCM PATCH: MultiConnector serializes stats with the concrete class name
     # UCMConnectorV1, while vllm-ascend registers only UCMConnector.
-    factory.register_connector(
-        "UCMConnectorV1", UCM_CONNECTOR_MODULE, "UCMConnectorV1"
-    )
+    factory.register_connector("UCMConnectorV1", UCM_CONNECTOR_MODULE, "UCMConnectorV1")
 
 
 def patch_ucm_connector_registration(mod: Any) -> None:
@@ -43,6 +39,4 @@ def patch_ucm_connector_registration(mod: Any) -> None:
     logger.debug("Patched vllm-ascend UCMConnectorV1 metrics alias registration")
 
 
-when_imported("vllm_ascend.distributed.kv_transfer")(
-    patch_ucm_connector_registration
-)
+when_imported("vllm_ascend.distributed.kv_transfer")(patch_ucm_connector_registration)


### PR DESCRIPTION
## Purpose

Fix `MultiConnector` metrics deserialization failures when using UCM with vLLM Ascend.

vLLM Ascend registers `UCMConnector` as an alias for the concrete `UCMConnectorV1` class, while `MultiConnector` serializes metrics using `UCMConnectorV1`. This mismatch causes `Connector 'UCMConnectorV1' is not registered`.

## Modifications

- Add a runtime patch that registers `UCMConnectorV1` as an additional factory alias.
- Preserve the existing `UCMConnector` registration and configuration.
- Handle cases where the vLLM Ascend connector registration runs before or after the UCM patch.
- Enable the patch for vLLM Ascend `0.18.0`, `0.19.1`, `0.20.2`, and `0.22.1`.
- Add explicit `UCM PATCH` comments around the compatibility logic.
