### PR TITLE
[Feat] Add shared BufferPool for Ascend memory

### DIFF
--- a/ucm/shared/CMakeLists.txt
+++ b/ucm/shared/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_subdirectory(vendor)
 add_subdirectory(infra)
 add_subdirectory(trans)
+if(RUNTIME_ENVIRONMENT STREQUAL "ascend")
+    add_subdirectory(pool)
+endif()
 add_subdirectory(metrics)
 add_subdirectory(test)

--- a/ucm/shared/pool/CMakeLists.txt
+++ b/ucm/shared/pool/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(buffer_pool STATIC
+    buffer_pool.cc
+)
+
+target_include_directories(buffer_pool PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+target_link_libraries(buffer_pool
+    PUBLIC
+        infra_status
+        infra_thread
+    PRIVATE
+        trans
+)

--- a/ucm/shared/pool/buffer_pool.cc
+++ b/ucm/shared/pool/buffer_pool.cc
@@ -128,13 +128,9 @@ Status BufferPool::Init(std::string name, MemoryType type, std::size_t slot_capa
     return Status::OK();
 }
 
-Status BufferPool::Allocate(std::size_t size, Slot& slot)
+Status BufferPool::Allocate(Slot& slot)
 {
     if (!region_) { return Status::Error("buffer pool not initialized"); }
-    if (size == 0) { return Status::InvalidParam(name_ + ": size must be non-zero"); }
-    if (size > slot_capacity_) {
-        return Status::InvalidParam(name_ + ": size exceeds slot_capacity");
-    }
 
     const auto idx = index_pool_.Acquire();
     if (idx == IndexPool::npos) {
@@ -144,7 +140,7 @@ Status BufferPool::Allocate(std::size_t size, Slot& slot)
     const auto offset = static_cast<std::size_t>(idx) * slot_stride_;
     slot.local_addr = static_cast<char*>(region_.local_addr) + offset;
     slot.device_addr = static_cast<char*>(region_.device_addr) + offset;
-    slot.length = size;
+    slot.length = slot_capacity_;
     slot.slot_index = idx;
     return Status::OK();
 }

--- a/ucm/shared/pool/buffer_pool.cc
+++ b/ucm/shared/pool/buffer_pool.cc
@@ -40,13 +40,11 @@ bool BufferPool::ComputeSlotStride(std::size_t capacity, std::size_t& stride)
     constexpr auto kMaxSize = std::numeric_limits<std::size_t>::max();
     if (capacity == 0 || capacity > kMaxSize - (kSlotAddressAlignment - 1)) { return false; }
 
-    stride = (capacity + kSlotAddressAlignment - 1) / kSlotAddressAlignment *
-             kSlotAddressAlignment;
+    stride = (capacity + kSlotAddressAlignment - 1) / kSlotAddressAlignment * kSlotAddressAlignment;
     return true;
 }
 
-Status BufferPool::BufferRegion::Create(MemoryType type, std::size_t size,
-                                        BufferRegion& region)
+Status BufferPool::BufferRegion::Create(MemoryType type, std::size_t size, BufferRegion& region)
 {
     Trans::AscendBuffer ascendBuffer;
     switch (type) {

--- a/ucm/shared/pool/buffer_pool.cc
+++ b/ucm/shared/pool/buffer_pool.cc
@@ -89,7 +89,7 @@ void BufferPool::BufferRegion::Reset()
 }
 
 Status BufferPool::Init(std::string name, MemoryType type, std::size_t slot_capacity,
-                        std::size_t slot_num)
+                        std::size_t slot_num, bool enable_zero)
 {
     if (region_) { return Status::InvalidParam(name + " already initialized"); }
     if (slot_capacity == 0 || slot_num == 0) {
@@ -113,12 +113,15 @@ Status BufferPool::Init(std::string name, MemoryType type, std::size_t slot_capa
     slot_stride_ = slotStride;
     slot_num_ = slot_num;
     memory_type_ = type;
+    enable_zero_ = enable_zero;
     region_ = std::move(region);
 
-    status = ZeroMemory(region_.local_addr, total);
-    if (status.Failure()) {
-        Reset();
-        return status;
+    if (enable_zero_) {
+        status = ZeroMemory(region_.local_addr, total);
+        if (status.Failure()) {
+            Reset();
+            return status;
+        }
     }
 
     index_pool_.Setup(static_cast<IndexPool::Index>(slot_num_));
@@ -153,9 +156,11 @@ Status BufferPool::Free(std::uint32_t slot_index)
         return Status::InvalidParam(name_ + ": slot_index out of range");
     }
 
-    auto* slot = static_cast<char*>(region_.local_addr) + slot_index * slot_stride_;
-    auto status = ZeroMemory(slot, slot_stride_);
-    if (status.Failure()) { return status; }
+    if (enable_zero_) {
+        auto* slot = static_cast<char*>(region_.local_addr) + slot_index * slot_stride_;
+        auto status = ZeroMemory(slot, slot_stride_);
+        if (status.Failure()) { return status; }
+    }
 
     index_pool_.Release(static_cast<IndexPool::Index>(slot_index));
     return Status::OK();
@@ -169,6 +174,7 @@ void BufferPool::Reset()
     slot_stride_ = 0;
     slot_num_ = 0;
     memory_type_ = MemoryType::HOST;
+    enable_zero_ = false;
 }
 
 bool BufferPool::IsValidPointer(const void* ptr) const

--- a/ucm/shared/pool/buffer_pool.cc
+++ b/ucm/shared/pool/buffer_pool.cc
@@ -1,0 +1,197 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "pool/buffer_pool.h"
+#include <acl/acl.h>
+#include <cstring>
+#include <limits>
+#include <utility>
+#include "trans/ascend/ascend_buffer.h"
+
+namespace UC {
+namespace {
+
+constexpr std::size_t kSlotAddressAlignment = 64;
+
+}  // namespace
+
+bool BufferPool::ComputeSlotStride(std::size_t capacity, std::size_t& stride)
+{
+    constexpr auto kMaxSize = std::numeric_limits<std::size_t>::max();
+    if (capacity == 0 || capacity > kMaxSize - (kSlotAddressAlignment - 1)) { return false; }
+
+    stride = (capacity + kSlotAddressAlignment - 1) / kSlotAddressAlignment *
+             kSlotAddressAlignment;
+    return true;
+}
+
+Status BufferPool::BufferRegion::Create(MemoryType type, std::size_t size,
+                                        BufferRegion& region)
+{
+    Trans::AscendBuffer ascendBuffer;
+    switch (type) {
+        case MemoryType::HOST: {
+            auto owner = ascendBuffer.MakeHostBuffer(size);
+            if (!owner) { return Status::Error("failed to allocate host memory"); }
+            region.owner = std::move(owner);
+            region.local_addr = region.owner.get();
+            region.device_addr = region.owner.get();
+            return Status::OK();
+        }
+        case MemoryType::HOST_PINNED: {
+            void* deviceAddr = nullptr;
+            auto owner = ascendBuffer.MakeHostPinnedBuffer(size, &deviceAddr);
+            if (!owner || !deviceAddr) {
+                return Status::Error("failed to allocate host-pinned memory");
+            }
+            region.owner = std::move(owner);
+            region.local_addr = region.owner.get();
+            region.device_addr = deviceAddr;
+            return Status::OK();
+        }
+        case MemoryType::ASCEND_DEVICE: {
+            auto owner = ascendBuffer.MakeDeviceBuffer(size);
+            if (!owner) { return Status::Error("failed to allocate device memory"); }
+            region.owner = std::move(owner);
+            region.local_addr = region.owner.get();
+            region.device_addr = region.owner.get();
+            return Status::OK();
+        }
+        default: return Status::InvalidParam("unsupported memory type");
+    }
+}
+
+void BufferPool::BufferRegion::Reset()
+{
+    owner.reset();
+    local_addr = nullptr;
+    device_addr = nullptr;
+}
+
+Status BufferPool::Init(std::string name, MemoryType type, std::size_t slot_capacity,
+                        std::size_t slot_num)
+{
+    if (region_) { return Status::InvalidParam(name + " already initialized"); }
+    if (slot_capacity == 0 || slot_num == 0) {
+        return Status::InvalidParam(name + ": slot_capacity and slot_num must be non-zero");
+    }
+
+    std::size_t slotStride = 0;
+    if (!ComputeSlotStride(slot_capacity, slotStride) ||
+        slot_num > std::numeric_limits<std::size_t>::max() / slotStride ||
+        slot_num >= std::numeric_limits<IndexPool::Index>::max()) {
+        return Status::InvalidParam(name + ": slot layout size overflow");
+    }
+
+    BufferRegion region;
+    const auto total = slotStride * slot_num;
+    auto status = BufferRegion::Create(type, total, region);
+    if (status.Failure()) { return status; }
+
+    name_ = std::move(name);
+    slot_capacity_ = slot_capacity;
+    slot_stride_ = slotStride;
+    slot_num_ = slot_num;
+    memory_type_ = type;
+    region_ = std::move(region);
+
+    status = ZeroMemory(region_.local_addr, total);
+    if (status.Failure()) {
+        Reset();
+        return status;
+    }
+
+    index_pool_.Setup(static_cast<IndexPool::Index>(slot_num_));
+    return Status::OK();
+}
+
+Status BufferPool::Allocate(std::size_t size, Slot& slot)
+{
+    if (!region_) { return Status::Error("buffer pool not initialized"); }
+    if (size == 0) { return Status::InvalidParam(name_ + ": size must be non-zero"); }
+    if (size > slot_capacity_) {
+        return Status::InvalidParam(name_ + ": size exceeds slot_capacity");
+    }
+
+    const auto idx = index_pool_.Acquire();
+    if (idx == IndexPool::npos) {
+        return Status(Status::Retry().Underlying(), name_ + ": no free slots");
+    }
+
+    const auto offset = static_cast<std::size_t>(idx) * slot_stride_;
+    slot.local_addr = static_cast<char*>(region_.local_addr) + offset;
+    slot.device_addr = static_cast<char*>(region_.device_addr) + offset;
+    slot.length = size;
+    slot.slot_index = idx;
+    return Status::OK();
+}
+
+Status BufferPool::Free(std::uint32_t slot_index)
+{
+    if (!region_) { return Status::Error("buffer pool not initialized"); }
+    if (slot_index >= slot_num_) {
+        return Status::InvalidParam(name_ + ": slot_index out of range");
+    }
+
+    auto* slot = static_cast<char*>(region_.local_addr) + slot_index * slot_stride_;
+    auto status = ZeroMemory(slot, slot_stride_);
+    if (status.Failure()) { return status; }
+
+    index_pool_.Release(static_cast<IndexPool::Index>(slot_index));
+    return Status::OK();
+}
+
+void BufferPool::Reset()
+{
+    region_.Reset();
+    name_.clear();
+    slot_capacity_ = 0;
+    slot_stride_ = 0;
+    slot_num_ = 0;
+    memory_type_ = MemoryType::HOST;
+}
+
+bool BufferPool::IsValidPointer(const void* ptr) const
+{
+    if (!ptr || !region_) { return false; }
+    const auto base = reinterpret_cast<std::uintptr_t>(region_.local_addr);
+    const auto address = reinterpret_cast<std::uintptr_t>(ptr);
+    if (address < base) { return false; }
+
+    const auto offset = address - base;
+    return offset < GetTotalSize() && offset % slot_stride_ == 0;
+}
+
+Status BufferPool::ZeroMemory(void* ptr, std::size_t size) const
+{
+    if (memory_type_ == MemoryType::ASCEND_DEVICE) {
+        if (aclrtMemset(ptr, size, 0, size) != ACL_SUCCESS) {
+            return Status::Error(name_ + ": failed to zero device memory");
+        }
+    } else {
+        std::memset(ptr, 0, size);
+    }
+    return Status::OK();
+}
+
+}  // namespace UC

--- a/ucm/shared/pool/buffer_pool.h
+++ b/ucm/shared/pool/buffer_pool.h
@@ -54,7 +54,7 @@ public:
     BufferPool& operator=(const BufferPool&) = delete;
 
     Status Init(std::string name, MemoryType type, std::size_t slot_capacity,
-                std::size_t slot_num);
+                std::size_t slot_num, bool enable_zero = false);
     Status Allocate(std::size_t size, Slot& slot);
     Status Free(std::uint32_t slot_index);
     void Reset();
@@ -88,6 +88,7 @@ private:
     std::size_t slot_stride_{0};
     std::size_t slot_num_{0};
     MemoryType memory_type_{MemoryType::HOST};
+    bool enable_zero_{false};
 
     BufferRegion region_;
     IndexPool index_pool_;

--- a/ucm/shared/pool/buffer_pool.h
+++ b/ucm/shared/pool/buffer_pool.h
@@ -55,7 +55,7 @@ public:
 
     Status Init(std::string name, MemoryType type, std::size_t slot_capacity,
                 std::size_t slot_num, bool enable_zero = false);
-    Status Allocate(std::size_t size, Slot& slot);
+    Status Allocate(Slot& slot);
     Status Free(std::uint32_t slot_index);
     void Reset();
 

--- a/ucm/shared/pool/buffer_pool.h
+++ b/ucm/shared/pool/buffer_pool.h
@@ -53,8 +53,8 @@ public:
     BufferPool(const BufferPool&) = delete;
     BufferPool& operator=(const BufferPool&) = delete;
 
-    Status Init(std::string name, MemoryType type, std::size_t slot_capacity,
-                std::size_t slot_num, bool enable_zero = false);
+    Status Init(std::string name, MemoryType type, std::size_t slot_capacity, std::size_t slot_num,
+                bool enable_zero = false);
     Status Allocate(Slot& slot);
     Status Free(std::uint32_t slot_index);
     void Reset();

--- a/ucm/shared/pool/buffer_pool.h
+++ b/ucm/shared/pool/buffer_pool.h
@@ -1,0 +1,96 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include "status/status.h"
+#include "thread/index_pool.h"
+
+namespace UC {
+
+class BufferPool {
+public:
+    enum class MemoryType {
+        HOST = 0,
+        HOST_PINNED = 1,
+        ASCEND_DEVICE = 2,
+    };
+
+    struct Slot {
+        void* local_addr{nullptr};
+        void* device_addr{nullptr};
+        std::size_t length{0};
+        std::uint32_t slot_index{UINT32_MAX};
+    };
+
+    BufferPool() = default;
+    ~BufferPool() = default;
+
+    BufferPool(const BufferPool&) = delete;
+    BufferPool& operator=(const BufferPool&) = delete;
+
+    Status Init(std::string name, MemoryType type, std::size_t slot_capacity,
+                std::size_t slot_num);
+    Status Allocate(std::size_t size, Slot& slot);
+    Status Free(std::uint32_t slot_index);
+    void Reset();
+
+    bool IsInitialized() const { return static_cast<bool>(region_); }
+    bool IsValidPointer(const void* ptr) const;
+
+    const std::string& GetName() const { return name_; }
+    void* GetLocalAddr() const { return region_.local_addr; }
+    void* GetDeviceAddr() const { return region_.device_addr; }
+    std::size_t GetTotalSize() const { return slot_stride_ * slot_num_; }
+    MemoryType GetMemoryType() const { return memory_type_; }
+
+private:
+    struct BufferRegion {
+        static Status Create(MemoryType type, std::size_t size, BufferRegion& region);
+
+        explicit operator bool() const { return owner != nullptr; }
+        void Reset();
+
+        std::shared_ptr<void> owner;
+        void* local_addr{nullptr};
+        void* device_addr{nullptr};
+    };
+
+    static bool ComputeSlotStride(std::size_t capacity, std::size_t& stride);
+    Status ZeroMemory(void* ptr, std::size_t size) const;
+
+    std::string name_;
+    std::size_t slot_capacity_{0};
+    std::size_t slot_stride_{0};
+    std::size_t slot_num_{0};
+    MemoryType memory_type_{MemoryType::HOST};
+
+    BufferRegion region_;
+    IndexPool index_pool_;
+};
+
+}  // namespace UC

--- a/ucm/shared/test/CMakeLists.txt
+++ b/ucm/shared/test/CMakeLists.txt
@@ -1,11 +1,17 @@
 if(BUILD_UNIT_TESTS)
     include(GoogleTest)
     file(GLOB_RECURSE UCMSHARED_TEST_SOURCE_FILES "./case/*.cc")
+    if(NOT RUNTIME_ENVIRONMENT STREQUAL "ascend")
+        list(FILTER UCMSHARED_TEST_SOURCE_FILES EXCLUDE REGEX ".*[/\\\\]pool[/\\\\].*")
+    endif()
     add_executable(ucmshared.test ${UCMSHARED_TEST_SOURCE_FILES})
     target_include_directories(ucmshared.test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/case)
     target_link_libraries(ucmshared.test PRIVATE
         trans metrics infra_logger
         gtest_main gtest
     )
+    if(RUNTIME_ENVIRONMENT STREQUAL "ascend")
+        target_link_libraries(ucmshared.test PRIVATE buffer_pool)
+    endif()
     gtest_discover_tests(ucmshared.test)
 endif()

--- a/ucm/shared/test/case/pool/buffer_pool_test.cc
+++ b/ucm/shared/test/case/pool/buffer_pool_test.cc
@@ -57,7 +57,7 @@ TEST_F(BufferPoolTest, RejectsInvalidInitAndUseBeforeInit)
     BufferPool::Slot slot;
     EXPECT_FALSE(pool.IsInitialized());
 
-    auto status = pool.Allocate(1, slot);
+    auto status = pool.Allocate(slot);
     EXPECT_TRUE(status.Failure());
     EXPECT_EQ(status, Status::Error());
 
@@ -121,8 +121,8 @@ TEST_F(BufferPoolTest, HostPoolUsesAlignedSlotsAndReportsBusyWhenFull)
     BufferPool::Slot first;
     BufferPool::Slot second;
     BufferPool::Slot third;
-    ASSERT_TRUE(pool.Allocate(71, first).Success());
-    ASSERT_TRUE(pool.Allocate(71, second).Success());
+    ASSERT_TRUE(pool.Allocate(first).Success());
+    ASSERT_TRUE(pool.Allocate(second).Success());
     EXPECT_EQ(reinterpret_cast<std::uintptr_t>(second.local_addr) -
                   reinterpret_cast<std::uintptr_t>(first.local_addr),
               128);
@@ -135,7 +135,7 @@ TEST_F(BufferPoolTest, HostPoolUsesAlignedSlotsAndReportsBusyWhenFull)
     EXPECT_FALSE(
         pool.IsValidPointer(static_cast<char*>(pool.GetLocalAddr()) + pool.GetTotalSize()));
 
-    status = pool.Allocate(1, third);
+    status = pool.Allocate(third);
     EXPECT_TRUE(status.Failure());
     EXPECT_EQ(status, Status::Retry());
 }
@@ -155,8 +155,8 @@ TEST_F(BufferPoolTest, HostPinnedPoolKeepsLocalAndDeviceAddresses)
 
     BufferPool::Slot first;
     BufferPool::Slot second;
-    ASSERT_TRUE(pool.Allocate(64, first).Success());
-    ASSERT_TRUE(pool.Allocate(64, second).Success());
+    ASSERT_TRUE(pool.Allocate(first).Success());
+    ASSERT_TRUE(pool.Allocate(second).Success());
     EXPECT_EQ(first.local_addr, pool.GetLocalAddr());
     EXPECT_EQ(first.device_addr, pool.GetDeviceAddr());
     EXPECT_EQ(reinterpret_cast<std::uintptr_t>(second.local_addr) -
@@ -180,12 +180,12 @@ TEST_F(BufferPoolTest, DevicePoolZeroesReleasedSlot)
     EXPECT_EQ(pool.GetMemoryType(), MemoryType::ASCEND_DEVICE);
 
     BufferPool::Slot first;
-    ASSERT_TRUE(pool.Allocate(kSlotCapacity, first).Success());
+    ASSERT_TRUE(pool.Allocate(first).Success());
     ASSERT_EQ(aclrtMemset(first.local_addr, kSlotStride, 0xAB, kSlotStride), ACL_SUCCESS);
     ASSERT_TRUE(pool.Free(first.slot_index).Success());
 
     BufferPool::Slot second;
-    ASSERT_TRUE(pool.Allocate(kSlotCapacity, second).Success());
+    ASSERT_TRUE(pool.Allocate(second).Success());
     EXPECT_EQ(second.local_addr, first.local_addr);
     EXPECT_EQ(second.slot_index, first.slot_index);
 
@@ -205,12 +205,12 @@ TEST_F(BufferPoolTest, FreeZeroesAndReusesHostSlot)
     ASSERT_TRUE(status.Success()) << status.ToString();
 
     BufferPool::Slot first;
-    ASSERT_TRUE(pool.Allocate(71, first).Success());
+    ASSERT_TRUE(pool.Allocate(first).Success());
     std::memset(first.local_addr, 0xAB, kSlotStride);
     ASSERT_TRUE(pool.Free(first.slot_index).Success());
 
     BufferPool::Slot second;
-    ASSERT_TRUE(pool.Allocate(71, second).Success());
+    ASSERT_TRUE(pool.Allocate(second).Success());
     EXPECT_EQ(second.local_addr, first.local_addr);
     EXPECT_EQ(second.slot_index, first.slot_index);
 
@@ -227,12 +227,12 @@ TEST_F(BufferPoolTest, FreePreservesHostSlotWhenZeroingDisabled)
     ASSERT_TRUE(status.Success()) << status.ToString();
 
     BufferPool::Slot first;
-    ASSERT_TRUE(pool.Allocate(71, first).Success());
+    ASSERT_TRUE(pool.Allocate(first).Success());
     std::memset(first.local_addr, 0xAB, kSlotStride);
     ASSERT_TRUE(pool.Free(first.slot_index).Success());
 
     BufferPool::Slot second;
-    ASSERT_TRUE(pool.Allocate(71, second).Success());
+    ASSERT_TRUE(pool.Allocate(second).Success());
     EXPECT_EQ(second.local_addr, first.local_addr);
     EXPECT_EQ(second.slot_index, first.slot_index);
 
@@ -240,21 +240,12 @@ TEST_F(BufferPoolTest, FreePreservesHostSlotWhenZeroingDisabled)
     for (std::size_t i = 0; i < kSlotStride; ++i) { EXPECT_EQ(bytes[i], 0xAB); }
 }
 
-TEST_F(BufferPoolTest, RejectsInvalidAllocationAndFree)
+TEST_F(BufferPoolTest, RejectsInvalidFree)
 {
     BufferPool pool;
     ASSERT_TRUE(pool.Init("validation_pool", MemoryType::HOST, 64, 1).Success());
 
-    BufferPool::Slot slot;
-    auto status = pool.Allocate(0, slot);
-    EXPECT_TRUE(status.Failure());
-    EXPECT_EQ(status, Status::InvalidParam());
-
-    status = pool.Allocate(65, slot);
-    EXPECT_TRUE(status.Failure());
-    EXPECT_EQ(status, Status::InvalidParam());
-
-    status = pool.Free(1);
+    auto status = pool.Free(1);
     EXPECT_TRUE(status.Failure());
     EXPECT_EQ(status, Status::InvalidParam());
 }
@@ -284,7 +275,7 @@ TEST_F(BufferPoolTest, ConcurrentAllocateAndFree)
     auto worker = [&pool, &failed]() {
         for (int i = 0; i < kOpsPerThread; ++i) {
             BufferPool::Slot slot;
-            auto status = pool.Allocate(64, slot);
+            auto status = pool.Allocate(slot);
             if (status.Failure()) {
                 failed = true;
                 return;

--- a/ucm/shared/test/case/pool/buffer_pool_test.cc
+++ b/ucm/shared/test/case/pool/buffer_pool_test.cc
@@ -191,7 +191,7 @@ TEST_F(BufferPoolTest, DevicePoolZeroesReleasedSlot)
 
     std::array<std::uint8_t, kSlotStride> host{};
     ASSERT_EQ(aclrtMemcpy(host.data(), host.size(), second.local_addr, kSlotStride,
-                         ACL_MEMCPY_DEVICE_TO_HOST),
+                          ACL_MEMCPY_DEVICE_TO_HOST),
               ACL_SUCCESS);
     for (const auto value : host) { EXPECT_EQ(value, 0); }
 }

--- a/ucm/shared/test/case/pool/buffer_pool_test.cc
+++ b/ucm/shared/test/case/pool/buffer_pool_test.cc
@@ -106,7 +106,7 @@ TEST_F(BufferPoolTest, RejectsSlotLayoutOverflow)
 TEST_F(BufferPoolTest, HostPoolUsesAlignedSlotsAndReportsBusyWhenFull)
 {
     BufferPool pool;
-    auto status = pool.Init("host_pool", MemoryType::HOST, 71, 2);
+    auto status = pool.Init("host_pool", MemoryType::HOST, 71, 2, true);
     ASSERT_TRUE(status.Success()) << status.ToString();
     EXPECT_TRUE(pool.IsInitialized());
 
@@ -173,7 +173,7 @@ TEST_F(BufferPoolTest, DevicePoolZeroesReleasedSlot)
     constexpr std::size_t kSlotStride = 128;
 
     BufferPool pool;
-    auto status = pool.Init("device_pool", MemoryType::ASCEND_DEVICE, kSlotCapacity, 1);
+    auto status = pool.Init("device_pool", MemoryType::ASCEND_DEVICE, kSlotCapacity, 1, true);
     ASSERT_TRUE(status.Success()) << status.ToString();
     EXPECT_EQ(pool.GetLocalAddr(), pool.GetDeviceAddr());
     EXPECT_EQ(pool.GetTotalSize(), kSlotStride);
@@ -201,7 +201,7 @@ TEST_F(BufferPoolTest, FreeZeroesAndReusesHostSlot)
     constexpr std::size_t kSlotStride = 128;
 
     BufferPool pool;
-    auto status = pool.Init("reuse_pool", MemoryType::HOST, 71, 1);
+    auto status = pool.Init("reuse_pool", MemoryType::HOST, 71, 1, true);
     ASSERT_TRUE(status.Success()) << status.ToString();
 
     BufferPool::Slot first;
@@ -216,6 +216,28 @@ TEST_F(BufferPoolTest, FreeZeroesAndReusesHostSlot)
 
     const auto* bytes = static_cast<const std::uint8_t*>(second.local_addr);
     for (std::size_t i = 0; i < kSlotStride; ++i) { EXPECT_EQ(bytes[i], 0); }
+}
+
+TEST_F(BufferPoolTest, FreePreservesHostSlotWhenZeroingDisabled)
+{
+    constexpr std::size_t kSlotStride = 128;
+
+    BufferPool pool;
+    auto status = pool.Init("reuse_without_zero", MemoryType::HOST, 71, 1);
+    ASSERT_TRUE(status.Success()) << status.ToString();
+
+    BufferPool::Slot first;
+    ASSERT_TRUE(pool.Allocate(71, first).Success());
+    std::memset(first.local_addr, 0xAB, kSlotStride);
+    ASSERT_TRUE(pool.Free(first.slot_index).Success());
+
+    BufferPool::Slot second;
+    ASSERT_TRUE(pool.Allocate(71, second).Success());
+    EXPECT_EQ(second.local_addr, first.local_addr);
+    EXPECT_EQ(second.slot_index, first.slot_index);
+
+    const auto* bytes = static_cast<const std::uint8_t*>(second.local_addr);
+    for (std::size_t i = 0; i < kSlotStride; ++i) { EXPECT_EQ(bytes[i], 0xAB); }
 }
 
 TEST_F(BufferPoolTest, RejectsInvalidAllocationAndFree)

--- a/ucm/shared/test/case/pool/buffer_pool_test.cc
+++ b/ucm/shared/test/case/pool/buffer_pool_test.cc
@@ -1,0 +1,286 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "pool/buffer_pool.h"
+#include <acl/acl.h>
+#include <array>
+#include <atomic>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <limits>
+#include <thread>
+#include <vector>
+
+namespace UC {
+namespace {
+
+using MemoryType = BufferPool::MemoryType;
+
+class BufferPoolTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        aclInit(nullptr);
+        aclrtSetDevice(0);
+    }
+
+    static void TearDownTestSuite()
+    {
+        aclrtResetDevice(0);
+        aclFinalize();
+    }
+};
+
+TEST_F(BufferPoolTest, RejectsInvalidInitAndUseBeforeInit)
+{
+    BufferPool pool;
+    BufferPool::Slot slot;
+    EXPECT_FALSE(pool.IsInitialized());
+
+    auto status = pool.Allocate(1, slot);
+    EXPECT_TRUE(status.Failure());
+    EXPECT_EQ(status, Status::Error());
+
+    status = pool.Free(0);
+    EXPECT_TRUE(status.Failure());
+    EXPECT_EQ(status, Status::Error());
+
+    status = pool.Init("zero_capacity", MemoryType::HOST, 0, 1);
+    EXPECT_TRUE(status.Failure());
+    EXPECT_EQ(status, Status::InvalidParam());
+
+    status = pool.Init("zero_slots", MemoryType::HOST, 64, 0);
+    EXPECT_TRUE(status.Failure());
+    EXPECT_EQ(status, Status::InvalidParam());
+
+    status = pool.Init("unsupported", static_cast<MemoryType>(99), 64, 1);
+    EXPECT_TRUE(status.Failure());
+    EXPECT_EQ(status, Status::InvalidParam());
+    EXPECT_FALSE(pool.IsInitialized());
+}
+
+TEST_F(BufferPoolTest, RejectsRepeatedInit)
+{
+    BufferPool pool;
+    ASSERT_TRUE(pool.Init("first", MemoryType::HOST, 64, 1).Success());
+
+    auto status = pool.Init("second", MemoryType::HOST, 64, 1);
+    EXPECT_TRUE(status.Failure());
+    EXPECT_EQ(status, Status::InvalidParam());
+}
+
+TEST_F(BufferPoolTest, RejectsSlotLayoutOverflow)
+{
+    BufferPool pool;
+    auto status = pool.Init("capacity_overflow", MemoryType::HOST,
+                            std::numeric_limits<std::size_t>::max(), 2);
+    EXPECT_TRUE(status.Failure());
+    EXPECT_EQ(status, Status::InvalidParam());
+
+    status = pool.Init("index_overflow", MemoryType::HOST, 64,
+                       std::numeric_limits<std::uint32_t>::max());
+    EXPECT_TRUE(status.Failure());
+    EXPECT_EQ(status, Status::InvalidParam());
+}
+
+TEST_F(BufferPoolTest, HostPoolUsesAlignedSlotsAndReportsBusyWhenFull)
+{
+    BufferPool pool;
+    auto status = pool.Init("host_pool", MemoryType::HOST, 71, 2);
+    ASSERT_TRUE(status.Success()) << status.ToString();
+    EXPECT_TRUE(pool.IsInitialized());
+
+    ASSERT_NE(pool.GetLocalAddr(), nullptr);
+    EXPECT_EQ(pool.GetLocalAddr(), pool.GetDeviceAddr());
+    EXPECT_EQ(pool.GetTotalSize(), 256);
+    EXPECT_EQ(pool.GetMemoryType(), MemoryType::HOST);
+
+    const auto* bytes = static_cast<const std::uint8_t*>(pool.GetLocalAddr());
+    for (std::size_t i = 0; i < pool.GetTotalSize(); ++i) { EXPECT_EQ(bytes[i], 0); }
+
+    BufferPool::Slot first;
+    BufferPool::Slot second;
+    BufferPool::Slot third;
+    ASSERT_TRUE(pool.Allocate(71, first).Success());
+    ASSERT_TRUE(pool.Allocate(71, second).Success());
+    EXPECT_EQ(reinterpret_cast<std::uintptr_t>(second.local_addr) -
+                  reinterpret_cast<std::uintptr_t>(first.local_addr),
+              128);
+    EXPECT_EQ(reinterpret_cast<std::uintptr_t>(second.device_addr) -
+                  reinterpret_cast<std::uintptr_t>(first.device_addr),
+              128);
+    EXPECT_EQ(first.length, 71);
+    EXPECT_TRUE(pool.IsValidPointer(first.local_addr));
+    EXPECT_FALSE(pool.IsValidPointer(static_cast<char*>(first.local_addr) + 1));
+    EXPECT_FALSE(
+        pool.IsValidPointer(static_cast<char*>(pool.GetLocalAddr()) + pool.GetTotalSize()));
+
+    status = pool.Allocate(1, third);
+    EXPECT_TRUE(status.Failure());
+    EXPECT_EQ(status, Status::Retry());
+}
+
+TEST_F(BufferPoolTest, HostPinnedPoolKeepsLocalAndDeviceAddresses)
+{
+    BufferPool pool;
+    auto status = pool.Init("pinned_pool", MemoryType::HOST_PINNED, 4096, 2);
+    ASSERT_TRUE(status.Success()) << status.ToString();
+
+    ASSERT_NE(pool.GetLocalAddr(), nullptr);
+    ASSERT_NE(pool.GetDeviceAddr(), nullptr);
+    EXPECT_NE(pool.GetLocalAddr(), pool.GetDeviceAddr());
+    EXPECT_EQ(reinterpret_cast<std::uintptr_t>(pool.GetLocalAddr()) % 4096, 0);
+    EXPECT_EQ(pool.GetTotalSize(), 8192);
+    EXPECT_EQ(pool.GetMemoryType(), MemoryType::HOST_PINNED);
+
+    BufferPool::Slot first;
+    BufferPool::Slot second;
+    ASSERT_TRUE(pool.Allocate(64, first).Success());
+    ASSERT_TRUE(pool.Allocate(64, second).Success());
+    EXPECT_EQ(first.local_addr, pool.GetLocalAddr());
+    EXPECT_EQ(first.device_addr, pool.GetDeviceAddr());
+    EXPECT_EQ(reinterpret_cast<std::uintptr_t>(second.local_addr) -
+                  reinterpret_cast<std::uintptr_t>(first.local_addr),
+              4096);
+    EXPECT_EQ(reinterpret_cast<std::uintptr_t>(second.device_addr) -
+                  reinterpret_cast<std::uintptr_t>(first.device_addr),
+              4096);
+}
+
+TEST_F(BufferPoolTest, DevicePoolZeroesReleasedSlot)
+{
+    constexpr std::size_t kSlotCapacity = 71;
+    constexpr std::size_t kSlotStride = 128;
+
+    BufferPool pool;
+    auto status = pool.Init("device_pool", MemoryType::ASCEND_DEVICE, kSlotCapacity, 1);
+    ASSERT_TRUE(status.Success()) << status.ToString();
+    EXPECT_EQ(pool.GetLocalAddr(), pool.GetDeviceAddr());
+    EXPECT_EQ(pool.GetTotalSize(), kSlotStride);
+    EXPECT_EQ(pool.GetMemoryType(), MemoryType::ASCEND_DEVICE);
+
+    BufferPool::Slot first;
+    ASSERT_TRUE(pool.Allocate(kSlotCapacity, first).Success());
+    ASSERT_EQ(aclrtMemset(first.local_addr, kSlotStride, 0xAB, kSlotStride), ACL_SUCCESS);
+    ASSERT_TRUE(pool.Free(first.slot_index).Success());
+
+    BufferPool::Slot second;
+    ASSERT_TRUE(pool.Allocate(kSlotCapacity, second).Success());
+    EXPECT_EQ(second.local_addr, first.local_addr);
+    EXPECT_EQ(second.slot_index, first.slot_index);
+
+    std::array<std::uint8_t, kSlotStride> host{};
+    ASSERT_EQ(aclrtMemcpy(host.data(), host.size(), second.local_addr, kSlotStride,
+                         ACL_MEMCPY_DEVICE_TO_HOST),
+              ACL_SUCCESS);
+    for (const auto value : host) { EXPECT_EQ(value, 0); }
+}
+
+TEST_F(BufferPoolTest, FreeZeroesAndReusesHostSlot)
+{
+    constexpr std::size_t kSlotStride = 128;
+
+    BufferPool pool;
+    auto status = pool.Init("reuse_pool", MemoryType::HOST, 71, 1);
+    ASSERT_TRUE(status.Success()) << status.ToString();
+
+    BufferPool::Slot first;
+    ASSERT_TRUE(pool.Allocate(71, first).Success());
+    std::memset(first.local_addr, 0xAB, kSlotStride);
+    ASSERT_TRUE(pool.Free(first.slot_index).Success());
+
+    BufferPool::Slot second;
+    ASSERT_TRUE(pool.Allocate(71, second).Success());
+    EXPECT_EQ(second.local_addr, first.local_addr);
+    EXPECT_EQ(second.slot_index, first.slot_index);
+
+    const auto* bytes = static_cast<const std::uint8_t*>(second.local_addr);
+    for (std::size_t i = 0; i < kSlotStride; ++i) { EXPECT_EQ(bytes[i], 0); }
+}
+
+TEST_F(BufferPoolTest, RejectsInvalidAllocationAndFree)
+{
+    BufferPool pool;
+    ASSERT_TRUE(pool.Init("validation_pool", MemoryType::HOST, 64, 1).Success());
+
+    BufferPool::Slot slot;
+    auto status = pool.Allocate(0, slot);
+    EXPECT_TRUE(status.Failure());
+    EXPECT_EQ(status, Status::InvalidParam());
+
+    status = pool.Allocate(65, slot);
+    EXPECT_TRUE(status.Failure());
+    EXPECT_EQ(status, Status::InvalidParam());
+
+    status = pool.Free(1);
+    EXPECT_TRUE(status.Failure());
+    EXPECT_EQ(status, Status::InvalidParam());
+}
+
+TEST_F(BufferPoolTest, ResetAllowsReinitialization)
+{
+    BufferPool pool;
+    ASSERT_TRUE(pool.Init("first", MemoryType::HOST, 64, 1).Success());
+    pool.Reset();
+
+    EXPECT_FALSE(pool.IsInitialized());
+    EXPECT_EQ(pool.GetLocalAddr(), nullptr);
+    EXPECT_EQ(pool.GetDeviceAddr(), nullptr);
+    EXPECT_EQ(pool.GetTotalSize(), 0);
+    EXPECT_TRUE(pool.Init("second", MemoryType::HOST, 128, 2).Success());
+}
+
+TEST_F(BufferPoolTest, ConcurrentAllocateAndFree)
+{
+    BufferPool pool;
+    ASSERT_TRUE(pool.Init("concurrent_pool", MemoryType::HOST, 64, 32).Success());
+
+    constexpr int kThreadCount = 4;
+    constexpr int kOpsPerThread = 500;
+    std::atomic<bool> failed{false};
+
+    auto worker = [&pool, &failed]() {
+        for (int i = 0; i < kOpsPerThread; ++i) {
+            BufferPool::Slot slot;
+            auto status = pool.Allocate(64, slot);
+            if (status.Failure()) {
+                failed = true;
+                return;
+            }
+            std::memset(slot.local_addr, 0xAB, slot.length);
+            status = pool.Free(slot.slot_index);
+            if (status.Failure()) {
+                failed = true;
+                return;
+            }
+        }
+    };
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < kThreadCount; ++i) { threads.emplace_back(worker); }
+    for (auto& thread : threads) { thread.join(); }
+    EXPECT_FALSE(failed.load());
+}
+
+}  // namespace
+}  // namespace UC


### PR DESCRIPTION
## Purpose

Introduce a reusable fixed-slot buffer pool for HOST, HOST_PINNED, and ASCEND_DEVICE memory.

## Modifications 

- Add fixed-slot allocation and concurrent slot reuse based on IndexPool.
- Add optional zero behavior, disabled by default, to clear memory during initialization and slot release.

## Test

<img width="1151" height="632" alt="image" src="https://github.com/user-attachments/assets/1f39b47c-540d-4004-84c8-86ff1e3a1a34" />

