### PR TITLE
Codex/add sandbox copy cases

### DIFF
--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -42,6 +42,7 @@ python -m pip install -e toolkit
 | --- | --- |
 | `dev-sandbox` 构建 | CMake 3.18+、C++17 编译器。CUDA 后端需要 CUDA runtime；Ascend 后端需要 Ascend runtime。 |
 | `dev-sandbox copy` 的 GDR case | CUDA 后端，并且系统能找到 `libibverbs` 头文件和库。 |
+| `dev-sandbox copy` 的 Ascend FFTS direct H2D case | Ascend 后端，并且系统能找到 FFTS Plus 头文件和 `libruntime`。 |
 | `posix-aio` | 当前 UCM Python 包及其 native 扩展可用，`numpy` 可导入。 |
 | `nic-monitor` | Linux、`bash`、`ethtool`，并且需要 root 或 sudo 权限读取网卡统计。 |
 | NIC CSV 离线绘图 | `pandas`、`matplotlib`。 |
@@ -288,6 +289,7 @@ ucm-toolkit run dev-sandbox copy -t host_to_device_ce -t device_to_host_ce -s 1M
 | `-t <name>` | 必填 | case 名称，可重复指定多个。 |
 | `-s <size>` | `512M` | 单个数据块大小，只接受 `K/k` 或 `M/m` 后缀，例如 `16K`、`1M`。 |
 | `-n <count>` | `8` | 每个 buffer 中的数据块数量。 |
+| `-f`, `--frags`, `-frags <count>` | `0` | FFTS direct H2D 的每个 IO/task fragment 数。设置后 `-n` 表示 IO/task 数。 |
 | `-i <count>` | `128` | 迭代次数。 |
 | `-d <count>` | `8` | 设备数量。 |
 
@@ -316,7 +318,13 @@ ucm-toolkit run dev-sandbox copy -t unknown
 | | `device_to_anonymous_ce` | CE DMA 从设备拷到匿名锁页内存。**场景**：评估 D2H 到匿名锁页内存的带宽，适合回读到 mmap buffer 的场景。 |
 | | `anonymous_to_device_sm` | SM kernel 将匿名锁页内存数据拷到设备。**场景**：评估匿名锁页 + SM 组合的 H2D 带宽，适合与 CE 版本对比。 |
 | | `device_to_anonymous_sm` | SM kernel 将设备数据拷到匿名锁页内存。**场景**：评估匿名锁页 + SM 组合的 D2H 带宽。 |
-| **Ascend** | `host_to_device_ce_multi_stream` | 48 流并发 CE DMA 从主机到设备。**场景**：评估 Ascend 多流并行传输是否能提升 H2D 吞吐，适合多流调度优化。 |
+| **Ascend** | `host_to_device_ce_multi_stream` | 4 流并发 CE DMA 从主机到设备。**场景**：评估 Ascend 多流并行传输是否能提升 H2D 吞吐，适合多流调度优化。 |
+| | `one_share_host_to_all_device_ce_multi_stream` | 一块 POSIX shared memory host buffer 通过 fork fan-out 到所有 device，单卡内使用 4-stream CE。**场景**：覆盖 shared host 多进程 fan-out 的 multi-stream H2D。 |
+| | `all_host_to_all_device_ce_multi_stream` | 多卡各自 host buffer，通过 fork fan-out 并在每张卡内使用 4-stream CE。**场景**：评估多进程、多卡、multi-stream H2D 聚合吞吐。 |
+| | `all_odirect_host_to_all_device_ce_multi_stream` | 多卡各自 UCM O_DIRECT 风格 mmap host buffer，通过 fork fan-out 和 4-stream CE 拷到设备。**场景**：覆盖 direct-IO local host buffer 的 multi-stream H2D。 |
+| | `all_host_to_all_device_ffts_direct_h2d` | 多卡各自 mapped `aclrtMallocHost` buffer，通过 FFTS Plus direct H2D SDMA 拷到设备。**场景**：评估 direct H2D SDMA 的常规 pinned host 源。 |
+| | `one_share_host_to_all_device_ffts_direct_h2d` | 一块 POSIX shared memory host buffer 在子进程中 mapped/pinned register 后通过 FFTS Plus direct H2D SDMA 分发到所有 device。**场景**：覆盖 shared host direct H2D SDMA。 |
+| | `all_odirect_host_to_all_device_ffts_direct_h2d` | 多卡各自 UCM O_DIRECT 风格 mmap host buffer，mapped + pinned register 后通过 FFTS Plus direct H2D SDMA 拷到设备。**场景**：覆盖 direct-IO local host buffer 的 direct H2D SDMA。 |
 | **CUDA + libibverbs** | `host_to_device_gdr` | GPUDirect RDMA 直传主机数据到单卡设备内存。**场景**：评估 RDMA 直传到 GPU 是否比传统 CE 更快，适合 RDMA 通信基线。 |
 | | `one_host_to_all_device_gdr` | 同一份主机数据通过 GDR 广播到所有设备。**场景**：评估多卡 RDMA 直传的分发性能，适合对比 GDR 广播与 CE 广播。 |
 | | `all_host_to_all_device_gdr` | 多卡各自 host buffer 同时通过 GDR 拷到各自设备。**场景**：评估多 worker 并发 GDR 的总吞吐，适合大规模 RDMA 并行传输基线。 |
@@ -328,6 +336,18 @@ GDR case 使用 `GDR_NICS` 指定 device 与 RDMA 网卡映射，网卡数量需
 ```bash
 GDR_NICS=mlx5_0,mlx5_2,mlx5_4,mlx5_6,mlx5_8,mlx5_10,mlx5_12,mlx5_14 \
 ucm-toolkit run dev-sandbox copy -t all_host_to_all_device_gdr -s 16K -n 512 -i 128 -d 8
+```
+
+Ascend FFTS direct H2D case 只在构建时检测到 FFTS Plus 头文件和 `libruntime` 后编译。可用
+`COPY_FFTS_VALIDATE=1` 打开数据校验，`FFTS_MAX_READY_LANES` 调整 dispatcher ready lane 数，
+并用 `-frags` 控制每个 IO/task 的 fragment 数。
+
+```bash
+COPY_FFTS_VALIDATE=1 \
+ucm-toolkit run dev-sandbox copy -t all_host_to_all_device_ffts_direct_h2d -s 4M -n 100 -frags 128 -i 10 -d 8
+
+COPY_FFTS_VALIDATE=1 \
+ucm-toolkit run dev-sandbox copy -t all_odirect_host_to_all_device_ffts_direct_h2d -s 32K -n 100 -frags 128 -i 10 -d 8
 ```
 
 ### trans

--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -42,7 +42,6 @@ python -m pip install -e toolkit
 | --- | --- |
 | `dev-sandbox` 构建 | CMake 3.18+、C++17 编译器。CUDA 后端需要 CUDA runtime；Ascend 后端需要 Ascend runtime。 |
 | `dev-sandbox copy` 的 GDR case | CUDA 后端，并且系统能找到 `libibverbs` 头文件和库。 |
-| `dev-sandbox copy` 的 Ascend FFTS direct H2D case | Ascend 后端，并且系统能找到 FFTS Plus 头文件和 `libruntime`。 |
 | `posix-aio` | 当前 UCM Python 包及其 native 扩展可用，`numpy` 可导入。 |
 | `nic-monitor` | Linux、`bash`、`ethtool`，并且需要 root 或 sudo 权限读取网卡统计。 |
 | NIC CSV 离线绘图 | `pandas`、`matplotlib`。 |
@@ -319,12 +318,12 @@ ucm-toolkit run dev-sandbox copy -t unknown
 | | `anonymous_to_device_sm` | SM kernel 将匿名锁页内存数据拷到设备。**场景**：评估匿名锁页 + SM 组合的 H2D 带宽，适合与 CE 版本对比。 |
 | | `device_to_anonymous_sm` | SM kernel 将设备数据拷到匿名锁页内存。**场景**：评估匿名锁页 + SM 组合的 D2H 带宽。 |
 | **Ascend** | `host_to_device_ce_multi_stream` | 4 流并发 CE DMA 从主机到设备。**场景**：评估 Ascend 多流并行传输是否能提升 H2D 吞吐，适合多流调度优化。 |
-| | `one_share_host_to_all_device_ce_multi_stream` | 一块 POSIX shared memory host buffer 通过 fork fan-out 到所有 device，单卡内使用 4-stream CE。**场景**：覆盖 shared host 多进程 fan-out 的 multi-stream H2D。 |
+| | `one_share_host_to_all_device_ce_multi_stream` | 一块 POSIX shared memory host buffer 通过 fork fan-out 到所有 device，单卡内使用 4-stream CE。**场景**：模拟 MLA 模型中多卡同时读取同一份 shared host KV 数据并写入各自 device。 |
 | | `all_host_to_all_device_ce_multi_stream` | 多卡各自 host buffer，通过 fork fan-out 并在每张卡内使用 4-stream CE。**场景**：评估多进程、多卡、multi-stream H2D 聚合吞吐。 |
-| | `all_odirect_host_to_all_device_ce_multi_stream` | 多卡各自 UCM O_DIRECT 风格 mmap host buffer，通过 fork fan-out 和 4-stream CE 拷到设备。**场景**：覆盖 direct-IO local host buffer 的 multi-stream H2D。 |
+| | `all_odirect_host_to_all_device_ce_multi_stream` | 多卡各自 UCM O_DIRECT 风格 mmap host buffer，通过 fork fan-out 和 4-stream CE 拷到设备。**场景**：更贴近开启 O_DIRECT 后 GQA 模型中每张卡从本地 host buffer 同时读入 KV 数据的路径。 |
 | | `all_host_to_all_device_ffts_direct_h2d` | 多卡各自 mapped `aclrtMallocHost` buffer，通过 FFTS Plus direct H2D SDMA 拷到设备。**场景**：评估 direct H2D SDMA 的常规 pinned host 源。 |
-| | `one_share_host_to_all_device_ffts_direct_h2d` | 一块 POSIX shared memory host buffer 在子进程中 mapped/pinned register 后通过 FFTS Plus direct H2D SDMA 分发到所有 device。**场景**：覆盖 shared host direct H2D SDMA。 |
-| | `all_odirect_host_to_all_device_ffts_direct_h2d` | 多卡各自 UCM O_DIRECT 风格 mmap host buffer，mapped + pinned register 后通过 FFTS Plus direct H2D SDMA 拷到设备。**场景**：覆盖 direct-IO local host buffer 的 direct H2D SDMA。 |
+| | `one_share_host_to_all_device_ffts_direct_h2d` | 一块 POSIX shared memory host buffer 在子进程中 mapped/pinned register 后通过 FFTS Plus direct H2D SDMA 分发到所有 device。**场景**：模拟 MLA 模型中多卡同时读取同一份 shared host KV 数据，验证 FFTS direct H2D 的共享源读入路径。 |
+| | `all_odirect_host_to_all_device_ffts_direct_h2d` | 多卡各自 UCM O_DIRECT 风格 mmap host buffer，mapped + pinned register 后通过 FFTS Plus direct H2D SDMA 拷到设备。**场景**：更贴近开启 O_DIRECT 后 GQA 模型中每张卡从本地 host buffer 同时读入 KV 数据的 direct H2D 路径。 |
 | **CUDA + libibverbs** | `host_to_device_gdr` | GPUDirect RDMA 直传主机数据到单卡设备内存。**场景**：评估 RDMA 直传到 GPU 是否比传统 CE 更快，适合 RDMA 通信基线。 |
 | | `one_host_to_all_device_gdr` | 同一份主机数据通过 GDR 广播到所有设备。**场景**：评估多卡 RDMA 直传的分发性能，适合对比 GDR 广播与 CE 广播。 |
 | | `all_host_to_all_device_gdr` | 多卡各自 host buffer 同时通过 GDR 拷到各自设备。**场景**：评估多 worker 并发 GDR 的总吞吐，适合大规模 RDMA 并行传输基线。 |
@@ -336,18 +335,6 @@ GDR case 使用 `GDR_NICS` 指定 device 与 RDMA 网卡映射，网卡数量需
 ```bash
 GDR_NICS=mlx5_0,mlx5_2,mlx5_4,mlx5_6,mlx5_8,mlx5_10,mlx5_12,mlx5_14 \
 ucm-toolkit run dev-sandbox copy -t all_host_to_all_device_gdr -s 16K -n 512 -i 128 -d 8
-```
-
-Ascend FFTS direct H2D case 只在构建时检测到 FFTS Plus 头文件和 `libruntime` 后编译。可用
-`COPY_FFTS_VALIDATE=1` 打开数据校验，`FFTS_MAX_READY_LANES` 调整 dispatcher ready lane 数，
-并用 `-frags` 控制每个 IO/task 的 fragment 数。
-
-```bash
-COPY_FFTS_VALIDATE=1 \
-ucm-toolkit run dev-sandbox copy -t all_host_to_all_device_ffts_direct_h2d -s 4M -n 100 -frags 128 -i 10 -d 8
-
-COPY_FFTS_VALIDATE=1 \
-ucm-toolkit run dev-sandbox copy -t all_odirect_host_to_all_device_ffts_direct_h2d -s 32K -n 100 -frags 128 -i 10 -d 8
 ```
 
 ### trans

--- a/toolkit/src/dev-sandbox/cmake/DetectRuntime.cmake
+++ b/toolkit/src/dev-sandbox/cmake/DetectRuntime.cmake
@@ -64,6 +64,8 @@ function(detect_runtime_backend)
         set(_ASCEND_ROOT "$ENV{ASCEND_HOME}")
     elseif(DEFINED ENV{ASCEND_TOOLKIT_HOME})
         set(_ASCEND_ROOT "$ENV{ASCEND_TOOLKIT_HOME}")
+    elseif(DEFINED ENV{ASCEND_HOME_PATH})
+        set(_ASCEND_ROOT "$ENV{ASCEND_HOME_PATH}")
     elseif(EXISTS "/usr/local/Ascend/ascend-toolkit/latest")
         set(_ASCEND_ROOT "/usr/local/Ascend/ascend-toolkit/latest")
     endif()
@@ -79,9 +81,85 @@ function(detect_runtime_backend)
         )
 
         if(_ASCEND_INCLUDE_DIR AND _ASCEND_LIBRARY)
+            find_library(_ASCEND_RUNTIME_LIBRARY runtime
+                PATHS
+                    "${_ASCEND_ROOT}/lib64"
+                    "${_ASCEND_ROOT}/lib"
+                    "${_ASCEND_ROOT}/runtime/lib64"
+                    "${_ASCEND_ROOT}/runtime/lib"
+                    "${_ASCEND_ROOT}/aarch64-linux/lib64"
+                    "${_ASCEND_ROOT}/aarch64-linux/lib"
+                    "/usr/local/Ascend/cann/aarch64-linux/lib64"
+                    "/usr/local/Ascend/cann/aarch64-linux/lib"
+                NO_DEFAULT_PATH
+            )
+            find_path(_ASCEND_FFTS_INCLUDE_DIR
+                NAMES runtime/rt_ffts_plus.h rt_external_ffts.h
+                PATHS
+                    "${_ASCEND_ROOT}/include"
+                    "${_ASCEND_ROOT}/pkg_inc"
+                    "${_ASCEND_ROOT}/pkg_inc/runtime"
+                    "${_ASCEND_ROOT}/aarch64-linux/pkg_inc"
+                    "${_ASCEND_ROOT}/aarch64-linux/pkg_inc/runtime"
+                    "/usr/local/Ascend/cann/aarch64-linux/pkg_inc"
+                    "/usr/local/Ascend/cann/aarch64-linux/pkg_inc/runtime"
+                NO_DEFAULT_PATH
+            )
+            if(_ASCEND_FFTS_INCLUDE_DIR)
+                set(_ASCEND_FFTS_INCLUDE_DIRS "${_ASCEND_FFTS_INCLUDE_DIR}")
+                get_filename_component(_ASCEND_FFTS_INCLUDE_PARENT
+                    "${_ASCEND_FFTS_INCLUDE_DIR}" DIRECTORY)
+                if(_ASCEND_FFTS_INCLUDE_DIR MATCHES "/runtime$"
+                    AND EXISTS "${_ASCEND_FFTS_INCLUDE_PARENT}")
+                    list(APPEND _ASCEND_FFTS_INCLUDE_DIRS "${_ASCEND_FFTS_INCLUDE_PARENT}")
+                endif()
+
+                set(_ASCEND_FFTS_EXTRA_INCLUDE_CANDIDATES
+                    "${_ASCEND_ROOT}/pkg_inc"
+                    "${_ASCEND_ROOT}/pkg_inc/toolchain"
+                    "${_ASCEND_ROOT}/pkg_inc/profiling"
+                    "${_ASCEND_ROOT}/aarch64-linux/pkg_inc"
+                    "${_ASCEND_ROOT}/aarch64-linux/pkg_inc/toolchain"
+                    "${_ASCEND_ROOT}/aarch64-linux/pkg_inc/profiling"
+                    "/usr/local/Ascend/cann/aarch64-linux/pkg_inc"
+                    "/usr/local/Ascend/cann/aarch64-linux/pkg_inc/toolchain"
+                    "/usr/local/Ascend/cann/aarch64-linux/pkg_inc/profiling")
+                foreach(_ASCEND_EXTRA_INCLUDE_DIR
+                    ${_ASCEND_FFTS_EXTRA_INCLUDE_CANDIDATES})
+                    if(EXISTS "${_ASCEND_EXTRA_INCLUDE_DIR}")
+                        list(APPEND _ASCEND_FFTS_INCLUDE_DIRS "${_ASCEND_EXTRA_INCLUDE_DIR}")
+                    endif()
+                endforeach()
+                find_path(_ASCEND_PROF_COMMON_INCLUDE_DIR
+                    NAMES prof_common.h
+                    PATHS ${_ASCEND_FFTS_EXTRA_INCLUDE_CANDIDATES}
+                    NO_DEFAULT_PATH
+                )
+                if(_ASCEND_PROF_COMMON_INCLUDE_DIR)
+                    list(APPEND _ASCEND_FFTS_INCLUDE_DIRS
+                        "${_ASCEND_PROF_COMMON_INCLUDE_DIR}")
+                endif()
+                find_path(_ASCEND_PROF_API_INCLUDE_DIR
+                    NAMES prof_api.h toolchain/prof_api.h profiling/prof_api.h
+                    PATHS ${_ASCEND_FFTS_EXTRA_INCLUDE_CANDIDATES}
+                    NO_DEFAULT_PATH
+                )
+                if(_ASCEND_PROF_API_INCLUDE_DIR)
+                    list(APPEND _ASCEND_FFTS_INCLUDE_DIRS
+                        "${_ASCEND_PROF_API_INCLUDE_DIR}")
+                endif()
+                list(REMOVE_DUPLICATES _ASCEND_FFTS_INCLUDE_DIRS)
+            endif()
+
             message(STATUS "Found Ascend runtime: ${_ASCEND_ROOT}")
             message(STATUS "  Include: ${_ASCEND_INCLUDE_DIR}")
             message(STATUS "  Library: ${_ASCEND_LIBRARY}")
+            if(_ASCEND_RUNTIME_LIBRARY AND _ASCEND_FFTS_INCLUDE_DIR)
+                message(STATUS "  FFTS Includes: ${_ASCEND_FFTS_INCLUDE_DIRS}")
+                message(STATUS "  Runtime Library: ${_ASCEND_RUNTIME_LIBRARY}")
+            else()
+                message(STATUS "  FFTS support: disabled (missing FFTS header or libruntime)")
+            endif()
 
             # Create imported target
             add_library(Ascend::Runtime INTERFACE IMPORTED GLOBAL)
@@ -92,6 +170,11 @@ function(detect_runtime_backend)
             set(RUNTIME_BACKEND "Ascend" PARENT_SCOPE)
             set(ASCEND_FOUND TRUE PARENT_SCOPE)
             set(ASCEND_ROOT "${_ASCEND_ROOT}" PARENT_SCOPE)
+            if(_ASCEND_RUNTIME_LIBRARY AND _ASCEND_FFTS_INCLUDE_DIR)
+                set(HAVE_ASCEND_FFTS_RUNTIME TRUE PARENT_SCOPE)
+                set(ASCEND_RUNTIME_LIBRARY "${_ASCEND_RUNTIME_LIBRARY}" PARENT_SCOPE)
+                set(ASCEND_FFTS_INCLUDE_DIRS "${_ASCEND_FFTS_INCLUDE_DIRS}" PARENT_SCOPE)
+            endif()
 
             return()
         endif()

--- a/toolkit/src/dev-sandbox/module/copy/CMakeLists.txt
+++ b/toolkit/src/dev-sandbox/module/copy/CMakeLists.txt
@@ -20,6 +20,18 @@ if(RUNTIME_BACKEND STREQUAL "CUDA")
 elseif(RUNTIME_BACKEND STREQUAL "Ascend")
     file(GLOB RUNTIME_SOURCE_FILES "ascend/*.cc" "ascend/*.h")
     target_link_libraries(copy PRIVATE Ascend::Runtime)
+    if(HAVE_ASCEND_FFTS_RUNTIME)
+        list(APPEND RUNTIME_SOURCE_FILES
+            ascend/ffts_direct_h2d/copy_case_ffts_direct_h2d_ascend.cc)
+        target_include_directories(copy PRIVATE
+            ascend
+            ascend/ffts_direct_h2d
+            ascend/h2d_ffts_pipeline
+            ${ASCEND_FFTS_INCLUDE_DIRS})
+        target_link_libraries(copy PRIVATE "${ASCEND_RUNTIME_LIBRARY}")
+    else()
+        message(STATUS "Skipping copy FFTS direct H2D cases: FFTS headers or libruntime were not found")
+    endif()
 else()
     file(GLOB RUNTIME_SOURCE_FILES "simu/*.cc" "simu/*.h")
 endif()

--- a/toolkit/src/dev-sandbox/module/copy/ascend/copy_buffer_ascend.h
+++ b/toolkit/src/dev-sandbox/module/copy/ascend/copy_buffer_ascend.h
@@ -178,10 +178,7 @@ public:
         }
     }
 
-    std::string Name() const override
-    {
-        return "acl::odirect_mmap::" + std::to_string(device_);
-    }
+    std::string Name() const override { return "acl::odirect_mmap::" + std::to_string(device_); }
 
 private:
     size_t mappedBytes_ = 0;

--- a/toolkit/src/dev-sandbox/module/copy/ascend/copy_case_ascend.cc
+++ b/toolkit/src/dev-sandbox/module/copy/ascend/copy_case_ascend.cc
@@ -183,8 +183,7 @@ DEFINE_COPY_CASE_NO_RUNTIME(
 }
 
 DEFINE_COPY_CASE_NO_RUNTIME(
-    AllODirectHost2AllDeviceCEMultiStreamCase,
-    "all_odirect_host_to_all_device_ce_multi_stream",
+    AllODirectHost2AllDeviceCEMultiStreamCase, "all_odirect_host_to_all_device_ce_multi_stream",
     "memcpy from all UCM O_DIRECT style host to all device with ce using multi stream and fork "
     "submit",
     ctx)
@@ -192,8 +191,7 @@ DEFINE_COPY_CASE_NO_RUNTIME(
     constexpr auto streamCount = 4;
     CopyResult result;
     result.Push(ascend_copy::RunForkedCopyBatch(
-        ctx, "acl::odirect_mmap::all", "acl::device::all", "CE-MS-FORK",
-        [&](size_t device) {
+        ctx, "acl::odirect_mmap::all", "acl::device::all", "CE-MS-FORK", [&](size_t device) {
             ODirectHostCopyBuffer srcBuffer{device, ctx.size, ctx.num};
             DeviceCopyBuffer dstBuffer{device, ctx.size, ctx.num};
             H2DCEMultiStreamCopyInstance instance{ctx.iter, false, streamCount};

--- a/toolkit/src/dev-sandbox/module/copy/ascend/copy_case_ascend.cc
+++ b/toolkit/src/dev-sandbox/module/copy/ascend/copy_case_ascend.cc
@@ -24,6 +24,7 @@
 #include "copy_buffer_ascend.h"
 #include "copy_case.h"
 #include "copy_instance_ascend.h"
+#include "forked_copy_runner_ascend.h"
 
 DEFINE_COPY_CASE(Host2DeviceCECase, "host_to_device_ce",
                  "memcpy from host to device with ce one by one", ctx)
@@ -136,7 +137,7 @@ DEFINE_COPY_CASE(Anonymous2DeviceCECase, "anonymous_to_device_ce",
 DEFINE_COPY_CASE(Host2DeviceCEMultiStreamCase, "host_to_device_ce_multi_stream",
                  "memcpy from host to device with ce using multi stream one by one", ctx)
 {
-    constexpr auto streamCount = 48;
+    constexpr auto streamCount = 4;
     CopyResult result;
     for (size_t device = 0; device < ctx.nDevice; device++) {
         HostCopyBuffer srcBuffer{device, ctx.size, ctx.num};
@@ -144,5 +145,59 @@ DEFINE_COPY_CASE(Host2DeviceCEMultiStreamCase, "host_to_device_ce_multi_stream",
         H2DCEMultiStreamCopyInstance instance{ctx.iter, false, streamCount};
         result.Push(instance.DoCopy(&srcBuffer, &dstBuffer));
     }
+    result.Show("[[ " + Key() + " ]] " + Brief());
+}
+
+DEFINE_COPY_CASE_NO_RUNTIME(
+    OneShareHost2AllDeviceCEMultiStreamCase, "one_share_host_to_all_device_ce_multi_stream",
+    "memcpy from one shared host to all device with ce using multi stream and fork submit", ctx)
+{
+    constexpr auto streamCount = 4;
+    CopyResult result;
+    SharedHostRegion srcRegion{"one_share_host_to_all_device_ce_multi_stream", 0, ctx.size,
+                               ctx.num};
+    result.Push(ascend_copy::RunForkedCopyBatch(
+        ctx, srcRegion.Name(), "acl::device::all", "CE-MS-FORK", [&](size_t device) {
+            SharedHostCopyBuffer srcBuffer{srcRegion.ShmName(), device, ctx.size, ctx.num};
+            DeviceCopyBuffer dstBuffer{device, ctx.size, ctx.num};
+            H2DCEMultiStreamCopyInstance instance{ctx.iter, false, streamCount};
+            return instance.DoCopy(&srcBuffer, &dstBuffer);
+        }));
+    result.Show("[[ " + Key() + " ]] " + Brief());
+}
+
+DEFINE_COPY_CASE_NO_RUNTIME(
+    AllHost2AllDeviceCEMultiStreamCase, "all_host_to_all_device_ce_multi_stream",
+    "memcpy from all host to all device with ce using multi stream and fork submit", ctx)
+{
+    constexpr auto streamCount = 4;
+    CopyResult result;
+    result.Push(ascend_copy::RunForkedCopyBatch(
+        ctx, "acl::host::all", "acl::device::all", "CE-MS-FORK", [&](size_t device) {
+            HostCopyBuffer srcBuffer{device, ctx.size, ctx.num};
+            DeviceCopyBuffer dstBuffer{device, ctx.size, ctx.num};
+            H2DCEMultiStreamCopyInstance instance{ctx.iter, false, streamCount};
+            return instance.DoCopy(&srcBuffer, &dstBuffer);
+        }));
+    result.Show("[[ " + Key() + " ]] " + Brief());
+}
+
+DEFINE_COPY_CASE_NO_RUNTIME(
+    AllODirectHost2AllDeviceCEMultiStreamCase,
+    "all_odirect_host_to_all_device_ce_multi_stream",
+    "memcpy from all UCM O_DIRECT style host to all device with ce using multi stream and fork "
+    "submit",
+    ctx)
+{
+    constexpr auto streamCount = 4;
+    CopyResult result;
+    result.Push(ascend_copy::RunForkedCopyBatch(
+        ctx, "acl::odirect_mmap::all", "acl::device::all", "CE-MS-FORK",
+        [&](size_t device) {
+            ODirectHostCopyBuffer srcBuffer{device, ctx.size, ctx.num};
+            DeviceCopyBuffer dstBuffer{device, ctx.size, ctx.num};
+            H2DCEMultiStreamCopyInstance instance{ctx.iter, false, streamCount};
+            return instance.DoCopy(&srcBuffer, &dstBuffer);
+        }));
     result.Show("[[ " + Key() + " ]] " + Brief());
 }

--- a/toolkit/src/dev-sandbox/module/copy/ascend/ffts_direct_h2d/copy_case_ffts_direct_h2d_ascend.cc
+++ b/toolkit/src/dev-sandbox/module/copy/ascend/ffts_direct_h2d/copy_case_ffts_direct_h2d_ascend.cc
@@ -1,0 +1,193 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Mag1c.H
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <acl/acl.h>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <vector>
+#include "ascend/copy_buffer_ascend.h"
+#include "ascend/forked_copy_runner_ascend.h"
+#include "copy_case.h"
+#include "copy_instance_ffts_direct_h2d_ascend.h"
+#include "mapped_host_buffer_ffts_direct_h2d_ascend.h"
+
+namespace {
+
+bool FftsDirectValidationEnabled()
+{
+    const char* value = std::getenv("COPY_FFTS_VALIDATE");
+    if (value == nullptr) { return false; }
+    return std::strcmp(value, "1") == 0 || std::strcmp(value, "true") == 0 ||
+           std::strcmp(value, "TRUE") == 0 || std::strcmp(value, "on") == 0 ||
+           std::strcmp(value, "ON") == 0;
+}
+
+std::vector<uint8_t> MakeFftsDirectPattern(size_t fragmentIndex, size_t size)
+{
+    std::vector<uint8_t> data(size);
+    for (size_t i = 0; i < size; ++i) {
+        data[i] = static_cast<uint8_t>((fragmentIndex * 17 + i * 31 + (i >> 8)) & 0xFF);
+    }
+    return data;
+}
+
+void InitializeFftsDirectHostPatternedBuffer(const CopyBuffer& buffer)
+{
+    for (size_t i = 0; i < buffer.Number(); ++i) {
+        const auto pattern = MakeFftsDirectPattern(i, buffer.Size());
+        std::memcpy(buffer[i], pattern.data(), pattern.size());
+    }
+}
+
+void ResetFftsDirectDeviceBuffer(const CopyBuffer& buffer)
+{
+    ASCEND_ASSERT(aclrtSetDevice(buffer.Device()));
+    for (size_t i = 0; i < buffer.Number(); ++i) {
+        ASCEND_ASSERT(aclrtMemset(buffer[i], buffer.Size(), 0, buffer.Size()));
+    }
+}
+
+std::vector<uint8_t> CopyFftsDirectDeviceToHost(const CopyBuffer& buffer, size_t index)
+{
+    std::vector<uint8_t> data(buffer.Size());
+    ASCEND_ASSERT(aclrtSetDevice(buffer.Device()));
+    ASCEND_ASSERT(aclrtMemcpy(data.data(), data.size(), buffer[index], buffer.Size(),
+                              ACL_MEMCPY_DEVICE_TO_HOST));
+    return data;
+}
+
+bool ValidateFftsDirectPatternedBuffer(const CopyBuffer& buffer)
+{
+    for (size_t i = 0; i < buffer.Number(); ++i) {
+        auto actual = CopyFftsDirectDeviceToHost(buffer, i);
+        auto expected = MakeFftsDirectPattern(i, buffer.Size());
+        if (actual.size() != expected.size() ||
+            std::memcmp(actual.data(), expected.data(), expected.size()) != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void ValidateFftsDirectDeviceBufferIfEnabled(const CopyBuffer& buffer, bool enabled)
+{
+    if (enabled) { ASSERT(ValidateFftsDirectPatternedBuffer(buffer)); }
+}
+
+void PrintFftsDirectValidationPassIfEnabled(const CopyCase& copyCase, bool enabled)
+{
+    if (enabled) { std::cout << "[validation] " << copyCase.Key() << " PASS\n"; }
+}
+
+size_t FftsDirectTotalFragments(const CopyCase::Context& ctx)
+{
+    ASSERT(ctx.num > 0);
+    if (ctx.frags == 0) { return ctx.num; }
+    ASSERT(ctx.num <= std::numeric_limits<size_t>::max() / ctx.frags);
+    return ctx.num * ctx.frags;
+}
+
+}  // namespace
+
+DEFINE_COPY_CASE_NO_RUNTIME(
+    AllHost2AllDeviceFftsDirectH2DCase, "all_host_to_all_device_ffts_direct_h2d",
+    "copy all aclrtMallocHost mapped host buffers to all device buffers with ffts direct h2d",
+    ctx)
+{
+    CopyResult result;
+    const bool validationEnabled = FftsDirectValidationEnabled();
+    result.Push(ascend_copy::RunForkedCopyBatch(
+        ctx, "acl::host_mapped::all", "acl::device::all", "ffts-direct-h2d",
+        [&](size_t device) {
+            const auto fragments = FftsDirectTotalFragments(ctx);
+            FftsMappedHostCopyBuffer srcBuffer{device, ctx.size, fragments};
+            DeviceCopyBuffer dstBuffer{device, ctx.size, fragments};
+            InitializeFftsDirectHostPatternedBuffer(srcBuffer);
+            ResetFftsDirectDeviceBuffer(dstBuffer);
+
+            FftsDirectH2DCopyInstance instance{ctx.iter, false, ctx.frags};
+            auto childResult = instance.DoCopy(&srcBuffer, &dstBuffer);
+            ValidateFftsDirectDeviceBufferIfEnabled(dstBuffer, validationEnabled);
+            return childResult;
+        }));
+    PrintFftsDirectValidationPassIfEnabled(*this, validationEnabled);
+    result.Show("[[ " + Key() + " ]] " + Brief());
+}
+
+DEFINE_COPY_CASE_NO_RUNTIME(
+    AllODirectHost2AllDeviceFftsDirectH2DCase,
+    "all_odirect_host_to_all_device_ffts_direct_h2d",
+    "copy all UCM O_DIRECT style mmap mapped host buffers to all device buffers with "
+    "ffts direct h2d",
+    ctx)
+{
+    CopyResult result;
+    const bool validationEnabled = FftsDirectValidationEnabled();
+    result.Push(ascend_copy::RunForkedCopyBatch(
+        ctx, "acl::odirect_mmap::all", "acl::device::all", "ffts-direct-h2d",
+        [&](size_t device) {
+            const auto fragments = FftsDirectTotalFragments(ctx);
+            FftsODirectMappedHostCopyBuffer srcBuffer{device, ctx.size, fragments};
+            DeviceCopyBuffer dstBuffer{device, ctx.size, fragments};
+            InitializeFftsDirectHostPatternedBuffer(srcBuffer);
+            ResetFftsDirectDeviceBuffer(dstBuffer);
+
+            FftsDirectH2DCopyInstance instance{ctx.iter, false, ctx.frags};
+            auto childResult = instance.DoCopy(&srcBuffer, &dstBuffer);
+            ValidateFftsDirectDeviceBufferIfEnabled(dstBuffer, validationEnabled);
+            return childResult;
+        }));
+    PrintFftsDirectValidationPassIfEnabled(*this, validationEnabled);
+    result.Show("[[ " + Key() + " ]] " + Brief());
+}
+
+DEFINE_COPY_CASE_NO_RUNTIME(
+    OneShareHost2AllDeviceFftsDirectH2DCase, "one_share_host_to_all_device_ffts_direct_h2d",
+    "copy one shared mapped host buffer to all device buffers with ffts direct h2d using fork submit",
+    ctx)
+{
+    CopyResult result;
+    const bool validationEnabled = FftsDirectValidationEnabled();
+    const auto fragments = FftsDirectTotalFragments(ctx);
+    FftsMappedSharedHostRegion srcRegion{"one_share_host_to_all_device_ffts_direct_h2d", 0,
+                                         ctx.size, fragments};
+    InitializeFftsDirectHostPatternedBuffer(srcRegion);
+    result.Push(ascend_copy::RunForkedCopyBatch(
+        ctx, srcRegion.Name(), "acl::device::all", "ffts-direct-h2d", [&](size_t device) {
+            FftsMappedSharedHostCopyBuffer srcBuffer{srcRegion.ShmName(),
+                                                    srcRegion.MappedBytes(), device, ctx.size,
+                                                    fragments};
+            DeviceCopyBuffer dstBuffer{device, ctx.size, fragments};
+            ResetFftsDirectDeviceBuffer(dstBuffer);
+
+            FftsDirectH2DCopyInstance instance{ctx.iter, false, ctx.frags};
+            auto childResult = instance.DoCopy(&srcBuffer, &dstBuffer);
+            ValidateFftsDirectDeviceBufferIfEnabled(dstBuffer, validationEnabled);
+            return childResult;
+        }));
+    PrintFftsDirectValidationPassIfEnabled(*this, validationEnabled);
+    result.Show("[[ " + Key() + " ]] " + Brief());
+}

--- a/toolkit/src/dev-sandbox/module/copy/ascend/ffts_direct_h2d/copy_case_ffts_direct_h2d_ascend.cc
+++ b/toolkit/src/dev-sandbox/module/copy/ascend/ffts_direct_h2d/copy_case_ffts_direct_h2d_ascend.cc
@@ -114,14 +114,12 @@ size_t FftsDirectTotalFragments(const CopyCase::Context& ctx)
 
 DEFINE_COPY_CASE_NO_RUNTIME(
     AllHost2AllDeviceFftsDirectH2DCase, "all_host_to_all_device_ffts_direct_h2d",
-    "copy all aclrtMallocHost mapped host buffers to all device buffers with ffts direct h2d",
-    ctx)
+    "copy all aclrtMallocHost mapped host buffers to all device buffers with ffts direct h2d", ctx)
 {
     CopyResult result;
     const bool validationEnabled = FftsDirectValidationEnabled();
     result.Push(ascend_copy::RunForkedCopyBatch(
-        ctx, "acl::host_mapped::all", "acl::device::all", "ffts-direct-h2d",
-        [&](size_t device) {
+        ctx, "acl::host_mapped::all", "acl::device::all", "ffts-direct-h2d", [&](size_t device) {
             const auto fragments = FftsDirectTotalFragments(ctx);
             FftsMappedHostCopyBuffer srcBuffer{device, ctx.size, fragments};
             DeviceCopyBuffer dstBuffer{device, ctx.size, fragments};
@@ -138,8 +136,7 @@ DEFINE_COPY_CASE_NO_RUNTIME(
 }
 
 DEFINE_COPY_CASE_NO_RUNTIME(
-    AllODirectHost2AllDeviceFftsDirectH2DCase,
-    "all_odirect_host_to_all_device_ffts_direct_h2d",
+    AllODirectHost2AllDeviceFftsDirectH2DCase, "all_odirect_host_to_all_device_ffts_direct_h2d",
     "copy all UCM O_DIRECT style mmap mapped host buffers to all device buffers with "
     "ffts direct h2d",
     ctx)
@@ -147,8 +144,7 @@ DEFINE_COPY_CASE_NO_RUNTIME(
     CopyResult result;
     const bool validationEnabled = FftsDirectValidationEnabled();
     result.Push(ascend_copy::RunForkedCopyBatch(
-        ctx, "acl::odirect_mmap::all", "acl::device::all", "ffts-direct-h2d",
-        [&](size_t device) {
+        ctx, "acl::odirect_mmap::all", "acl::device::all", "ffts-direct-h2d", [&](size_t device) {
             const auto fragments = FftsDirectTotalFragments(ctx);
             FftsODirectMappedHostCopyBuffer srcBuffer{device, ctx.size, fragments};
             DeviceCopyBuffer dstBuffer{device, ctx.size, fragments};
@@ -164,10 +160,11 @@ DEFINE_COPY_CASE_NO_RUNTIME(
     result.Show("[[ " + Key() + " ]] " + Brief());
 }
 
-DEFINE_COPY_CASE_NO_RUNTIME(
-    OneShareHost2AllDeviceFftsDirectH2DCase, "one_share_host_to_all_device_ffts_direct_h2d",
-    "copy one shared mapped host buffer to all device buffers with ffts direct h2d using fork submit",
-    ctx)
+DEFINE_COPY_CASE_NO_RUNTIME(OneShareHost2AllDeviceFftsDirectH2DCase,
+                            "one_share_host_to_all_device_ffts_direct_h2d",
+                            "copy one shared mapped host buffer to all device buffers with ffts "
+                            "direct h2d using fork submit",
+                            ctx)
 {
     CopyResult result;
     const bool validationEnabled = FftsDirectValidationEnabled();
@@ -177,9 +174,8 @@ DEFINE_COPY_CASE_NO_RUNTIME(
     InitializeFftsDirectHostPatternedBuffer(srcRegion);
     result.Push(ascend_copy::RunForkedCopyBatch(
         ctx, srcRegion.Name(), "acl::device::all", "ffts-direct-h2d", [&](size_t device) {
-            FftsMappedSharedHostCopyBuffer srcBuffer{srcRegion.ShmName(),
-                                                    srcRegion.MappedBytes(), device, ctx.size,
-                                                    fragments};
+            FftsMappedSharedHostCopyBuffer srcBuffer{srcRegion.ShmName(), srcRegion.MappedBytes(),
+                                                     device, ctx.size, fragments};
             DeviceCopyBuffer dstBuffer{device, ctx.size, fragments};
             ResetFftsDirectDeviceBuffer(dstBuffer);
 

--- a/toolkit/src/dev-sandbox/module/copy/ascend/ffts_direct_h2d/copy_instance_ffts_direct_h2d_ascend.h
+++ b/toolkit/src/dev-sandbox/module/copy/ascend/ffts_direct_h2d/copy_instance_ffts_direct_h2d_ascend.h
@@ -135,9 +135,8 @@ protected:
 
         const auto submitStart = steady_clock::now();
         for (auto& ctx : contexts_) { SubmitContext(ctx); }
-        const auto submitCost =
-            static_cast<size_t>(duration_cast<microseconds>(steady_clock::now() - submitStart)
-                                    .count());
+        const auto submitCost = static_cast<size_t>(
+            duration_cast<microseconds>(steady_clock::now() - submitStart).count());
 
         ASCEND_ASSERT(aclrtSetDevice(contexts_[0].deviceId));
         for (size_t i = 1; i < contexts_.size(); ++i) {

--- a/toolkit/src/dev-sandbox/module/copy/ascend/ffts_direct_h2d/copy_instance_ffts_direct_h2d_ascend.h
+++ b/toolkit/src/dev-sandbox/module/copy/ascend/ffts_direct_h2d/copy_instance_ffts_direct_h2d_ascend.h
@@ -1,0 +1,175 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Mag1c.H
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#ifndef COPY_INSTANCE_FFTS_DIRECT_H2D_ASCEND_H
+#define COPY_INSTANCE_FFTS_DIRECT_H2D_ASCEND_H
+
+#include <chrono>
+#include <string>
+#include <utility>
+#include <vector>
+#include "ascend/error_handle_ascend.h"
+#include "copy_instance.h"
+#include "ffts_d2d_dispatcher_ascend.h"
+#include "mapped_host_buffer_ffts_direct_h2d_ascend.h"
+
+class FftsDirectH2DCopyInstance : public CopyInstance {
+protected:
+    struct DirectContext {
+        size_t deviceId = 0;
+        aclrtStream stream = nullptr;
+        aclrtEvent endEvent = nullptr;
+        std::vector<std::vector<AscendFftsCopySpec>> tasks;
+        FftsD2DDispatcher dispatcher;
+    };
+
+    std::vector<DirectContext> contexts_;
+    aclrtEvent totalStart_ = nullptr;
+    aclrtEvent totalEnd_ = nullptr;
+    size_t fragsPerTask_ = 0;
+
+    void Prepare(const std::vector<const CopyBuffer*>& srcBuffers,
+                 const std::vector<const CopyBuffer*>& dstBuffers) override
+    {
+        ASSERT(!srcBuffers.empty());
+        ASSERT(srcBuffers.size() == dstBuffers.size());
+
+        contexts_.clear();
+        contexts_.reserve(srcBuffers.size());
+        for (size_t i = 0; i < srcBuffers.size(); ++i) {
+            const auto* src = srcBuffers[i];
+            const auto* dst = dstBuffers[i];
+            ASSERT(src != nullptr);
+            ASSERT(dst != nullptr);
+            ASSERT(src->Number() == dst->Number());
+            ASSERT(src->Size() == dst->Size());
+
+            const auto* mappedSrc = dynamic_cast<const FftsDirectMappedHostBuffer*>(src);
+            ASSERT(mappedSrc != nullptr);
+
+            DirectContext ctx;
+            ctx.deviceId = AffinityDeviceId(*src, *dst);
+            const auto size = src->Size();
+            const auto number = src->Number();
+            ASSERT(number > 0);
+
+            ASCEND_ASSERT(aclrtSetDevice(ctx.deviceId));
+            ASCEND_ASSERT(aclrtCreateStream(&ctx.stream));
+            ASCEND_ASSERT(aclrtCreateEvent(&ctx.endEvent));
+
+            const auto taskFrags = fragsPerTask_ == 0 ? number : fragsPerTask_;
+            ASSERT(taskFrags > 0);
+            ASSERT(number % taskFrags == 0);
+            ctx.tasks.reserve(number / taskFrags);
+            for (size_t first = 0; first < number; first += taskFrags) {
+                std::vector<AscendFftsCopySpec> copies;
+                copies.reserve(taskFrags);
+                for (size_t fragment = first; fragment < first + taskFrags; ++fragment) {
+                    copies.push_back({(*dst)[fragment], mappedSrc->MappedAt(fragment), size});
+                }
+                ctx.tasks.push_back(std::move(copies));
+            }
+            contexts_.push_back(std::move(ctx));
+        }
+
+        ASCEND_ASSERT(aclrtSetDevice(contexts_[0].deviceId));
+        ASCEND_ASSERT(aclrtCreateEvent(&totalStart_));
+        ASCEND_ASSERT(aclrtCreateEvent(&totalEnd_));
+    }
+
+    void Cleanup() override
+    {
+        for (auto& ctx : contexts_) {
+            ASCEND_ASSERT(aclrtSetDevice(ctx.deviceId));
+            if (ctx.endEvent != nullptr) {
+                ASCEND_ASSERT(aclrtDestroyEvent(ctx.endEvent));
+                ctx.endEvent = nullptr;
+            }
+            if (ctx.stream != nullptr) {
+                ASCEND_ASSERT(aclrtDestroyStream(ctx.stream));
+                ctx.stream = nullptr;
+            }
+        }
+        if (!contexts_.empty()) { ASCEND_ASSERT(aclrtSetDevice(contexts_[0].deviceId)); }
+        if (totalStart_ != nullptr) {
+            ASCEND_ASSERT(aclrtDestroyEvent(totalStart_));
+            totalStart_ = nullptr;
+        }
+        if (totalEnd_ != nullptr) {
+            ASCEND_ASSERT(aclrtDestroyEvent(totalEnd_));
+            totalEnd_ = nullptr;
+        }
+        contexts_.clear();
+    }
+
+    std::pair<size_t, size_t> DoCopyOnce() override
+    {
+        using namespace std::chrono;
+
+        ASCEND_ASSERT(aclrtSetDevice(contexts_[0].deviceId));
+        ASCEND_ASSERT(aclrtRecordEvent(totalStart_, contexts_[0].stream));
+        for (size_t i = 1; i < contexts_.size(); ++i) {
+            ASCEND_ASSERT(aclrtSetDevice(contexts_[i].deviceId));
+            ASCEND_ASSERT(aclrtStreamWaitEvent(contexts_[i].stream, totalStart_));
+        }
+
+        const auto submitStart = steady_clock::now();
+        for (auto& ctx : contexts_) { SubmitContext(ctx); }
+        const auto submitCost =
+            static_cast<size_t>(duration_cast<microseconds>(steady_clock::now() - submitStart)
+                                    .count());
+
+        ASCEND_ASSERT(aclrtSetDevice(contexts_[0].deviceId));
+        for (size_t i = 1; i < contexts_.size(); ++i) {
+            ASCEND_ASSERT(aclrtStreamWaitEvent(contexts_[0].stream, contexts_[i].endEvent));
+        }
+        ASCEND_ASSERT(aclrtRecordEvent(totalEnd_, contexts_[0].stream));
+        ASCEND_ASSERT(aclrtSynchronizeStream(contexts_[0].stream));
+
+        float copyCostMs = 0.0f;
+        ASCEND_ASSERT(aclrtEventElapsedTime(&copyCostMs, totalStart_, totalEnd_));
+        const auto copyCost = static_cast<size_t>(copyCostMs * 1000);
+        return {copyCost, submitCost};
+    }
+
+    static void SubmitContext(DirectContext& ctx)
+    {
+        ASCEND_ASSERT(aclrtSetDevice(ctx.deviceId));
+        for (const auto& copies : ctx.tasks) {
+            const auto readyCount = ctx.dispatcher.BuildCopies(copies);
+            ASSERT(readyCount > 0);
+            ctx.dispatcher.Launch(ctx.stream, readyCount);
+        }
+        ASCEND_ASSERT(aclrtRecordEvent(ctx.endEvent, ctx.stream));
+    }
+
+public:
+    FftsDirectH2DCopyInstance(size_t iterations, bool affinitySrc, size_t fragsPerTask = 0)
+        : CopyInstance(iterations, affinitySrc), fragsPerTask_(fragsPerTask)
+    {
+    }
+
+    std::string Name() const override { return "ffts-direct-h2d"; }
+};
+
+#endif  // COPY_INSTANCE_FFTS_DIRECT_H2D_ASCEND_H

--- a/toolkit/src/dev-sandbox/module/copy/ascend/ffts_direct_h2d/mapped_host_buffer_ffts_direct_h2d_ascend.h
+++ b/toolkit/src/dev-sandbox/module/copy/ascend/ffts_direct_h2d/mapped_host_buffer_ffts_direct_h2d_ascend.h
@@ -154,10 +154,7 @@ public:
         return static_cast<void*>(static_cast<char*>(mappedAddr_) + i * size_);
     }
 
-    std::string Name() const override
-    {
-        return "acl::host_mapped::" + std::to_string(device_);
-    }
+    std::string Name() const override { return "acl::host_mapped::" + std::to_string(device_); }
 
 private:
     void* mappedAddr_ = nullptr;
@@ -202,10 +199,7 @@ public:
         return static_cast<void*>(static_cast<char*>(mappedAddr_) + i * size_);
     }
 
-    std::string Name() const override
-    {
-        return "acl::odirect_mmap::" + std::to_string(device_);
-    }
+    std::string Name() const override { return "acl::odirect_mmap::" + std::to_string(device_); }
 
 private:
     void* mappedAddr_ = nullptr;

--- a/toolkit/src/dev-sandbox/module/copy/ascend/ffts_direct_h2d/mapped_host_buffer_ffts_direct_h2d_ascend.h
+++ b/toolkit/src/dev-sandbox/module/copy/ascend/ffts_direct_h2d/mapped_host_buffer_ffts_direct_h2d_ascend.h
@@ -21,9 +21,11 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  * */
-#ifndef COPY_BUFFER_ASCEND_H
-#define COPY_BUFFER_ASCEND_H
+#ifndef MAPPED_HOST_BUFFER_FFTS_DIRECT_H2D_ASCEND_H
+#define MAPPED_HOST_BUFFER_FFTS_DIRECT_H2D_ASCEND_H
 
+#include <acl/acl.h>
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <fcntl.h>
@@ -32,14 +34,21 @@
 #include <sys/mman.h>
 #include <unistd.h>
 #include <utility>
+#include "ascend/error_handle_ascend.h"
 #include "copy_buffer.h"
-#include "error_handle_ascend.h"
+#include "error_handle.h"
 
 #ifndef MAP_HUGE_SHIFT
 #define MAP_HUGE_SHIFT 26
 #endif
 
-inline size_t CheckedTotalBytes(size_t size, size_t number)
+class FftsDirectMappedHostBuffer {
+public:
+    virtual ~FftsDirectMappedHostBuffer() = default;
+    virtual void* MappedAt(size_t i) const = 0;
+};
+
+inline size_t FftsDirectCheckedTotalBytes(size_t size, size_t number)
 {
     ASSERT(number == 0 || size <= std::numeric_limits<size_t>::max() / number);
     const auto total = size * number;
@@ -47,9 +56,24 @@ inline size_t CheckedTotalBytes(size_t size, size_t number)
     return total;
 }
 
-inline size_t RoundUpToAlignment(size_t bytes, size_t alignment)
+inline size_t FftsDirectRoundUpToPageSize(size_t bytes)
 {
-    ASSERT(alignment > 0);
+    constexpr size_t kPageSize = 4096;
+    const auto remainder = bytes % kPageSize;
+    if (remainder == 0) { return bytes; }
+    const auto padding = kPageSize - remainder;
+    ASSERT(bytes <= std::numeric_limits<size_t>::max() - padding);
+    return bytes + padding;
+}
+
+inline bool FftsDirectIsPageAligned(const void* ptr)
+{
+    constexpr size_t kPageSize = 4096;
+    return reinterpret_cast<std::uintptr_t>(ptr) % kPageSize == 0;
+}
+
+inline size_t FftsDirectRoundUp(size_t bytes, size_t alignment)
+{
     const auto remainder = bytes % alignment;
     if (remainder == 0) { return bytes; }
     const auto padding = alignment - remainder;
@@ -57,13 +81,7 @@ inline size_t RoundUpToAlignment(size_t bytes, size_t alignment)
     return bytes + padding;
 }
 
-inline bool IsPageAligned(const void* ptr)
-{
-    constexpr size_t kPageSize = 4096;
-    return reinterpret_cast<std::uintptr_t>(ptr) % kPageSize == 0;
-}
-
-inline void* MmapODirectHugeTlb(size_t& bytes, bool useGiganticPages)
+inline void* FftsDirectMmapHugeTlb(size_t& bytes, bool useGiganticPages)
 {
     constexpr size_t kHugePageSize = 2ull * 1024ull * 1024ull;
     constexpr size_t kGiganticPageSize = 1ull * 1024ull * 1024ull * 1024ull;
@@ -71,7 +89,7 @@ inline void* MmapODirectHugeTlb(size_t& bytes, bool useGiganticPages)
     constexpr int kGiganticPageFlag = 30 << MAP_HUGE_SHIFT;
 
     const auto pageSize = useGiganticPages ? kGiganticPageSize : kHugePageSize;
-    const auto alignedBytes = RoundUpToAlignment(bytes, pageSize);
+    const auto alignedBytes = FftsDirectRoundUp(bytes, pageSize);
     const auto pageFlag = useGiganticPages ? kGiganticPageFlag : kHugePageFlag;
     constexpr auto prot = PROT_READ | PROT_WRITE;
     const auto flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_HUGETLB | pageFlag;
@@ -80,10 +98,10 @@ inline void* MmapODirectHugeTlb(size_t& bytes, bool useGiganticPages)
     return ptr;
 }
 
-inline void* MmapODirectWithTransparentHugePage(size_t& bytes)
+inline void* FftsDirectMmapWithTransparentHugePage(size_t& bytes)
 {
     constexpr size_t kHugePageSize = 2ull * 1024ull * 1024ull;
-    const auto alignedBytes = RoundUpToAlignment(bytes, kHugePageSize);
+    const auto alignedBytes = FftsDirectRoundUp(bytes, kHugePageSize);
     constexpr auto prot = PROT_READ | PROT_WRITE;
     constexpr auto flags = MAP_PRIVATE | MAP_ANONYMOUS;
     auto* ptr = mmap(nullptr, alignedBytes, prot, flags, -1, 0);
@@ -94,70 +112,69 @@ inline void* MmapODirectWithTransparentHugePage(size_t& bytes)
     return ptr;
 }
 
-inline void* MmapODirectHostBuffer(size_t& bytes)
+inline void* FftsDirectMmapODirectHostBuffer(size_t& bytes)
 {
     constexpr size_t kGiganticPageSize = 1ull * 1024ull * 1024ull * 1024ull;
     const bool useGiganticPages = bytes >= kGiganticPageSize;
-    auto* ptr = MmapODirectHugeTlb(bytes, useGiganticPages);
-    if (ptr == MAP_FAILED && useGiganticPages) { ptr = MmapODirectHugeTlb(bytes, false); }
-    if (ptr == MAP_FAILED) { ptr = MmapODirectWithTransparentHugePage(bytes); }
+    auto* ptr = FftsDirectMmapHugeTlb(bytes, useGiganticPages);
+    if (ptr == MAP_FAILED && useGiganticPages) { ptr = FftsDirectMmapHugeTlb(bytes, false); }
+    if (ptr == MAP_FAILED) { ptr = FftsDirectMmapWithTransparentHugePage(bytes); }
     return ptr;
 }
 
-class HostCopyBuffer : public CopyBuffer {
+class FftsMappedHostCopyBuffer : public CopyBuffer, public FftsDirectMappedHostBuffer {
 public:
-    HostCopyBuffer(size_t device, size_t size, size_t number) : CopyBuffer{device, size, number}
+    FftsMappedHostCopyBuffer(size_t device, size_t size, size_t number)
+        : CopyBuffer{device, size, number}
     {
-        const auto total = size * number;
+        const auto total = FftsDirectCheckedTotalBytes(size, number);
+        mappedBytes_ = FftsDirectRoundUpToPageSize(total);
         ASCEND_ASSERT(aclrtSetDevice(device_));
-        ASCEND_ASSERT(aclrtMallocHost(&addr_, total));
+        ASCEND_ASSERT(aclrtMallocHost(&addr_, mappedBytes_));
+        ASSERT(FftsDirectIsPageAligned(addr_));
         std::memset(addr_, 'h', total);
+        ASCEND_ASSERT(aclrtHostRegisterV2(addr_, mappedBytes_, ACL_HOST_REG_MAPPED));
+        registered_ = true;
+        ASCEND_ASSERT(aclrtHostGetDevicePointer(addr_, &mappedAddr_, 0));
     }
-    ~HostCopyBuffer() override
+
+    ~FftsMappedHostCopyBuffer() override
     {
-        if (addr_) {
+        if (addr_ != nullptr) {
             ASCEND_ASSERT(aclrtSetDevice(device_));
+            if (registered_) { ASCEND_ASSERT(aclrtHostUnregister(addr_)); }
             ASCEND_ASSERT(aclrtFreeHost(addr_));
+            addr_ = nullptr;
         }
     }
-    std::string Name() const override { return "acl::host::" + std::to_string(device_); }
+
+    void* MappedAt(size_t i) const override
+    {
+        ASSERT(i < number_);
+        return static_cast<void*>(static_cast<char*>(mappedAddr_) + i * size_);
+    }
+
+    std::string Name() const override
+    {
+        return "acl::host_mapped::" + std::to_string(device_);
+    }
+
+private:
+    void* mappedAddr_ = nullptr;
+    size_t mappedBytes_ = 0;
+    bool registered_ = false;
 };
 
-class AnonymousCopyBuffer : public CopyBuffer {
+class FftsODirectMappedHostCopyBuffer : public CopyBuffer, public FftsDirectMappedHostBuffer {
 public:
-    AnonymousCopyBuffer(size_t device, size_t size, size_t number)
+    FftsODirectMappedHostCopyBuffer(size_t device, size_t size, size_t number)
         : CopyBuffer{device, size, number}
     {
-        const auto total = size * number;
-        ASCEND_ASSERT(aclrtSetDevice(device_));
-        constexpr auto prot = PROT_READ | PROT_WRITE;
-        constexpr auto flags = MAP_ANONYMOUS | MAP_PRIVATE | MAP_POPULATE;
-        addr_ = mmap(nullptr, total, prot, flags, -1, 0);
-        ASSERT(addr_ != MAP_FAILED);
-        std::memset(addr_, 'a', total);
-        ASCEND_ASSERT(aclrtHostRegisterV2(addr_, total, ACL_HOST_REG_MAPPED | ACL_HOST_REG_PINNED));
-    }
-    ~AnonymousCopyBuffer() override
-    {
-        if (addr_) {
-            ASCEND_ASSERT(aclrtSetDevice(device_));
-            ASCEND_ASSERT(aclrtHostUnregister(addr_));
-            munmap(addr_, size_ * number_);
-        }
-    }
-    std::string Name() const override { return "acl::anon::" + std::to_string(device_); }
-};
-
-class ODirectHostCopyBuffer : public CopyBuffer {
-public:
-    ODirectHostCopyBuffer(size_t device, size_t size, size_t number)
-        : CopyBuffer{device, size, number}
-    {
-        const auto total = CheckedTotalBytes(size, number);
+        const auto total = FftsDirectCheckedTotalBytes(size, number);
         mappedBytes_ = total;
-        addr_ = MmapODirectHostBuffer(mappedBytes_);
+        addr_ = FftsDirectMmapODirectHostBuffer(mappedBytes_);
         ASSERT(addr_ != MAP_FAILED);
-        ASSERT(IsPageAligned(addr_));
+        ASSERT(FftsDirectIsPageAligned(addr_));
         std::memset(addr_, 'o', total);
         locked_ = (mlock(addr_, mappedBytes_) == 0);
 
@@ -165,9 +182,10 @@ public:
         ASCEND_ASSERT(
             aclrtHostRegisterV2(addr_, mappedBytes_, ACL_HOST_REG_MAPPED | ACL_HOST_REG_PINNED));
         registered_ = true;
+        ASCEND_ASSERT(aclrtHostGetDevicePointer(addr_, &mappedAddr_, 0));
     }
 
-    ~ODirectHostCopyBuffer() override
+    ~FftsODirectMappedHostCopyBuffer() override
     {
         if (addr_ != nullptr && addr_ != MAP_FAILED) {
             ASCEND_ASSERT(aclrtSetDevice(device_));
@@ -178,100 +196,109 @@ public:
         }
     }
 
+    void* MappedAt(size_t i) const override
+    {
+        ASSERT(i < number_);
+        return static_cast<void*>(static_cast<char*>(mappedAddr_) + i * size_);
+    }
+
     std::string Name() const override
     {
         return "acl::odirect_mmap::" + std::to_string(device_);
     }
 
 private:
+    void* mappedAddr_ = nullptr;
     size_t mappedBytes_ = 0;
     bool registered_ = false;
     bool locked_ = false;
 };
 
-class SharedHostRegion : public CopyBuffer {
+class FftsMappedSharedHostRegion : public CopyBuffer {
 public:
-    SharedHostRegion(std::string tag, size_t device, size_t size, size_t number)
+    FftsMappedSharedHostRegion(std::string tag, size_t device, size_t size, size_t number)
         : CopyBuffer{device, size, number}
     {
-        shmName_ = "/copy_ascend_" + std::to_string(getpid()) + "_" + tag + "_" +
+        const auto total = FftsDirectCheckedTotalBytes(size, number);
+        mappedBytes_ = FftsDirectRoundUpToPageSize(total);
+        shmName_ = "/copy_ascend_ffts_direct_" + std::to_string(getpid()) + "_" + tag + "_" +
                    std::to_string(reinterpret_cast<std::uintptr_t>(this));
-        const auto total = CheckedTotalBytes(size, number);
         const auto fd = shm_open(shmName_.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
         ASSERT(fd != -1);
-        ASSERT(ftruncate(fd, total) == 0);
+        ASSERT(ftruncate(fd, mappedBytes_) == 0);
         constexpr auto prot = PROT_READ | PROT_WRITE;
         constexpr auto flags = MAP_SHARED | MAP_POPULATE;
-        addr_ = mmap(nullptr, total, prot, flags, fd, 0);
+        addr_ = mmap(nullptr, mappedBytes_, prot, flags, fd, 0);
         const auto closeStatus = close(fd);
         ASSERT(closeStatus == 0);
         ASSERT(addr_ != MAP_FAILED);
         std::memset(addr_, 's', total);
     }
 
-    ~SharedHostRegion() override
+    ~FftsMappedSharedHostRegion() override
     {
-        if (addr_) { munmap(addr_, size_ * number_); }
+        if (addr_ != nullptr) {
+            munmap(addr_, mappedBytes_);
+            addr_ = nullptr;
+        }
         if (!shmName_.empty()) { shm_unlink(shmName_.c_str()); }
     }
 
     const std::string& ShmName() const { return shmName_; }
+    size_t MappedBytes() const { return mappedBytes_; }
     std::string Name() const override { return "acl::shm::0"; }
 
 private:
     std::string shmName_;
+    size_t mappedBytes_ = 0;
 };
 
-class SharedHostCopyBuffer : public CopyBuffer {
+class FftsMappedSharedHostCopyBuffer : public CopyBuffer, public FftsDirectMappedHostBuffer {
 public:
-    SharedHostCopyBuffer(std::string shmName, size_t device, size_t size, size_t number)
-        : CopyBuffer{device, size, number}, shmName_{std::move(shmName)}
+    FftsMappedSharedHostCopyBuffer(std::string shmName, size_t mappedBytes, size_t device,
+                                   size_t size, size_t number)
+        : CopyBuffer{device, size, number}, shmName_{std::move(shmName)}, mappedBytes_{mappedBytes}
     {
-        const auto total = CheckedTotalBytes(size, number);
+        ASSERT(FftsDirectCheckedTotalBytes(size, number) <= mappedBytes_);
         const auto fd = shm_open(shmName_.c_str(), O_RDWR, 0600);
         ASSERT(fd != -1);
         constexpr auto prot = PROT_READ | PROT_WRITE;
         constexpr auto flags = MAP_SHARED | MAP_POPULATE;
-        addr_ = mmap(nullptr, total, prot, flags, fd, 0);
+        addr_ = mmap(nullptr, mappedBytes_, prot, flags, fd, 0);
         const auto closeStatus = close(fd);
         ASSERT(closeStatus == 0);
         ASSERT(addr_ != MAP_FAILED);
+
         ASCEND_ASSERT(aclrtSetDevice(device_));
-        ASCEND_ASSERT(aclrtHostRegisterV2(addr_, total, ACL_HOST_REG_MAPPED | ACL_HOST_REG_PINNED));
+        ASCEND_ASSERT(
+            aclrtHostRegisterV2(addr_, mappedBytes_, ACL_HOST_REG_MAPPED | ACL_HOST_REG_PINNED));
+        registered_ = true;
+        ASCEND_ASSERT(aclrtHostGetDevicePointer(addr_, &mappedAddr_, 0));
     }
 
-    ~SharedHostCopyBuffer() override
+    ~FftsMappedSharedHostCopyBuffer() override
     {
-        if (addr_) {
+        if (addr_ != nullptr) {
             ASCEND_ASSERT(aclrtSetDevice(device_));
-            ASCEND_ASSERT(aclrtHostUnregister(addr_));
-            munmap(addr_, size_ * number_);
+            if (registered_) { ASCEND_ASSERT(aclrtHostUnregister(addr_)); }
+            munmap(addr_, mappedBytes_);
+            addr_ = nullptr;
         }
+    }
+
+    void* MappedAt(size_t i) const override
+    {
+        ASSERT(i < number_);
+        return static_cast<void*>(static_cast<char*>(mappedAddr_) + i * size_);
     }
 
     std::string Name() const override { return "acl::shm::0"; }
 
 private:
     std::string shmName_;
+    void* mappedAddr_ = nullptr;
+    size_t mappedBytes_ = 0;
+    bool registered_ = false;
 };
 
-class DeviceCopyBuffer : public CopyBuffer {
-public:
-    DeviceCopyBuffer(size_t device, size_t size, size_t number) : CopyBuffer{device, size, number}
-    {
-        const auto total = size * number;
-        ASCEND_ASSERT(aclrtSetDevice(device_));
-        ASCEND_ASSERT(aclrtMalloc(&addr_, total, ACL_MEM_MALLOC_HUGE_FIRST));
-        ASCEND_ASSERT(aclrtMemset(addr_, total, 'd', total));
-    }
-    ~DeviceCopyBuffer() override
-    {
-        if (addr_) {
-            ASCEND_ASSERT(aclrtSetDevice(device_));
-            ASCEND_ASSERT(aclrtFree(addr_));
-        }
-    }
-    std::string Name() const override { return "acl::device::" + std::to_string(device_); }
-};
-
-#endif  // COPY_BUFFER_ASCEND_H
+#endif  // MAPPED_HOST_BUFFER_FFTS_DIRECT_H2D_ASCEND_H

--- a/toolkit/src/dev-sandbox/module/copy/ascend/forked_copy_runner_ascend.h
+++ b/toolkit/src/dev-sandbox/module/copy/ascend/forked_copy_runner_ascend.h
@@ -1,0 +1,292 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Mag1c.H
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#ifndef FORKED_COPY_RUNNER_ASCEND_H
+#define FORKED_COPY_RUNNER_ASCEND_H
+
+#include <algorithm>
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <functional>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+#include "copy_case.h"
+#include "copy_result.h"
+#include "copy_runtime.h"
+#include "error_handle.h"
+
+namespace ascend_copy {
+
+using ForkedChildCopyFn = std::function<CopyResult::Result(size_t device)>;
+
+struct ForkedChildProcess {
+    pid_t pid = -1;
+    int readFd = -1;
+    size_t device = 0;
+};
+
+struct ResultWireHeader {
+    std::uint64_t srcLen = 0;
+    std::uint64_t dstLen = 0;
+    std::uint64_t methodLen = 0;
+    std::uint64_t size = 0;
+    std::uint64_t count = 0;
+    std::uint64_t submitCount = 0;
+    std::uint64_t copyCount = 0;
+};
+
+inline bool WriteExact(int fd, const void* data, size_t size)
+{
+    const auto* cursor = static_cast<const char*>(data);
+    while (size > 0) {
+        const auto written = write(fd, cursor, size);
+        if (written < 0) {
+            if (errno == EINTR) { continue; }
+            return false;
+        }
+        if (written == 0) { return false; }
+        cursor += written;
+        size -= static_cast<size_t>(written);
+    }
+    return true;
+}
+
+inline bool ReadExact(int fd, void* data, size_t size)
+{
+    auto* cursor = static_cast<char*>(data);
+    while (size > 0) {
+        const auto nread = read(fd, cursor, size);
+        if (nread < 0) {
+            if (errno == EINTR) { continue; }
+            return false;
+        }
+        if (nread == 0) { return false; }
+        cursor += nread;
+        size -= static_cast<size_t>(nread);
+    }
+    return true;
+}
+
+inline bool WriteString(int fd, const std::string& value)
+{
+    return value.empty() || WriteExact(fd, value.data(), value.size());
+}
+
+inline bool ReadString(int fd, std::uint64_t size, std::string& value)
+{
+    value.assign(static_cast<size_t>(size), '\0');
+    return value.empty() || ReadExact(fd, value.data(), value.size());
+}
+
+inline bool WriteCosts(int fd, const std::vector<size_t>& costs)
+{
+    for (const auto cost : costs) {
+        const std::uint64_t wireCost = static_cast<std::uint64_t>(cost);
+        if (!WriteExact(fd, &wireCost, sizeof(wireCost))) { return false; }
+    }
+    return true;
+}
+
+inline bool ReadCosts(int fd, std::uint64_t count, std::vector<size_t>& costs)
+{
+    costs.resize(static_cast<size_t>(count));
+    for (auto& cost : costs) {
+        std::uint64_t wireCost = 0;
+        if (!ReadExact(fd, &wireCost, sizeof(wireCost))) { return false; }
+        cost = static_cast<size_t>(wireCost);
+    }
+    return true;
+}
+
+inline bool WriteResult(int fd, const CopyResult::Result& result)
+{
+    ResultWireHeader header;
+    header.srcLen = static_cast<std::uint64_t>(result.src.size());
+    header.dstLen = static_cast<std::uint64_t>(result.dst.size());
+    header.methodLen = static_cast<std::uint64_t>(result.method.size());
+    header.size = static_cast<std::uint64_t>(result.size);
+    header.count = static_cast<std::uint64_t>(result.count);
+    header.submitCount = static_cast<std::uint64_t>(result.submitCosts.size());
+    header.copyCount = static_cast<std::uint64_t>(result.copyCosts.size());
+
+    return WriteExact(fd, &header, sizeof(header)) && WriteString(fd, result.src) &&
+           WriteString(fd, result.dst) && WriteString(fd, result.method) &&
+           WriteCosts(fd, result.submitCosts) && WriteCosts(fd, result.copyCosts);
+}
+
+inline bool ReadResult(int fd, CopyResult::Result& result)
+{
+    ResultWireHeader header;
+    if (!ReadExact(fd, &header, sizeof(header))) { return false; }
+
+    std::string src;
+    std::string dst;
+    std::string method;
+    std::vector<size_t> submitCosts;
+    std::vector<size_t> copyCosts;
+    if (!ReadString(fd, header.srcLen, src) || !ReadString(fd, header.dstLen, dst) ||
+        !ReadString(fd, header.methodLen, method) ||
+        !ReadCosts(fd, header.submitCount, submitCosts) ||
+        !ReadCosts(fd, header.copyCount, copyCosts)) {
+        return false;
+    }
+
+    result = CopyResult::Result{std::move(src),
+                                std::move(dst),
+                                std::move(method),
+                                static_cast<size_t>(header.size),
+                                static_cast<size_t>(header.count),
+                                std::move(submitCosts),
+                                std::move(copyCosts)};
+    return true;
+}
+
+[[noreturn]] inline void RunChildCopy(size_t device, int writeFd,
+                                      const ForkedChildCopyFn& childCopy)
+{
+    int status = EXIT_FAILURE;
+    {
+        try {
+            CopyRuntime runtime;
+            auto result = childCopy(device);
+            status = WriteResult(writeFd, result) ? EXIT_SUCCESS : EXIT_FAILURE;
+        } catch (const std::exception& e) {
+            std::fprintf(stderr, "[fork-copy] device %zu failed: %s\n", device, e.what());
+        } catch (...) {
+            std::fprintf(stderr, "[fork-copy] device %zu failed with unknown error\n", device);
+        }
+    }
+    close(writeFd);
+    std::_Exit(status);
+}
+
+inline std::vector<size_t> MergeMaxCosts(const std::vector<CopyResult::Result>& results,
+                                         bool submit)
+{
+    ASSERT(!results.empty());
+    const auto& first = submit ? results.front().submitCosts : results.front().copyCosts;
+    std::vector<size_t> merged(first.size(), 0);
+    for (const auto& result : results) {
+        const auto& costs = submit ? result.submitCosts : result.copyCosts;
+        ASSERT(costs.size() == merged.size());
+        for (size_t i = 0; i < costs.size(); ++i) {
+            merged[i] = std::max(merged[i], costs[i]);
+        }
+    }
+    return merged;
+}
+
+inline CopyResult::Result MergeForkedResults(std::vector<CopyResult::Result>&& results,
+                                             std::string srcName, std::string dstName,
+                                             std::string methodName)
+{
+    ASSERT(!results.empty());
+    size_t totalCount = 0;
+    for (const auto& result : results) {
+        ASSERT(result.size == results.front().size);
+        totalCount += result.count;
+    }
+
+    return {std::move(srcName),
+            std::move(dstName),
+            std::move(methodName),
+            results.front().size,
+            totalCount,
+            MergeMaxCosts(results, true),
+            MergeMaxCosts(results, false)};
+}
+
+inline std::vector<CopyResult::Result> RunForkedCopyBatchPerDevice(
+    const CopyCase::Context& ctx, const ForkedChildCopyFn& childCopy)
+{
+    ASSERT(ctx.nDevice > 0);
+    std::vector<ForkedChildProcess> children;
+    children.reserve(ctx.nDevice);
+
+    for (size_t device = 0; device < ctx.nDevice; ++device) {
+        int pipeFds[2];
+        ASSERT(pipe(pipeFds) == 0);
+        const auto pid = fork();
+        ASSERT(pid != -1);
+        if (pid == 0) {
+            close(pipeFds[0]);
+            RunChildCopy(device, pipeFds[1], childCopy);
+        }
+
+        close(pipeFds[1]);
+        children.push_back({pid, pipeFds[0], device});
+    }
+
+    std::vector<CopyResult::Result> childResults;
+    childResults.reserve(children.size());
+    bool failed = false;
+    for (auto& child : children) {
+        CopyResult::Result result{"", "", "", 0, 0, {}, {}};
+        if (!ReadResult(child.readFd, result)) {
+            std::fprintf(stderr, "[fork-copy] failed to read result from device %zu\n",
+                         child.device);
+            failed = true;
+        } else {
+            childResults.push_back(std::move(result));
+        }
+        close(child.readFd);
+    }
+
+    for (const auto& child : children) {
+        int status = 0;
+        pid_t waited = -1;
+        do {
+            waited = waitpid(child.pid, &status, 0);
+        } while (waited == -1 && errno == EINTR);
+        ASSERT(waited == child.pid);
+        if (!WIFEXITED(status) || WEXITSTATUS(status) != EXIT_SUCCESS) {
+            std::fprintf(stderr, "[fork-copy] child for device %zu exited abnormally\n",
+                         child.device);
+            failed = true;
+        }
+    }
+    ASSERT(!failed);
+    ASSERT(childResults.size() == ctx.nDevice);
+
+    return childResults;
+}
+
+inline CopyResult::Result RunForkedCopyBatch(const CopyCase::Context& ctx, std::string srcName,
+                                             std::string dstName, std::string methodName,
+                                             const ForkedChildCopyFn& childCopy)
+{
+    auto childResults = RunForkedCopyBatchPerDevice(ctx, childCopy);
+    return MergeForkedResults(std::move(childResults), std::move(srcName), std::move(dstName),
+                              std::move(methodName));
+}
+
+}  // namespace ascend_copy
+
+#endif  // FORKED_COPY_RUNNER_ASCEND_H

--- a/toolkit/src/dev-sandbox/module/copy/ascend/forked_copy_runner_ascend.h
+++ b/toolkit/src/dev-sandbox/module/copy/ascend/forked_copy_runner_ascend.h
@@ -196,9 +196,7 @@ inline std::vector<size_t> MergeMaxCosts(const std::vector<CopyResult::Result>& 
     for (const auto& result : results) {
         const auto& costs = submit ? result.submitCosts : result.copyCosts;
         ASSERT(costs.size() == merged.size());
-        for (size_t i = 0; i < costs.size(); ++i) {
-            merged[i] = std::max(merged[i], costs[i]);
-        }
+        for (size_t i = 0; i < costs.size(); ++i) { merged[i] = std::max(merged[i], costs[i]); }
     }
     return merged;
 }
@@ -214,12 +212,8 @@ inline CopyResult::Result MergeForkedResults(std::vector<CopyResult::Result>&& r
         totalCount += result.count;
     }
 
-    return {std::move(srcName),
-            std::move(dstName),
-            std::move(methodName),
-            results.front().size,
-            totalCount,
-            MergeMaxCosts(results, true),
+    return {std::move(srcName),           std::move(dstName), std::move(methodName),
+            results.front().size,         totalCount,         MergeMaxCosts(results, true),
             MergeMaxCosts(results, false)};
 }
 

--- a/toolkit/src/dev-sandbox/module/copy/ascend/h2d_ffts_pipeline/ffts_d2d_dispatcher_ascend.h
+++ b/toolkit/src/dev-sandbox/module/copy/ascend/h2d_ffts_pipeline/ffts_d2d_dispatcher_ascend.h
@@ -1,0 +1,214 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Mag1c.H
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#ifndef FFTS_D2D_DISPATCHER_ASCEND_H
+#define FFTS_D2D_DISPATCHER_ASCEND_H
+
+#include <acl/acl.h>
+#include <algorithm>
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <vector>
+#include "error_handle.h"
+
+#if __has_include("runtime/rt_ffts_plus.h")
+#include "runtime/rt_ffts_plus.h"
+#elif __has_include("rt_external_ffts.h")
+#include "rt_external_ffts.h"
+#else
+#error "FFTS Plus header was not found. Configure Ascend FFTS include directories in CMake."
+#endif
+
+constexpr uint32_t kFftsSdmaFp32AtomicMoveSqe = 0x1E70;
+constexpr uint16_t kFftsContextMaxNum = 128;
+constexpr uint16_t kDefaultFftsMaxReadyLanes = 8;
+constexpr uint8_t kFftsCommunicationTask = 0x5A;
+constexpr const char* kFftsMaxReadyLanesEnv = "FFTS_MAX_READY_LANES";
+
+static_assert(sizeof(rtFftsPlusComCtx_t) == 128, "rtFftsPlusComCtx_t must be 128 bytes");
+static_assert(sizeof(rtFftsPlusSdmaCtx_t) == 128, "rtFftsPlusSdmaCtx_t must be 128 bytes");
+
+#define ASCEND_RT_ASSERT(expr)                                                        \
+    do {                                                                              \
+        auto __rtErr = (expr);                                                        \
+        if ((__rtErr) != RT_ERROR_NONE) {                                             \
+            fprintf(stderr, "[RT Error %d] in expression %s at %s:%d\n",              \
+                    static_cast<int>(__rtErr), #expr, __FILE__, __LINE__);            \
+            exit(EXIT_FAILURE);                                                       \
+        }                                                                             \
+    } while (0)
+
+struct AscendFftsCopySpec {
+    void* dst;
+    const void* src;
+    size_t size;
+};
+
+class FftsD2DDispatcher {
+public:
+    void Reserve(size_t count) { contexts_.reserve(count); }
+
+    void Reset()
+    {
+        contexts_.clear();
+        completed_ = false;
+    }
+
+    void AddMemcpy(void* dst, const void* src, size_t size)
+    {
+        ASSERT(!completed_);
+        ASSERT(dst != nullptr);
+        ASSERT(src != nullptr);
+        ASSERT(size > 0);
+        ASSERT(size <= std::numeric_limits<uint32_t>::max());
+        ASSERT(contexts_.size() < std::numeric_limits<uint16_t>::max());
+
+        rtFftsPlusComCtx_t comCtx{};
+        auto* sdmaCtx = reinterpret_cast<rtFftsPlusSdmaCtx_t*>(&comCtx);
+        BuildSdmaCtx(dst, src, size, sdmaCtx);
+        contexts_.push_back(comCtx);
+    }
+
+    void AddDependency(uint32_t predecessorId, uint32_t successorId)
+    {
+        ASSERT(predecessorId < contexts_.size());
+        ASSERT(successorId < contexts_.size());
+
+        auto& predecessor = contexts_[predecessorId];
+        auto& successor = contexts_[successorId];
+        ASSERT(predecessor.successorNum < RT_CTX_SUCCESSOR_NUM);
+        ASSERT(successor.predCntInit < std::numeric_limits<uint8_t>::max());
+
+        predecessor.successorList[predecessor.successorNum] =
+            static_cast<uint16_t>(successorId);
+        predecessor.successorNum++;
+        successor.predCntInit++;
+        successor.predCnt++;
+    }
+
+    uint16_t BuildCopies(const std::vector<AscendFftsCopySpec>& copies)
+    {
+        Reset();
+        if (copies.empty()) { return 0; }
+
+        Reserve(copies.size());
+        const uint16_t maxReadyLanes = MaxReadyLanes();
+        const uint16_t laneCount =
+            static_cast<uint16_t>(std::min<size_t>(copies.size(), maxReadyLanes));
+        std::vector<int32_t> lastTaskId(laneCount, -1);
+
+        for (size_t i = 0; i < copies.size(); ++i) {
+            AddMemcpy(copies[i].dst, copies[i].src, copies[i].size);
+
+            const size_t lane = i % laneCount;
+            const uint32_t taskId = static_cast<uint32_t>(contexts_.size() - 1);
+            if (lastTaskId[lane] >= 0) {
+                AddDependency(static_cast<uint32_t>(lastTaskId[lane]), taskId);
+            }
+            lastTaskId[lane] = static_cast<int32_t>(taskId);
+        }
+
+        return laneCount;
+    }
+
+    void Launch(aclrtStream stream, uint16_t readyContextNum)
+    {
+        ASSERT(!contexts_.empty());
+        ASSERT(readyContextNum > 0);
+        ASSERT(readyContextNum <= contexts_.size());
+
+        rtFftsPlusSqe_t sqe{};
+        sqe.fftsType = RT_FFTS_PLUS_TYPE;
+        sqe.totalContextNum = static_cast<uint16_t>(contexts_.size());
+        sqe.readyContextNum = readyContextNum;
+        sqe.preloadContextNum = std::min<uint16_t>(readyContextNum, kFftsContextMaxNum);
+        sqe.timeout = 0;
+        sqe.subType = kFftsCommunicationTask;
+
+        rtFftsPlusTaskInfo_t task{};
+        task.fftsPlusSqe = &sqe;
+        task.descBuf = contexts_.data();
+        task.descBufLen = sizeof(rtFftsPlusComCtx_t) * contexts_.size();
+        task.descAddrType = RT_FFTS_PLUS_CTX_DESC_ADDR_TYPE_HOST;
+        task.argsHandleInfoNum = 0;
+        task.argsHandleInfoPtr = nullptr;
+
+        completed_ = true;
+        ASCEND_RT_ASSERT(
+            rtFftsPlusTaskLaunchWithFlag(&task, reinterpret_cast<rtStream_t>(stream), 0));
+    }
+
+private:
+    static uint16_t MaxReadyLanes()
+    {
+        const char* value = std::getenv(kFftsMaxReadyLanesEnv);
+        if (value == nullptr || value[0] == '\0') { return kDefaultFftsMaxReadyLanes; }
+
+        char* end = nullptr;
+        errno = 0;
+        const unsigned long parsed = std::strtoul(value, &end, 10);
+        if (errno != 0 || end == value || *end != '\0' || parsed == 0) {
+            return kDefaultFftsMaxReadyLanes;
+        }
+
+        const auto maxValue =
+            static_cast<unsigned long>(std::numeric_limits<uint16_t>::max());
+        if (parsed > maxValue) { return std::numeric_limits<uint16_t>::max(); }
+        return static_cast<uint16_t>(parsed);
+    }
+
+    static uint64_t PtrToU64(const void* ptr)
+    {
+        return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(ptr));
+    }
+
+    static void BuildSdmaCtx(void* dst, const void* src, size_t size, rtFftsPlusSdmaCtx_t* ctx)
+    {
+        constexpr uint32_t kShift = 32;
+        constexpr uint64_t kLowMask = 0xFFFFFFFFULL;
+
+        const uint64_t srcAddr = PtrToU64(src);
+        const uint64_t dstAddr = PtrToU64(dst);
+
+        ctx->contextType = RT_CTX_TYPE_SDMA;
+        ctx->threadDim = 1;
+        ctx->sdmaSqeHeader = kFftsSdmaFp32AtomicMoveSqe;
+        ctx->sourceAddressBaseL = static_cast<uint32_t>(srcAddr & kLowMask);
+        ctx->sourceAddressBaseH = static_cast<uint32_t>(srcAddr >> kShift);
+        ctx->sourceAddressOffset = 0;
+        ctx->destinationAddressBaseL = static_cast<uint32_t>(dstAddr & kLowMask);
+        ctx->destinationAddressBaseH = static_cast<uint32_t>(dstAddr >> kShift);
+        ctx->destinationAddressOffset = 0;
+        ctx->nonTailDataLength = static_cast<uint32_t>(size);
+        ctx->tailDataLength = static_cast<uint32_t>(size);
+    }
+
+    std::vector<rtFftsPlusComCtx_t> contexts_;
+    bool completed_ = false;
+};
+
+#endif  // FFTS_D2D_DISPATCHER_ASCEND_H

--- a/toolkit/src/dev-sandbox/module/copy/ascend/h2d_ffts_pipeline/ffts_d2d_dispatcher_ascend.h
+++ b/toolkit/src/dev-sandbox/module/copy/ascend/h2d_ffts_pipeline/ffts_d2d_dispatcher_ascend.h
@@ -52,14 +52,14 @@ constexpr const char* kFftsMaxReadyLanesEnv = "FFTS_MAX_READY_LANES";
 static_assert(sizeof(rtFftsPlusComCtx_t) == 128, "rtFftsPlusComCtx_t must be 128 bytes");
 static_assert(sizeof(rtFftsPlusSdmaCtx_t) == 128, "rtFftsPlusSdmaCtx_t must be 128 bytes");
 
-#define ASCEND_RT_ASSERT(expr)                                                        \
-    do {                                                                              \
-        auto __rtErr = (expr);                                                        \
-        if ((__rtErr) != RT_ERROR_NONE) {                                             \
-            fprintf(stderr, "[RT Error %d] in expression %s at %s:%d\n",              \
-                    static_cast<int>(__rtErr), #expr, __FILE__, __LINE__);            \
-            exit(EXIT_FAILURE);                                                       \
-        }                                                                             \
+#define ASCEND_RT_ASSERT(expr)                                             \
+    do {                                                                   \
+        auto __rtErr = (expr);                                             \
+        if ((__rtErr) != RT_ERROR_NONE) {                                  \
+            fprintf(stderr, "[RT Error %d] in expression %s at %s:%d\n",   \
+                    static_cast<int>(__rtErr), #expr, __FILE__, __LINE__); \
+            exit(EXIT_FAILURE);                                            \
+        }                                                                  \
     } while (0)
 
 struct AscendFftsCopySpec {
@@ -103,8 +103,7 @@ public:
         ASSERT(predecessor.successorNum < RT_CTX_SUCCESSOR_NUM);
         ASSERT(successor.predCntInit < std::numeric_limits<uint8_t>::max());
 
-        predecessor.successorList[predecessor.successorNum] =
-            static_cast<uint16_t>(successorId);
+        predecessor.successorList[predecessor.successorNum] = static_cast<uint16_t>(successorId);
         predecessor.successorNum++;
         successor.predCntInit++;
         successor.predCnt++;
@@ -175,8 +174,7 @@ private:
             return kDefaultFftsMaxReadyLanes;
         }
 
-        const auto maxValue =
-            static_cast<unsigned long>(std::numeric_limits<uint16_t>::max());
+        const auto maxValue = static_cast<unsigned long>(std::numeric_limits<uint16_t>::max());
         if (parsed > maxValue) { return std::numeric_limits<uint16_t>::max(); }
         return static_cast<uint16_t>(parsed);
     }

--- a/toolkit/src/dev-sandbox/module/copy/copy_case.h
+++ b/toolkit/src/dev-sandbox/module/copy/copy_case.h
@@ -37,12 +37,14 @@ public:
     struct Context {
         size_t size;
         size_t num;
+        size_t frags;
         size_t iter;
         size_t nDevice;
     };
     CopyCase(std::string key, std::string brief) : key_{std::move(key)}, brief_{std::move(brief)} {}
     virtual ~CopyCase() = default;
     virtual void Run(const Context& ctx) const = 0;
+    virtual bool RequiresRuntimeInitialization() const { return true; }
     const std::string& Key() const { return key_; }
     const std::string& Brief() const { return brief_; }
 };
@@ -83,6 +85,16 @@ public:
     class ClassName : public CopyCase {                         \
     public:                                                     \
         ClassName() : CopyCase(Key, Brief) {}                   \
+        void Run(const Context&) const override;                \
+    };                                                          \
+    static Registrar<ClassName> global_##ClassName##_registrar; \
+    void ClassName::Run(const Context& Ctx) const
+
+#define DEFINE_COPY_CASE_NO_RUNTIME(ClassName, Key, Brief, Ctx) \
+    class ClassName : public CopyCase {                         \
+    public:                                                     \
+        ClassName() : CopyCase(Key, Brief) {}                   \
+        bool RequiresRuntimeInitialization() const override { return false; } \
         void Run(const Context&) const override;                \
     };                                                          \
     static Registrar<ClassName> global_##ClassName##_registrar; \

--- a/toolkit/src/dev-sandbox/module/copy/copy_case.h
+++ b/toolkit/src/dev-sandbox/module/copy/copy_case.h
@@ -90,14 +90,14 @@ public:
     static Registrar<ClassName> global_##ClassName##_registrar; \
     void ClassName::Run(const Context& Ctx) const
 
-#define DEFINE_COPY_CASE_NO_RUNTIME(ClassName, Key, Brief, Ctx) \
-    class ClassName : public CopyCase {                         \
-    public:                                                     \
-        ClassName() : CopyCase(Key, Brief) {}                   \
+#define DEFINE_COPY_CASE_NO_RUNTIME(ClassName, Key, Brief, Ctx)               \
+    class ClassName : public CopyCase {                                       \
+    public:                                                                   \
+        ClassName() : CopyCase(Key, Brief) {}                                 \
         bool RequiresRuntimeInitialization() const override { return false; } \
-        void Run(const Context&) const override;                \
-    };                                                          \
-    static Registrar<ClassName> global_##ClassName##_registrar; \
+        void Run(const Context&) const override;                              \
+    };                                                                        \
+    static Registrar<ClassName> global_##ClassName##_registrar;               \
     void ClassName::Run(const Context& Ctx) const
 
 #endif

--- a/toolkit/src/dev-sandbox/module/copy/copy_main.cc
+++ b/toolkit/src/dev-sandbox/module/copy/copy_main.cc
@@ -29,7 +29,8 @@
 
 struct ArgsParser {
     std::unordered_set<std::string> names;
-    CopyCase::Context ctx{.size = 512ull * 1024ull * 1024ull, .num = 8, .iter = 128, .nDevice = 8};
+    CopyCase::Context ctx{
+        .size = 512ull * 1024ull * 1024ull, .num = 8, .frags = 0, .iter = 128, .nDevice = 8};
 
     static void Help(std::string_view proc)
     {
@@ -37,7 +38,11 @@ struct ArgsParser {
         fmt::println("Options:");
         fmt::println("  -t <name>        Case name");
         fmt::println("  -s <size>        Data size in KB/MB (e.g., 4K, 16K, 1M, default: 512MB)");
-        fmt::println("  -n <count>       Data number (default: 8)");
+        fmt::println("  -n <count>       Data number (default: 8). For ffts direct H2D with");
+        fmt::println("                   --frags/-frags, this is IO/task count.");
+        fmt::println("  -f/--frags/-frags <n>");
+        fmt::println("                   Fragments per IO/task for ffts direct H2D");
+        fmt::println("                   (default: 0, legacy single task)");
         fmt::println("  -i <count>       Iteration count (default: 128)");
         fmt::println("  -d <count>       Number of devices (default: 8)");
     }
@@ -80,6 +85,8 @@ struct ArgsParser {
                 ctx.size = ParseSize(argv[++i]);
             } else if (arg == "-n" && i + 1 < argc) {
                 ctx.num = ParseUnsigned(argv[++i], "Invalid data count.");
+            } else if ((arg == "-f" || arg == "--frags" || arg == "-frags") && i + 1 < argc) {
+                ctx.frags = ParseUnsigned(argv[++i], "Invalid fragment count.");
             } else if (arg == "-i" && i + 1 < argc) {
                 ctx.iter = ParseUnsigned(argv[++i], "Invalid iteration count.");
             } else if (arg == "-d" && i + 1 < argc) {
@@ -99,7 +106,6 @@ int main(int argc, char const* argv[])
         ArgsParser::Help(argv[0]);
         return -1;
     }
-    CopyRuntime runtime;
     const auto cases = CopyCaseFactory::Instance().Filter(args.names);
     if (cases.empty()) {
         for (auto& c : CopyCaseFactory::Instance().AllCases()) {
@@ -107,6 +113,13 @@ int main(int argc, char const* argv[])
         }
         return -1;
     }
-    for (auto& c : cases) { c->Run(args.ctx); }
+    for (auto& c : cases) {
+        if (c->RequiresRuntimeInitialization()) {
+            CopyRuntime runtime;
+            c->Run(args.ctx);
+        } else {
+            c->Run(args.ctx);
+        }
+    }
     return 0;
 }

--- a/toolkit/src/dev-sandbox/module/copy/copy_result.h
+++ b/toolkit/src/dev-sandbox/module/copy/copy_result.h
@@ -39,13 +39,13 @@ public:
         size_t size;
         size_t count;
         struct {
-            size_t min;
-            size_t max;
-            size_t avg;
-            size_t p50;
-            size_t p90;
+            size_t min = 0;
+            size_t max = 0;
+            size_t avg = 0;
+            size_t p50 = 0;
+            size_t p90 = 0;
 
-            void Parse(std::vector<size_t>&& costs)
+            void Parse(const std::vector<size_t>& costs)
             {
                 if (costs.empty()) return;
                 size_t sum = 0;
@@ -56,25 +56,30 @@ public:
                     sum += cost;
                 }
                 avg = sum / costs.size();
-                std::sort(costs.begin(), costs.end());
-                p50 = costs[costs.size() / 2];
-                p90 = costs[costs.size() * 9 / 10];
+                auto sorted = costs;
+                std::sort(sorted.begin(), sorted.end());
+                p50 = sorted[sorted.size() / 2];
+                p90 = sorted[sorted.size() * 9 / 10];
             }
             std::string ToString() const
             {
                 return fmt::format("{} / {} / {} / {} / {}", min, max, avg, p50, p90);
             }
         } submit, copy;
+        std::vector<size_t> submitCosts;
+        std::vector<size_t> copyCosts;
         Result(std::string src, std::string dst, std::string method, size_t size, size_t count,
                std::vector<size_t>&& submitCosts, std::vector<size_t>&& copyCosts)
             : src(std::move(src)),
               dst(std::move(dst)),
               method(std::move(method)),
               size(size),
-              count(count)
+              count(count),
+              submitCosts(std::move(submitCosts)),
+              copyCosts(std::move(copyCosts))
         {
-            submit.Parse(std::move(submitCosts));
-            copy.Parse(std::move(copyCosts));
+            submit.Parse(this->submitCosts);
+            copy.Parse(this->copyCosts);
         }
     };
     void Push(Result&& result) { results_.push_back(std::move(result)); }

--- a/toolkit/src/dev-sandbox/readme.md
+++ b/toolkit/src/dev-sandbox/readme.md
@@ -23,6 +23,7 @@ cmake --build build -j
 -t <name>   case 名称，可重复指定多个 -t
 -s <size>   单个数据块大小，例如 16K、1M，默认 512M
 -n <count>  每个 buffer 内的数据块数量，默认 8
+-f/--frags/-frags <n>  FFTS direct H2D fragments per IO/task，默认 0
 -i <count>  迭代次数，默认 128
 -d <count>  设备数量，默认 8
 ```
@@ -68,6 +69,30 @@ case。
 | case | 传输方向 | 说明 |
 | --- | --- | --- |
 | `host_to_device_ce_multi_stream` | host -> device | 使用多 stream 提交 H2D 拷贝 |
+| `one_share_host_to_all_device_ce_multi_stream` | shared host -> all devices | 4-stream CE with fork fan-out from one POSIX shared memory source |
+| `all_host_to_all_device_ce_multi_stream` | host[i] -> device[i] | 4-stream CE with one forked process per device |
+| `all_odirect_host_to_all_device_ce_multi_stream` | O_DIRECT-style host[i] -> device[i] | 4-stream CE from UCM O_DIRECT-style mmap host buffers |
+| `all_host_to_all_device_ffts_direct_h2d` | mapped host[i] -> device[i] | FFTS Plus direct H2D SDMA from mapped `aclrtMallocHost` buffers |
+| `one_share_host_to_all_device_ffts_direct_h2d` | shared mapped host -> all devices | FFTS Plus direct H2D SDMA from one POSIX shared memory source |
+| `all_odirect_host_to_all_device_ffts_direct_h2d` | O_DIRECT-style mapped host[i] -> device[i] | FFTS Plus direct H2D SDMA from UCM O_DIRECT-style mmap host buffers |
+
+### Ascend FFTS direct H2D
+
+FFTS direct H2D cases are compiled only when Ascend FFTS headers and `libruntime` are detected.
+Use `COPY_FFTS_VALIDATE=1` to enable data validation, `FFTS_MAX_READY_LANES` to tune the dispatcher
+ready lane count, and `-frags` to control fragments per IO/task. When `-frags` is set, `-n` is the
+IO/task count and the total fragment count is `-n * -frags`.
+
+```bash
+COPY_FFTS_VALIDATE=1 \
+./build/module/copy/copy -t all_host_to_all_device_ffts_direct_h2d -s 4M -n 100 -frags 128 -i 10 -d 8
+
+COPY_FFTS_VALIDATE=1 \
+./build/module/copy/copy -t one_share_host_to_all_device_ffts_direct_h2d -s 32K -n 100 -frags 128 -i 10 -d 8
+
+COPY_FFTS_VALIDATE=1 \
+./build/module/copy/copy -t all_odirect_host_to_all_device_ffts_direct_h2d -s 32K -n 100 -frags 128 -i 10 -d 8
+```
 
 ### GDR
 

--- a/toolkit/src/dev-sandbox/readme.md
+++ b/toolkit/src/dev-sandbox/readme.md
@@ -69,30 +69,12 @@ case。
 | case | 传输方向 | 说明 |
 | --- | --- | --- |
 | `host_to_device_ce_multi_stream` | host -> device | 使用多 stream 提交 H2D 拷贝 |
-| `one_share_host_to_all_device_ce_multi_stream` | shared host -> all devices | 4-stream CE with fork fan-out from one POSIX shared memory source |
+| `one_share_host_to_all_device_ce_multi_stream` | shared host -> all devices | 4-stream CE; simulates MLA model workers reading the same shared host KV buffer into multiple devices |
 | `all_host_to_all_device_ce_multi_stream` | host[i] -> device[i] | 4-stream CE with one forked process per device |
-| `all_odirect_host_to_all_device_ce_multi_stream` | O_DIRECT-style host[i] -> device[i] | 4-stream CE from UCM O_DIRECT-style mmap host buffers |
+| `all_odirect_host_to_all_device_ce_multi_stream` | O_DIRECT-style host[i] -> device[i] | 4-stream CE; matches GQA model multi-card reads from per-device O_DIRECT-style local host buffers |
 | `all_host_to_all_device_ffts_direct_h2d` | mapped host[i] -> device[i] | FFTS Plus direct H2D SDMA from mapped `aclrtMallocHost` buffers |
-| `one_share_host_to_all_device_ffts_direct_h2d` | shared mapped host -> all devices | FFTS Plus direct H2D SDMA from one POSIX shared memory source |
-| `all_odirect_host_to_all_device_ffts_direct_h2d` | O_DIRECT-style mapped host[i] -> device[i] | FFTS Plus direct H2D SDMA from UCM O_DIRECT-style mmap host buffers |
-
-### Ascend FFTS direct H2D
-
-FFTS direct H2D cases are compiled only when Ascend FFTS headers and `libruntime` are detected.
-Use `COPY_FFTS_VALIDATE=1` to enable data validation, `FFTS_MAX_READY_LANES` to tune the dispatcher
-ready lane count, and `-frags` to control fragments per IO/task. When `-frags` is set, `-n` is the
-IO/task count and the total fragment count is `-n * -frags`.
-
-```bash
-COPY_FFTS_VALIDATE=1 \
-./build/module/copy/copy -t all_host_to_all_device_ffts_direct_h2d -s 4M -n 100 -frags 128 -i 10 -d 8
-
-COPY_FFTS_VALIDATE=1 \
-./build/module/copy/copy -t one_share_host_to_all_device_ffts_direct_h2d -s 32K -n 100 -frags 128 -i 10 -d 8
-
-COPY_FFTS_VALIDATE=1 \
-./build/module/copy/copy -t all_odirect_host_to_all_device_ffts_direct_h2d -s 32K -n 100 -frags 128 -i 10 -d 8
-```
+| `one_share_host_to_all_device_ffts_direct_h2d` | shared mapped host -> all devices | FFTS Plus direct H2D SDMA; simulates MLA model workers reading one shared host KV buffer into multiple devices |
+| `all_odirect_host_to_all_device_ffts_direct_h2d` | O_DIRECT-style mapped host[i] -> device[i] | FFTS Plus direct H2D SDMA; matches GQA model multi-card reads from per-device O_DIRECT-style local host buffers |
 
 ### GDR
 

--- a/toolkit/src/dev-sandbox/readme.md
+++ b/toolkit/src/dev-sandbox/readme.md
@@ -23,7 +23,7 @@ cmake --build build -j
 -t <name>   case 名称，可重复指定多个 -t
 -s <size>   单个数据块大小，例如 16K、1M，默认 512M
 -n <count>  每个 buffer 内的数据块数量，默认 8
--f/--frags/-frags <n>  FFTS direct H2D fragments per IO/task，默认 0
+-f/--frags/-frags <n>  FFTS direct H2D 每个 IO/task 的 fragment 数，默认 0
 -i <count>  迭代次数，默认 128
 -d <count>  设备数量，默认 8
 ```
@@ -69,12 +69,12 @@ case。
 | case | 传输方向 | 说明 |
 | --- | --- | --- |
 | `host_to_device_ce_multi_stream` | host -> device | 使用多 stream 提交 H2D 拷贝 |
-| `one_share_host_to_all_device_ce_multi_stream` | shared host -> all devices | 4-stream CE; simulates MLA model workers reading the same shared host KV buffer into multiple devices |
-| `all_host_to_all_device_ce_multi_stream` | host[i] -> device[i] | 4-stream CE with one forked process per device |
-| `all_odirect_host_to_all_device_ce_multi_stream` | O_DIRECT-style host[i] -> device[i] | 4-stream CE; matches GQA model multi-card reads from per-device O_DIRECT-style local host buffers |
-| `all_host_to_all_device_ffts_direct_h2d` | mapped host[i] -> device[i] | FFTS Plus direct H2D SDMA from mapped `aclrtMallocHost` buffers |
-| `one_share_host_to_all_device_ffts_direct_h2d` | shared mapped host -> all devices | FFTS Plus direct H2D SDMA; simulates MLA model workers reading one shared host KV buffer into multiple devices |
-| `all_odirect_host_to_all_device_ffts_direct_h2d` | O_DIRECT-style mapped host[i] -> device[i] | FFTS Plus direct H2D SDMA; matches GQA model multi-card reads from per-device O_DIRECT-style local host buffers |
+| `one_share_host_to_all_device_ce_multi_stream` | 共享 host -> 所有 device | 4-stream CE；模拟 MLA 模型中多卡同时读取同一份 shared host KV buffer 并写入各自 device |
+| `all_host_to_all_device_ce_multi_stream` | host[i] -> device[i] | 每张卡对应一个 fork 子进程，单卡内使用 4-stream CE |
+| `all_odirect_host_to_all_device_ce_multi_stream` | O_DIRECT 风格 host[i] -> device[i] | 4-stream CE；更贴近开启 O_DIRECT 后 GQA 模型中每张卡从本地 host buffer 同时读入 KV 数据的路径 |
+| `all_host_to_all_device_ffts_direct_h2d` | mapped host[i] -> device[i] | 从 mapped `aclrtMallocHost` buffer 发起 FFTS Plus direct H2D SDMA |
+| `one_share_host_to_all_device_ffts_direct_h2d` | 共享 mapped host -> 所有 device | FFTS Plus direct H2D SDMA；模拟 MLA 模型中多卡同时读取同一份 shared host KV buffer |
+| `all_odirect_host_to_all_device_ffts_direct_h2d` | O_DIRECT 风格 mapped host[i] -> device[i] | FFTS Plus direct H2D SDMA；更贴近开启 O_DIRECT 后 GQA 模型中每张卡从本地 host buffer 同时读入 KV 数据的 direct H2D 路径 |
 
 ### GDR
 


### PR DESCRIPTION
## 背景

补齐 `dev-sandbox copy` 中 UCM 当前未覆盖的 Ascend 多卡 H2D 场景，方便对比 CE multi-stream、O_DIRECT 风格 host buffer，以及 FFTS direct H2D 路径。

## 修改内容

- 新增 CE multi-stream case，单卡 stream number 固定为 4：
  - `one_share_host_to_all_device_ce_multi_stream`
  - `all_host_to_all_device_ce_multi_stream`
  - `all_odirect_host_to_all_device_ce_multi_stream`
- 新增 Ascend FFTS direct H2D case：
  - `all_host_to_all_device_ffts_direct_h2d`
  - `one_share_host_to_all_device_ffts_direct_h2d`
  - `all_odirect_host_to_all_device_ffts_direct_h2d`
- 支持 fork runner、多卡并发执行、共享 host buffer、O_DIRECT 风格 host buffer、mapped/pinned host buffer，以及 `-frags` 参数。
- 更新 toolkit 和 dev-sandbox 文档，补充 case 场景说明：
  - `one_share_host...` 用于模拟 MLA 模型多卡同时读取同一份 shared host KV buffer。
  - `all_odirect...` 更贴近开启 O_DIRECT 后 GQA 模型中多卡分别从本地 host buffer 同时读入 KV 数据。
## Test

Ascend 环境实机验证，使用 7 张卡运行新增 CE multi-stream case。

| Case | Command | Size(KB) | Count | Submit(us) Min/Max/Avg/P50/P90 | Copy(us) Min/Max/Avg/P50/P90 | BW(GB/s) |
| --- | --- | ---: | ---: | --- | --- | ---: |
| `one_share_host_to_all_device_ce_multi_stream` | `ucm-toolkit run dev-sandbox copy -t one_share_host_to_all_device_ce_multi_stream -s 32K -n 160 -i 200 -d 7` | 32 | 1120 | 279 / 551 / 310 / 306 / 330 | 1563 / 2478 / 1857 / 1845 / 2017 | 18.406 |
| `all_odirect_host_to_all_device_ce_multi_stream` | `ucm-toolkit run dev-sandbox copy -t all_odirect_host_to_all_device_ce_multi_stream -s 32K -n 512 -i 20 -d 7` | 32 | 3584 | 991 / 1128 / 1057 / 1057 / 1109 | 4428 / 5371 / 4925 / 4895 / 5313 | 22.208 |
| `all_host_to_all_device_ce_multi_stream` | `ucm-toolkit run dev-sandbox copy -t all_host_to_all_device_ce_multi_stream -s 1M -n 512 -i 200 -d 7` | 1024 | 3584 | 919 / 1048 / 973 / 975 / 1004 | 20566 / 20673 / 20599 / 20596 / 20622 | 169.911 |