### PR TITLE
[Feat] Implement shard metadata management

### DIFF
--- a/ucm/shared/infra/thread/lock.h
+++ b/ucm/shared/infra/thread/lock.h
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,7 @@
 #define UNIFIEDCACHE_INFRA_LOCK_H
 
 #include <atomic>
+#include <shared_mutex>
 
 #if defined(__x86_64__)
 #include <immintrin.h>
@@ -65,6 +66,46 @@ public:
 
 private:
     SpinLock& lock_;
+};
+
+class RwLock {
+public:
+    RwLock() = default;
+    RwLock(const RwLock&) = delete;
+    RwLock& operator=(const RwLock&) = delete;
+
+    void LockReadOnly() noexcept { mtx_.lock_shared(); }
+    void UnlockReadOnly() noexcept { mtx_.unlock_shared(); }
+    bool TryLockReadOnly() noexcept { return mtx_.try_lock_shared(); }
+
+    void LockReadWrite() noexcept { mtx_.lock(); }
+    void UnlockReadWrite() noexcept { mtx_.unlock(); }
+    bool TryLockReadWrite() noexcept { return mtx_.try_lock(); }
+
+private:
+    std::shared_mutex mtx_;
+};
+
+class ReadOnlyGuard {
+public:
+    explicit ReadOnlyGuard(RwLock& lock) : lock_(lock) { lock_.LockReadOnly(); }
+    ~ReadOnlyGuard() { lock_.UnlockReadOnly(); }
+    ReadOnlyGuard(const ReadOnlyGuard&) = delete;
+    ReadOnlyGuard& operator=(const ReadOnlyGuard&) = delete;
+
+private:
+    RwLock& lock_;
+};
+
+class ReadWriteGuard {
+public:
+    explicit ReadWriteGuard(RwLock& lock) : lock_(lock) { lock_.LockReadWrite(); }
+    ~ReadWriteGuard() { lock_.UnlockReadWrite(); }
+    ReadWriteGuard(const ReadWriteGuard&) = delete;
+    ReadWriteGuard& operator=(const ReadWriteGuard&) = delete;
+
+private:
+    RwLock& lock_;
 };
 
 }  // namespace UC

--- a/ucm/shared/test/case/infra/lock_test.cc
+++ b/ucm/shared/test/case/infra/lock_test.cc
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,7 @@
 
 #include "thread/lock.h"
 #include <atomic>
+#include <chrono>
 #include <gtest/gtest.h>
 #include <thread>
 #include <vector>
@@ -88,4 +89,152 @@ TEST_F(UCSpinLockTest, MutualExclusionUnderContention)
     }
     for (auto& th : threads) { th.join(); }
     EXPECT_EQ(value.load(), nThread * iterPerThread);
+}
+
+class UCRwLockTest : public ::testing::Test {};
+
+TEST_F(UCRwLockTest, ReadOnlyLockUnlock)
+{
+    UC::RwLock lock;
+    lock.LockReadOnly();
+    EXPECT_TRUE(lock.TryLockReadOnly());
+    EXPECT_FALSE(lock.TryLockReadWrite());
+    lock.UnlockReadOnly();
+    EXPECT_FALSE(lock.TryLockReadWrite());
+    lock.UnlockReadOnly();
+    EXPECT_TRUE(lock.TryLockReadWrite());
+    lock.UnlockReadWrite();
+}
+
+TEST_F(UCRwLockTest, ReadWriteLockUnlock)
+{
+    UC::RwLock lock;
+    lock.LockReadWrite();
+    EXPECT_FALSE(lock.TryLockReadOnly());
+    EXPECT_FALSE(lock.TryLockReadWrite());
+    lock.UnlockReadWrite();
+    EXPECT_TRUE(lock.TryLockReadOnly());
+    lock.UnlockReadOnly();
+}
+
+TEST_F(UCRwLockTest, ReadOnlyGuardReleasesOnScopeExit)
+{
+    UC::RwLock lock;
+    {
+        UC::ReadOnlyGuard guard(lock);
+        EXPECT_FALSE(lock.TryLockReadWrite());
+    }
+    EXPECT_TRUE(lock.TryLockReadWrite());
+    lock.UnlockReadWrite();
+}
+
+TEST_F(UCRwLockTest, ReadWriteGuardReleasesOnScopeExit)
+{
+    UC::RwLock lock;
+    {
+        UC::ReadWriteGuard guard(lock);
+        EXPECT_FALSE(lock.TryLockReadOnly());
+        EXPECT_FALSE(lock.TryLockReadWrite());
+    }
+    EXPECT_TRUE(lock.TryLockReadOnly());
+    lock.UnlockReadOnly();
+    EXPECT_TRUE(lock.TryLockReadWrite());
+    lock.UnlockReadWrite();
+}
+
+TEST_F(UCRwLockTest, WriteBlocksReadersFromOtherThread)
+{
+    UC::RwLock lock;
+    std::atomic<bool> writerReady{false};
+    std::atomic<bool> stopHold{false};
+    std::thread writer([&] {
+        lock.LockReadWrite();
+        writerReady.store(true, std::memory_order_release);
+        while (!stopHold.load(std::memory_order_acquire)) { std::this_thread::yield(); }
+        lock.UnlockReadWrite();
+    });
+    while (!writerReady.load(std::memory_order_acquire)) { std::this_thread::yield(); }
+    EXPECT_FALSE(lock.TryLockReadOnly());
+    EXPECT_FALSE(lock.TryLockReadWrite());
+    stopHold.store(true, std::memory_order_release);
+    writer.join();
+    EXPECT_TRUE(lock.TryLockReadOnly());
+    lock.UnlockReadOnly();
+}
+
+TEST_F(UCRwLockTest, ReadBlocksWriterFromOtherThread)
+{
+    UC::RwLock lock;
+    std::atomic<bool> readerReady{false};
+    std::atomic<bool> stopHold{false};
+    std::thread reader([&] {
+        lock.LockReadOnly();
+        readerReady.store(true, std::memory_order_release);
+        while (!stopHold.load(std::memory_order_acquire)) { std::this_thread::yield(); }
+        lock.UnlockReadOnly();
+    });
+    while (!readerReady.load(std::memory_order_acquire)) { std::this_thread::yield(); }
+    EXPECT_FALSE(lock.TryLockReadWrite());
+    EXPECT_TRUE(lock.TryLockReadOnly());
+    lock.UnlockReadOnly();
+    stopHold.store(true, std::memory_order_release);
+    reader.join();
+    EXPECT_TRUE(lock.TryLockReadWrite());
+    lock.UnlockReadWrite();
+}
+
+TEST_F(UCRwLockTest, MultipleReadersShareLock)
+{
+    constexpr int nReader = 8;
+    UC::RwLock lock;
+    std::atomic<int> activeReaders{0};
+    std::atomic<int> maxReaders{0};
+    std::atomic<bool> stop{false};
+    std::vector<std::thread> threads;
+    threads.reserve(nReader);
+    for (int t = 0; t < nReader; ++t) {
+        threads.emplace_back([&] {
+            while (!stop.load(std::memory_order_acquire)) {
+                UC::ReadOnlyGuard guard(lock);
+                int cur = activeReaders.fetch_add(1, std::memory_order_acq_rel) + 1;
+                int prev = maxReaders.load(std::memory_order_acquire);
+                while (cur > prev &&
+                       !maxReaders.compare_exchange_weak(prev, cur, std::memory_order_acq_rel)) {}
+                std::this_thread::yield();
+                activeReaders.fetch_sub(1, std::memory_order_acq_rel);
+            }
+        });
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    stop.store(true, std::memory_order_release);
+    for (auto& th : threads) { th.join(); }
+    EXPECT_GT(maxReaders.load(), 1);
+}
+
+TEST_F(UCRwLockTest, WritersAreMutuallyExclusive)
+{
+    constexpr int nWriter = 8;
+    constexpr int iterPerThread = 500;
+    UC::RwLock lock;
+    std::atomic<int> value{0};
+    std::atomic<int> maxConcurrentWriters{0};
+    std::atomic<int> activeWriters{0};
+    std::vector<std::thread> threads;
+    threads.reserve(nWriter);
+    for (int t = 0; t < nWriter; ++t) {
+        threads.emplace_back([&] {
+            for (int i = 0; i < iterPerThread; ++i) {
+                UC::ReadWriteGuard guard(lock);
+                int cur = activeWriters.fetch_add(1, std::memory_order_acq_rel) + 1;
+                int prev = maxConcurrentWriters.load(std::memory_order_acquire);
+                while (cur > prev && !maxConcurrentWriters.compare_exchange_weak(
+                                         prev, cur, std::memory_order_acq_rel)) {}
+                value.fetch_add(1, std::memory_order_relaxed);
+                activeWriters.fetch_sub(1, std::memory_order_acq_rel);
+            }
+        });
+    }
+    for (auto& th : threads) { th.join(); }
+    EXPECT_EQ(value.load(), nWriter * iterPerThread);
+    EXPECT_EQ(maxConcurrentWriters.load(), 1);
 }

--- a/ucm/store/dram/cc/entry.h
+++ b/ucm/store/dram/cc/entry.h
@@ -33,6 +33,7 @@
 namespace UC::DramStore {
 
 using Spinlock = UC::SpinLock;
+using RwLock = UC::RwLock;
 using BlockId = UC::Detail::BlockId;
 
 enum class EntryStatus {
@@ -62,6 +63,30 @@ struct Entry {
         if (leaseTimeout > now) { return false; }
         status = EntryStatus::DELETING;
         return true;
+    }
+
+    void SetLeaseTimeout(std::chrono::system_clock::time_point timeout)
+    {
+        SpinLockGuard guard(lock);
+        leaseTimeout = timeout;
+    }
+
+    void IncRefCnt()
+    {
+        SpinLockGuard guard(lock);
+        ++refCnt;
+    }
+
+    void DecRefCnt()
+    {
+        SpinLockGuard guard(lock);
+        if (refCnt > 0) { --refCnt; }
+    }
+
+    void SetStatus(EntryStatus newStatus)
+    {
+        SpinLockGuard guard(lock);
+        status = newStatus;
     }
 };
 

--- a/ucm/store/dram/cc/metadata.cc
+++ b/ucm/store/dram/cc/metadata.cc
@@ -1,0 +1,132 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "metadata.h"
+#include "logger/logger.h"
+#include "pos_eviction_policy.h"
+#include "ttl_eviction_policy.h"
+
+namespace UC::DramStore {
+namespace {
+std::unique_ptr<EvictionPolicy> CreateEvictionPolicy(EvictionPolicyType type)
+{
+    switch (type) {
+        case EvictionPolicyType::TTL: return std::make_unique<TtlEvictionPolicy>();
+        case EvictionPolicyType::POSITION: return std::make_unique<PosEvictionPolicy>();
+        default: break;
+    }
+    UC_ERROR("CreateEvictionPolicy: invalid EvictionPolicyType {}.", static_cast<int>(type));
+    return nullptr;
+}
+}  // namespace
+
+ShardMetadata::ShardMetadata(const MetadataConfig& config)
+    : periodicEvictor_(CreateEvictionPolicy(config.periodicType)),
+      deepEvictor_(CreateEvictionPolicy(config.deepType)),
+      leaseTime_(config.leaseTime),
+      defaultEvictRatio_(config.defaultEvictRatio)
+{
+}
+
+Status ShardMetadata::AddKey(const BlockId& key, EntryPtr entry)
+{
+    ReadWriteGuard lock(mtx_);
+    if (metadata_.find(key) != metadata_.end()) {
+        UC_INFO("ShardMetadata AddKey: key already exists, skip.");
+        return Status::OK();
+    }
+    auto st = periodicEvictor_->AddKey(key, entry);
+    if (!st.Success()) {
+        UC_ERROR("ShardMetadata AddKey: periodicEvictor AddKey failed.");
+        return st;
+    }
+    st = deepEvictor_->AddKey(key, entry);
+    if (!st.Success()) {
+        UC_ERROR("ShardMetadata AddKey: deepEvictor AddKey failed, rollback periodicEvictor.");
+        periodicEvictor_->DeleteKey(key);
+        return st;
+    }
+    metadata_.emplace(key, std::move(entry));
+    return Status::OK();
+}
+
+Status ShardMetadata::AccessKey(const BlockId& key)
+{
+    ReadOnlyGuard lock(mtx_);
+    auto it = metadata_.find(key);
+    if (it == metadata_.end()) { return Status::NotFound(); }
+    it->second->SetLeaseTimeout(std::chrono::system_clock::now() + leaseTime_);
+    periodicEvictor_->AccessKey(key);
+    deepEvictor_->AccessKey(key);
+    return Status::OK();
+}
+
+Status ShardMetadata::DeleteKey(const BlockId& key)
+{
+    ReadWriteGuard lock(mtx_);
+    if (metadata_.find(key) == metadata_.end()) { return Status::NotFound(); }
+    periodicEvictor_->DeleteKey(key);
+    deepEvictor_->DeleteKey(key);
+    metadata_.erase(key);
+    return Status::OK();
+}
+
+bool ShardMetadata::QueryKey(const BlockId& key) const
+{
+    ReadOnlyGuard lock(mtx_);
+    return metadata_.find(key) != metadata_.end();
+}
+
+bool ShardMetadata::QueryKey(const BlockId& key, EntryPtr& entry) const
+{
+    ReadOnlyGuard lock(mtx_);
+    auto it = metadata_.find(key);
+    if (it == metadata_.end()) {
+        entry = nullptr;
+        return false;
+    }
+    entry = it->second;
+    return true;
+}
+
+std::size_t ShardMetadata::GetKeyCnt() const noexcept
+{
+    ReadOnlyGuard lock(mtx_);
+    return metadata_.size();
+}
+
+std::vector<BlockId> ShardMetadata::EvictPeriodic()
+{
+    ReadOnlyGuard lock(mtx_);
+    return periodicEvictor_->GetEvictionResults(defaultEvictRatio_);
+}
+
+std::vector<BlockId> ShardMetadata::EvictDeep() { return EvictDeep(defaultEvictRatio_); }
+
+std::vector<BlockId> ShardMetadata::EvictDeep(double evict_ratio)
+{
+    ReadOnlyGuard lock(mtx_);
+    return deepEvictor_->GetEvictionResults(evict_ratio);
+}
+
+}  // namespace UC::DramStore

--- a/ucm/store/dram/cc/metadata.h
+++ b/ucm/store/dram/cc/metadata.h
@@ -1,0 +1,77 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#ifndef UNIFIEDCACHE_DRAM_STORE_CC_METADATA_H
+#define UNIFIEDCACHE_DRAM_STORE_CC_METADATA_H
+
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+#include "entry.h"
+#include "eviction_policy.h"
+#include "status/status.h"
+
+namespace UC::DramStore {
+
+struct MetadataConfig {
+    EvictionPolicyType periodicType;
+    EvictionPolicyType deepType;
+    std::chrono::milliseconds leaseTime;
+    double defaultEvictRatio;
+};
+
+/**
+ * @brief Per-shard metadata container owning the key→Entry lookup map and
+ *        eviction coordination logic.
+ *
+ * ShardMetadata is the single entry-lifecycle surface for a shard. All public
+ * operations take an RwLock for read-only or read-write guard.
+ */
+class ShardMetadata {
+public:
+    explicit ShardMetadata(const MetadataConfig& config);
+
+    Status AddKey(const BlockId& key, EntryPtr entry);
+    Status AccessKey(const BlockId& key);
+    Status DeleteKey(const BlockId& key);
+    bool QueryKey(const BlockId& key) const;
+    bool QueryKey(const BlockId& key, EntryPtr& entry) const;
+    std::size_t GetKeyCnt() const noexcept;
+    std::vector<BlockId> EvictPeriodic();
+    std::vector<BlockId> EvictDeep();
+    std::vector<BlockId> EvictDeep(double evict_ratio);
+
+private:
+    mutable RwLock mtx_;
+    std::unordered_map<BlockId, EntryPtr, UC::Detail::BlockIdHasher> metadata_;
+    std::unique_ptr<EvictionPolicy> periodicEvictor_;
+    std::unique_ptr<EvictionPolicy> deepEvictor_;
+    std::chrono::milliseconds leaseTime_;
+    double defaultEvictRatio_;
+};
+
+}  // namespace UC::DramStore
+
+#endif

--- a/ucm/store/test/case/dram/dram_metadata_test.cc
+++ b/ucm/store/test/case/dram/dram_metadata_test.cc
@@ -1,0 +1,173 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <chrono>
+#include <gtest/gtest.h>
+#include <memory>
+#include "dram/cc/entry.h"
+#include "dram/cc/metadata.h"
+#include "dram_test_common.h"
+
+using UC::DramStore::EntryPtr;
+using UC::DramStore::EntryStatus;
+using UC::DramStore::EvictionPolicyType;
+using UC::DramStore::MetadataConfig;
+using UC::DramStore::ShardMetadata;
+using UC::Test::Dram::Clock;
+using UC::Test::Dram::KeyFromHex;
+using UC::Test::Dram::MakeEntry;
+using UC::Test::Dram::TimePoint;
+
+namespace {
+MetadataConfig MakeConfig(EvictionPolicyType periodic = EvictionPolicyType::TTL,
+                          EvictionPolicyType deep = EvictionPolicyType::POSITION,
+                          std::chrono::milliseconds leaseTime = std::chrono::milliseconds(100),
+                          double defaultEvictRatio = 1.0)
+{
+    return MetadataConfig{periodic, deep, leaseTime, defaultEvictRatio};
+}
+}  // namespace
+
+class UCShardMetadataTest : public testing::Test {
+protected:
+    const TimePoint past_ = Clock::now() - std::chrono::seconds(10);
+    const TimePoint future_ = Clock::now() + std::chrono::seconds(10);
+};
+
+TEST_F(UCShardMetadataTest, AddKeyReturnsOk)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    EXPECT_TRUE(md.AddKey(k, MakeEntry(k, 0, past_)).Success());
+}
+
+TEST_F(UCShardMetadataTest, AddKeyDuplicateReturnsOkAndKeepsSingleEntry)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    EXPECT_TRUE(md.AddKey(k, MakeEntry(k, 0, past_)).Success());
+    EXPECT_TRUE(md.AddKey(k, MakeEntry(k, 0, past_)).Success());
+    EXPECT_EQ(md.GetKeyCnt(), 1UL);
+}
+
+TEST_F(UCShardMetadataTest, AddKeyNullptrReturnsInvalidParam)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    EXPECT_FALSE(md.AddKey(k, nullptr).Success());
+}
+
+TEST_F(UCShardMetadataTest, DeleteKeyReturnsOkAndSecondIsNotFound)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    EXPECT_TRUE(md.AddKey(k, MakeEntry(k, 0, past_)).Success());
+    EXPECT_TRUE(md.DeleteKey(k).Success());
+    EXPECT_FALSE(md.DeleteKey(k).Success());
+}
+
+TEST_F(UCShardMetadataTest, QueryKeyReturnsTrueAfterAdd)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    md.AddKey(k, MakeEntry(k, 0, past_));
+    EXPECT_TRUE(md.QueryKey(k));
+}
+
+TEST_F(UCShardMetadataTest, QueryKeyReturnsFalseWhenMissing)
+{
+    ShardMetadata md(MakeConfig());
+    EXPECT_FALSE(md.QueryKey(KeyFromHex("a1")));
+}
+
+TEST_F(UCShardMetadataTest, QueryKeyWithEntryOutFillsEntry)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    auto added = MakeEntry(k, 0, past_);
+    md.AddKey(k, added);
+    EntryPtr out;
+    EXPECT_TRUE(md.QueryKey(k, out));
+    EXPECT_EQ(out, added);
+}
+
+TEST_F(UCShardMetadataTest, QueryKeyWithEntryOutReturnsFalseWhenMissing)
+{
+    ShardMetadata md(MakeConfig());
+    EntryPtr out = std::make_shared<UC::DramStore::Entry>();
+    EXPECT_FALSE(md.QueryKey(KeyFromHex("a1"), out));
+    EXPECT_EQ(out, nullptr);
+}
+
+TEST_F(UCShardMetadataTest, GetKeyCntReflectsAddsAndDeletes)
+{
+    ShardMetadata md(MakeConfig());
+    EXPECT_EQ(md.GetKeyCnt(), 0UL);
+    auto k1 = KeyFromHex("a1");
+    auto k2 = KeyFromHex("a2");
+    md.AddKey(k1, MakeEntry(k1, 0, past_));
+    md.AddKey(k2, MakeEntry(k2, 0, past_));
+    EXPECT_EQ(md.GetKeyCnt(), 2UL);
+    md.DeleteKey(k1);
+    EXPECT_EQ(md.GetKeyCnt(), 1UL);
+}
+
+TEST_F(UCShardMetadataTest, AccessKeyReturnsNotFoundWhenMissing)
+{
+    ShardMetadata md(MakeConfig());
+    EXPECT_FALSE(md.AccessKey(KeyFromHex("a1")).Success());
+}
+
+TEST_F(UCShardMetadataTest, AccessKeyUpdatesLeaseTimeout)
+{
+    ShardMetadata md(MakeConfig(EvictionPolicyType::TTL, EvictionPolicyType::POSITION,
+                                std::chrono::milliseconds(100)));
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, 0, past_);
+    md.AddKey(k, entry);
+    EXPECT_EQ(entry->leaseTimeout, TimePoint{});
+    EXPECT_TRUE(md.AccessKey(k).Success());
+    EXPECT_GT(entry->leaseTimeout, Clock::now());
+}
+
+TEST_F(UCShardMetadataTest, EvictPeriodicEvictsExpiredOnly)
+{
+    ShardMetadata md(MakeConfig());
+    auto kExpired = KeyFromHex("a1");
+    auto kFresh = KeyFromHex("a2");
+    md.AddKey(kExpired, MakeEntry(kExpired, 0, past_));
+    md.AddKey(kFresh, MakeEntry(kFresh, 0, future_));
+    auto victims = md.EvictPeriodic();
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(victims[0], kExpired);
+}
+
+TEST_F(UCShardMetadataTest, EvictPeriodicEvictsNothingWhenAllFresh)
+{
+    ShardMetadata md(MakeConfig());
+    auto k1 = KeyFromHex("a1");
+    auto k2 = KeyFromHex("a2");
+    md.AddKey(k1, MakeEntry(k1, 0, future_));
+    md.AddKey(k2, MakeEntry(k2, 0, future_));
+    EXPECT_TRUE(md.EvictPeriodic().empty());
+}


### PR DESCRIPTION
## Purpose
Implementation of shard metadata management, use to maintain the mapping relationship of key and entry, and perform add/delete/access/query/evict for a single shard metadata.
<img width="80%" alt="image" src="https://github.com/user-attachments/assets/cfb56257-7ff5-46e1-bd1b-2a2a8763ce67" />

## Modifications 
1. `lock.h`: Implement `RwLock` (read-only and read-write ops) based on `std::shared_mutex`, and add RAII guard for it.
2. `entry.h`: Add modification operations of entry.
3. `metadata.h`/`metadata.cc`: Implement `ShardMetadata`.
4. `lock_test.cc`: Add unit tests for `RwLock`.
5. `dram_metadata_test.cc`: Unit tests for `ShardMetadata`.

## Test
**RwLock:**
```
        Start  10: UCRwLockTest.ReadOnlyLockUnlock
 10/134 Test  #10: UCRwLockTest.ReadOnlyLockUnlock ...................................................................   Passed    0.00 sec
        Start  11: UCRwLockTest.ReadWriteLockUnlock
 11/134 Test  #11: UCRwLockTest.ReadWriteLockUnlock ..................................................................   Passed    0.00 sec
        Start  12: UCRwLockTest.ReadOnlyGuardReleasesOnScopeExit
 12/134 Test  #12: UCRwLockTest.ReadOnlyGuardReleasesOnScopeExit .....................................................   Passed    0.00 sec
        Start  13: UCRwLockTest.ReadWriteGuardReleasesOnScopeExit
 13/134 Test  #13: UCRwLockTest.ReadWriteGuardReleasesOnScopeExit ....................................................   Passed    0.00 sec
        Start  14: UCRwLockTest.WriteBlocksReadersFromOtherThread
 14/134 Test  #14: UCRwLockTest.WriteBlocksReadersFromOtherThread ....................................................   Passed    0.00 sec
        Start  15: UCRwLockTest.ReadBlocksWriterFromOtherThread
 15/134 Test  #15: UCRwLockTest.ReadBlocksWriterFromOtherThread ......................................................   Passed    0.00 sec
        Start  16: UCRwLockTest.MultipleReadersShareLock
 16/134 Test  #16: UCRwLockTest.MultipleReadersShareLock .............................................................   Passed    0.05 sec
        Start  17: UCRwLockTest.WritersAreMutuallyExclusive
 17/134 Test  #17: UCRwLockTest.WritersAreMutuallyExclusive ..........................................................   Passed    0.00 sec
```
**ShardMetadata:**
```
        Start  64: UCShardMetadataTest.AddKeyReturnsOk
 64/134 Test  #64: UCShardMetadataTest.AddKeyReturnsOk ...............................................................   Passed    0.02 sec
        Start  65: UCShardMetadataTest.AddKeyDuplicateReturnsOkAndKeepsSingleEntry
 65/134 Test  #65: UCShardMetadataTest.AddKeyDuplicateReturnsOkAndKeepsSingleEntry ...................................   Passed    0.01 sec
        Start  66: UCShardMetadataTest.AddKeyNullptrReturnsInvalidParam
 66/134 Test  #66: UCShardMetadataTest.AddKeyNullptrReturnsInvalidParam ..............................................   Passed    0.01 sec
        Start  67: UCShardMetadataTest.DeleteKeyReturnsOkAndSecondIsNotFound
 67/134 Test  #67: UCShardMetadataTest.DeleteKeyReturnsOkAndSecondIsNotFound .........................................   Passed    0.01 sec
        Start  68: UCShardMetadataTest.QueryKeyReturnsTrueAfterAdd
 68/134 Test  #68: UCShardMetadataTest.QueryKeyReturnsTrueAfterAdd ...................................................   Passed    0.01 sec
        Start  69: UCShardMetadataTest.QueryKeyReturnsFalseWhenMissing
 69/134 Test  #69: UCShardMetadataTest.QueryKeyReturnsFalseWhenMissing ...............................................   Passed    0.01 sec
        Start  70: UCShardMetadataTest.QueryKeyWithEntryOutFillsEntry
 70/134 Test  #70: UCShardMetadataTest.QueryKeyWithEntryOutFillsEntry ................................................   Passed    0.01 sec
        Start  71: UCShardMetadataTest.QueryKeyWithEntryOutReturnsFalseWhenMissing
 71/134 Test  #71: UCShardMetadataTest.QueryKeyWithEntryOutReturnsFalseWhenMissing ...................................   Passed    0.01 sec
        Start  72: UCShardMetadataTest.GetKeyCntReflectsAddsAndDeletes
 72/134 Test  #72: UCShardMetadataTest.GetKeyCntReflectsAddsAndDeletes ...............................................   Passed    0.01 sec
        Start  73: UCShardMetadataTest.AccessKeyReturnsNotFoundWhenMissing
 73/134 Test  #73: UCShardMetadataTest.AccessKeyReturnsNotFoundWhenMissing ...........................................   Passed    0.01 sec
        Start  74: UCShardMetadataTest.AccessKeyUpdatesLeaseTimeout
 74/134 Test  #74: UCShardMetadataTest.AccessKeyUpdatesLeaseTimeout ..................................................   Passed    0.01 sec
        Start  75: UCShardMetadataTest.EvictPeriodicEvictsExpiredOnly
 75/134 Test  #75: UCShardMetadataTest.EvictPeriodicEvictsExpiredOnly ................................................   Passed    0.01 sec
        Start  76: UCShardMetadataTest.EvictPeriodicEvictsNothingWhenAllFresh
 76/134 Test  #76: UCShardMetadataTest.EvictPeriodicEvictsNothingWhenAllFresh ........................................   Passed    0.01 sec
```
