### PR TITLE
[bugfix]wait_for WA block in wait_for_save

### DIFF
--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -1339,21 +1339,34 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         if wa_dump_keys:
             event_handle = self._get_dump_event_handle()
             window_ptrs = np.vstack(wa_ptr_rows)
-            if dump_request_ids not in self.tp_dump_tasks:
-                self.tp_dump_tasks[dump_request_ids] = []
             try:
-                self.tp_dump_tasks[dump_request_ids].append(
-                    self._submit_dump_task(
-                        "WA",
-                        self.wa_store,
-                        wa_dump_keys,
-                        window_ptrs,
-                        event_handle,
-                    )
+                # Sliding-window blocks can be released and reused by the next
+                # allocate_slots() call while the request is still running.
+                # Wait for the WA dump here so the store no longer references
+                # those source blocks when wait_for_save() returns.
+                wa_dump_task = self._submit_dump_task(
+                    "WA",
+                    self.wa_store,
+                    wa_dump_keys,
+                    window_ptrs,
+                    event_handle,
                 )
+                try:
+                    wa_dump_task.store.wait(wa_dump_task.task)
+                except Exception as e:
+                    logger.error(
+                        "Synchronous FAWA WA dump task failed; external cache "
+                        f"may miss. keys={wa_dump_task.key_count}, "
+                        f"{type(e).__name__}: {e}"
+                    )
+                    self._record_counter("connector_dump_wait_errors_total")
+                finally:
+                    self.device.destroy_event_handle(wa_dump_task.event_handle)
             except Exception as e:
                 self.device.destroy_event_handle(event_handle)
-                logger.error(f"dump FAWA kv cache failed. {type(e).__name__}: {e}")
+                logger.error(
+                    f"dump FAWA WA kv cache failed. {type(e).__name__}: {e}"
+                )
                 self._record_counter("connector_dump_submit_errors_total")
 
     def _poll_completed_dump_tasks(self) -> None:

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -1364,9 +1364,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                     self.device.destroy_event_handle(wa_dump_task.event_handle)
             except Exception as e:
                 self.device.destroy_event_handle(event_handle)
-                logger.error(
-                    f"dump FAWA WA kv cache failed. {type(e).__name__}: {e}"
-                )
+                logger.error(f"dump FAWA WA kv cache failed. {type(e).__name__}: {e}")
                 self._record_counter("connector_dump_submit_errors_total")
 
     def _poll_completed_dump_tasks(self) -> None:


### PR DESCRIPTION
## Purpose
Prevent sliding-window KV cache blocks from being released or reused while an asynchronous WA dump may still be reading them. This change also helps verify whether premature WA block reuse causes the intermittent corrupted output observed with DeepSeek V4 in long-context Agent workloads.
## Modifications
- Wait synchronously for each WA dump task in wait_for_save().
- Release the WA event handle only after the dump task completes or fails.
- Stop adding WA dump tasks to the asynchronous pending-task queue.
- Keep FA dumps asynchronous because full-attention blocks are protected by the request-level delayed-free lifecycle.
- Improve WA dump error messages while preserving the existing best-effort failure handling.