### PR TITLE
[fix] Preserve errno when POSIX AIO setup fails

### DIFF
--- a/ucm/store/posix/cc/aio_impl.cc
+++ b/ucm/store/posix/cc/aio_impl.cc
@@ -178,12 +178,13 @@ Status AioImpl::Setup(size_t timeoutMs)
         "submitTimeoutMs={}.",
         queueDepth_, epollTimeoutMs_, sweepIntervalMs_, submitTimeoutMs_);
     auto ret = AioSetup(queueDepth_, &ctx_);
+    auto eno = errno;
     if (ret != 0) {
-        UC_ERROR("Failed({}) to call AioSetup.", ret);
-        return Status::Error(std::to_string(ret));
+        UC_ERROR("Failed(ret={}, errno={}, message={}) to call AioSetup.", ret, eno, strerror(eno));
+        return Status{eno, std::string(strerror(eno))};
     }
     eventFd_ = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
-    auto eno = errno;
+    eno = errno;
     if (eventFd_ < 0) {
         UC_ERROR("Failed({}) to call eventfd.", eno);
         return Status::Error(std::string(strerror(eno)));


### PR DESCRIPTION
## Purpose

Improve error reporting when native POSIX AIO context initialization fails.

Previously, `AioSetup()` only propagated its `-1` return value, while the actual failure reason stored in `errno` was lost:

```text
RuntimeError: -1, -1
```

## Modifications

- Capture `errno` immediately after calling `AioSetup()`.
- Log the system call return value, errno, and corresponding error message.
- Return a `Status` containing the actual errno and error message.
- Reuse the existing `eno` variable for subsequent `eventfd` and epoll operations.
- Keep the existing error handling of subsequent system calls unchanged.

After this change, the Python exception contains the actual failure reason:

```text
RuntimeError: 11, Resource temporarily unavailable
```

## Test

- Reproduced an `io_setup()` failure after exhausting the system AIO event limit.
- Verified that the Python exception reports errno `11` and `Resource temporarily unavailable`.
- Passed `git diff --check`.