### PR TITLE
[Feat] Implement absolute position based eviction policy

### DIFF
--- a/ucm/store/dram/cc/eviction_policy.h
+++ b/ucm/store/dram/cc/eviction_policy.h
@@ -32,6 +32,11 @@
 
 namespace UC::DramStore {
 
+enum class EvictionPolicyType {
+    TTL = 0,
+    POSITION,
+};
+
 /**
  * @brief Abstract interface for cache eviction policies.
  *

--- a/ucm/store/dram/cc/pos_eviction_policy.h
+++ b/ucm/store/dram/cc/pos_eviction_policy.h
@@ -1,0 +1,75 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#ifndef UNIFIEDCACHE_DRAM_STORE_CC_POS_EVICTION_POLICY_H
+#define UNIFIEDCACHE_DRAM_STORE_CC_POS_EVICTION_POLICY_H
+
+#include <chrono>
+#include <vector>
+#include "entry.h"
+#include "eviction_policy.h"
+#include "logger/logger.h"
+
+namespace UC::DramStore {
+
+struct PosEntryCmp {
+    bool operator()(const EntryPtr& a, const EntryPtr& b) const noexcept
+    {
+        if (a->position != b->position) { return a->position > b->position; }
+        return a->lifeTimeout < b->lifeTimeout;
+    }
+};
+
+/**
+ * @brief Eviction policy that removes a fraction of entries selected by
+ *        position priority.
+ *
+ * Position represents the absolute position of the current metadata's KV
+ * cache within the inference request. Entries are ordered by position
+ * descending, tiebroken by lifeTimeout ascending. GetEvictionResults evicts
+ * up to evict_ratio * size() entries from the front of the ordering.
+ */
+class PosEvictionPolicy : public OrderedEvictionPolicy<PosEntryCmp> {
+public:
+    std::vector<BlockId> GetEvictionResults(double evict_ratio) override
+    {
+        std::vector<BlockId> victims;
+        const auto now = std::chrono::system_clock::now();
+        std::size_t target =
+            static_cast<std::size_t>(static_cast<double>(entries_.size()) * evict_ratio);
+        if (target > entries_.size()) { target = entries_.size(); }
+        for (const auto& entry : entries_) {
+            if (victims.size() >= target) { break; }
+            if (!entry->TryMarkEvicting(now)) { continue; }
+            victims.push_back(entry->key);
+        }
+        if (!victims.empty()) {
+            UC_INFO("PosEvictionPolicy evict {} of {} entries.", victims.size(), entries_.size());
+        }
+        return victims;
+    }
+};
+
+}  // namespace UC::DramStore
+
+#endif

--- a/ucm/store/test/case/dram/dram_pos_eviction_policy_test.cc
+++ b/ucm/store/test/case/dram/dram_pos_eviction_policy_test.cc
@@ -1,0 +1,175 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <chrono>
+#include <gtest/gtest.h>
+#include <memory>
+#include "dram/cc/entry.h"
+#include "dram/cc/pos_eviction_policy.h"
+#include "dram_test_common.h"
+
+using UC::DramStore::PosEvictionPolicy;
+using UC::Test::Dram::Clock;
+using UC::Test::Dram::EntryStatus;
+using UC::Test::Dram::KeyFromHex;
+using UC::Test::Dram::MakeEntry;
+using UC::Test::Dram::TimePoint;
+
+class UCPosEvictionPolicyTest : public testing::Test {
+protected:
+    PosEvictionPolicy policy_;
+    const TimePoint past_ = Clock::now() - std::chrono::seconds(10);
+    const TimePoint future_ = Clock::now() + std::chrono::seconds(10);
+};
+
+TEST_F(UCPosEvictionPolicyTest, AddKeyReturnsOk)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
+}
+
+TEST_F(UCPosEvictionPolicyTest, AddKeyDuplicateReturnsDuplicateKey)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
+    ASSERT_FALSE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
+}
+
+TEST_F(UCPosEvictionPolicyTest, AddKeyNullptrReturnsInvalidParam)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_FALSE(policy_.AddKey(key, nullptr).Success());
+}
+
+TEST_F(UCPosEvictionPolicyTest, DeleteKeyReturnsOkAndSecondIsNotFound)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
+    ASSERT_TRUE(policy_.DeleteKey(key).Success());
+    ASSERT_FALSE(policy_.DeleteKey(key).Success());
+}
+
+TEST_F(UCPosEvictionPolicyTest, AccessKeyReturnsOk)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
+    ASSERT_TRUE(policy_.AccessKey(key).Success());
+}
+
+TEST_F(UCPosEvictionPolicyTest, GetEvictionResultsEmptyWhenNoEntries)
+{
+    EXPECT_TRUE(policy_.GetEvictionResults(1.0).empty());
+}
+
+TEST_F(UCPosEvictionPolicyTest, GetEvictionResultsEvictsAllAtFullRatio)
+{
+    auto k1 = KeyFromHex("a1");
+    auto k2 = KeyFromHex("a2");
+    auto k3 = KeyFromHex("a3");
+    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1, 1, past_)).Success());
+    ASSERT_TRUE(policy_.AddKey(k2, MakeEntry(k2, 2, past_)).Success());
+    ASSERT_TRUE(policy_.AddKey(k3, MakeEntry(k3, 3, past_)).Success());
+    auto victims = policy_.GetEvictionResults(1.0);
+    ASSERT_EQ(victims.size(), 3UL);
+}
+
+TEST_F(UCPosEvictionPolicyTest, GetEvictionResultsRespectsEvictRatio)
+{
+    auto k1 = KeyFromHex("a1");
+    auto k2 = KeyFromHex("a2");
+    auto k3 = KeyFromHex("a3");
+    auto k4 = KeyFromHex("a4");
+    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1, 1, past_)).Success());
+    ASSERT_TRUE(policy_.AddKey(k2, MakeEntry(k2, 2, past_)).Success());
+    ASSERT_TRUE(policy_.AddKey(k3, MakeEntry(k3, 3, past_)).Success());
+    ASSERT_TRUE(policy_.AddKey(k4, MakeEntry(k4, 4, past_)).Success());
+    auto victims = policy_.GetEvictionResults(0.5);
+    ASSERT_EQ(victims.size(), 2UL);
+    EXPECT_EQ(victims[0], k4);
+    EXPECT_EQ(victims[1], k3);
+}
+
+TEST_F(UCPosEvictionPolicyTest, GetEvictionResultsOrdersByPositionDescending)
+{
+    auto kLow = KeyFromHex("a1");
+    auto kHigh = KeyFromHex("a2");
+    auto kMid = KeyFromHex("a3");
+    ASSERT_TRUE(policy_.AddKey(kLow, MakeEntry(kLow, 1, past_)).Success());
+    ASSERT_TRUE(policy_.AddKey(kHigh, MakeEntry(kHigh, 3, past_)).Success());
+    ASSERT_TRUE(policy_.AddKey(kMid, MakeEntry(kMid, 2, past_)).Success());
+    auto victims = policy_.GetEvictionResults(1.0);
+    ASSERT_EQ(victims.size(), 3UL);
+    EXPECT_EQ(victims[0], kHigh);
+    EXPECT_EQ(victims[1], kMid);
+    EXPECT_EQ(victims[2], kLow);
+}
+
+TEST_F(UCPosEvictionPolicyTest, GetEvictionResultsTiebreaksByLifeTimeoutAscending)
+{
+    auto kLater = KeyFromHex("a1");
+    auto kEarlier = KeyFromHex("a2");
+    ASSERT_TRUE(policy_.AddKey(kLater, MakeEntry(kLater, 5, future_)).Success());
+    ASSERT_TRUE(policy_.AddKey(kEarlier, MakeEntry(kEarlier, 5, past_)).Success());
+    auto victims = policy_.GetEvictionResults(1.0);
+    ASSERT_EQ(victims.size(), 2UL);
+    EXPECT_EQ(victims[0], kEarlier);
+    EXPECT_EQ(victims[1], kLater);
+}
+
+TEST_F(UCPosEvictionPolicyTest, GetEvictionResultsSkipsNonReadyAndContinues)
+{
+    auto kDeleting = KeyFromHex("a1");
+    auto kReady = KeyFromHex("a2");
+    ASSERT_TRUE(
+        policy_.AddKey(kDeleting, MakeEntry(kDeleting, 5, past_, EntryStatus::DELETING)).Success());
+    ASSERT_TRUE(policy_.AddKey(kReady, MakeEntry(kReady, 1, past_, EntryStatus::READY)).Success());
+    auto victims = policy_.GetEvictionResults(1.0);
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(victims[0], kReady);
+}
+
+TEST_F(UCPosEvictionPolicyTest, GetEvictionResultsSkipsNonZeroRefCnt)
+{
+    auto k = KeyFromHex("a1");
+    ASSERT_TRUE(
+        policy_.AddKey(k, MakeEntry(k, 1, past_, EntryStatus::READY, /*refCnt=*/1)).Success());
+    EXPECT_TRUE(policy_.GetEvictionResults(1.0).empty());
+}
+
+TEST_F(UCPosEvictionPolicyTest, GetEvictionResultsSkipsLeasedEntry)
+{
+    auto k = KeyFromHex("a1");
+    ASSERT_TRUE(
+        policy_.AddKey(k, MakeEntry(k, 1, past_, EntryStatus::READY, 0, future_)).Success());
+    EXPECT_TRUE(policy_.GetEvictionResults(1.0).empty());
+}
+
+TEST_F(UCPosEvictionPolicyTest, GetEvictionResultsMarksVictimsAsDeleting)
+{
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, 1, past_);
+    ASSERT_TRUE(policy_.AddKey(k, entry).Success());
+    auto victims = policy_.GetEvictionResults(1.0);
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(entry->status, EntryStatus::DELETING);
+}

--- a/ucm/store/test/case/dram/dram_test_common.h
+++ b/ucm/store/test/case/dram/dram_test_common.h
@@ -1,0 +1,64 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#ifndef UNIFIEDCACHE_TEST_DRAM_COMMON_H
+#define UNIFIEDCACHE_TEST_DRAM_COMMON_H
+
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include "detail/types_helper.h"
+#include "dram/cc/entry.h"
+
+namespace UC::Test::Dram {
+
+using Clock = std::chrono::system_clock;
+using TimePoint = Clock::time_point;
+
+using UC::DramStore::Entry;
+using UC::DramStore::EntryPtr;
+using UC::DramStore::EntryStatus;
+
+inline EntryPtr MakeEntry(UC::Detail::BlockId key, uint32_t position = 0,
+                          TimePoint lifeTimeout = TimePoint{},
+                          EntryStatus status = EntryStatus::READY, uint32_t refCnt = 0,
+                          TimePoint leaseTimeout = TimePoint{})
+{
+    auto e = std::make_shared<Entry>();
+    e->key = key;
+    e->position = position;
+    e->lifeTimeout = lifeTimeout;
+    e->status = status;
+    e->refCnt = refCnt;
+    e->leaseTimeout = leaseTimeout;
+    return e;
+}
+
+inline UC::Detail::BlockId KeyFromHex(const char* hex)
+{
+    return UC::Test::Detail::TypesHelper::MakeBlockId(hex);
+}
+
+}  // namespace UC::Test::Dram
+
+#endif

--- a/ucm/store/test/case/dram/dram_ttl_eviction_policy_test.cc
+++ b/ucm/store/test/case/dram/dram_ttl_eviction_policy_test.cc
@@ -24,36 +24,16 @@
 #include <chrono>
 #include <gtest/gtest.h>
 #include <memory>
-#include "detail/types_helper.h"
 #include "dram/cc/entry.h"
 #include "dram/cc/ttl_eviction_policy.h"
+#include "dram_test_common.h"
 
-namespace {
-using Clock = std::chrono::system_clock;
-using TimePoint = Clock::time_point;
-using UC::DramStore::Entry;
-using UC::DramStore::EntryPtr;
-using UC::DramStore::EntryStatus;
 using UC::DramStore::TtlEvictionPolicy;
-
-EntryPtr MakeEntry(UC::Detail::BlockId key, TimePoint lifeTimeout,
-                   EntryStatus status = EntryStatus::READY, uint32_t refCnt = 0,
-                   TimePoint leaseTimeout = TimePoint{})
-{
-    auto e = std::make_shared<Entry>();
-    e->key = key;
-    e->lifeTimeout = lifeTimeout;
-    e->status = status;
-    e->refCnt = refCnt;
-    e->leaseTimeout = leaseTimeout;
-    return e;
-}
-
-UC::Detail::BlockId KeyFromHex(const char* hex)
-{
-    return UC::Test::Detail::TypesHelper::MakeBlockId(hex);
-}
-}  // namespace
+using UC::Test::Dram::Clock;
+using UC::Test::Dram::EntryStatus;
+using UC::Test::Dram::KeyFromHex;
+using UC::Test::Dram::MakeEntry;
+using UC::Test::Dram::TimePoint;
 
 class UCTtlEvictionPolicyTest : public testing::Test {
 protected:
@@ -65,14 +45,14 @@ protected:
 TEST_F(UCTtlEvictionPolicyTest, AddKeyReturnsOk)
 {
     auto key = KeyFromHex("a1");
-    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, past_)).Success());
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
 }
 
 TEST_F(UCTtlEvictionPolicyTest, AddKeyDuplicateReturnsDuplicateKey)
 {
     auto key = KeyFromHex("a1");
-    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, past_)).Success());
-    ASSERT_FALSE(policy_.AddKey(key, MakeEntry(key, past_)).Success());
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
+    ASSERT_FALSE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
 }
 
 TEST_F(UCTtlEvictionPolicyTest, AddKeyNullptrReturnsInvalidParam)
@@ -85,7 +65,7 @@ TEST_F(UCTtlEvictionPolicyTest, AddKeyNullptrReturnsInvalidParam)
 TEST_F(UCTtlEvictionPolicyTest, DeleteKeyReturnsOkAndSecondIsNotFound)
 {
     auto key = KeyFromHex("a1");
-    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, past_)).Success());
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
     ASSERT_TRUE(policy_.DeleteKey(key).Success());
     ASSERT_FALSE(policy_.DeleteKey(key).Success());
 }
@@ -93,7 +73,7 @@ TEST_F(UCTtlEvictionPolicyTest, DeleteKeyReturnsOkAndSecondIsNotFound)
 TEST_F(UCTtlEvictionPolicyTest, AccessKeyReturnsOk)
 {
     auto key = KeyFromHex("a1");
-    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, past_)).Success());
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
     ASSERT_TRUE(policy_.AccessKey(key).Success());
 }
 
@@ -106,15 +86,15 @@ TEST_F(UCTtlEvictionPolicyTest, GetEvictionResultsEmptyWhenAllFuture)
 {
     auto k1 = KeyFromHex("a1");
     auto k2 = KeyFromHex("a2");
-    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1, future_)).Success());
-    ASSERT_TRUE(policy_.AddKey(k2, MakeEntry(k2, future_)).Success());
+    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1, 0, future_)).Success());
+    ASSERT_TRUE(policy_.AddKey(k2, MakeEntry(k2, 0, future_)).Success());
     EXPECT_TRUE(policy_.GetEvictionResults(1.0).empty());
 }
 
 TEST_F(UCTtlEvictionPolicyTest, GetEvictionResultsEvictsExpiredReadyEntry)
 {
     auto k1 = KeyFromHex("a1");
-    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1, past_)).Success());
+    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1, 0, past_)).Success());
     auto victims = policy_.GetEvictionResults(1.0);
     ASSERT_EQ(victims.size(), 1UL);
     EXPECT_EQ(victims[0], k1);
@@ -126,12 +106,15 @@ TEST_F(UCTtlEvictionPolicyTest, GetEvictionResultsSkipsNonReadyAndContinues)
     auto kExpiredReady = KeyFromHex("a2");
     auto kFutureReady = KeyFromHex("a3");
     ASSERT_TRUE(
-        policy_.AddKey(kExpiredDeleting, MakeEntry(kExpiredDeleting, past_, EntryStatus::DELETING))
+        policy_
+            .AddKey(kExpiredDeleting, MakeEntry(kExpiredDeleting, 0, past_, EntryStatus::DELETING))
             .Success());
-    ASSERT_TRUE(policy_.AddKey(kExpiredReady, MakeEntry(kExpiredReady, past_, EntryStatus::READY))
-                    .Success());
-    ASSERT_TRUE(policy_.AddKey(kFutureReady, MakeEntry(kFutureReady, future_, EntryStatus::READY))
-                    .Success());
+    ASSERT_TRUE(
+        policy_.AddKey(kExpiredReady, MakeEntry(kExpiredReady, 0, past_, EntryStatus::READY))
+            .Success());
+    ASSERT_TRUE(
+        policy_.AddKey(kFutureReady, MakeEntry(kFutureReady, 0, future_, EntryStatus::READY))
+            .Success());
     auto victims = policy_.GetEvictionResults(1.0);
     ASSERT_EQ(victims.size(), 1UL);
     EXPECT_EQ(victims[0], kExpiredReady);
@@ -140,21 +123,23 @@ TEST_F(UCTtlEvictionPolicyTest, GetEvictionResultsSkipsNonReadyAndContinues)
 TEST_F(UCTtlEvictionPolicyTest, GetEvictionResultsSkipsNonZeroRefCnt)
 {
     auto k = KeyFromHex("a1");
-    ASSERT_TRUE(policy_.AddKey(k, MakeEntry(k, past_, EntryStatus::READY, /*refCnt=*/1)).Success());
+    ASSERT_TRUE(
+        policy_.AddKey(k, MakeEntry(k, 0, past_, EntryStatus::READY, /*refCnt=*/1)).Success());
     EXPECT_TRUE(policy_.GetEvictionResults(1.0).empty());
 }
 
 TEST_F(UCTtlEvictionPolicyTest, GetEvictionResultsSkipsLeasedEntry)
 {
     auto k = KeyFromHex("a1");
-    ASSERT_TRUE(policy_.AddKey(k, MakeEntry(k, past_, EntryStatus::READY, 0, future_)).Success());
+    ASSERT_TRUE(
+        policy_.AddKey(k, MakeEntry(k, 0, past_, EntryStatus::READY, 0, future_)).Success());
     EXPECT_TRUE(policy_.GetEvictionResults(1.0).empty());
 }
 
 TEST_F(UCTtlEvictionPolicyTest, GetEvictionResultsMarksVictimsAsDeleting)
 {
     auto k = KeyFromHex("a1");
-    auto entry = MakeEntry(k, past_);
+    auto entry = MakeEntry(k, 0, past_);
     ASSERT_TRUE(policy_.AddKey(k, entry).Success());
     auto victims = policy_.GetEvictionResults(1.0);
     ASSERT_EQ(victims.size(), 1UL);


### PR DESCRIPTION
## Purpose
Implement PosEvictionPolicy to perform eviction started from the entry who has larger position.
Position refers to the absolute position of the KV cache within the request. The underlying idea is that KV cache entries located further back are less important, because the prefix cache performs matching from the beginning to the end.

**Absolute position eviction flow chart:**
<img width="40%" alt="image" src="https://github.com/user-attachments/assets/38795984-e029-4209-ae97-f157551ec49e" />

**Class diagram:**
<img width="80%" alt="image" src="https://github.com/user-attachments/assets/48fafe58-50bd-401d-afe8-12a94fcfef3b" />

## Modifications
1. `pos_eviction_policy.h`: Implementation of PosEvictionPolicy, inherited from OrderedEvictionPolicy.
2. `dram_pos_eviction_policy_test.cc`: Unit tests of PosEvictionPolicy.
3. `dram_test_common.h`: Common code for dram pool testing.
4. `dram_ttl_eviction_policy_test.cc`: Adaption after extracting common logic.
5. `eviction_policy.h`: Add EvictionPolicyType enum class for later usage.

## Test
```
        Start  56: UCPosEvictionPolicyTest.AddKeyReturnsOk
 56/113 Test  #56: UCPosEvictionPolicyTest.AddKeyReturnsOk ...........................................................   Passed    0.01 sec
        Start  57: UCPosEvictionPolicyTest.AddKeyDuplicateReturnsDuplicateKey
 57/113 Test  #57: UCPosEvictionPolicyTest.AddKeyDuplicateReturnsDuplicateKey ........................................   Passed    0.01 sec
        Start  58: UCPosEvictionPolicyTest.AddKeyNullptrReturnsInvalidParam
 58/113 Test  #58: UCPosEvictionPolicyTest.AddKeyNullptrReturnsInvalidParam ..........................................   Passed    0.01 sec
        Start  59: UCPosEvictionPolicyTest.DeleteKeyReturnsOkAndSecondIsNotFound
 59/113 Test  #59: UCPosEvictionPolicyTest.DeleteKeyReturnsOkAndSecondIsNotFound .....................................   Passed    0.01 sec
        Start  60: UCPosEvictionPolicyTest.AccessKeyReturnsOk
 60/113 Test  #60: UCPosEvictionPolicyTest.AccessKeyReturnsOk ........................................................   Passed    0.01 sec
        Start  61: UCPosEvictionPolicyTest.GetEvictionResultsEmptyWhenNoEntries
 61/113 Test  #61: UCPosEvictionPolicyTest.GetEvictionResultsEmptyWhenNoEntries ......................................   Passed    0.01 sec
        Start  62: UCPosEvictionPolicyTest.GetEvictionResultsEvictsAllAtFullRatio
 62/113 Test  #62: UCPosEvictionPolicyTest.GetEvictionResultsEvictsAllAtFullRatio ....................................   Passed    0.01 sec
        Start  63: UCPosEvictionPolicyTest.GetEvictionResultsRespectsEvictRatio
 63/113 Test  #63: UCPosEvictionPolicyTest.GetEvictionResultsRespectsEvictRatio ......................................   Passed    0.01 sec
        Start  64: UCPosEvictionPolicyTest.GetEvictionResultsOrdersByPositionDescending
 64/113 Test  #64: UCPosEvictionPolicyTest.GetEvictionResultsOrdersByPositionDescending ..............................   Passed    0.01 sec
        Start  65: UCPosEvictionPolicyTest.GetEvictionResultsTiebreaksByLifeTimeoutAscending
 65/113 Test  #65: UCPosEvictionPolicyTest.GetEvictionResultsTiebreaksByLifeTimeoutAscending .........................   Passed    0.01 sec
        Start  66: UCPosEvictionPolicyTest.GetEvictionResultsSkipsNonReadyAndContinues
 66/113 Test  #66: UCPosEvictionPolicyTest.GetEvictionResultsSkipsNonReadyAndContinues ...............................   Passed    0.01 sec
        Start  67: UCPosEvictionPolicyTest.GetEvictionResultsSkipsNonZeroRefCnt
 67/113 Test  #67: UCPosEvictionPolicyTest.GetEvictionResultsSkipsNonZeroRefCnt ......................................   Passed    0.01 sec
        Start  68: UCPosEvictionPolicyTest.GetEvictionResultsSkipsLeasedEntry
 68/113 Test  #68: UCPosEvictionPolicyTest.GetEvictionResultsSkipsLeasedEntry ........................................   Passed    0.01 sec
        Start  69: UCPosEvictionPolicyTest.GetEvictionResultsMarksVictimsAsDeleting
 69/113 Test  #69: UCPosEvictionPolicyTest.GetEvictionResultsMarksVictimsAsDeleting ..................................   Passed    0.01 sec
```
