### PR TITLE
[BugFix] Update the hotness of all ranks

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -404,10 +404,12 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
         self.chunk_size = self.block_size
         self.blocks_per_chunk = self.chunk_size // self.block_size
+        self._other_rank_hashers: list[RequestHasher] = []
 
         defer_scheduler_store = getattr(self, "_defer_scheduler_store", False)
         if role == KVConnectorRole.SCHEDULER:
             self.request_hasher = RequestHasher(vllm_config, 0)
+            self._other_rank_hashers = self._make_other_rank_hashers(vllm_config)
             self._seed = self.request_hasher("UCM_HASH_SEED")
             # init scheduler-size connector
             if not defer_scheduler_store:
@@ -436,6 +438,12 @@ class UCMDirectConnector(KVConnectorBase_V1):
     @staticmethod
     def _record_counter(name: str, value: float = 1.0) -> None:
         _record_counter(name, value)
+
+    def _make_other_rank_hashers(self, vllm_config) -> list[RequestHasher]:
+        if self.is_mla:
+            return []
+        tp_size = vllm_config.parallel_config.tensor_parallel_size
+        return [RequestHasher(vllm_config, rank_id) for rank_id in range(1, tp_size)]
 
     def _apply_sdma_direct_launch_granularity(self, config: dict[str, Any]) -> None:
         if "cache_sdma_direct_launch_granularity" in config:
@@ -585,6 +593,19 @@ class UCMDirectConnector(KVConnectorBase_V1):
         if self.device is None:
             raise RuntimeError(f"Unsupported device platform for UCMDirectConnector.")
 
+    def _prefetch_other_rank_hashes(self, rank0_block_ids: list[bytes]) -> None:
+        if not self._other_rank_hashers or not rank0_block_ids:
+            return
+
+        other_rank_block_ids = [
+            rank_hasher(block_id)
+            for rank_hasher in self._other_rank_hashers
+            for block_id in rank0_block_ids
+        ]
+
+        if other_rank_block_ids:
+            self.store.prefetch(other_rank_block_ids)
+
     def get_num_new_matched_tokens(
         self,
         request: "Request",
@@ -622,10 +643,13 @@ class UCMDirectConnector(KVConnectorBase_V1):
         external_hit_blocks = 0
         if external_block_ids:
             try:
-                external_hit_blocks = (
+                external_hit_hashes = (
                     self.store.lookup_on_prefix(external_block_ids) + 1
                 )
-                external_hit_blocks //= self.cp_world_size
+                self._prefetch_other_rank_hashes(
+                    external_block_ids[:external_hit_hashes]
+                )
+                external_hit_blocks = external_hit_hashes // self.cp_world_size
             except Exception as e:
                 logger.error(
                     f"request {request.request_id} look up error. {type(e).__name__}: {e}"
@@ -1627,6 +1651,7 @@ class UCMCPConnector(UCMLayerWiseConnector):
 
         if role == KVConnectorRole.SCHEDULER:
             self.request_hasher = RequestHasher(vllm_config, 0)
+            self._other_rank_hashers = self._make_other_rank_hashers(vllm_config)
             self._seed = self.request_hasher("UCM_HASH_SEED")
             # init scheduler-size connector
             self.store = self._create_store(None)

--- a/ucm/store/cache/cc/buffer_manager.h
+++ b/ucm/store/cache/cc/buffer_manager.h
@@ -77,6 +77,10 @@ public:
         }
         return LookupOnPrefixFast(blocks, num);
     }
+    void Prefetch(const Detail::BlockId* blocks, size_t num)
+    {
+        if (backend_) { backend_->Prefetch(blocks, num); }
+    }
 
 private:
     void Lookup(const Detail::BlockId* blocks, size_t num, std::vector<uint8_t>& results,

--- a/ucm/store/cache/cc/cache_store.cc
+++ b/ucm/store/cache/cc/cache_store.cc
@@ -84,7 +84,10 @@ public:
         if (!res) [[unlikely]] { UC_ERROR("Failed({}) to lookup blocks({}).", res.Error(), num); }
         return res;
     }
-    void Prefetch(const Detail::BlockId* blocks, size_t num) override {}
+    void Prefetch(const Detail::BlockId* blocks, size_t num) override
+    {
+        bufferMgr_.Prefetch(blocks, num);
+    }
     Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override
     {
         if (!transEnable_) { return Status::Error("transfer is not enable"); }

--- a/ucm/store/compress/cc/compressor.cc
+++ b/ucm/store/compress/cc/compressor.cc
@@ -95,7 +95,10 @@ Expected<ssize_t> Compressor::LookupOnPrefix(const Detail::BlockId* blocks, size
     return res;
 }
 
-void Compressor::Prefetch(const Detail::BlockId*, size_t) {}
+void Compressor::Prefetch(const Detail::BlockId* blocks, size_t num)
+{
+    impl_->backend->Prefetch(blocks, num);
+}
 
 Expected<Detail::TaskHandle> Compressor::Load(Detail::TaskDesc task)
 {

--- a/ucm/store/mooncakestore/cc/mooncake_store.cc
+++ b/ucm/store/mooncakestore/cc/mooncake_store.cc
@@ -163,8 +163,7 @@ public:
 
     void Prefetch(const Detail::BlockId* blocks, size_t num) override
     {
-        (void)blocks;
-        (void)num;
+        if (config_.storeBackend) { config_.storeBackend->Prefetch(blocks, num); }
     }
 
     Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override

--- a/ucm/store/posix/cc/posix_store.cc
+++ b/ucm/store/posix/cc/posix_store.cc
@@ -66,7 +66,10 @@ public:
         if (!res) [[unlikely]] { UC_ERROR("Failed({}) to lookup blocks({}).", res.Error(), num); }
         return res;
     }
-    void Prefetch(const Detail::BlockId* blocks, size_t num) override {}
+    void Prefetch(const Detail::BlockId* blocks, size_t num) override
+    {
+        spaceMgr_.Prefetch(blocks, num);
+    }
     Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override
     {
         if (!transEnable_) { return Status::Error("transfer is not enable"); }

--- a/ucm/store/posix/cc/space_manager.cc
+++ b/ucm/store/posix/cc/space_manager.cc
@@ -114,6 +114,13 @@ uint8_t SpaceManager::Lookup(const Detail::BlockId* block)
     return true;
 }
 
+void SpaceManager::Prefetch(const Detail::BlockId* blocks, size_t num)
+{
+    if (!hotnessTrackerEnable_) { return; }
+
+    for (size_t i = 0; i < num; i++) { hotnessTracker_.Touch(blocks[i]); }
+}
+
 void SpaceManager::OnLookupPrefix(PrefixLookupContext& ctx)
 {
     for (size_t i = ctx.begin; i < ctx.end; i += ctx.nWorker) {

--- a/ucm/store/posix/cc/space_manager.h
+++ b/ucm/store/posix/cc/space_manager.h
@@ -56,6 +56,7 @@ public:
     Status Setup(const Config& config);
     Expected<std::vector<uint8_t>> Lookup(const Detail::BlockId* blocks, size_t num);
     Expected<ssize_t> LookupOnPrefix(const Detail::BlockId* blocks, size_t num);
+    void Prefetch(const Detail::BlockId* blocks, size_t num);
     const SpaceLayout* GetLayout() const { return &layout_; }
 
 private:


### PR DESCRIPTION
## Purpose

Fix an issue where prefix lookup only refreshed the hotness of rank 0 block files. In TP scenarios, blocks for other ranks could remain cold and be reclaimed by Posix GC, causing later KV load failures even though the request had recently hit the external cache.

## Modifications

- Added scheduler-side other-rank hash generation for non-MLA models.
- After lookup_on_prefix, prefetch/touch the matched block hashes for other TP ranks to refresh their hotness.
- Implemented Prefetch forwarding across store wrappers

## Test
Tested on Minimax-2.5-W8A8, tp 8 with posix_capacity_gb setting to 240, observing that no load failure happened while former hit blocks already being moved. **Noticed hash one block cost 0.5 us ~ 2.0 us**.