### PR TITLE
[Feat] Implement metadata mgr for dram pool

### DIFF
--- a/ucm/store/dram/cc/entry.h
+++ b/ucm/store/dram/cc/entry.h
@@ -42,16 +42,30 @@ enum class EntryStatus {
     DELETING,
 };
 
+/**
+ * @brief Per-key cache entry record.
+ *
+ * Concurrency contract:
+ *   - `refCnt`, `leaseTimeout`, `status` are mutable after construction; they
+ *     MUST be read or written while holding `lock` (the member Spinlock).
+ *   - All other fields are immutable after the entry is published.
+ */
 struct Entry {
     BlockId key;
-    uint32_t refCnt{0};
     uint32_t shard{0};
+
+    // Attributes for buffer
     uint32_t slot{0};
     void* addr{nullptr};
     std::size_t size{0};
+
+    // Mutable attributes guarded by Spinlock
+    Spinlock lock;
+    uint32_t refCnt{0};
     std::chrono::system_clock::time_point leaseTimeout{};
     EntryStatus status{EntryStatus::INITIALIZED};
-    Spinlock lock;
+
+    // Attributes for eviction
     std::chrono::system_clock::time_point lifeTimeout{};
     uint32_t position{0};
 

--- a/ucm/store/dram/cc/metadata.cc
+++ b/ucm/store/dram/cc/metadata.cc
@@ -22,6 +22,7 @@
  * SOFTWARE.
  * */
 #include "metadata.h"
+#include <cstdlib>
 #include "logger/logger.h"
 #include "pos_eviction_policy.h"
 #include "ttl_eviction_policy.h"
@@ -145,6 +146,37 @@ std::vector<BlockId> ShardMetadata::EvictDeep(double evict_ratio)
 {
     ReadOnlyGuard lock(mtx_);
     return deepEvictor_->GetEvictionResults(evict_ratio);
+}
+
+Status MetadataManager::StoreBegin(const BlockId& key, EntryPtr entry)
+{
+    auto idx = ShardIdx(key);
+    entry->shard = static_cast<uint32_t>(idx);
+    // TODO: integrate BufferManager allocation for entry.
+    Status st = Status::OK();
+    if (!st.Success()) {
+        EvictOneShard(*shards_[rand() % kShardCnt]);
+        // TODO: retry BufferManager allocation, update st.
+        if (!st.Success()) { EvictOneShard(*shards_[rand() % kShardCnt], true); }
+    }
+    return shards_[idx]->StoreBegin(key, std::move(entry));
+}
+
+void MetadataManager::EvictLoop()
+{
+    while (true) {
+        std::unique_lock<std::mutex> lock(cvMtx_);
+        cv_.wait_for(lock, evictPeriod_, [this] { return stop_.load(); });
+        if (stop_.load()) { return; }
+        for (auto& s : shards_) { EvictOneShard(*s); }
+    }
+}
+
+void MetadataManager::EvictOneShard(ShardMetadata& s, bool deep)
+{
+    auto victims = deep ? s.EvictDeep(defaultEvictRatio_) : s.EvictPeriodic(defaultEvictRatio_);
+    // TODO: integrate BufferManager release for victim entries.
+    for (const auto& k : victims) { s.Delete(k); }
 }
 
 }  // namespace UC::DramStore

--- a/ucm/store/dram/cc/metadata.h
+++ b/ucm/store/dram/cc/metadata.h
@@ -24,10 +24,16 @@
 #ifndef UNIFIEDCACHE_DRAM_STORE_CC_METADATA_H
 #define UNIFIEDCACHE_DRAM_STORE_CC_METADATA_H
 
+#include <array>
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <memory>
+#include <mutex>
+#include <thread>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 #include "entry.h"
 #include "eviction_policy.h"
@@ -40,6 +46,7 @@ struct MetadataConfig {
     EvictionPolicyType deepType;
     std::chrono::milliseconds leaseTime;
     double defaultEvictRatio;
+    std::chrono::milliseconds evictPeriod;
 };
 
 /**
@@ -129,6 +136,70 @@ private:
     std::unique_ptr<EvictionPolicy> periodicEvictor_;
     std::unique_ptr<EvictionPolicy> deepEvictor_;
     std::chrono::milliseconds leaseTime_;
+};
+
+/**
+ * @brief Metadata manager owns N ShardMetadata instances.
+ *
+ * Responsible for the system's metadata management, buffer allocation, and
+ * buffer release logic. Dispatches per-key operations to the selected shard.
+ */
+class MetadataManager {
+public:
+    explicit MetadataManager(const MetadataConfig& config)
+        : defaultEvictRatio_(config.defaultEvictRatio),
+          evictPeriod_(config.evictPeriod),
+          stop_(false)
+    {
+        for (auto& s : shards_) { s = std::make_unique<ShardMetadata>(config); }
+        evictThread_ = std::thread([this] { EvictLoop(); });
+    }
+
+    ~MetadataManager()
+    {
+        stop_.store(true);
+        cv_.notify_all();
+        if (evictThread_.joinable()) { evictThread_.join(); }
+    }
+
+    MetadataManager(const MetadataManager&) = delete;
+    MetadataManager& operator=(const MetadataManager&) = delete;
+
+    Status StoreBegin(const BlockId& key, EntryPtr entry);
+    Status StoreEnd(const BlockId& key) { return ShardOf(key).StoreEnd(key); }
+    Status LoadBegin(const BlockId& key) { return ShardOf(key).LoadBegin(key); }
+    Status LoadEnd(const BlockId& key) { return ShardOf(key).LoadEnd(key); }
+    bool Exist(const BlockId& key) { return ShardOf(key).Exist(key); }
+    bool Query(const BlockId& key) const { return ShardOf(key).Query(key); }
+    Status Delete(const BlockId& key) { return ShardOf(key).Delete(key); }
+
+    std::size_t GetKeyCnt() const noexcept
+    {
+        std::size_t total = 0;
+        for (const auto& s : shards_) { total += s->GetKeyCnt(); }
+        return total;
+    }
+
+private:
+    static std::size_t ShardIdx(const BlockId& key)
+    {
+        return UC::Detail::BlockIdHasher{}(key) % kShardCnt;
+    }
+    ShardMetadata& ShardOf(const BlockId& key) { return *shards_[ShardIdx(key)]; }
+    const ShardMetadata& ShardOf(const BlockId& key) const { return *shards_[ShardIdx(key)]; }
+    void EvictLoop();
+    void EvictOneShard(ShardMetadata& s, bool deep = false);
+
+    static constexpr std::size_t kShardCnt = 1024;
+    std::array<std::unique_ptr<ShardMetadata>, kShardCnt> shards_;
+
+    // For eviction logic
+    double defaultEvictRatio_;
+    std::chrono::milliseconds evictPeriod_;
+    std::atomic<bool> stop_;
+    std::mutex cvMtx_;
+    std::condition_variable cv_;
+    std::thread evictThread_;
 };
 
 }  // namespace UC::DramStore

--- a/ucm/store/test/case/dram/dram_metadata_test.cc
+++ b/ucm/store/test/case/dram/dram_metadata_test.cc
@@ -24,14 +24,19 @@
 #include <chrono>
 #include <gtest/gtest.h>
 #include <memory>
+#include <set>
+#include <string>
+#include <vector>
 #include "dram/cc/entry.h"
 #include "dram/cc/metadata.h"
 #include "dram_test_common.h"
 
+using UC::Detail::BlockId;
 using UC::DramStore::EntryPtr;
 using UC::DramStore::EntryStatus;
 using UC::DramStore::EvictionPolicyType;
 using UC::DramStore::MetadataConfig;
+using UC::DramStore::MetadataManager;
 using UC::DramStore::ShardMetadata;
 using UC::Test::Dram::Clock;
 using UC::Test::Dram::KeyFromHex;
@@ -42,9 +47,10 @@ namespace {
 MetadataConfig MakeConfig(EvictionPolicyType periodic = EvictionPolicyType::TTL,
                           EvictionPolicyType deep = EvictionPolicyType::POSITION,
                           std::chrono::milliseconds leaseTime = std::chrono::milliseconds(100),
-                          double defaultEvictRatio = 1.0)
+                          double defaultEvictRatio = 1.0,
+                          std::chrono::milliseconds evictPeriod = std::chrono::seconds(60))
 {
-    return MetadataConfig{periodic, deep, leaseTime, defaultEvictRatio};
+    return MetadataConfig{periodic, deep, leaseTime, defaultEvictRatio, evictPeriod};
 }
 }  // namespace
 
@@ -257,4 +263,73 @@ TEST_F(UCShardMetadataTest, FullLifecycleStoreStoreEndLoadExist)
     EXPECT_GT(entry->leaseTimeout, Clock::now());
     EXPECT_TRUE(md.LoadEnd(k).Success());
     EXPECT_EQ(entry->refCnt, 0U);
+}
+
+class UCMetadataManagerTest : public testing::Test {
+protected:
+    const TimePoint past_ = Clock::now() - std::chrono::seconds(10);
+    const TimePoint future_ = Clock::now() + std::chrono::seconds(10);
+};
+
+TEST_F(UCMetadataManagerTest, SameKeyGoesToSameShard)
+{
+    MetadataManager mgr(MakeConfig());
+    auto k = KeyFromHex("a1");
+    auto e1 = MakeEntry(k, 0, future_, EntryStatus::INITIALIZED);
+    EXPECT_TRUE(mgr.StoreBegin(k, e1).Success());
+    EXPECT_TRUE(mgr.StoreEnd(k).Success());
+    auto e2 = MakeEntry(k, 0, future_, EntryStatus::INITIALIZED);
+    mgr.StoreBegin(k, e2);
+    EXPECT_TRUE(mgr.Query(k));
+    EXPECT_EQ(e1->shard, e2->shard);
+}
+
+TEST_F(UCMetadataManagerTest, DifferentKeysMayHitDifferentShards)
+{
+    MetadataManager mgr(MakeConfig());
+    std::set<uint32_t> shards;
+    for (int i = 0; i < 10; ++i) {
+        auto k = KeyFromHex(("a" + std::to_string(i)).c_str());
+        auto e = MakeEntry(k, 0, future_, EntryStatus::INITIALIZED);
+        mgr.StoreBegin(k, e);
+        shards.insert(e->shard);
+    }
+    EXPECT_GE(shards.size(), 2U);
+}
+
+TEST_F(UCMetadataManagerTest, PerKeyOpsDispatchAndRoundtrip)
+{
+    MetadataManager mgr(MakeConfig());
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, 0, future_, EntryStatus::INITIALIZED);
+    EXPECT_TRUE(mgr.StoreBegin(k, entry).Success());
+    EXPECT_EQ(entry->status, EntryStatus::INITIALIZED);
+    EXPECT_TRUE(mgr.StoreEnd(k).Success());
+    EXPECT_EQ(entry->status, EntryStatus::READY);
+    EXPECT_TRUE(mgr.Query(k));
+    EXPECT_FALSE(mgr.Query(KeyFromHex("a2")));
+    EXPECT_TRUE(mgr.Exist(k));
+    EXPECT_GT(entry->leaseTimeout, Clock::now());
+    EXPECT_TRUE(mgr.LoadBegin(k).Success());
+    EXPECT_EQ(entry->refCnt, 1U);
+    EXPECT_TRUE(mgr.LoadEnd(k).Success());
+    EXPECT_EQ(entry->refCnt, 0U);
+    EXPECT_TRUE(mgr.Delete(k).Success());
+    EXPECT_FALSE(mgr.Query(k));
+}
+
+TEST_F(UCMetadataManagerTest, GetKeyCntAggregatesAcrossShards)
+{
+    MetadataManager mgr(MakeConfig());
+    EXPECT_EQ(mgr.GetKeyCnt(), 0U);
+    std::vector<BlockId> keys;
+    for (int i = 0; i < 10; ++i) {
+        auto k = KeyFromHex(("a" + std::to_string(i)).c_str());
+        keys.push_back(k);
+        EXPECT_TRUE(
+            mgr.StoreBegin(k, MakeEntry(k, 0, future_, EntryStatus::INITIALIZED)).Success());
+    }
+    EXPECT_EQ(mgr.GetKeyCnt(), 10U);
+    for (int i = 0; i < 5; ++i) { EXPECT_TRUE(mgr.Delete(keys[i]).Success()); }
+    EXPECT_EQ(mgr.GetKeyCnt(), 5U);
 }


### PR DESCRIPTION
## Purpose
Implement `MetadataManager`, which is responsible for the whole system's metadata management. It contains 1024 `ShardMetadata` as default, and dispatches key to the selected shard by hash. It maintains a background thread to perform periodic evictions between all shards.

- **Class diagram:**

<img width="50%" alt="image" src="https://github.com/user-attachments/assets/a71b6fe7-8077-4763-b531-ef27a90030de" />

- **Store flow chart:**

<img width="600" height="1020" alt="image" src="https://github.com/user-attachments/assets/38206855-57a9-41e9-9c4f-4060a2767e7f" />

- **Exist flow chart:**

<img width="600" height="520" alt="image" src="https://github.com/user-attachments/assets/0451c7e0-7dc3-49e0-a863-e05484ee7760" />

- **Load flow chart:**

<img width="600" height="920" alt="image" src="https://github.com/user-attachments/assets/27838b35-8af4-4b9b-bc59-1fc5daa757e5" />

- **Evict flow chart:**

<img width="600" height="780" alt="image" src="https://github.com/user-attachments/assets/012cb8d3-b882-482b-9abd-38ea3f541af6" />

## Modifications
1. `entry.h`: Add some comments for `Entry` attributes.
2. `metadata.h`/`metadata.cc`: Implement `MetadataManager`.
3. `dram_metadata_test.cc`: Add unit tests for `MetadataManager`.

## Test
```
        Start 105: UCMetadataManagerTest.SameKeyGoesToSameShard
105/166 Test #105: UCMetadataManagerTest.SameKeyGoesToSameShard ......................................................   Passed    0.01 sec
        Start 106: UCMetadataManagerTest.DifferentKeysMayHitDifferentShards
106/166 Test #106: UCMetadataManagerTest.DifferentKeysMayHitDifferentShards ..........................................   Passed    0.01 sec
        Start 107: UCMetadataManagerTest.PerKeyOpsDispatchAndRoundtrip
107/166 Test #107: UCMetadataManagerTest.PerKeyOpsDispatchAndRoundtrip ...............................................   Passed    0.01 sec
        Start 108: UCMetadataManagerTest.GetKeyCntAggregatesAcrossShards
108/166 Test #108: UCMetadataManagerTest.GetKeyCntAggregatesAcrossShards .............................................   Passed    0.01 sec
```