### PR TITLE
[Feat] Implement LRU eviction policy

### DIFF
--- a/ucm/store/dram/cc/lru_eviction_policy.h
+++ b/ucm/store/dram/cc/lru_eviction_policy.h
@@ -79,11 +79,11 @@ public:
     std::vector<BlockId> GetEvictionResults(double evictRatio) override
     {
         std::vector<BlockId> victims;
-        if (evictRatio <= 0.0 || index_.empty()) { return victims; }
+        if (!std::isfinite(evictRatio) || evictRatio <= 0.0 || index_.empty()) { return victims; }
 
-        evictRatio = std::min(evictRatio, 1.0);
-        const auto target = static_cast<std::size_t>(
-            std::ceil(static_cast<double>(index_.size()) * evictRatio));
+        const double boundedRatio = std::min(evictRatio, 1.0);
+        const auto target =
+            static_cast<std::size_t>(static_cast<double>(index_.size()) * boundedRatio);
         const auto now = std::chrono::system_clock::now();
 
         for (auto it = lruList_.rbegin(); it != lruList_.rend() && victims.size() < target; ++it) {

--- a/ucm/store/dram/cc/lru_eviction_policy.h
+++ b/ucm/store/dram/cc/lru_eviction_policy.h
@@ -51,8 +51,8 @@ public:
         if (entry == nullptr) { return Status::InvalidParam(); }
         if (index_.find(key) != index_.end()) { return Status::DuplicateKey(); }
 
-        lruList_.push_front(key);
-        index_.emplace(key, LruNode{std::move(entry), lruList_.begin()});
+        lruList_.push_front(std::move(entry));
+        index_.emplace(key, lruList_.begin());
         return Status::OK();
     }
 
@@ -61,7 +61,7 @@ public:
         auto mapIt = index_.find(key);
         if (mapIt == index_.end()) { return Status::NotFound(); }
 
-        lruList_.erase(mapIt->second.iter);
+        lruList_.erase(mapIt->second);
         index_.erase(mapIt);
         return Status::OK();
     }
@@ -71,8 +71,7 @@ public:
         auto mapIt = index_.find(key);
         if (mapIt == index_.end()) { return Status::NotFound(); }
 
-        lruList_.splice(lruList_.begin(), lruList_, mapIt->second.iter);
-        mapIt->second.iter = lruList_.begin();
+        lruList_.splice(lruList_.begin(), lruList_, mapIt->second);
         return Status::OK();
     }
 
@@ -87,10 +86,9 @@ public:
         const auto now = std::chrono::system_clock::now();
 
         for (auto it = lruList_.rbegin(); it != lruList_.rend() && victims.size() < target; ++it) {
-            auto mapIt = index_.find(*it);
-            if (mapIt == index_.end()) { continue; }
-            if (!mapIt->second.entry->TryMarkEvicting(now)) { continue; }
-            victims.push_back(*it);
+            const auto& entry = *it;
+            if (!entry->TryMarkEvicting(now)) { continue; }
+            victims.push_back(entry->key);
         }
 
         if (!victims.empty()) {
@@ -100,15 +98,11 @@ public:
     }
 
 private:
-    using ListIter = std::list<BlockId>::iterator;
+    using LruList = std::list<EntryPtr>;
+    using ListIter = LruList::iterator;
 
-    struct LruNode {
-        EntryPtr entry;
-        ListIter iter;
-    };
-
-    std::list<BlockId> lruList_;
-    std::unordered_map<BlockId, LruNode, UC::Detail::BlockIdHasher> index_;
+    LruList lruList_;
+    std::unordered_map<BlockId, ListIter, UC::Detail::BlockIdHasher> index_;
 };
 
 }  // namespace UC::DramStore

--- a/ucm/store/dram/cc/lru_eviction_policy.h
+++ b/ucm/store/dram/cc/lru_eviction_policy.h
@@ -1,0 +1,116 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#ifndef UNIFIEDCACHE_DRAM_STORE_CC_LRU_EVICTION_POLICY_H
+#define UNIFIEDCACHE_DRAM_STORE_CC_LRU_EVICTION_POLICY_H
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <list>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "entry.h"
+#include "eviction_policy.h"
+#include "logger/logger.h"
+
+namespace UC::DramStore {
+
+/**
+ * @brief Eviction policy that removes least-recently-used entries first.
+ *
+ * The front of lruList_ is the most recently used entry, and the back is the
+ * least recently used entry. GetEvictionResults scans from the back and marks
+ * eligible entries as DELETING through Entry::TryMarkEvicting().
+ */
+class LruEvictionPolicy : public EvictionPolicy {
+public:
+    Status AddKey(const BlockId& key, EntryPtr entry) override
+    {
+        if (entry == nullptr) { return Status::InvalidParam(); }
+        if (index_.find(key) != index_.end()) { return Status::DuplicateKey(); }
+
+        lruList_.push_front(key);
+        index_.emplace(key, LruNode{std::move(entry), lruList_.begin()});
+        return Status::OK();
+    }
+
+    Status DeleteKey(const BlockId& key) override
+    {
+        auto mapIt = index_.find(key);
+        if (mapIt == index_.end()) { return Status::NotFound(); }
+
+        lruList_.erase(mapIt->second.iter);
+        index_.erase(mapIt);
+        return Status::OK();
+    }
+
+    Status AccessKey(const BlockId& key) override
+    {
+        auto mapIt = index_.find(key);
+        if (mapIt == index_.end()) { return Status::NotFound(); }
+
+        lruList_.splice(lruList_.begin(), lruList_, mapIt->second.iter);
+        mapIt->second.iter = lruList_.begin();
+        return Status::OK();
+    }
+
+    std::vector<BlockId> GetEvictionResults(double evictRatio) override
+    {
+        std::vector<BlockId> victims;
+        if (evictRatio <= 0.0 || index_.empty()) { return victims; }
+
+        evictRatio = std::min(evictRatio, 1.0);
+        const auto target = static_cast<std::size_t>(
+            std::ceil(static_cast<double>(index_.size()) * evictRatio));
+        const auto now = std::chrono::system_clock::now();
+
+        for (auto it = lruList_.rbegin(); it != lruList_.rend() && victims.size() < target; ++it) {
+            auto mapIt = index_.find(*it);
+            if (mapIt == index_.end()) { continue; }
+            if (!mapIt->second.entry->TryMarkEvicting(now)) { continue; }
+            victims.push_back(*it);
+        }
+
+        if (!victims.empty()) {
+            UC_INFO("LruEvictionPolicy evict {} of {} entries.", victims.size(), index_.size());
+        }
+        return victims;
+    }
+
+private:
+    using ListIter = std::list<BlockId>::iterator;
+
+    struct LruNode {
+        EntryPtr entry;
+        ListIter iter;
+    };
+
+    std::list<BlockId> lruList_;
+    std::unordered_map<BlockId, LruNode, UC::Detail::BlockIdHasher> index_;
+};
+
+}  // namespace UC::DramStore
+
+#endif

--- a/ucm/store/test/case/dram/dram_lru_eviction_policy_test.cc
+++ b/ucm/store/test/case/dram/dram_lru_eviction_policy_test.cc
@@ -23,6 +23,7 @@
  * */
 #include <chrono>
 #include <gtest/gtest.h>
+#include <limits>
 #include <memory>
 #include "detail/types_helper.h"
 #include "dram/cc/entry.h"
@@ -105,6 +106,15 @@ TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsEmptyWhenEvictRatioIsZero)
     EXPECT_TRUE(policy_.GetEvictionResults(0.0).empty());
 }
 
+TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsEmptyWhenEvictRatioIsInvalid)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key)).Success());
+
+    EXPECT_TRUE(policy_.GetEvictionResults(-0.1).empty());
+    EXPECT_TRUE(policy_.GetEvictionResults(std::numeric_limits<double>::quiet_NaN()).empty());
+}
+
 TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsEvictsOldestEntryFirst)
 {
     auto k1 = KeyFromHex("a1");
@@ -114,9 +124,39 @@ TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsEvictsOldestEntryFirst)
     ASSERT_TRUE(policy_.AddKey(k2, MakeEntry(k2)).Success());
     ASSERT_TRUE(policy_.AddKey(k3, MakeEntry(k3)).Success());
 
-    auto victims = policy_.GetEvictionResults(0.1);
+    auto victims = policy_.GetEvictionResults(0.34);
     ASSERT_EQ(victims.size(), 1UL);
     EXPECT_EQ(victims[0], k1);
+}
+
+TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsRespectsEvictRatio)
+{
+    auto k1 = KeyFromHex("a1");
+    auto k2 = KeyFromHex("a2");
+    auto k3 = KeyFromHex("a3");
+    auto k4 = KeyFromHex("a4");
+    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1)).Success());
+    ASSERT_TRUE(policy_.AddKey(k2, MakeEntry(k2)).Success());
+    ASSERT_TRUE(policy_.AddKey(k3, MakeEntry(k3)).Success());
+    ASSERT_TRUE(policy_.AddKey(k4, MakeEntry(k4)).Success());
+
+    auto victims = policy_.GetEvictionResults(0.5);
+    ASSERT_EQ(victims.size(), 2UL);
+    EXPECT_EQ(victims[0], k1);
+    EXPECT_EQ(victims[1], k2);
+}
+
+TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsClampsRatioAboveOne)
+{
+    auto k1 = KeyFromHex("a1");
+    auto k2 = KeyFromHex("a2");
+    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1)).Success());
+    ASSERT_TRUE(policy_.AddKey(k2, MakeEntry(k2)).Success());
+
+    auto victims = policy_.GetEvictionResults(1.5);
+    ASSERT_EQ(victims.size(), 2UL);
+    EXPECT_EQ(victims[0], k1);
+    EXPECT_EQ(victims[1], k2);
 }
 
 TEST_F(UCLruEvictionPolicyTest, AccessKeyMovesEntryToRecent)
@@ -129,9 +169,36 @@ TEST_F(UCLruEvictionPolicyTest, AccessKeyMovesEntryToRecent)
     ASSERT_TRUE(policy_.AddKey(k3, MakeEntry(k3)).Success());
     ASSERT_TRUE(policy_.AccessKey(k1).Success());
 
-    auto victims = policy_.GetEvictionResults(0.1);
+    auto victims = policy_.GetEvictionResults(0.34);
     ASSERT_EQ(victims.size(), 1UL);
     EXPECT_EQ(victims[0], k2);
+}
+
+TEST_F(UCLruEvictionPolicyTest, DeleteKeyPreservesLruOrder)
+{
+    auto k1 = KeyFromHex("a1");
+    auto k2 = KeyFromHex("a2");
+    auto k3 = KeyFromHex("a3");
+    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1)).Success());
+    ASSERT_TRUE(policy_.AddKey(k2, MakeEntry(k2)).Success());
+    ASSERT_TRUE(policy_.AddKey(k3, MakeEntry(k3)).Success());
+    ASSERT_TRUE(policy_.DeleteKey(k2).Success());
+
+    auto victims = policy_.GetEvictionResults(0.5);
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(victims[0], k1);
+}
+
+TEST_F(UCLruEvictionPolicyTest, DeleteKeyAllowsReinsert)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key)).Success());
+    ASSERT_TRUE(policy_.DeleteKey(key).Success());
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key)).Success());
+
+    auto victims = policy_.GetEvictionResults(1.0);
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(victims[0], key);
 }
 
 TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsSkipsNonReadyAndContinues)
@@ -150,8 +217,8 @@ TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsSkipsNonZeroRefCnt)
 {
     auto kInUse = KeyFromHex("a1");
     auto kReady = KeyFromHex("a2");
-    ASSERT_TRUE(policy_.AddKey(kInUse, MakeEntry(kInUse, EntryStatus::READY, /*refCnt=*/1))
-                    .Success());
+    ASSERT_TRUE(
+        policy_.AddKey(kInUse, MakeEntry(kInUse, EntryStatus::READY, /*refCnt=*/1)).Success());
     ASSERT_TRUE(policy_.AddKey(kReady, MakeEntry(kReady)).Success());
 
     auto victims = policy_.GetEvictionResults(1.0);
@@ -163,13 +230,27 @@ TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsSkipsLeasedEntry)
 {
     auto kLeased = KeyFromHex("a1");
     auto kReady = KeyFromHex("a2");
-    ASSERT_TRUE(policy_.AddKey(kLeased, MakeEntry(kLeased, EntryStatus::READY, 0, future_))
-                    .Success());
+    ASSERT_TRUE(
+        policy_.AddKey(kLeased, MakeEntry(kLeased, EntryStatus::READY, 0, future_)).Success());
     ASSERT_TRUE(policy_.AddKey(kReady, MakeEntry(kReady)).Success());
 
     auto victims = policy_.GetEvictionResults(1.0);
     ASSERT_EQ(victims.size(), 1UL);
     EXPECT_EQ(victims[0], kReady);
+}
+
+TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsEmptyWhenAllEntriesIneligible)
+{
+    auto kDeleting = KeyFromHex("a1");
+    auto kInUse = KeyFromHex("a2");
+    auto kLeased = KeyFromHex("a3");
+    ASSERT_TRUE(policy_.AddKey(kDeleting, MakeEntry(kDeleting, EntryStatus::DELETING)).Success());
+    ASSERT_TRUE(
+        policy_.AddKey(kInUse, MakeEntry(kInUse, EntryStatus::READY, /*refCnt=*/1)).Success());
+    ASSERT_TRUE(
+        policy_.AddKey(kLeased, MakeEntry(kLeased, EntryStatus::READY, 0, future_)).Success());
+
+    EXPECT_TRUE(policy_.GetEvictionResults(1.0).empty());
 }
 
 TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsMarksVictimsAsDeleting)

--- a/ucm/store/test/case/dram/dram_lru_eviction_policy_test.cc
+++ b/ucm/store/test/case/dram/dram_lru_eviction_policy_test.cc
@@ -24,35 +24,15 @@
 #include <chrono>
 #include <gtest/gtest.h>
 #include <limits>
-#include <memory>
-#include "detail/types_helper.h"
-#include "dram/cc/entry.h"
 #include "dram/cc/lru_eviction_policy.h"
+#include "dram_test_common.h"
 
-namespace {
-using Clock = std::chrono::system_clock;
-using TimePoint = Clock::time_point;
-using UC::DramStore::Entry;
-using UC::DramStore::EntryPtr;
-using UC::DramStore::EntryStatus;
 using UC::DramStore::LruEvictionPolicy;
-
-EntryPtr MakeEntry(UC::Detail::BlockId key, EntryStatus status = EntryStatus::READY,
-                   uint32_t refCnt = 0, TimePoint leaseTimeout = TimePoint{})
-{
-    auto e = std::make_shared<Entry>();
-    e->key = key;
-    e->status = status;
-    e->refCnt = refCnt;
-    e->leaseTimeout = leaseTimeout;
-    return e;
-}
-
-UC::Detail::BlockId KeyFromHex(const char* hex)
-{
-    return UC::Test::Detail::TypesHelper::MakeBlockId(hex);
-}
-}  // namespace
+using UC::Test::Dram::Clock;
+using UC::Test::Dram::EntryStatus;
+using UC::Test::Dram::KeyFromHex;
+using UC::Test::Dram::MakeEntry;
+using UC::Test::Dram::TimePoint;
 
 class UCLruEvictionPolicyTest : public testing::Test {
 protected:
@@ -205,7 +185,9 @@ TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsSkipsNonReadyAndContinues)
 {
     auto kDeleting = KeyFromHex("a1");
     auto kReady = KeyFromHex("a2");
-    ASSERT_TRUE(policy_.AddKey(kDeleting, MakeEntry(kDeleting, EntryStatus::DELETING)).Success());
+    ASSERT_TRUE(
+        policy_.AddKey(kDeleting, MakeEntry(kDeleting, 0, TimePoint{}, EntryStatus::DELETING))
+            .Success());
     ASSERT_TRUE(policy_.AddKey(kReady, MakeEntry(kReady)).Success());
 
     auto victims = policy_.GetEvictionResults(1.0);
@@ -218,7 +200,8 @@ TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsSkipsNonZeroRefCnt)
     auto kInUse = KeyFromHex("a1");
     auto kReady = KeyFromHex("a2");
     ASSERT_TRUE(
-        policy_.AddKey(kInUse, MakeEntry(kInUse, EntryStatus::READY, /*refCnt=*/1)).Success());
+        policy_.AddKey(kInUse, MakeEntry(kInUse, 0, TimePoint{}, EntryStatus::READY, /*refCnt=*/1))
+            .Success());
     ASSERT_TRUE(policy_.AddKey(kReady, MakeEntry(kReady)).Success());
 
     auto victims = policy_.GetEvictionResults(1.0);
@@ -231,7 +214,8 @@ TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsSkipsLeasedEntry)
     auto kLeased = KeyFromHex("a1");
     auto kReady = KeyFromHex("a2");
     ASSERT_TRUE(
-        policy_.AddKey(kLeased, MakeEntry(kLeased, EntryStatus::READY, 0, future_)).Success());
+        policy_.AddKey(kLeased, MakeEntry(kLeased, 0, TimePoint{}, EntryStatus::READY, 0, future_))
+            .Success());
     ASSERT_TRUE(policy_.AddKey(kReady, MakeEntry(kReady)).Success());
 
     auto victims = policy_.GetEvictionResults(1.0);
@@ -244,11 +228,15 @@ TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsEmptyWhenAllEntriesIneligible)
     auto kDeleting = KeyFromHex("a1");
     auto kInUse = KeyFromHex("a2");
     auto kLeased = KeyFromHex("a3");
-    ASSERT_TRUE(policy_.AddKey(kDeleting, MakeEntry(kDeleting, EntryStatus::DELETING)).Success());
     ASSERT_TRUE(
-        policy_.AddKey(kInUse, MakeEntry(kInUse, EntryStatus::READY, /*refCnt=*/1)).Success());
+        policy_.AddKey(kDeleting, MakeEntry(kDeleting, 0, TimePoint{}, EntryStatus::DELETING))
+            .Success());
     ASSERT_TRUE(
-        policy_.AddKey(kLeased, MakeEntry(kLeased, EntryStatus::READY, 0, future_)).Success());
+        policy_.AddKey(kInUse, MakeEntry(kInUse, 0, TimePoint{}, EntryStatus::READY, /*refCnt=*/1))
+            .Success());
+    ASSERT_TRUE(
+        policy_.AddKey(kLeased, MakeEntry(kLeased, 0, TimePoint{}, EntryStatus::READY, 0, future_))
+            .Success());
 
     EXPECT_TRUE(policy_.GetEvictionResults(1.0).empty());
 }

--- a/ucm/store/test/case/dram/dram_lru_eviction_policy_test.cc
+++ b/ucm/store/test/case/dram/dram_lru_eviction_policy_test.cc
@@ -1,0 +1,185 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <chrono>
+#include <gtest/gtest.h>
+#include <memory>
+#include "detail/types_helper.h"
+#include "dram/cc/entry.h"
+#include "dram/cc/lru_eviction_policy.h"
+
+namespace {
+using Clock = std::chrono::system_clock;
+using TimePoint = Clock::time_point;
+using UC::DramStore::Entry;
+using UC::DramStore::EntryPtr;
+using UC::DramStore::EntryStatus;
+using UC::DramStore::LruEvictionPolicy;
+
+EntryPtr MakeEntry(UC::Detail::BlockId key, EntryStatus status = EntryStatus::READY,
+                   uint32_t refCnt = 0, TimePoint leaseTimeout = TimePoint{})
+{
+    auto e = std::make_shared<Entry>();
+    e->key = key;
+    e->status = status;
+    e->refCnt = refCnt;
+    e->leaseTimeout = leaseTimeout;
+    return e;
+}
+
+UC::Detail::BlockId KeyFromHex(const char* hex)
+{
+    return UC::Test::Detail::TypesHelper::MakeBlockId(hex);
+}
+}  // namespace
+
+class UCLruEvictionPolicyTest : public testing::Test {
+protected:
+    LruEvictionPolicy policy_;
+    const TimePoint future_ = Clock::now() + std::chrono::seconds(10);
+};
+
+TEST_F(UCLruEvictionPolicyTest, AddKeyReturnsOk)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key)).Success());
+}
+
+TEST_F(UCLruEvictionPolicyTest, AddKeyDuplicateReturnsDuplicateKey)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key)).Success());
+    ASSERT_FALSE(policy_.AddKey(key, MakeEntry(key)).Success());
+}
+
+TEST_F(UCLruEvictionPolicyTest, AddKeyNullptrReturnsInvalidParam)
+{
+    auto key = KeyFromHex("a1");
+    auto st = policy_.AddKey(key, nullptr);
+    ASSERT_FALSE(st.Success());
+}
+
+TEST_F(UCLruEvictionPolicyTest, DeleteKeyReturnsOkAndSecondIsNotFound)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key)).Success());
+    ASSERT_TRUE(policy_.DeleteKey(key).Success());
+    ASSERT_FALSE(policy_.DeleteKey(key).Success());
+}
+
+TEST_F(UCLruEvictionPolicyTest, AccessKeyReturnsNotFoundForMissingKey)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_FALSE(policy_.AccessKey(key).Success());
+}
+
+TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsEmptyWhenNoEntries)
+{
+    EXPECT_TRUE(policy_.GetEvictionResults(1.0).empty());
+}
+
+TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsEmptyWhenEvictRatioIsZero)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key)).Success());
+    EXPECT_TRUE(policy_.GetEvictionResults(0.0).empty());
+}
+
+TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsEvictsOldestEntryFirst)
+{
+    auto k1 = KeyFromHex("a1");
+    auto k2 = KeyFromHex("a2");
+    auto k3 = KeyFromHex("a3");
+    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1)).Success());
+    ASSERT_TRUE(policy_.AddKey(k2, MakeEntry(k2)).Success());
+    ASSERT_TRUE(policy_.AddKey(k3, MakeEntry(k3)).Success());
+
+    auto victims = policy_.GetEvictionResults(0.1);
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(victims[0], k1);
+}
+
+TEST_F(UCLruEvictionPolicyTest, AccessKeyMovesEntryToRecent)
+{
+    auto k1 = KeyFromHex("a1");
+    auto k2 = KeyFromHex("a2");
+    auto k3 = KeyFromHex("a3");
+    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1)).Success());
+    ASSERT_TRUE(policy_.AddKey(k2, MakeEntry(k2)).Success());
+    ASSERT_TRUE(policy_.AddKey(k3, MakeEntry(k3)).Success());
+    ASSERT_TRUE(policy_.AccessKey(k1).Success());
+
+    auto victims = policy_.GetEvictionResults(0.1);
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(victims[0], k2);
+}
+
+TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsSkipsNonReadyAndContinues)
+{
+    auto kDeleting = KeyFromHex("a1");
+    auto kReady = KeyFromHex("a2");
+    ASSERT_TRUE(policy_.AddKey(kDeleting, MakeEntry(kDeleting, EntryStatus::DELETING)).Success());
+    ASSERT_TRUE(policy_.AddKey(kReady, MakeEntry(kReady)).Success());
+
+    auto victims = policy_.GetEvictionResults(1.0);
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(victims[0], kReady);
+}
+
+TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsSkipsNonZeroRefCnt)
+{
+    auto kInUse = KeyFromHex("a1");
+    auto kReady = KeyFromHex("a2");
+    ASSERT_TRUE(policy_.AddKey(kInUse, MakeEntry(kInUse, EntryStatus::READY, /*refCnt=*/1))
+                    .Success());
+    ASSERT_TRUE(policy_.AddKey(kReady, MakeEntry(kReady)).Success());
+
+    auto victims = policy_.GetEvictionResults(1.0);
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(victims[0], kReady);
+}
+
+TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsSkipsLeasedEntry)
+{
+    auto kLeased = KeyFromHex("a1");
+    auto kReady = KeyFromHex("a2");
+    ASSERT_TRUE(policy_.AddKey(kLeased, MakeEntry(kLeased, EntryStatus::READY, 0, future_))
+                    .Success());
+    ASSERT_TRUE(policy_.AddKey(kReady, MakeEntry(kReady)).Success());
+
+    auto victims = policy_.GetEvictionResults(1.0);
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(victims[0], kReady);
+}
+
+TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsMarksVictimsAsDeleting)
+{
+    auto key = KeyFromHex("a1");
+    auto entry = MakeEntry(key);
+    ASSERT_TRUE(policy_.AddKey(key, entry).Success());
+
+    auto victims = policy_.GetEvictionResults(1.0);
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(victims[0], key);
+    EXPECT_EQ(entry->status, EntryStatus::DELETING);
+}


### PR DESCRIPTION
## What

- Add an LRU eviction policy based on `std::list` and `std::unordered_map`.
- Move accessed entries to the most-recently-used position.
- Select eviction candidates from the least-recently-used end.
- Skip entries that are not ready, referenced, or still leased.
- Validate eviction ratios and align ratio rounding with the position eviction policy.

## Tests

- Add, duplicate add, delete, and reinsert tests.
- Verify LRU ordering and access updates.
- Verify eviction ratio handling.
- Verify invalid and oversized ratios.
- Verify non-ready, referenced, and leased entries are skipped.
- Verify selected entries are marked as `DELETING`.

## Verification

- Targeted LRU compilation and behavior tests passed.
- clang-format 20 check passed.
- `git diff --check` passed.
- Full CMake/CTest was not run locally because the current macOS environment is incompatible with the project's Linux linker flags.