### PR TITLE
[Feat] Implement ttl eviction policy

### DIFF
--- a/ucm/store/dram/cc/dram_store.cc
+++ b/ucm/store/dram/cc/dram_store.cc
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/ucm/store/dram/cc/eviction_policy.h
+++ b/ucm/store/dram/cc/eviction_policy.h
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,8 @@
 #ifndef UNIFIEDCACHE_DRAM_STORE_CC_EVICTION_POLICY_H
 #define UNIFIEDCACHE_DRAM_STORE_CC_EVICTION_POLICY_H
 
+#include <set>
+#include <unordered_map>
 #include <vector>
 #include "entry.h"
 #include "status/status.h"
@@ -89,6 +91,47 @@ public:
      *         The ordering is policy-defined.
      */
     virtual std::vector<BlockId> GetEvictionResults(double evict_ratio) = 0;
+};
+
+/**
+ * @brief Common base for eviction policies backed by a std::multiset ordered
+ *        by a policy-specific comparator.
+ *
+ * Provides shared implementations of AddKey, DeleteKey, and AccessKey.
+ * Subclasses must supply their own comparator type as the template parameter
+ * and implement GetEvictionResults().
+ *
+ * @tparam Cmp Comparator type for ordering EntryPtr in the multiset.
+ */
+template <typename Cmp>
+class OrderedEvictionPolicy : public EvictionPolicy {
+public:
+    Status AddKey(const BlockId& key, EntryPtr entry) override
+    {
+        if (entry == nullptr) { return Status::InvalidParam(); }
+        if (index_.find(key) != index_.end()) { return Status::DuplicateKey(); }
+        auto it = entries_.insert(std::move(entry));
+        index_.emplace(key, it);
+        return Status::OK();
+    }
+
+    Status DeleteKey(const BlockId& key) override
+    {
+        auto mapIt = index_.find(key);
+        if (mapIt == index_.end()) { return Status::NotFound(); }
+        entries_.erase(mapIt->second);
+        index_.erase(mapIt);
+        return Status::OK();
+    }
+
+    Status AccessKey(const BlockId& /*key*/) override { return Status::OK(); }
+
+protected:
+    using EntrySet = std::multiset<EntryPtr, Cmp>;
+    using EntryIter = typename EntrySet::iterator;
+
+    EntrySet entries_;
+    std::unordered_map<BlockId, EntryIter, UC::Detail::BlockIdHasher> index_;
 };
 
 }  // namespace UC::DramStore

--- a/ucm/store/dram/cc/ttl_eviction_policy.h
+++ b/ucm/store/dram/cc/ttl_eviction_policy.h
@@ -21,51 +21,48 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  * */
-#ifndef UNIFIEDCACHE_DRAM_STORE_CC_ENTRY_H
-#define UNIFIEDCACHE_DRAM_STORE_CC_ENTRY_H
+#ifndef UNIFIEDCACHE_DRAM_STORE_CC_TTL_EVICTION_POLICY_H
+#define UNIFIEDCACHE_DRAM_STORE_CC_TTL_EVICTION_POLICY_H
 
 #include <chrono>
-#include <cstdint>
-#include <memory>
-#include "thread/lock.h"
-#include "type/types.h"
+#include <vector>
+#include "entry.h"
+#include "eviction_policy.h"
+#include "logger/logger.h"
 
 namespace UC::DramStore {
 
-using Spinlock = UC::SpinLock;
-using BlockId = UC::Detail::BlockId;
-
-enum class EntryStatus {
-    INITIALIZED = 0,
-    READY,
-    DELETING,
-};
-
-struct Entry {
-    BlockId key;
-    uint32_t refCnt{0};
-    uint32_t shard{0};
-    uint32_t slot{0};
-    void* addr{nullptr};
-    std::size_t size{0};
-    std::chrono::system_clock::time_point leaseTimeout{};
-    EntryStatus status{EntryStatus::INITIALIZED};
-    Spinlock lock;
-    std::chrono::system_clock::time_point lifeTimeout{};
-    uint32_t position{0};
-
-    bool TryMarkEvicting(std::chrono::system_clock::time_point now)
+struct TtlEntryCmp {
+    bool operator()(const EntryPtr& a, const EntryPtr& b) const noexcept
     {
-        SpinLockGuard guard(lock);
-        if (status != EntryStatus::READY) { return false; }
-        if (refCnt != 0) { return false; }
-        if (leaseTimeout > now) { return false; }
-        status = EntryStatus::DELETING;
-        return true;
+        return a->lifeTimeout < b->lifeTimeout;
     }
 };
 
-using EntryPtr = std::shared_ptr<Entry>;
+/**
+ * @brief Eviction policy that removes all entries whose lifetime has expired.
+ *
+ * Entries are ordered by lifeTimeout ascending. GetEvictionResults iterates
+ * from the earliest-expiring entry and breaks at the first entry whose
+ * lifeTimeout is still in the future.
+ */
+class TtlEvictionPolicy : public OrderedEvictionPolicy<TtlEntryCmp> {
+public:
+    std::vector<BlockId> GetEvictionResults(double /*evict_ratio*/) override
+    {
+        std::vector<BlockId> victims;
+        const auto now = std::chrono::system_clock::now();
+        for (const auto& entry : entries_) {
+            if (entry->lifeTimeout > now) { break; }
+            if (!entry->TryMarkEvicting(now)) { continue; }
+            victims.push_back(entry->key);
+        }
+        if (!victims.empty()) {
+            UC_INFO("TtlEvictionPolicy evict {} of {} entries.", victims.size(), entries_.size());
+        }
+        return victims;
+    }
+};
 
 }  // namespace UC::DramStore
 

--- a/ucm/store/test/CMakeLists.txt
+++ b/ucm/store/test/CMakeLists.txt
@@ -7,7 +7,7 @@ if(BUILD_UNIT_TESTS)
     add_executable(ucmstore.test ${UCMSTORE_TEST_SOURCE_FILES})
     target_include_directories(ucmstore.test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/case)
     target_link_libraries(ucmstore.test PRIVATE
-        posixstore cachestore fakestore pcstore
+        posixstore cachestore fakestore pcstore dramstore
         gtest_main gtest gmock
     )
     if(BUILD_UCM_ASU)

--- a/ucm/store/test/case/dram/dram_ttl_eviction_policy_test.cc
+++ b/ucm/store/test/case/dram/dram_ttl_eviction_policy_test.cc
@@ -1,0 +1,162 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <chrono>
+#include <gtest/gtest.h>
+#include <memory>
+#include "detail/types_helper.h"
+#include "dram/cc/entry.h"
+#include "dram/cc/ttl_eviction_policy.h"
+
+namespace {
+using Clock = std::chrono::system_clock;
+using TimePoint = Clock::time_point;
+using UC::DramStore::Entry;
+using UC::DramStore::EntryPtr;
+using UC::DramStore::EntryStatus;
+using UC::DramStore::TtlEvictionPolicy;
+
+EntryPtr MakeEntry(UC::Detail::BlockId key, TimePoint lifeTimeout,
+                   EntryStatus status = EntryStatus::READY, uint32_t refCnt = 0,
+                   TimePoint leaseTimeout = TimePoint{})
+{
+    auto e = std::make_shared<Entry>();
+    e->key = key;
+    e->lifeTimeout = lifeTimeout;
+    e->status = status;
+    e->refCnt = refCnt;
+    e->leaseTimeout = leaseTimeout;
+    return e;
+}
+
+UC::Detail::BlockId KeyFromHex(const char* hex)
+{
+    return UC::Test::Detail::TypesHelper::MakeBlockId(hex);
+}
+}  // namespace
+
+class UCTtlEvictionPolicyTest : public testing::Test {
+protected:
+    TtlEvictionPolicy policy_;
+    const TimePoint past_ = Clock::now() - std::chrono::seconds(10);
+    const TimePoint future_ = Clock::now() + std::chrono::seconds(10);
+};
+
+TEST_F(UCTtlEvictionPolicyTest, AddKeyReturnsOk)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, past_)).Success());
+}
+
+TEST_F(UCTtlEvictionPolicyTest, AddKeyDuplicateReturnsDuplicateKey)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, past_)).Success());
+    ASSERT_FALSE(policy_.AddKey(key, MakeEntry(key, past_)).Success());
+}
+
+TEST_F(UCTtlEvictionPolicyTest, AddKeyNullptrReturnsInvalidParam)
+{
+    auto key = KeyFromHex("a1");
+    auto st = policy_.AddKey(key, nullptr);
+    ASSERT_FALSE(st.Success());
+}
+
+TEST_F(UCTtlEvictionPolicyTest, DeleteKeyReturnsOkAndSecondIsNotFound)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, past_)).Success());
+    ASSERT_TRUE(policy_.DeleteKey(key).Success());
+    ASSERT_FALSE(policy_.DeleteKey(key).Success());
+}
+
+TEST_F(UCTtlEvictionPolicyTest, AccessKeyReturnsOk)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, past_)).Success());
+    ASSERT_TRUE(policy_.AccessKey(key).Success());
+}
+
+TEST_F(UCTtlEvictionPolicyTest, GetEvictionResultsEmptyWhenNoEntries)
+{
+    EXPECT_TRUE(policy_.GetEvictionResults(1.0).empty());
+}
+
+TEST_F(UCTtlEvictionPolicyTest, GetEvictionResultsEmptyWhenAllFuture)
+{
+    auto k1 = KeyFromHex("a1");
+    auto k2 = KeyFromHex("a2");
+    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1, future_)).Success());
+    ASSERT_TRUE(policy_.AddKey(k2, MakeEntry(k2, future_)).Success());
+    EXPECT_TRUE(policy_.GetEvictionResults(1.0).empty());
+}
+
+TEST_F(UCTtlEvictionPolicyTest, GetEvictionResultsEvictsExpiredReadyEntry)
+{
+    auto k1 = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1, past_)).Success());
+    auto victims = policy_.GetEvictionResults(1.0);
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(victims[0], k1);
+}
+
+TEST_F(UCTtlEvictionPolicyTest, GetEvictionResultsSkipsNonReadyAndContinues)
+{
+    auto kExpiredDeleting = KeyFromHex("a1");
+    auto kExpiredReady = KeyFromHex("a2");
+    auto kFutureReady = KeyFromHex("a3");
+    ASSERT_TRUE(
+        policy_.AddKey(kExpiredDeleting, MakeEntry(kExpiredDeleting, past_, EntryStatus::DELETING))
+            .Success());
+    ASSERT_TRUE(policy_.AddKey(kExpiredReady, MakeEntry(kExpiredReady, past_, EntryStatus::READY))
+                    .Success());
+    ASSERT_TRUE(policy_.AddKey(kFutureReady, MakeEntry(kFutureReady, future_, EntryStatus::READY))
+                    .Success());
+    auto victims = policy_.GetEvictionResults(1.0);
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(victims[0], kExpiredReady);
+}
+
+TEST_F(UCTtlEvictionPolicyTest, GetEvictionResultsSkipsNonZeroRefCnt)
+{
+    auto k = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(k, MakeEntry(k, past_, EntryStatus::READY, /*refCnt=*/1)).Success());
+    EXPECT_TRUE(policy_.GetEvictionResults(1.0).empty());
+}
+
+TEST_F(UCTtlEvictionPolicyTest, GetEvictionResultsSkipsLeasedEntry)
+{
+    auto k = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(k, MakeEntry(k, past_, EntryStatus::READY, 0, future_)).Success());
+    EXPECT_TRUE(policy_.GetEvictionResults(1.0).empty());
+}
+
+TEST_F(UCTtlEvictionPolicyTest, GetEvictionResultsMarksVictimsAsDeleting)
+{
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, past_);
+    ASSERT_TRUE(policy_.AddKey(k, entry).Success());
+    auto victims = policy_.GetEvictionResults(1.0);
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(entry->status, EntryStatus::DELETING);
+}


### PR DESCRIPTION
## Purpose
Implemet ttl eivction policy to evict all expired metadata.
The lifeTimeout attribute will be set when the data is added to server and will not be changed, the policy will try to evict all expired data.

**TTL eviction flow chart:**
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/77fbc099-a556-4f65-87c1-8d298b85d1da" />

**Class diagram:**
<img width="50%" alt="image" src="https://github.com/user-attachments/assets/5dc6f869-63c7-4ae3-8451-fb973811f4a8" />

## Modifications
1. `eviction_policy.h`: Add a new base class OrderedEvictionPolicy, use a multiset to order the entries and share implementations of AddKey, DeleteKey. Use a unordered_map to store the mapping of entry and its related iterator inside multiset for O(1) deletion.
2. `ttl_eviction_policy.h`: Inherited from OrderedEvictionPolicy, implemented GetEvictionResults and compare function, evict expired metadata.
3. `dram_ttl_eviction_policy_test.cc`: Unit tests for TtlEvictionPolicy.

## Test
```
      Start 56: UCTtlEvictionPolicyTest.AddKeyReturnsOk
56/99 Test #56: UCTtlEvictionPolicyTest.AddKeyReturnsOk ...........................................................   Passed    0.01 sec
      Start 57: UCTtlEvictionPolicyTest.AddKeyDuplicateReturnsDuplicateKey
57/99 Test #57: UCTtlEvictionPolicyTest.AddKeyDuplicateReturnsDuplicateKey ........................................   Passed    0.01 sec
      Start 58: UCTtlEvictionPolicyTest.AddKeyNullptrReturnsInvalidParam
58/99 Test #58: UCTtlEvictionPolicyTest.AddKeyNullptrReturnsInvalidParam ..........................................   Passed    0.01 sec
      Start 59: UCTtlEvictionPolicyTest.DeleteKeyReturnsOkAndSecondIsNotFound
59/99 Test #59: UCTtlEvictionPolicyTest.DeleteKeyReturnsOkAndSecondIsNotFound .....................................   Passed    0.01 sec
      Start 60: UCTtlEvictionPolicyTest.AccessKeyReturnsOk
60/99 Test #60: UCTtlEvictionPolicyTest.AccessKeyReturnsOk ........................................................   Passed    0.01 sec
      Start 61: UCTtlEvictionPolicyTest.GetEvictionResultsEmptyWhenNoEntries
61/99 Test #61: UCTtlEvictionPolicyTest.GetEvictionResultsEmptyWhenNoEntries ......................................   Passed    0.01 sec
      Start 62: UCTtlEvictionPolicyTest.GetEvictionResultsEmptyWhenAllFuture
62/99 Test #62: UCTtlEvictionPolicyTest.GetEvictionResultsEmptyWhenAllFuture ......................................   Passed    0.01 sec
      Start 63: UCTtlEvictionPolicyTest.GetEvictionResultsEvictsExpiredReadyEntry
63/99 Test #63: UCTtlEvictionPolicyTest.GetEvictionResultsEvictsExpiredReadyEntry .................................   Passed    0.01 sec
      Start 64: UCTtlEvictionPolicyTest.GetEvictionResultsSkipsNonReadyAndContinues
64/99 Test #64: UCTtlEvictionPolicyTest.GetEvictionResultsSkipsNonReadyAndContinues ...............................   Passed    0.01 sec
      Start 65: UCTtlEvictionPolicyTest.GetEvictionResultsSkipsNonZeroRefCnt
65/99 Test #65: UCTtlEvictionPolicyTest.GetEvictionResultsSkipsNonZeroRefCnt ......................................   Passed    0.01 sec
      Start 66: UCTtlEvictionPolicyTest.GetEvictionResultsSkipsLeasedEntry
66/99 Test #66: UCTtlEvictionPolicyTest.GetEvictionResultsSkipsLeasedEntry ........................................   Passed    0.01 sec
      Start 67: UCTtlEvictionPolicyTest.GetEvictionResultsMarksVictimsAsDeleting
67/99 Test #67: UCTtlEvictionPolicyTest.GetEvictionResultsMarksVictimsAsDeleting ..................................   Passed    0.01 sec
```