### PR TITLE
[Fix] Remove Register_Memory in StoreV1

### DIFF
--- a/examples/ucm_mooncake_config.yaml
+++ b/examples/ucm_mooncake_config.yaml
@@ -20,6 +20,7 @@ ucm_connectors:
       replica_num: 1
       storage_backends: "/mnt/test"
       io_direct: true
+      posix_io_engine: "aio"
       share_buffer_capacity_gb: 64
 
 # prerequisiteHandle requires event sync to ensure NPU compute finishes

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -613,7 +613,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
         )
 
         self.store = self._create_store(self.kv_cache_layout, store_cores)
-        self._register_kv_cache_memory()
 
         if worker_cores:
             try:
@@ -624,31 +623,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
         if self.device is None:
             raise RuntimeError(f"Unsupported device platform for UCMDirectConnector.")
-
-    def _register_kv_cache_memory(self):
-        for layer_name, kv_layer in self.kv_caches.items():
-            if isinstance(kv_layer, torch.Tensor):
-                if kv_layer.dim() == 5:
-                    num_blocks = kv_layer.shape[1]
-                    block_size = kv_layer[0].shape[1:].numel() * kv_layer.element_size()
-                    total_size = num_blocks * block_size
-                    self.store.register_memory(kv_layer[0].data_ptr(), total_size)
-                    self.store.register_memory(kv_layer[1].data_ptr(), total_size)
-                elif kv_layer.dim() == 3:
-                    num_blocks = kv_layer.shape[0]
-                    total_size = kv_layer.numel() * kv_layer.element_size()
-                    self.store.register_memory(kv_layer.data_ptr(), total_size)
-                else:
-                    raise ValueError(
-                        f"Unsupported kv cache tensor shape: {kv_layer.shape}"
-                    )
-            elif isinstance(kv_layer, Tuple):
-                for tensor in kv_layer:
-                    total_size = tensor.numel() * tensor.element_size()
-                    self.store.register_memory(tensor.data_ptr(), total_size)
-            else:
-                raise TypeError(f"Unsupported kv cache type: {type(kv_layer)}")
-        logger.info(f"Registered {len(self.kv_caches)} layers' kv cache memory")
 
     def get_num_new_matched_tokens(
         self,

--- a/ucm/store/cache/cc/cache_store.cc
+++ b/ucm/store/cache/cc/cache_store.cc
@@ -115,7 +115,6 @@ public:
         if (s.Failure()) [[unlikely]] { UC_ERROR("Failed({}) to wait task({}).", s, taskId); }
         return s;
     }
-    Status RegisterMemory(void* base_addr, size_t total_size) override { return Status::OK(); }
 
 private:
     Config ParseConfig(const Detail::Dictionary& config)

--- a/ucm/store/compress/cc/compressor.cc
+++ b/ucm/store/compress/cc/compressor.cc
@@ -131,12 +131,6 @@ Status Compressor::Wait(Detail::TaskHandle taskId)
     return s;
 }
 
-Status Compressor::RegisterMemory(void* base_addr, size_t total_size)
-{
-    if (!impl_->backend) { return Status::OK(); }
-    return impl_->backend->RegisterMemory(base_addr, total_size);
-}
-
 }  // namespace UC::Compressor
 
 extern "C" UC::StoreV1* MakeCompressStore() { return new UC::Compressor::Compressor(); }

--- a/ucm/store/compress/cc/compressor.h
+++ b/ucm/store/compress/cc/compressor.h
@@ -20,7 +20,6 @@ public:
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override;
     Expected<bool> Check(Detail::TaskHandle taskId) override;
     Status Wait(Detail::TaskHandle taskId) override;
-    Status RegisterMemory(void* base_addr, size_t total_size) override;
 
 private:
     std::shared_ptr<CompressorImpl> impl_;

--- a/ucm/store/ds3fs/cc/ds3fs_store.cc
+++ b/ucm/store/ds3fs/cc/ds3fs_store.cc
@@ -171,13 +171,6 @@ Status Ds3fsStore::Wait(Detail::TaskHandle taskId)
     return s;
 }
 
-Status Ds3fsStore::RegisterMemory(void* base_addr, size_t total_size)
-{
-    (void)base_addr;
-    (void)total_size;
-    return Status::OK();
-}
-
 }  // namespace UC::Ds3fsStore
 
 extern "C" UC::StoreV1* MakeDs3fsStore() { return new UC::Ds3fsStore::Ds3fsStore(); }

--- a/ucm/store/ds3fs/cc/ds3fs_store.h
+++ b/ucm/store/ds3fs/cc/ds3fs_store.h
@@ -42,7 +42,6 @@ public:
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override;
     Expected<bool> Check(Detail::TaskHandle taskId) override;
     Status Wait(Detail::TaskHandle taskId) override;
-    Status RegisterMemory(void* base_addr, size_t total_size) override;
 
 private:
     std::shared_ptr<Ds3fsStoreImpl> impl_;

--- a/ucm/store/empty/cc/empty_store.cc
+++ b/ucm/store/empty/cc/empty_store.cc
@@ -42,7 +42,6 @@ public:
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) { return NextId(); }
     Expected<bool> Check(Detail::TaskHandle taskId) { return true; }
     Status Wait(Detail::TaskHandle taskId) { return Status::OK(); }
-    Status RegisterMemory(void* base_addr, size_t total_size) { return Status::OK(); }
 
 private:
     static Detail::TaskHandle NextId() noexcept

--- a/ucm/store/fake/cc/fake_store.cc
+++ b/ucm/store/fake/cc/fake_store.cc
@@ -82,7 +82,6 @@ public:
     }
     Expected<bool> Check(Detail::TaskHandle taskId) override { return true; }
     Status Wait(Detail::TaskHandle taskId) override { return Status::OK(); }
-    Status RegisterMemory(void* base_addr, size_t total_size) override { return Status::OK(); }
 
 private:
     static Detail::TaskHandle NextId() noexcept

--- a/ucm/store/mooncakestore/cc/global_config.h
+++ b/ucm/store/mooncakestore/cc/global_config.h
@@ -65,6 +65,9 @@ struct Config {
     size_t shareBufferNumber{0};
 
     StoreV1* storeBackend{nullptr};
+
+    std::vector<uintptr_t> gpuKvBufferAddrs{};
+    std::vector<size_t> gpuKvBufferSizes{};
 };
 
 }  // namespace UC::MooncakeStore

--- a/ucm/store/mooncakestore/cc/mooncake_store.cc
+++ b/ucm/store/mooncakestore/cc/mooncake_store.cc
@@ -104,6 +104,8 @@ public:
         if (transEnable_) {
             s = transMgr_.Setup(config);
             if (s.Failure()) [[unlikely]] { return s; }
+            s = RegisterKvBuffers(config);
+            if (s.Failure()) [[unlikely]] { return s; }
         } else {
             s = SetupRpcClient(config);
             if (s.Failure()) [[unlikely]] { return s; }
@@ -190,29 +192,30 @@ public:
 
     Status Wait(Detail::TaskHandle taskId) override { return transMgr_.Wait(taskId); }
 
-    Status RegisterMemory(void* base_addr, size_t total_size) override
+private:
+    Status RegisterKvBuffers(const Config& config)
     {
-        if (!transEnable_) { return Status::OK(); }
         auto client = transMgr_.GetRealClient();
         if (!client) { return Status::OK(); }
+        if (config.gpuKvBufferAddrs.empty()) { return Status::OK(); }
 
         std::lock_guard<std::mutex> lk(registerMtx_);
-        if (registered_.count(base_addr)) {
-            UC_DEBUG("buffer already registered: addr={}", base_addr);
-            return Status::OK();
-        }
+        for (size_t i = 0; i < config.gpuKvBufferAddrs.size(); ++i) {
+            void* addr = reinterpret_cast<void*>(config.gpuKvBufferAddrs[i]);
+            size_t size = config.gpuKvBufferSizes[i];
+            if (registered_.count(addr)) { continue; }
 
-        int rc = client->register_buffer(base_addr, total_size);
-        if (rc != 0) {
-            UC_ERROR("register_buffer failed: addr={}, size={}, rc={}", base_addr, total_size, rc);
-            return Status::Error("register_buffer failed");
+            int rc = client->register_buffer(addr, size);
+            if (rc != 0) {
+                UC_ERROR("register_buffer failed: addr={}, size={}, rc={}", addr, size, rc);
+                return Status::Error("register_buffer failed");
+            }
+            registered_[addr] = size;
+            UC_DEBUG("Registered buffer addr={}, size={}", addr, size);
         }
-        registered_[base_addr] = total_size;
-        UC_DEBUG("Registered buffer addr={}, size={}", base_addr, total_size);
         return Status::OK();
     }
 
-private:
     Status SetupRpcClient(const Config& config)
     {
         auto dummyTE = std::make_shared<mooncake::TransferEngine>();
@@ -300,6 +303,8 @@ private:
         inConfig.GetNumber("local_rank_size", config.localRankSize);
         inConfig.Get("unique_id", config.uniqueId);
         inConfig.Get("store_backend", config.storeBackend);
+        inConfig.GetNumbers("gpu_kv_buffer_addrs", config.gpuKvBufferAddrs);
+        inConfig.GetNumbers("gpu_kv_buffer_sizes", config.gpuKvBufferSizes);
         DeriveShareBufferNumber(inConfig, config);
         DeriveHostBufPoolSize(inConfig, config);
         return config;

--- a/ucm/store/pcstore/pcstore_connector_v1.py
+++ b/ucm/store/pcstore/pcstore_connector_v1.py
@@ -258,12 +258,3 @@ class UcmPcStoreV1(UcmKVStoreBaseV1):
             ``True`` if the task has finished, ``False`` if still in-flight.
         """
         return self.store.Check(task.task_id)
-
-    def register_memory(self, base_addr: int, total_size: int) -> None:
-        """Register device memory range for transfer operations.
-
-        Args:
-            base_addr: Base address of the memory region (as Python int).
-            total_size: Total size of the memory region in bytes.
-        """
-        pass

--- a/ucm/store/pipeline/connector.py
+++ b/ucm/store/pipeline/connector.py
@@ -177,9 +177,6 @@ class UcmPipelineStore(UcmKVStoreBaseV1):
     def check(self, task: Task) -> bool:
         return self.store_.Check(task.task_id)
 
-    def register_memory(self, base_addr: int, total_size: int) -> None:
-        self.store_.RegisterMemory(base_addr, total_size)
-
 
 def _cache_ds3fs_pipeline_builder(
     config: Dict[str, object], pipeline: ucmpipelinestore.PipelineStore

--- a/ucm/store/pipeline/cpy/pipeline_store.py.cc
+++ b/ucm/store/pipeline/cpy/pipeline_store.py.cc
@@ -168,11 +168,6 @@ public:
         }
         ThrowIfFailed(status);
     }
-    void RegisterMemory(uintptr_t base_addr, size_t total_size)
-    {
-        auto status = StoreBack()->RegisterMemory((void*)base_addr, total_size);
-        ThrowIfFailed(status);
-    }
 };
 
 }  // namespace UC::PipelineStore
@@ -197,5 +192,4 @@ PYBIND11_MODULE(ucmpipelinestore, m)
           py::arg("addrs").noconvert(), py::arg("prerequisite_handle") = 0);
     s.def("Check", &PipelineStore::Check);
     s.def("Wait", &PipelineStore::Wait);
-    s.def("RegisterMemory", &PipelineStore::RegisterMemory);
 }

--- a/ucm/store/posix/cc/posix_store.cc
+++ b/ucm/store/posix/cc/posix_store.cc
@@ -97,7 +97,6 @@ public:
         if (s.Failure()) [[unlikely]] { UC_ERROR("Failed({}) to wait task({}).", s, taskId); }
         return s;
     }
-    Status RegisterMemory(void* base_addr, size_t total_size) override { return Status::OK(); }
 
 private:
     Config ParseConfig(const Detail::Dictionary& inConfig)

--- a/ucm/store/test/case/detail/mock_store.h
+++ b/ucm/store/test/case/detail/mock_store.h
@@ -32,7 +32,6 @@ namespace UC::Test::Detail {
 class MockStore : public UC::StoreV1 {
 public:
     MOCK_METHOD((UC::Status), Setup, (const UC::Detail::Dictionary&), (override));
-    MOCK_METHOD((UC::Status), RegisterMemory, (void*, size_t), (override));
     MOCK_METHOD((std::string), Readme, (), (const, override));
     MOCK_METHOD((UC::Expected<std::vector<uint8_t>>), Lookup,
                 (const UC::Detail::BlockId* blocks, size_t num), (override));

--- a/ucm/store/ucmstore_v1.h
+++ b/ucm/store/ucmstore_v1.h
@@ -147,19 +147,6 @@ public:
      */
     virtual Status Wait(Detail::TaskHandle taskId) = 0;
 
-    /**
-     * @brief Register device memory range for transfer operations.
-     *
-     * This method should be called once during initialization to register
-     * the entire KV cache memory range. Subsequent Load/Dump operations
-     * will use addresses within this registered range.
-     *
-     * @param base_addr Base address of the memory region.
-     * @param total_size Total size of the memory region in bytes.
-     * @return Status::OK on success, error code on failure.
-     */
-    virtual Status RegisterMemory(void* base_addr, size_t total_size) = 0;
-
 protected:
     /**
      * @brief Protected default constructor.

--- a/ucm/store/ucmstore_v1.py
+++ b/ucm/store/ucmstore_v1.py
@@ -202,17 +202,3 @@ class UcmKVStoreBaseV1(ABC):
             ``True`` if the task has finished, ``False`` if still in-flight.
         """
         pass
-
-    @abstractmethod
-    def register_memory(self, base_addr: int, total_size: int) -> None:
-        """Register device memory range for transfer operations.
-
-        This method should be called once during initialization to register
-        the entire KV cache memory range. Subsequent Load/Dump operations
-        will use addresses within this registered range.
-
-        Args:
-            base_addr: Base address of the memory region (as Python int).
-            total_size: Total size of the memory region in bytes.
-        """
-        pass


### PR DESCRIPTION
## Purpose
Remove the RegisterMemory interface from the StoreV1 base class to avoid the issue where all existing and future Store implementations are forced to provide empty implementations of this method

## Modifications 
No Modifications .

## Test
