### PR TITLE
fix: recompute enough tokens on full UCM cache hit

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -1279,6 +1279,9 @@ class UCMLayerWiseConnector(UCMDirectConnector):
         logger.info("Init UCMLayerWiseConnector.")
 
     def _get_full_hit_recompute_tokens(self) -> int:
+        if not self.use_layerwise:
+            return super()._get_full_hit_recompute_tokens()
+
         speculative_config = getattr(self._vllm_config, "speculative_config", None)
         if speculative_config is None:
             return 2

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -472,6 +472,23 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self.hash_block_size = self.block_size
         self.block_size *= self.cp_world_size
 
+    def _get_full_hit_recompute_tokens(self) -> int:
+        speculative_config = getattr(self._vllm_config, "speculative_config", None)
+        if speculative_config is None:
+            return 2
+
+        spec_token_num = getattr(speculative_config, "num_speculative_tokens", 0)
+        try:
+            spec_token_num = int(spec_token_num)
+        except (TypeError, ValueError):
+            logger.warning(
+                f"Invalid speculative token count: {spec_token_num}. "
+                "Fallback to recomputing two tokens on full UCM cache hit."
+            )
+            spec_token_num = 0
+
+        return max(spec_token_num, 0) + 2
+
     @staticmethod
     def _record_counter(name: str, value: float = 1.0) -> None:
         _record_counter(name, value)
@@ -693,12 +710,13 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
         external_hit_tokens = external_hit_blocks * self.block_size
 
-        # When all the tokens are cached in ssd or hbm,
-        # we need to recompute the last token. This if condition will be removed
-        # once vLLM scheduler provides a better solution in the future.
+        # When all the tokens are cached in ssd or hbm, recompute enough tokens
+        # to keep layerwise loads on the prefill path when speculative decode is
+        # enabled. This branch will be removed once vLLM scheduler provides a
+        # better solution in the future.
         num_total_hit_tokens = total_hit_block_num * self.block_size
         if num_total_hit_tokens == request.num_tokens:
-            external_hit_tokens -= 1
+            external_hit_tokens -= self._get_full_hit_recompute_tokens()
 
         self.requests_meta[request.request_id] = RequestMeta(
             ucm_block_ids=ucm_block_ids,

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -473,21 +473,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self.block_size *= self.cp_world_size
 
     def _get_full_hit_recompute_tokens(self) -> int:
-        speculative_config = getattr(self._vllm_config, "speculative_config", None)
-        if speculative_config is None:
-            return 2
-
-        spec_token_num = getattr(speculative_config, "num_speculative_tokens", 0)
-        try:
-            spec_token_num = int(spec_token_num)
-        except (TypeError, ValueError):
-            logger.warning(
-                f"Invalid speculative token count: {spec_token_num}. "
-                "Fallback to recomputing two tokens on full UCM cache hit."
-            )
-            spec_token_num = 0
-
-        return max(spec_token_num, 0) + 2
+        return 1
 
     @staticmethod
     def _record_counter(name: str, value: float = 1.0) -> None:
@@ -716,7 +702,17 @@ class UCMDirectConnector(KVConnectorBase_V1):
         # better solution in the future.
         num_total_hit_tokens = total_hit_block_num * self.block_size
         if num_total_hit_tokens == request.num_tokens:
-            external_hit_tokens -= self._get_full_hit_recompute_tokens()
+            recompute_tokens = self._get_full_hit_recompute_tokens()
+            if external_hit_tokens < recompute_tokens:
+                logger.error(
+                    f"Full UCM cache hit fallback would make external hit tokens negative: "
+                    f"request_id: {request.request_id}, "
+                    f"external_hit_tokens: {external_hit_tokens}, "
+                    f"recompute_tokens: {recompute_tokens}, "
+                    f"num_total_hit_tokens: {num_total_hit_tokens}, "
+                    f"request_tokens: {request.num_tokens}"
+                )
+            external_hit_tokens = max(0, external_hit_tokens - recompute_tokens)
 
         self.requests_meta[request.request_id] = RequestMeta(
             ucm_block_ids=ucm_block_ids,
@@ -1281,6 +1277,23 @@ class UCMLayerWiseConnector(UCMDirectConnector):
         self._mtp_layer_end: Optional[int] = None
         self._init_mtp_layerwise_dump_state()
         logger.info("Init UCMLayerWiseConnector.")
+
+    def _get_full_hit_recompute_tokens(self) -> int:
+        speculative_config = getattr(self._vllm_config, "speculative_config", None)
+        if speculative_config is None:
+            return 2
+
+        spec_token_num = getattr(speculative_config, "num_speculative_tokens", 0)
+        try:
+            spec_token_num = int(spec_token_num)
+        except (TypeError, ValueError):
+            logger.warning(
+                f"Invalid speculative token count: {spec_token_num}. "
+                "Fallback to recomputing two tokens on full layerwise UCM cache hit."
+            )
+            spec_token_num = 0
+
+        return max(spec_token_num, 0) + 2
 
     def _layerwise_batch_stats(
         self, total_end: float, save_tail_ms: Optional[float] = None


### PR DESCRIPTION
## Summary

This PR adjusts the full-hit fallback behavior in the UCM layerwise load path.

When a request is fully hit in UCM, the connector intentionally reduces the reported external hit tokens so vLLM recomputes a small tail of the request. This PR changes that fallback from a fixed 1-token recompute to recomputing enough tokens to avoid the vLLM-Ascend decode-only graph path:

- without speculative decode: recompute 2 tokens
- with speculative decode / MTP: recompute `num_speculative_tokens + 2` tokens

Updated path:

- `@ucm/integration/vllm/ucm_connector.py`

The HMA / FAWA / v4 path is not changed by this PR and keeps the existing 1-token fallback.

## Motivation

Before this change, a full UCM cache hit recomputed only the last token:

```python
if num_total_hit_tokens == request.num_tokens:
    external_hit_tokens -= 1
```

That makes vLLM schedule a 1-token forward.

In vLLM-Ascend, decode / prefill classification is based on:

```python
if max_query_len <= decode_threshold:
    return num_reqs, 0, num_tokens, 0
```

For normal decode, `decode_threshold` is 1. When speculative decode / MTP is enabled, vLLM-Ascend raises it to `1 + num_speculative_tokens`.

With `FULL_DECODE_ONLY`, decode batches can enter full graph replay. During replay, the Python runnable is not executed again; graph replay calls `entry.aclgraph.replay()` directly.

For traditional MHA attention, UCM layerwise wait is executed by the Python attention wrapper. Therefore, if the full-hit fallback produces a decode-shaped forward and that forward is replayed by graph, the Python wrapper is not re-entered. In that case, `wait_for_layer_load`, related logs, and layerwise wait metrics may not be observed on the replay path.

The observed chain is:

```text
UCM full cache hit
  -> external hit tokens are reduced by too few tokens
  -> scheduler computes a small num_new_tokens
  -> vLLM-Ascend classifies the batch as decode when max_query_len <= decode_threshold
  -> FULL_DECODE_ONLY dispatches decode to full graph
  -> graph replay calls entry.aclgraph.replay()
  -> Python MHA wrapper is not re-executed
  -> wait_for_layer_load / logs / layerwise metrics are not observed
```

## Change

This PR computes the fallback recompute size from vLLM's speculative config:

```python
recompute_tokens = num_speculative_tokens + 2
```

For non-speculative decode, this is equivalent to recomputing 2 tokens.

For MTP / speculative decode, this makes the recomputed tail larger than vLLM-Ascend's decode threshold:

```text
required recompute tokens = decode_threshold + 1
                          = (1 + num_speculative_tokens) + 1
                          = num_speculative_tokens + 2
```

As a result, full-hit layerwise load requests stay on the prefill-shaped path even when MTP increases the decode threshold.

## Validation

- `py_compile @ucm/integration/vllm/ucm_connector.py @ucm/integration/vllm/hma_connector.py`
- `git diff --check`