### PR TITLE
[Feat] Implement shard metadata management

### DIFF
--- a/ucm/shared/infra/thread/lock.h
+++ b/ucm/shared/infra/thread/lock.h
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,7 @@
 #define UNIFIEDCACHE_INFRA_LOCK_H
 
 #include <atomic>
+#include <shared_mutex>
 
 #if defined(__x86_64__)
 #include <immintrin.h>
@@ -65,6 +66,46 @@ public:
 
 private:
     SpinLock& lock_;
+};
+
+class RwLock {
+public:
+    RwLock() = default;
+    RwLock(const RwLock&) = delete;
+    RwLock& operator=(const RwLock&) = delete;
+
+    void LockReadOnly() noexcept { mtx_.lock_shared(); }
+    void UnlockReadOnly() noexcept { mtx_.unlock_shared(); }
+    bool TryLockReadOnly() noexcept { return mtx_.try_lock_shared(); }
+
+    void LockReadWrite() noexcept { mtx_.lock(); }
+    void UnlockReadWrite() noexcept { mtx_.unlock(); }
+    bool TryLockReadWrite() noexcept { return mtx_.try_lock(); }
+
+private:
+    std::shared_mutex mtx_;
+};
+
+class ReadOnlyGuard {
+public:
+    explicit ReadOnlyGuard(RwLock& lock) : lock_(lock) { lock_.LockReadOnly(); }
+    ~ReadOnlyGuard() { lock_.UnlockReadOnly(); }
+    ReadOnlyGuard(const ReadOnlyGuard&) = delete;
+    ReadOnlyGuard& operator=(const ReadOnlyGuard&) = delete;
+
+private:
+    RwLock& lock_;
+};
+
+class ReadWriteGuard {
+public:
+    explicit ReadWriteGuard(RwLock& lock) : lock_(lock) { lock_.LockReadWrite(); }
+    ~ReadWriteGuard() { lock_.UnlockReadWrite(); }
+    ReadWriteGuard(const ReadWriteGuard&) = delete;
+    ReadWriteGuard& operator=(const ReadWriteGuard&) = delete;
+
+private:
+    RwLock& lock_;
 };
 
 }  // namespace UC

--- a/ucm/shared/test/case/infra/lock_test.cc
+++ b/ucm/shared/test/case/infra/lock_test.cc
@@ -1,7 +1,7 @@
 /**
  * MIT License
  *
- * Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,6 +24,7 @@
 
 #include "thread/lock.h"
 #include <atomic>
+#include <chrono>
 #include <gtest/gtest.h>
 #include <thread>
 #include <vector>
@@ -88,4 +89,152 @@ TEST_F(UCSpinLockTest, MutualExclusionUnderContention)
     }
     for (auto& th : threads) { th.join(); }
     EXPECT_EQ(value.load(), nThread * iterPerThread);
+}
+
+class UCRwLockTest : public ::testing::Test {};
+
+TEST_F(UCRwLockTest, ReadOnlyLockUnlock)
+{
+    UC::RwLock lock;
+    lock.LockReadOnly();
+    EXPECT_TRUE(lock.TryLockReadOnly());
+    EXPECT_FALSE(lock.TryLockReadWrite());
+    lock.UnlockReadOnly();
+    EXPECT_FALSE(lock.TryLockReadWrite());
+    lock.UnlockReadOnly();
+    EXPECT_TRUE(lock.TryLockReadWrite());
+    lock.UnlockReadWrite();
+}
+
+TEST_F(UCRwLockTest, ReadWriteLockUnlock)
+{
+    UC::RwLock lock;
+    lock.LockReadWrite();
+    EXPECT_FALSE(lock.TryLockReadOnly());
+    EXPECT_FALSE(lock.TryLockReadWrite());
+    lock.UnlockReadWrite();
+    EXPECT_TRUE(lock.TryLockReadOnly());
+    lock.UnlockReadOnly();
+}
+
+TEST_F(UCRwLockTest, ReadOnlyGuardReleasesOnScopeExit)
+{
+    UC::RwLock lock;
+    {
+        UC::ReadOnlyGuard guard(lock);
+        EXPECT_FALSE(lock.TryLockReadWrite());
+    }
+    EXPECT_TRUE(lock.TryLockReadWrite());
+    lock.UnlockReadWrite();
+}
+
+TEST_F(UCRwLockTest, ReadWriteGuardReleasesOnScopeExit)
+{
+    UC::RwLock lock;
+    {
+        UC::ReadWriteGuard guard(lock);
+        EXPECT_FALSE(lock.TryLockReadOnly());
+        EXPECT_FALSE(lock.TryLockReadWrite());
+    }
+    EXPECT_TRUE(lock.TryLockReadOnly());
+    lock.UnlockReadOnly();
+    EXPECT_TRUE(lock.TryLockReadWrite());
+    lock.UnlockReadWrite();
+}
+
+TEST_F(UCRwLockTest, WriteBlocksReadersFromOtherThread)
+{
+    UC::RwLock lock;
+    std::atomic<bool> writerReady{false};
+    std::atomic<bool> stopHold{false};
+    std::thread writer([&] {
+        lock.LockReadWrite();
+        writerReady.store(true, std::memory_order_release);
+        while (!stopHold.load(std::memory_order_acquire)) { std::this_thread::yield(); }
+        lock.UnlockReadWrite();
+    });
+    while (!writerReady.load(std::memory_order_acquire)) { std::this_thread::yield(); }
+    EXPECT_FALSE(lock.TryLockReadOnly());
+    EXPECT_FALSE(lock.TryLockReadWrite());
+    stopHold.store(true, std::memory_order_release);
+    writer.join();
+    EXPECT_TRUE(lock.TryLockReadOnly());
+    lock.UnlockReadOnly();
+}
+
+TEST_F(UCRwLockTest, ReadBlocksWriterFromOtherThread)
+{
+    UC::RwLock lock;
+    std::atomic<bool> readerReady{false};
+    std::atomic<bool> stopHold{false};
+    std::thread reader([&] {
+        lock.LockReadOnly();
+        readerReady.store(true, std::memory_order_release);
+        while (!stopHold.load(std::memory_order_acquire)) { std::this_thread::yield(); }
+        lock.UnlockReadOnly();
+    });
+    while (!readerReady.load(std::memory_order_acquire)) { std::this_thread::yield(); }
+    EXPECT_FALSE(lock.TryLockReadWrite());
+    EXPECT_TRUE(lock.TryLockReadOnly());
+    lock.UnlockReadOnly();
+    stopHold.store(true, std::memory_order_release);
+    reader.join();
+    EXPECT_TRUE(lock.TryLockReadWrite());
+    lock.UnlockReadWrite();
+}
+
+TEST_F(UCRwLockTest, MultipleReadersShareLock)
+{
+    constexpr int nReader = 8;
+    UC::RwLock lock;
+    std::atomic<int> activeReaders{0};
+    std::atomic<int> maxReaders{0};
+    std::atomic<bool> stop{false};
+    std::vector<std::thread> threads;
+    threads.reserve(nReader);
+    for (int t = 0; t < nReader; ++t) {
+        threads.emplace_back([&] {
+            while (!stop.load(std::memory_order_acquire)) {
+                UC::ReadOnlyGuard guard(lock);
+                int cur = activeReaders.fetch_add(1, std::memory_order_acq_rel) + 1;
+                int prev = maxReaders.load(std::memory_order_acquire);
+                while (cur > prev &&
+                       !maxReaders.compare_exchange_weak(prev, cur, std::memory_order_acq_rel)) {}
+                std::this_thread::yield();
+                activeReaders.fetch_sub(1, std::memory_order_acq_rel);
+            }
+        });
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    stop.store(true, std::memory_order_release);
+    for (auto& th : threads) { th.join(); }
+    EXPECT_GT(maxReaders.load(), 1);
+}
+
+TEST_F(UCRwLockTest, WritersAreMutuallyExclusive)
+{
+    constexpr int nWriter = 8;
+    constexpr int iterPerThread = 500;
+    UC::RwLock lock;
+    std::atomic<int> value{0};
+    std::atomic<int> maxConcurrentWriters{0};
+    std::atomic<int> activeWriters{0};
+    std::vector<std::thread> threads;
+    threads.reserve(nWriter);
+    for (int t = 0; t < nWriter; ++t) {
+        threads.emplace_back([&] {
+            for (int i = 0; i < iterPerThread; ++i) {
+                UC::ReadWriteGuard guard(lock);
+                int cur = activeWriters.fetch_add(1, std::memory_order_acq_rel) + 1;
+                int prev = maxConcurrentWriters.load(std::memory_order_acquire);
+                while (cur > prev && !maxConcurrentWriters.compare_exchange_weak(
+                                         prev, cur, std::memory_order_acq_rel)) {}
+                value.fetch_add(1, std::memory_order_relaxed);
+                activeWriters.fetch_sub(1, std::memory_order_acq_rel);
+            }
+        });
+    }
+    for (auto& th : threads) { th.join(); }
+    EXPECT_EQ(value.load(), nWriter * iterPerThread);
+    EXPECT_EQ(maxConcurrentWriters.load(), 1);
 }

--- a/ucm/store/dram/cc/entry.h
+++ b/ucm/store/dram/cc/entry.h
@@ -33,6 +33,7 @@
 namespace UC::DramStore {
 
 using Spinlock = UC::SpinLock;
+using RwLock = UC::RwLock;
 using BlockId = UC::Detail::BlockId;
 
 enum class EntryStatus {
@@ -54,6 +55,12 @@ struct Entry {
     std::chrono::system_clock::time_point lifeTimeout{};
     uint32_t position{0};
 
+    bool IsInitial()
+    {
+        SpinLockGuard guard(lock);
+        return status == EntryStatus::INITIALIZED && refCnt == 0;
+    }
+
     bool TryMarkEvicting(std::chrono::system_clock::time_point now)
     {
         SpinLockGuard guard(lock);
@@ -61,6 +68,39 @@ struct Entry {
         if (refCnt != 0) { return false; }
         if (leaseTimeout > now) { return false; }
         status = EntryStatus::DELETING;
+        return true;
+    }
+
+    bool TryMarkReady()
+    {
+        SpinLockGuard guard(lock);
+        if (status != EntryStatus::INITIALIZED) { return false; }
+        status = EntryStatus::READY;
+        return true;
+    }
+
+    bool TryMarkHit(std::chrono::system_clock::time_point timeout)
+    {
+        SpinLockGuard guard(lock);
+        if (status != EntryStatus::READY) { return false; }
+        leaseTimeout = timeout;
+        return true;
+    }
+
+    bool TryIncRef()
+    {
+        SpinLockGuard guard(lock);
+        if (status != EntryStatus::READY) { return false; }
+        ++refCnt;
+        return true;
+    }
+
+    bool TryDecRef()
+    {
+        SpinLockGuard guard(lock);
+        if (status != EntryStatus::READY) { return false; }
+        if (refCnt == 0) { return false; }
+        --refCnt;
         return true;
     }
 };

--- a/ucm/store/dram/cc/metadata.cc
+++ b/ucm/store/dram/cc/metadata.cc
@@ -1,0 +1,150 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "metadata.h"
+#include "logger/logger.h"
+#include "pos_eviction_policy.h"
+#include "ttl_eviction_policy.h"
+
+namespace UC::DramStore {
+namespace {
+std::unique_ptr<EvictionPolicy> CreateEvictionPolicy(EvictionPolicyType type)
+{
+    switch (type) {
+        case EvictionPolicyType::TTL: return std::make_unique<TtlEvictionPolicy>();
+        case EvictionPolicyType::POSITION: return std::make_unique<PosEvictionPolicy>();
+        default: break;
+    }
+    UC_ERROR("CreateEvictionPolicy: invalid EvictionPolicyType {}, fallback to TTL.",
+             static_cast<int>(type));
+    return std::make_unique<TtlEvictionPolicy>();
+}
+}  // namespace
+
+ShardMetadata::ShardMetadata(const MetadataConfig& config)
+    : periodicEvictor_(CreateEvictionPolicy(config.periodicType)),
+      deepEvictor_(CreateEvictionPolicy(config.deepType)),
+      leaseTime_(config.leaseTime)
+{
+}
+
+Status ShardMetadata::StoreBegin(const BlockId& key, EntryPtr entry)
+{
+    ReadWriteGuard lock(mtx_);
+    if (metadata_.find(key) != metadata_.end()) {
+        UC_INFO("ShardMetadata StoreBegin: key already exists, skip.");
+        return Status::OK();
+    }
+    if (entry == nullptr || !entry->IsInitial()) {
+        UC_ERROR("ShardMetadata StoreBegin: entry not in initial state.");
+        return Status::InvalidParam();
+    }
+    auto st = periodicEvictor_->AddKey(key, entry);
+    if (!st.Success()) {
+        UC_ERROR("ShardMetadata StoreBegin: periodicEvictor AddKey failed.");
+        return st;
+    }
+    st = deepEvictor_->AddKey(key, entry);
+    if (!st.Success()) {
+        UC_ERROR("ShardMetadata StoreBegin: deepEvictor AddKey failed, rollback periodicEvictor.");
+        periodicEvictor_->DeleteKey(key);
+        return st;
+    }
+    metadata_.emplace(key, std::move(entry));
+    return Status::OK();
+}
+
+Status ShardMetadata::StoreEnd(const BlockId& key)
+{
+    ReadOnlyGuard lock(mtx_);
+    auto it = metadata_.find(key);
+    if (it == metadata_.end()) { return Status::NotFound(); }
+    auto& entry = it->second;
+    return entry->TryMarkReady() ? Status::OK() : Status::Error();
+}
+
+Status ShardMetadata::LoadBegin(const BlockId& key)
+{
+    ReadOnlyGuard lock(mtx_);
+    auto it = metadata_.find(key);
+    if (it == metadata_.end()) { return Status::NotFound(); }
+    auto& entry = it->second;
+    if (!entry->TryIncRef()) { return Status::Error(); }
+    periodicEvictor_->AccessKey(key);
+    deepEvictor_->AccessKey(key);
+    return Status::OK();
+}
+
+Status ShardMetadata::LoadEnd(const BlockId& key)
+{
+    ReadOnlyGuard lock(mtx_);
+    auto it = metadata_.find(key);
+    if (it == metadata_.end()) { return Status::NotFound(); }
+    auto& entry = it->second;
+    return entry->TryDecRef() ? Status::OK() : Status::Error();
+}
+
+bool ShardMetadata::Exist(const BlockId& key)
+{
+    ReadOnlyGuard lock(mtx_);
+    auto it = metadata_.find(key);
+    if (it == metadata_.end()) { return false; }
+    auto& entry = it->second;
+    return entry->TryMarkHit(std::chrono::system_clock::now() + leaseTime_);
+}
+
+bool ShardMetadata::Query(const BlockId& key) const
+{
+    ReadOnlyGuard lock(mtx_);
+    return metadata_.find(key) != metadata_.end();
+}
+
+Status ShardMetadata::Delete(const BlockId& key)
+{
+    ReadWriteGuard lock(mtx_);
+    if (metadata_.find(key) == metadata_.end()) { return Status::NotFound(); }
+    periodicEvictor_->DeleteKey(key);
+    deepEvictor_->DeleteKey(key);
+    metadata_.erase(key);
+    return Status::OK();
+}
+
+std::size_t ShardMetadata::GetKeyCnt() const noexcept
+{
+    ReadOnlyGuard lock(mtx_);
+    return metadata_.size();
+}
+
+std::vector<BlockId> ShardMetadata::EvictPeriodic(double evict_ratio)
+{
+    ReadOnlyGuard lock(mtx_);
+    return periodicEvictor_->GetEvictionResults(evict_ratio);
+}
+
+std::vector<BlockId> ShardMetadata::EvictDeep(double evict_ratio)
+{
+    ReadOnlyGuard lock(mtx_);
+    return deepEvictor_->GetEvictionResults(evict_ratio);
+}
+
+}  // namespace UC::DramStore

--- a/ucm/store/dram/cc/metadata.h
+++ b/ucm/store/dram/cc/metadata.h
@@ -1,0 +1,136 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#ifndef UNIFIEDCACHE_DRAM_STORE_CC_METADATA_H
+#define UNIFIEDCACHE_DRAM_STORE_CC_METADATA_H
+
+#include <chrono>
+#include <cstddef>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+#include "entry.h"
+#include "eviction_policy.h"
+#include "status/status.h"
+
+namespace UC::DramStore {
+
+struct MetadataConfig {
+    EvictionPolicyType periodicType;
+    EvictionPolicyType deepType;
+    std::chrono::milliseconds leaseTime;
+    double defaultEvictRatio;
+};
+
+/**
+ * @brief Per-shard metadata container owning the key→Entry lookup map and
+ *        eviction coordination logic.
+ *
+ * ShardMetadata is the single entry-lifecycle surface for a shard. All public
+ * operations take an RwLock for read-only or read-write guard.
+ */
+class ShardMetadata {
+public:
+    explicit ShardMetadata(const MetadataConfig& config);
+
+    /**
+     * @brief Begin storing a new key. Write-locks the shard.
+     * @param key BlockId to register.
+     * @param entry Shared ownership of the Entry to associate with the key.
+     * @return Status::OK() on success; Status::InvalidParam() for a nullptr or
+     *         non-initial entry.
+     */
+    Status StoreBegin(const BlockId& key, EntryPtr entry);
+
+    /**
+     * @brief Finalize storage: transition the entry from INITIALIZED to READY.
+     *        Read-locks the shard.
+     * @return Status::OK() on success; Status::NotFound() if the key is
+     *         missing; Status::Error() if the entry is not INITIALIZED.
+     */
+    Status StoreEnd(const BlockId& key);
+
+    /**
+     * @brief Begin a load: increment the entry's refCnt and notify both
+     *        eviction policies of the access. Read-locks the shard.
+     * @return Status::OK() on success; Status::NotFound() if the key is
+     *         missing; Status::Error() if the entry is not READY.
+     */
+    Status LoadBegin(const BlockId& key);
+
+    /**
+     * @brief End a load: decrement the entry's refCnt. Read-locks the shard.
+     * @return Status::OK() on success; Status::NotFound() if the key is
+     *         missing; Status::Error() if the entry is not READY or refCnt
+     *         is already 0.
+     */
+    Status LoadEnd(const BlockId& key);
+
+    /**
+     * @brief Check whether the key is present and READY, refreshing its lease
+     *        timeout on a hit. Read-locks the shard.
+     * @return true if the key exists and the entry is READY (lease refreshed);
+     *         false otherwise (missing or not READY).
+     */
+    bool Exist(const BlockId& key);
+
+    /**
+     * @brief Check whether the key is present in the lookup map. Read-locks
+     *        the shard.
+     * @return true if the key exists, false otherwise.
+     */
+    bool Query(const BlockId& key) const;
+
+    /**
+     * @brief Delete a key and its entry. Write-locks the shard. Removes the
+     *        key from both eviction policies and the lookup map.
+     * @return Status::OK() on success; Status::NotFound() if the key is
+     *         missing.
+     */
+    Status Delete(const BlockId& key);
+
+    /**
+     * @brief Return the number of keys tracked by this shard. Read-locks.
+     */
+    std::size_t GetKeyCnt() const noexcept;
+
+    /**
+     * @brief Run the eviction policy and return the victim keys.
+     *        Read-locks the shard.
+     * @param evict_ratio Fraction of eligible entries to evict, in [0, 1].
+     * @return Keys selected for eviction.
+     */
+    std::vector<BlockId> EvictPeriodic(double evict_ratio);
+    std::vector<BlockId> EvictDeep(double evict_ratio);
+
+private:
+    mutable RwLock mtx_;
+    std::unordered_map<BlockId, EntryPtr, UC::Detail::BlockIdHasher> metadata_;
+    std::unique_ptr<EvictionPolicy> periodicEvictor_;
+    std::unique_ptr<EvictionPolicy> deepEvictor_;
+    std::chrono::milliseconds leaseTime_;
+};
+
+}  // namespace UC::DramStore
+
+#endif

--- a/ucm/store/test/case/dram/dram_metadata_test.cc
+++ b/ucm/store/test/case/dram/dram_metadata_test.cc
@@ -1,0 +1,260 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <chrono>
+#include <gtest/gtest.h>
+#include <memory>
+#include "dram/cc/entry.h"
+#include "dram/cc/metadata.h"
+#include "dram_test_common.h"
+
+using UC::DramStore::EntryPtr;
+using UC::DramStore::EntryStatus;
+using UC::DramStore::EvictionPolicyType;
+using UC::DramStore::MetadataConfig;
+using UC::DramStore::ShardMetadata;
+using UC::Test::Dram::Clock;
+using UC::Test::Dram::KeyFromHex;
+using UC::Test::Dram::MakeEntry;
+using UC::Test::Dram::TimePoint;
+
+namespace {
+MetadataConfig MakeConfig(EvictionPolicyType periodic = EvictionPolicyType::TTL,
+                          EvictionPolicyType deep = EvictionPolicyType::POSITION,
+                          std::chrono::milliseconds leaseTime = std::chrono::milliseconds(100),
+                          double defaultEvictRatio = 1.0)
+{
+    return MetadataConfig{periodic, deep, leaseTime, defaultEvictRatio};
+}
+}  // namespace
+
+class UCShardMetadataTest : public testing::Test {
+protected:
+    const TimePoint past_ = Clock::now() - std::chrono::seconds(10);
+    const TimePoint future_ = Clock::now() + std::chrono::seconds(10);
+};
+
+TEST_F(UCShardMetadataTest, StoreBeginReturnsOk)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    EXPECT_TRUE(md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED)).Success());
+}
+
+TEST_F(UCShardMetadataTest, StoreBeginDuplicateReturnsOkAndKeepsSingleEntry)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    EXPECT_TRUE(md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED)).Success());
+    EXPECT_TRUE(md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED)).Success());
+    EXPECT_EQ(md.GetKeyCnt(), 1UL);
+}
+
+TEST_F(UCShardMetadataTest, StoreBeginNullptrReturnsInvalidParam)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    EXPECT_FALSE(md.StoreBegin(k, nullptr).Success());
+}
+
+TEST_F(UCShardMetadataTest, StoreBeginRejectsReadyEntry)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    EXPECT_FALSE(md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::READY)).Success());
+}
+
+TEST_F(UCShardMetadataTest, StoreBeginRejectsNonZeroRefCnt)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    EXPECT_FALSE(
+        md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED, /*refCnt=*/1)).Success());
+}
+
+TEST_F(UCShardMetadataTest, StoreEndMarksInitializedAsReady)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
+    md.StoreBegin(k, entry);
+    EXPECT_EQ(entry->status, EntryStatus::INITIALIZED);
+    EXPECT_TRUE(md.StoreEnd(k).Success());
+    EXPECT_EQ(entry->status, EntryStatus::READY);
+}
+
+TEST_F(UCShardMetadataTest, StoreEndReturnsErrorWhenNotInitialized)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
+    md.StoreBegin(k, entry);
+    ASSERT_TRUE(md.StoreEnd(k).Success());
+    EXPECT_FALSE(md.StoreEnd(k).Success());
+}
+
+TEST_F(UCShardMetadataTest, StoreEndReturnsNotFoundWhenMissing)
+{
+    ShardMetadata md(MakeConfig());
+    EXPECT_FALSE(md.StoreEnd(KeyFromHex("a1")).Success());
+}
+
+TEST_F(UCShardMetadataTest, LoadBeginReturnsNotFoundWhenMissing)
+{
+    ShardMetadata md(MakeConfig());
+    EXPECT_FALSE(md.LoadBegin(KeyFromHex("a1")).Success());
+}
+
+TEST_F(UCShardMetadataTest, LoadBeginIncrementsRefCnt)
+{
+    ShardMetadata md(MakeConfig(EvictionPolicyType::TTL, EvictionPolicyType::POSITION,
+                                std::chrono::milliseconds(100)));
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
+    md.StoreBegin(k, entry);
+    md.StoreEnd(k);
+    EXPECT_EQ(entry->refCnt, 0U);
+    EXPECT_TRUE(md.LoadBegin(k).Success());
+    EXPECT_EQ(entry->refCnt, 1U);
+}
+
+TEST_F(UCShardMetadataTest, LoadBeginReturnsErrorWhenNotReady)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
+    md.StoreBegin(k, entry);
+    EXPECT_FALSE(md.LoadBegin(k).Success());
+    EXPECT_EQ(entry->refCnt, 0U);
+}
+
+TEST_F(UCShardMetadataTest, LoadEndReturnsNotFoundWhenMissing)
+{
+    ShardMetadata md(MakeConfig());
+    EXPECT_FALSE(md.LoadEnd(KeyFromHex("a1")).Success());
+}
+
+TEST_F(UCShardMetadataTest, LoadEndDecrementsRefCnt)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
+    md.StoreBegin(k, entry);
+    md.StoreEnd(k);
+    md.LoadBegin(k);
+    ASSERT_EQ(entry->refCnt, 1U);
+    EXPECT_TRUE(md.LoadEnd(k).Success());
+    EXPECT_EQ(entry->refCnt, 0U);
+}
+
+TEST_F(UCShardMetadataTest, LoadEndReturnsErrorWhenRefCntIsZero)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED));
+    md.StoreEnd(k);
+    EXPECT_FALSE(md.LoadEnd(k).Success());
+}
+
+TEST_F(UCShardMetadataTest, ExistReturnsTrueAndRefreshesLeaseWhenReady)
+{
+    ShardMetadata md(MakeConfig(EvictionPolicyType::TTL, EvictionPolicyType::POSITION,
+                                std::chrono::milliseconds(100)));
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
+    md.StoreBegin(k, entry);
+    md.StoreEnd(k);
+    EXPECT_EQ(entry->leaseTimeout, TimePoint{});
+    EXPECT_TRUE(md.Exist(k));
+    EXPECT_GT(entry->leaseTimeout, Clock::now());
+}
+
+TEST_F(UCShardMetadataTest, ExistReturnsFalseWhenNotReady)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
+    md.StoreBegin(k, entry);
+    EXPECT_FALSE(md.Exist(k));
+}
+
+TEST_F(UCShardMetadataTest, ExistReturnsFalseWhenMissing)
+{
+    ShardMetadata md(MakeConfig());
+    EXPECT_FALSE(md.Exist(KeyFromHex("a1")));
+}
+
+TEST_F(UCShardMetadataTest, QueryReturnsTrueAfterAdd)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED));
+    EXPECT_TRUE(md.Query(k));
+}
+
+TEST_F(UCShardMetadataTest, QueryReturnsFalseWhenMissing)
+{
+    ShardMetadata md(MakeConfig());
+    EXPECT_FALSE(md.Query(KeyFromHex("a1")));
+}
+
+TEST_F(UCShardMetadataTest, DeleteReturnsOkAndSecondIsNotFound)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    EXPECT_TRUE(md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED)).Success());
+    EXPECT_TRUE(md.Delete(k).Success());
+    EXPECT_FALSE(md.Delete(k).Success());
+}
+
+TEST_F(UCShardMetadataTest, GetKeyCntReflectsAddsAndDeletes)
+{
+    ShardMetadata md(MakeConfig());
+    EXPECT_EQ(md.GetKeyCnt(), 0UL);
+    auto k1 = KeyFromHex("a1");
+    auto k2 = KeyFromHex("a2");
+    md.StoreBegin(k1, MakeEntry(k1, 0, past_, EntryStatus::INITIALIZED));
+    md.StoreBegin(k2, MakeEntry(k2, 0, past_, EntryStatus::INITIALIZED));
+    EXPECT_EQ(md.GetKeyCnt(), 2UL);
+    md.Delete(k1);
+    EXPECT_EQ(md.GetKeyCnt(), 1UL);
+}
+
+TEST_F(UCShardMetadataTest, FullLifecycleStoreStoreEndLoadExist)
+{
+    ShardMetadata md(MakeConfig(EvictionPolicyType::TTL, EvictionPolicyType::POSITION,
+                                std::chrono::milliseconds(100)));
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
+    EXPECT_TRUE(md.StoreBegin(k, entry).Success());
+    EXPECT_EQ(entry->status, EntryStatus::INITIALIZED);
+    EXPECT_FALSE(md.LoadBegin(k).Success());
+    EXPECT_TRUE(md.StoreEnd(k).Success());
+    EXPECT_EQ(entry->status, EntryStatus::READY);
+    EXPECT_TRUE(md.LoadBegin(k).Success());
+    EXPECT_EQ(entry->refCnt, 1U);
+    EXPECT_TRUE(md.Exist(k));
+    EXPECT_GT(entry->leaseTimeout, Clock::now());
+    EXPECT_TRUE(md.LoadEnd(k).Success());
+    EXPECT_EQ(entry->refCnt, 0U);
+}


### PR DESCRIPTION
## Purpose
Implementation of shard metadata management, use to maintain the mapping relationship of key and entry, and perform data manage operations for a single shard metadata.
<img width="2406" height="1812" alt="image" src="https://github.com/user-attachments/assets/1f2893ac-903a-4147-a553-ef114c6d822d" />


## Modifications 
1. `lock.h`: Implement `RwLock` (read-only and read-write ops) based on `std::shared_mutex`, and add RAII guard for it.
2. `entry.h`: Add modification operations of entry.
3. `metadata.h`/`metadata.cc`: Implement `ShardMetadata`.
4. `lock_test.cc`: Add unit tests for `RwLock`.
5. `dram_metadata_test.cc`: Unit tests for `ShardMetadata`.

## Test
**RwLock:**
```
        Start  10: UCRwLockTest.ReadOnlyLockUnlock
 10/134 Test  #10: UCRwLockTest.ReadOnlyLockUnlock ...................................................................   Passed    0.00 sec
        Start  11: UCRwLockTest.ReadWriteLockUnlock
 11/134 Test  #11: UCRwLockTest.ReadWriteLockUnlock ..................................................................   Passed    0.00 sec
        Start  12: UCRwLockTest.ReadOnlyGuardReleasesOnScopeExit
 12/134 Test  #12: UCRwLockTest.ReadOnlyGuardReleasesOnScopeExit .....................................................   Passed    0.00 sec
        Start  13: UCRwLockTest.ReadWriteGuardReleasesOnScopeExit
 13/134 Test  #13: UCRwLockTest.ReadWriteGuardReleasesOnScopeExit ....................................................   Passed    0.00 sec
        Start  14: UCRwLockTest.WriteBlocksReadersFromOtherThread
 14/134 Test  #14: UCRwLockTest.WriteBlocksReadersFromOtherThread ....................................................   Passed    0.00 sec
        Start  15: UCRwLockTest.ReadBlocksWriterFromOtherThread
 15/134 Test  #15: UCRwLockTest.ReadBlocksWriterFromOtherThread ......................................................   Passed    0.00 sec
        Start  16: UCRwLockTest.MultipleReadersShareLock
 16/134 Test  #16: UCRwLockTest.MultipleReadersShareLock .............................................................   Passed    0.05 sec
        Start  17: UCRwLockTest.WritersAreMutuallyExclusive
 17/134 Test  #17: UCRwLockTest.WritersAreMutuallyExclusive ..........................................................   Passed    0.00 sec
```
**ShardMetadata:**
```
        Start  64: UCShardMetadataTest.StoreBeginReturnsOk
 64/143 Test  #64: UCShardMetadataTest.StoreBeginReturnsOk ...........................................................   Passed    0.01 sec
        Start  65: UCShardMetadataTest.StoreBeginDuplicateReturnsOkAndKeepsSingleEntry
 65/143 Test  #65: UCShardMetadataTest.StoreBeginDuplicateReturnsOkAndKeepsSingleEntry ...............................   Passed    0.01 sec
        Start  66: UCShardMetadataTest.StoreBeginNullptrReturnsInvalidParam
 66/143 Test  #66: UCShardMetadataTest.StoreBeginNullptrReturnsInvalidParam ..........................................   Passed    0.01 sec
        Start  67: UCShardMetadataTest.StoreBeginRejectsReadyEntry
 67/143 Test  #67: UCShardMetadataTest.StoreBeginRejectsReadyEntry ...................................................   Passed    0.01 sec
        Start  68: UCShardMetadataTest.StoreBeginRejectsNonZeroRefCnt
 68/143 Test  #68: UCShardMetadataTest.StoreBeginRejectsNonZeroRefCnt ................................................   Passed    0.01 sec
        Start  69: UCShardMetadataTest.StoreEndMarksInitializedAsReady
 69/143 Test  #69: UCShardMetadataTest.StoreEndMarksInitializedAsReady ...............................................   Passed    0.01 sec
        Start  70: UCShardMetadataTest.StoreEndReturnsErrorWhenNotInitialized
 70/143 Test  #70: UCShardMetadataTest.StoreEndReturnsErrorWhenNotInitialized ........................................   Passed    0.01 sec
        Start  71: UCShardMetadataTest.StoreEndReturnsNotFoundWhenMissing
 71/143 Test  #71: UCShardMetadataTest.StoreEndReturnsNotFoundWhenMissing ............................................   Passed    0.01 sec
        Start  72: UCShardMetadataTest.LoadBeginReturnsNotFoundWhenMissing
 72/143 Test  #72: UCShardMetadataTest.LoadBeginReturnsNotFoundWhenMissing ...........................................   Passed    0.01 sec
        Start  73: UCShardMetadataTest.LoadBeginIncrementsRefCnt
 73/143 Test  #73: UCShardMetadataTest.LoadBeginIncrementsRefCnt .....................................................   Passed    0.01 sec
        Start  74: UCShardMetadataTest.LoadBeginReturnsErrorWhenNotReady
 74/143 Test  #74: UCShardMetadataTest.LoadBeginReturnsErrorWhenNotReady .............................................   Passed    0.01 sec
        Start  75: UCShardMetadataTest.LoadEndReturnsNotFoundWhenMissing
 75/143 Test  #75: UCShardMetadataTest.LoadEndReturnsNotFoundWhenMissing .............................................   Passed    0.01 sec
        Start  76: UCShardMetadataTest.LoadEndDecrementsRefCnt
 76/143 Test  #76: UCShardMetadataTest.LoadEndDecrementsRefCnt .......................................................   Passed    0.01 sec
        Start  77: UCShardMetadataTest.LoadEndReturnsErrorWhenRefCntIsZero
 77/143 Test  #77: UCShardMetadataTest.LoadEndReturnsErrorWhenRefCntIsZero ...........................................   Passed    0.01 sec
        Start  78: UCShardMetadataTest.ExistReturnsTrueAndRefreshesLeaseWhenReady
 78/143 Test  #78: UCShardMetadataTest.ExistReturnsTrueAndRefreshesLeaseWhenReady ....................................   Passed    0.01 sec
        Start  79: UCShardMetadataTest.ExistReturnsFalseWhenNotReady
 79/143 Test  #79: UCShardMetadataTest.ExistReturnsFalseWhenNotReady .................................................   Passed    0.01 sec
        Start  80: UCShardMetadataTest.ExistReturnsFalseWhenMissing
 80/143 Test  #80: UCShardMetadataTest.ExistReturnsFalseWhenMissing ..................................................   Passed    0.01 sec
        Start  81: UCShardMetadataTest.QueryReturnsTrueAfterAdd
 81/143 Test  #81: UCShardMetadataTest.QueryReturnsTrueAfterAdd ......................................................   Passed    0.01 sec
        Start  82: UCShardMetadataTest.QueryReturnsFalseWhenMissing
 82/143 Test  #82: UCShardMetadataTest.QueryReturnsFalseWhenMissing ..................................................   Passed    0.01 sec
        Start  83: UCShardMetadataTest.DeleteReturnsOkAndSecondIsNotFound
 83/143 Test  #83: UCShardMetadataTest.DeleteReturnsOkAndSecondIsNotFound ............................................   Passed    0.01 sec
        Start  84: UCShardMetadataTest.GetKeyCntReflectsAddsAndDeletes
 84/143 Test  #84: UCShardMetadataTest.GetKeyCntReflectsAddsAndDeletes ...............................................   Passed    0.01 sec
        Start  85: UCShardMetadataTest.FullLifecycleStoreStoreEndLoadExist
 85/143 Test  #85: UCShardMetadataTest.FullLifecycleStoreStoreEndLoadExist ...........................................   Passed    0.01 sec
```

