### PR TITLE
[Feat] hixlTransport support multi-instance

### DIFF
--- a/ucm/transport/p2p/include/one_sided/core/transport.h
+++ b/ucm/transport/p2p/include/one_sided/core/transport.h
@@ -58,7 +58,7 @@ struct MemoryRegion {
     void* addr = nullptr;
     uint64_t length = 0;
     MemoryType type = MemoryType::Host;
-    int device_id = -1;
+    int32_t device_id = -1;
 };
 
 struct InitAttrs {

--- a/ucm/transport/p2p/include/one_sided/core/transport_init_attrs.h
+++ b/ucm/transport/p2p/include/one_sided/core/transport_init_attrs.h
@@ -3,14 +3,20 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <vector>
 #include "core/transport.h"
 
 namespace transport {
 
 struct HixlInitAttrs : public InitAttrs {
-    std::string local_engine;
-    std::map<std::string, std::string> options;
-    int device_id = -1;
+    struct Instance {
+        int32_t port = 0;
+        int32_t device_id = -1;
+        std::map<std::string, std::string> options;
+    };
+
+    std::string ip = "127.0.0.1";
+    std::vector<Instance> instances;
     int32_t connect_timeout_ms = 1000;
     int32_t transfer_timeout_ms = 1000;
 };

--- a/ucm/transport/p2p/include/one_sided/core/transport_manager.h
+++ b/ucm/transport/p2p/include/one_sided/core/transport_manager.h
@@ -66,8 +66,7 @@ private:
     mutable std::recursive_mutex peer_mutex_;
     std::unordered_map<TransportProtocol, Transport*> protocol_map_;
     std::vector<InstalledTransport> transports_;
-    std::unordered_map<MemoryHandle, MemoryRecord> memories_;
-    MemoryHandle next_memory_handle_ = 1;
+    std::unordered_map<MemoryHandle, std::unique_ptr<MemoryRecord>> memories_;
     std::unordered_map<TransferHandle, TransferRecord> transfers_;
     TransferHandle next_transfer_handle_ = 1;
 };

--- a/ucm/transport/p2p/include/one_sided/hixl/hixl_transport.h
+++ b/ucm/transport/p2p/include/one_sided/hixl/hixl_transport.h
@@ -1,19 +1,24 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
-#include <map>
+#include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
-#include "acl/acl.h"
+#include <vector>
 #include "core/transport.h"
 #include "core/transport_init_attrs.h"
-#include "hixl/hixl.h"
+#include "hixl/hixl_types.h"
 
 namespace transport {
 
-struct HixlTransportMetadata {
-    std::string local_engine;
+class HixlInstance;
+
+struct HixlInstanceInfo {
+    Endpoint endpoint;
+    int32_t device_id = -1;
 };
 
 class HixlTransport final : public Transport {
@@ -25,8 +30,8 @@ public:
     HixlTransport& operator=(const HixlTransport&) = delete;
 
     TransportProtocol Protocol() const override;
-    Status Init(const InitAttrs& options) override;
-    Status Init(const HixlInitAttrs& options);
+    Status Init(const InitAttrs& attrs) override;
+    Status Init(const HixlInitAttrs& attrs);
     Status Shutdown() override;
     Status RegisterMemory(const MemoryRegion& memory, MemoryHandle& handle) override;
     Status UnregisterMemory(MemoryHandle handle) override;
@@ -40,31 +45,36 @@ public:
 
 private:
     struct Peer {
-        std::string remote_engine;
-        Metadata metadata;
+        std::vector<HixlInstanceInfo> instances;
+        size_t local_index = SIZE_MAX;
         bool connected = false;
     };
 
     struct LocalMemoryRecord {
         MemoryRegion region;
-        hixl::MemHandle native_handle = nullptr;
+        std::unordered_map<size_t, hixl::MemHandle> native_handles;
     };
 
-    bool ValidateMemory(uint64_t address, uint64_t length) const;
-    Status BuildTransfer(const Operation& batch, std::vector<hixl::TransferOpDesc>& descs);
+    struct PendingTransfer {
+        size_t instance_index = SIZE_MAX;
+        hixl::TransferReq request = nullptr;
+    };
 
-    std::string local_engine_;
-    std::map<std::string, std::string> options_;
-    aclrtContext context_ = nullptr;
-    int device_id_ = -1;
+    Status ValidateTransferLocked(const Operation& batch, size_t instance_index) const;
+    Status BuildRouteLocked(const ManagerID& manager_id, Peer& peer);
+    Status DisconnectRoute(const Peer& peer, bool ignore_failure);
+
     int32_t connect_timeout_ms_ = 1000;
     int32_t transfer_timeout_ms_ = 1000;
+    std::vector<std::unique_ptr<HixlInstance>> instances_;
     std::unordered_map<ManagerID, Peer> peers_;
-    hixl::Hixl hixl_;
-    std::unordered_map<uint64_t, LocalMemoryRecord> memories_;
-    std::unordered_map<TransferHandle, hixl::TransferReq> pending_transfers_;
+    std::unordered_map<MemoryHandle, std::unique_ptr<LocalMemoryRecord>> memories_;
+    std::unordered_map<TransferHandle, PendingTransfer> pending_transfers_;
     TransferHandle next_transfer_handle_ = 1;
-    mutable std::recursive_mutex mutex_;
+    mutable std::shared_mutex lifecycle_mutex_;
+    mutable std::shared_mutex peers_mutex_;
+    mutable std::shared_mutex memories_mutex_;
+    mutable std::mutex pending_mutex_;
 };
 
 }  // namespace transport

--- a/ucm/transport/p2p/src/one_sided/core/transport_manager.cpp
+++ b/ucm/transport/p2p/src/one_sided/core/transport_manager.cpp
@@ -73,36 +73,6 @@ Status DecodePeerAdvertisement(const Metadata& in, PeerAdvertisement& advertisem
     return offset == in.size() ? Status::Ok : Status::InvalidArgument;
 }
 
-bool SameMemoryRegion(const MemoryRegion& left, const MemoryRegion& right)
-{
-    return left.addr == right.addr && left.length == right.length && left.type == right.type &&
-           left.device_id == right.device_id;
-}
-
-bool MemoryRange(const MemoryRegion& memory, uint64_t* begin, uint64_t* end)
-{
-    const auto range_begin = detail::PtrToU64(memory.addr);
-    if (memory.length > std::numeric_limits<uint64_t>::max() - range_begin) { return false; }
-    if (begin != nullptr) { *begin = range_begin; }
-    if (end != nullptr) { *end = range_begin + memory.length; }
-    return true;
-}
-
-bool MemoryRegionOverlaps(const MemoryRegion& left, const MemoryRegion& right)
-{
-    if (left.type != right.type || left.device_id != right.device_id) { return false; }
-
-    uint64_t left_begin = 0;
-    uint64_t left_end = 0;
-    uint64_t right_begin = 0;
-    uint64_t right_end = 0;
-    if (!MemoryRange(left, &left_begin, &left_end) ||
-        !MemoryRange(right, &right_begin, &right_end)) {
-        return true;
-    }
-    return left_begin < right_end && right_begin < left_end;
-}
-
 bool TransportForDirect(OperationDirect direct, TransportProtocol& protocol)
 {
     if (direct != OperationDirect::RemoteDeviceHost) { return false; }
@@ -167,7 +137,6 @@ Status TransportManager::Shutdown()
         if (status != Status::Ok && result == Status::Ok) { result = status; }
     }
     memories_.clear();
-    next_memory_handle_ = 1;
     transfers_.clear();
     next_transfer_handle_ = 1;
     protocol_map_.clear();
@@ -251,19 +220,14 @@ Status TransportManager::RegisterMemory(const MemoryRegion& memory, MemoryHandle
 {
     handle = kInvalidMemoryHandle;
     if (memory.addr == nullptr || memory.length == 0) { return Status::InvalidArgument; }
-    if (!MemoryRange(memory, nullptr, nullptr)) { return Status::InvalidArgument; }
+    const auto address = detail::PtrToU64(memory.addr);
+    if (memory.length > std::numeric_limits<uint64_t>::max() - address) {
+        return Status::InvalidArgument;
+    }
     if (transports_.empty()) { return Status::Failed; }
 
-    for (const auto& item : memories_) {
-        if (SameMemoryRegion(item.second.region, memory)) {
-            handle = item.first;
-            return Status::Ok;
-        }
-        if (MemoryRegionOverlaps(item.second.region, memory)) { return Status::InvalidArgument; }
-    }
-
-    MemoryRecord record;
-    record.region = memory;
+    auto record = std::make_unique<MemoryRecord>();
+    record->region = memory;
     for (const auto& item : transports_) {
         MemoryHandle transport_handle = kInvalidMemoryHandle;
         auto status = item.transport->RegisterMemory(memory, transport_handle);
@@ -278,9 +242,9 @@ Status TransportManager::RegisterMemory(const MemoryRegion& memory, MemoryHandle
                 detail::PtrToU64(memory.addr), memory.length);
             continue;
         }
-        record.transport_handles.emplace(item.protocol, transport_handle);
+        record->transport_handles.emplace(item.protocol, transport_handle);
     }
-    if (record.transport_handles.empty()) {
+    if (record->transport_handles.empty()) {
         UC_ERROR(
             "transport manager register memory failed: no transport accepted addr=0x{:x} "
             "length={}",
@@ -288,8 +252,7 @@ Status TransportManager::RegisterMemory(const MemoryRegion& memory, MemoryHandle
         return Status::Failed;
     }
 
-    handle = next_memory_handle_++;
-    if (handle == kInvalidMemoryHandle) { handle = next_memory_handle_++; }
+    handle = reinterpret_cast<MemoryHandle>(record.get());
     memories_.emplace(handle, std::move(record));
     return Status::Ok;
 }
@@ -301,7 +264,7 @@ Status TransportManager::UnregisterMemory(MemoryHandle handle)
     const auto it = memories_.find(handle);
     if (it == memories_.end()) { return Status::Failed; }
 
-    for (const auto& item : it->second.transport_handles) {
+    for (const auto& item : it->second->transport_handles) {
         const auto transport_it = protocol_map_.find(item.first);
         if (transport_it == protocol_map_.end()) {
             UC_ERROR("transport manager unregister memory failed protocol={} handle={}",

--- a/ucm/transport/p2p/src/one_sided/hixl/hixl_instance.cpp
+++ b/ucm/transport/p2p/src/one_sided/hixl/hixl_instance.cpp
@@ -1,0 +1,278 @@
+#include "hixl/hixl_instance.h"
+#include <acl/acl.h>
+#include <exception>
+#include <utility>
+#include "hixl/hixl.h"
+#include "logger/logger.h"
+
+namespace transport {
+namespace {
+
+std::vector<hixl::TransferOpDesc> BuildTransferOpDesc(const std::vector<Segment>& segments)
+{
+    std::vector<hixl::TransferOpDesc> descs;
+    descs.reserve(segments.size());
+    for (const auto& segment : segments) {
+        descs.push_back(hixl::TransferOpDesc{
+            reinterpret_cast<uintptr_t>(segment.local_addr),
+            static_cast<uintptr_t>(segment.remote_addr),
+            static_cast<size_t>(segment.length),
+        });
+    }
+    return descs;
+}
+
+}  // namespace
+
+HixlInstance::HixlInstance(Endpoint local_endpoint, int32_t device_id)
+    : local_endpoint_(std::move(local_endpoint)), device_id_(device_id)
+{
+}
+
+HixlInstance::~HixlInstance() { Finalize(); }
+
+Status HixlInstance::Initialize(const std::map<std::string, std::string>& options)
+{
+    std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (initialized_) { return Status::Ok; }
+        stopping_ = false;
+    }
+    if (worker_.joinable()) { worker_.join(); }
+
+    std::promise<Status> initialize_result;
+    auto initialize_future = initialize_result.get_future();
+    worker_ = std::thread(&HixlInstance::WorkerMain, this, options, std::move(initialize_result));
+    const auto status = initialize_future.get();
+    if (status != Status::Ok && worker_.joinable()) { worker_.join(); }
+    return status;
+}
+
+Status HixlInstance::Run(Task task)
+{
+    QueuedTask queued(std::move(task));
+    auto result = queued.get_future();
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!initialized_ || stopping_) { return Status::Failed; }
+        tasks_.push_back(std::move(queued));
+    }
+    cv_.notify_one();
+    try {
+        return result.get();
+    } catch (const std::exception& e) {
+        UC_ERROR("[Transport][HIXL] worker task failed: {}", e.what());
+    } catch (...) {
+        UC_ERROR("[Transport][HIXL] worker task failed with unknown exception");
+    }
+    return Status::Failed;
+}
+
+void HixlInstance::Finalize()
+{
+    std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!worker_.joinable()) { return; }
+        stopping_ = true;
+    }
+    cv_.notify_one();
+    worker_.join();
+}
+
+void HixlInstance::WorkerMain(std::map<std::string, std::string> options,
+                              std::promise<Status> initialize_result)
+{
+    const auto set_device_status = aclrtSetDevice(device_id_);
+    if (set_device_status != ACL_ERROR_NONE) {
+        UC_ERROR("[Transport][HIXL] set device failed: aclrtSetDevice({}) returned {}", device_id_,
+                 static_cast<int>(set_device_status));
+        initialize_result.set_value(Status::Failed);
+        return;
+    }
+
+    {
+        hixl::Hixl engine;
+        std::map<hixl::AscendString, hixl::AscendString> hixl_options;
+        for (const auto& item : options) {
+            hixl_options.emplace(item.first.c_str(), item.second.c_str());
+        }
+
+        const auto local_engine = local_endpoint_.ToString();
+        const auto init_status = engine.Initialize(local_engine.c_str(), hixl_options);
+        if (init_status != hixl::SUCCESS) {
+            UC_ERROR("[Transport][HIXL] init failed: Initialize(\"{}\") returned {}", local_engine,
+                     static_cast<int>(init_status));
+            initialize_result.set_value(Status::Failed);
+        } else {
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                initialized_ = true;
+            }
+            initialize_result.set_value(Status::Ok);
+            ProcessTasks(engine);
+            engine.Finalize();
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        initialized_ = false;
+    }
+    const auto reset_device_status = aclrtResetDevice(device_id_);
+    if (reset_device_status != ACL_ERROR_NONE) {
+        UC_WARN("[Transport][HIXL] reset device failed: aclrtResetDevice({}) returned {}",
+                device_id_, static_cast<int>(reset_device_status));
+    }
+}
+
+void HixlInstance::ProcessTasks(hixl::Hixl& engine)
+{
+    for (;;) {
+        QueuedTask queued;
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            cv_.wait(lock, [this] { return stopping_ || !tasks_.empty(); });
+            if (stopping_ && tasks_.empty()) { break; }
+            queued = std::move(tasks_.front());
+            tasks_.pop_front();
+        }
+        queued(engine);
+    }
+}
+
+Status HixlInstance::RegisterMemory(const MemoryRegion& memory, hixl::MemHandle& handle)
+{
+    hixl::MemHandle native_handle = nullptr;
+    const auto status = Run([&](hixl::Hixl& engine) {
+        hixl::MemDesc desc{};
+        desc.addr = reinterpret_cast<uintptr_t>(memory.addr);
+        desc.len = static_cast<size_t>(memory.length);
+        const auto type = memory.type == MemoryType::Device ? hixl::MEM_DEVICE : hixl::MEM_HOST;
+        const auto native_status = engine.RegisterMem(desc, type, native_handle);
+        if (native_status != hixl::SUCCESS) {
+            UC_ERROR(
+                "[Transport][HIXL] register memory failed: engine={} device={} "
+                "RegisterMem(addr=0x{:x}, length={}) returned {}",
+                local_endpoint_.ToString(), device_id_, reinterpret_cast<uintptr_t>(memory.addr),
+                memory.length, static_cast<int>(native_status));
+            return Status::Failed;
+        }
+        return Status::Ok;
+    });
+    if (status == Status::Ok) { handle = native_handle; }
+    return status;
+}
+
+Status HixlInstance::UnregisterMemory(hixl::MemHandle handle)
+{
+    return Run([&](hixl::Hixl& engine) {
+        const auto native_status = engine.DeregisterMem(handle);
+        if (native_status != hixl::SUCCESS) {
+            UC_ERROR(
+                "[Transport][HIXL] unregister memory failed: engine={} DeregisterMem(handle={}) "
+                "returned {}",
+                local_endpoint_.ToString(), handle, static_cast<int>(native_status));
+            return Status::Failed;
+        }
+        return Status::Ok;
+    });
+}
+
+Status HixlInstance::Connect(const std::string& remote_engine, int32_t timeout_ms)
+{
+    return Run([&](hixl::Hixl& engine) {
+        const auto native_status = engine.Connect(remote_engine.c_str(), timeout_ms);
+        if (native_status != hixl::SUCCESS) {
+            UC_ERROR(
+                "[Transport][HIXL] connect failed: local_engine=\"{}\" remote_engine=\"{}\" "
+                "returned {}",
+                local_endpoint_.ToString(), remote_engine, static_cast<int>(native_status));
+            return Status::Failed;
+        }
+        return Status::Ok;
+    });
+}
+
+Status HixlInstance::Disconnect(const std::string& remote_engine, int32_t timeout_ms)
+{
+    return Run([&](hixl::Hixl& engine) {
+        const auto native_status = engine.Disconnect(remote_engine.c_str(), timeout_ms);
+        if (native_status != hixl::SUCCESS) {
+            UC_WARN("[Transport][HIXL] disconnect returned: Disconnect(\"{}\") returned {}",
+                    remote_engine, static_cast<int>(native_status));
+            return Status::Failed;
+        }
+        return Status::Ok;
+    });
+}
+
+Status HixlInstance::TransferSync(const std::string& remote_engine, Opcode opcode,
+                                  const std::vector<Segment>& segments, int32_t timeout_ms)
+{
+    return Run([&](hixl::Hixl& engine) {
+        const auto descs = BuildTransferOpDesc(segments);
+        const auto operation = opcode == Opcode::Read ? hixl::READ : hixl::WRITE;
+        const auto native_status =
+            engine.TransferSync(remote_engine.c_str(), operation, descs, timeout_ms);
+        if (native_status != hixl::SUCCESS) {
+            UC_ERROR(
+                "[Transport][HIXL] operation failed: TransferSync(\"{}\", ops={}, timeout_ms={}) "
+                "returned {}",
+                remote_engine, descs.size(), timeout_ms, static_cast<int>(native_status));
+            return Status::Failed;
+        }
+        return Status::Ok;
+    });
+}
+
+Status HixlInstance::TransferAsync(const std::string& remote_engine, Opcode opcode,
+                                   const std::vector<Segment>& segments, hixl::TransferReq& request)
+{
+    hixl::TransferReq native_request = nullptr;
+    const auto status = Run([&](hixl::Hixl& engine) {
+        const auto descs = BuildTransferOpDesc(segments);
+        hixl::TransferArgs args;
+        const auto operation = opcode == Opcode::Read ? hixl::READ : hixl::WRITE;
+        const auto native_status =
+            engine.TransferAsync(remote_engine.c_str(), operation, descs, args, native_request);
+        if (native_status != hixl::SUCCESS || native_request == nullptr) {
+            UC_ERROR(
+                "[Transport][HIXL] async operation failed: TransferAsync(\"{}\", ops={}) returned "
+                "{} request={}",
+                remote_engine, descs.size(), static_cast<int>(native_status), native_request);
+            return Status::Failed;
+        }
+        return Status::Ok;
+    });
+    if (status == Status::Ok) { request = native_request; }
+    return status;
+}
+
+Status HixlInstance::GetTransferStatus(hixl::TransferReq request, TransferStatus& status)
+{
+    status = TransferStatus::Failed;
+    return Run([&](hixl::Hixl& engine) {
+        hixl::TransferStatus native_transfer_status = hixl::TransferStatus::WAITING;
+        const auto native_status = engine.GetTransferStatus(request, native_transfer_status);
+        if (native_status != hixl::SUCCESS) {
+            UC_ERROR("[Transport][HIXL] get transfer status failed: req={} returned {}", request,
+                     static_cast<int>(native_status));
+            return Status::Failed;
+        }
+        switch (native_transfer_status) {
+            case hixl::TransferStatus::WAITING: status = TransferStatus::Waiting; break;
+            case hixl::TransferStatus::COMPLETED: status = TransferStatus::Completed; break;
+            case hixl::TransferStatus::FAILED:
+            case hixl::TransferStatus::TIMEOUT: status = TransferStatus::Failed; break;
+        }
+        return Status::Ok;
+    });
+}
+
+const Endpoint& HixlInstance::LocalEndpoint() const { return local_endpoint_; }
+
+int32_t HixlInstance::DeviceId() const { return device_id_; }
+
+}  // namespace transport

--- a/ucm/transport/p2p/src/one_sided/hixl/hixl_instance.h
+++ b/ucm/transport/p2p/src/one_sided/hixl/hixl_instance.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <future>
+#include <map>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+#include "core/transport.h"
+#include "hixl/hixl_types.h"
+
+namespace hixl {
+class Hixl;
+}
+
+namespace transport {
+
+// Owns one HIXL engine and serializes its operations on a dedicated worker thread.
+class HixlInstance final {
+public:
+    HixlInstance(Endpoint local_endpoint, int32_t device_id);
+    ~HixlInstance();
+
+    HixlInstance(const HixlInstance&) = delete;
+    HixlInstance& operator=(const HixlInstance&) = delete;
+
+    Status Initialize(const std::map<std::string, std::string>& options);
+    void Finalize();
+
+    Status RegisterMemory(const MemoryRegion& memory, hixl::MemHandle& handle);
+    Status UnregisterMemory(hixl::MemHandle handle);
+    Status Connect(const std::string& remote_engine, int32_t timeout_ms);
+    Status Disconnect(const std::string& remote_engine, int32_t timeout_ms);
+    Status TransferSync(const std::string& remote_engine, Opcode opcode,
+                        const std::vector<Segment>& segments, int32_t timeout_ms);
+    Status TransferAsync(const std::string& remote_engine, Opcode opcode,
+                         const std::vector<Segment>& segments, hixl::TransferReq& request);
+    Status GetTransferStatus(hixl::TransferReq request, TransferStatus& status);
+
+    const Endpoint& LocalEndpoint() const;
+    int32_t DeviceId() const;
+
+private:
+    using Task = std::function<Status(hixl::Hixl&)>;
+    using QueuedTask = std::packaged_task<Status(hixl::Hixl&)>;
+
+    Status Run(Task task);
+    void WorkerMain(std::map<std::string, std::string> options,
+                    std::promise<Status> initialize_result);
+    void ProcessTasks(hixl::Hixl& engine);
+
+    Endpoint local_endpoint_;
+    int32_t device_id_ = -1;
+    std::thread worker_;
+
+    // Serializes Initialize and Finalize, including worker creation and join.
+    std::mutex lifecycle_mutex_;
+
+    // Protects tasks_, stopping_, and initialized_; cv_ coordinates state changes.
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    std::deque<QueuedTask> tasks_;
+    bool stopping_ = false;
+    bool initialized_ = false;
+};
+
+}  // namespace transport

--- a/ucm/transport/p2p/src/one_sided/hixl/hixl_transport.cpp
+++ b/ucm/transport/p2p/src/one_sided/hixl/hixl_transport.cpp
@@ -1,39 +1,98 @@
 #include "hixl/hixl_transport.h"
+#include <arpa/inet.h>
+#include <limits>
+#include <netdb.h>
+#include <netinet/in.h>
 #include <string>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <utility>
 #include <vector>
-#include "common/acl_runtime_context.h"
 #include "common/metadata_codec.h"
+#include "hixl/hixl_instance.h"
 #include "logger/logger.h"
 
 namespace transport {
 namespace {
 
-Status EncodeMetadata(const HixlTransportMetadata& metadata, Metadata& out)
+Status PickAvailablePort(const std::string& host, uint16_t& port)
 {
-    if (metadata.local_engine.empty()) { return Status::InvalidArgument; }
-    out.clear();
-    return detail::AppendString(out, metadata.local_engine) ? Status::Ok : Status::InvalidArgument;
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    addrinfo* results = nullptr;
+    if (getaddrinfo(host.c_str(), "0", &hints, &results) != 0) { return Status::Failed; }
+
+    Status status = Status::Failed;
+    for (auto* item = results; item != nullptr; item = item->ai_next) {
+        const int candidate = socket(item->ai_family, item->ai_socktype, item->ai_protocol);
+        if (candidate < 0) { continue; }
+
+        if (bind(candidate, item->ai_addr, item->ai_addrlen) == 0) {
+            sockaddr_storage address{};
+            socklen_t address_length = sizeof(address);
+            if (getsockname(candidate, reinterpret_cast<sockaddr*>(&address), &address_length) ==
+                0) {
+                if (address.ss_family == AF_INET) {
+                    port = ntohs(reinterpret_cast<sockaddr_in*>(&address)->sin_port);
+                    status = port == 0 ? Status::Failed : Status::Ok;
+                } else if (address.ss_family == AF_INET6) {
+                    port = ntohs(reinterpret_cast<sockaddr_in6*>(&address)->sin6_port);
+                    status = port == 0 ? Status::Failed : Status::Ok;
+                }
+            }
+        }
+
+        close(candidate);
+        if (status == Status::Ok) { break; }
+    }
+
+    freeaddrinfo(results);
+    return status;
 }
 
-Status DecodeMetadata(const Metadata& in, HixlTransportMetadata& metadata)
+Status EncodeMetadata(const std::vector<HixlInstanceInfo>& instances, Metadata& out)
 {
-    size_t offset = 0;
-    if (!detail::ReadString(in, offset, metadata.local_engine) || offset != in.size() ||
-        metadata.local_engine.empty()) {
+    if (instances.empty() || instances.size() > std::numeric_limits<uint32_t>::max()) {
         return Status::InvalidArgument;
+    }
+
+    out.clear();
+    if (!detail::AppendU32(out, static_cast<uint32_t>(instances.size()))) {
+        return Status::InvalidArgument;
+    }
+    for (const auto& instance : instances) {
+        if (instance.device_id < 0 || !detail::AppendString(out, instance.endpoint.host) ||
+            !detail::AppendU16(out, instance.endpoint.port) ||
+            !detail::AppendU32(out, static_cast<uint32_t>(instance.device_id))) {
+            return Status::InvalidArgument;
+        }
     }
     return Status::Ok;
 }
 
-TransferStatus ConvertTransferStatus(hixl::TransferStatus status)
+Status DecodeMetadata(const Metadata& in, std::vector<HixlInstanceInfo>& instances)
 {
-    switch (status) {
-        case hixl::TransferStatus::WAITING: return TransferStatus::Waiting;
-        case hixl::TransferStatus::COMPLETED: return TransferStatus::Completed;
-        case hixl::TransferStatus::FAILED:
-        case hixl::TransferStatus::TIMEOUT: return TransferStatus::Failed;
+    size_t offset = 0;
+    uint32_t count = 0;
+    if (!detail::ReadU32(in, offset, count) || count == 0) { return Status::InvalidArgument; }
+
+    instances.clear();
+    instances.reserve(count);
+    for (uint32_t i = 0; i < count; ++i) {
+        HixlInstanceInfo instance;
+        uint32_t device_id = 0;
+        if (!detail::ReadString(in, offset, instance.endpoint.host) ||
+            !detail::ReadU16(in, offset, instance.endpoint.port) ||
+            !detail::ReadU32(in, offset, device_id) ||
+            device_id > static_cast<uint32_t>(std::numeric_limits<int32_t>::max())) {
+            return Status::InvalidArgument;
+        }
+        instance.device_id = static_cast<int32_t>(device_id);
+        instances.push_back(std::move(instance));
     }
-    return TransferStatus::Failed;
+    return offset == in.size() ? Status::Ok : Status::InvalidArgument;
 }
 
 }  // namespace
@@ -47,109 +106,80 @@ HixlTransport::~HixlTransport()
 
 TransportProtocol HixlTransport::Protocol() const { return TransportProtocol::Hixl; }
 
-Status HixlTransport::Init(const InitAttrs& options)
+Status HixlTransport::Init(const InitAttrs& attrs)
 {
-    const auto* attrs = dynamic_cast<const HixlInitAttrs*>(&options);
-    return attrs == nullptr ? Status::InvalidArgument : Init(*attrs);
+    const auto* hixl_attrs = dynamic_cast<const HixlInitAttrs*>(&attrs);
+    return hixl_attrs == nullptr ? Status::InvalidArgument : Init(*hixl_attrs);
 }
 
-Status HixlTransport::Init(const HixlInitAttrs& options)
+Status HixlTransport::Init(const HixlInitAttrs& attrs)
 {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    if (options.local_engine.empty() || options.device_id < 0) { return Status::InvalidArgument; }
+    if (!instances_.empty()) { return Status::Ok; }
+    if (attrs.instances.empty()) { return Status::InvalidArgument; }
 
-    aclrtContext previous_context = nullptr;
-    (void)aclrtGetCurrentContext(&previous_context);
-    const auto set_device_status = aclrtSetDevice(options.device_id);
-    if (set_device_status != ACL_ERROR_NONE) {
-        UC_ERROR("transport hixl set device failed: aclrtSetDevice({}) returned {}",
-                 options.device_id, static_cast<int>(set_device_status));
-        return Status::Failed;
-    }
-    aclrtContext context = nullptr;
-    const auto get_context_status = aclrtGetCurrentContext(&context);
-    if (get_context_status != ACL_ERROR_NONE || context == nullptr) {
-        UC_ERROR("transport hixl get context failed: aclrtGetCurrentContext returned {}",
-                 static_cast<int>(get_context_status));
-        if (previous_context != nullptr) { (void)aclrtSetCurrentContext(previous_context); }
-        return Status::Failed;
+    for (size_t i = 0; i < attrs.instances.size(); ++i) {
+        const auto& instance_attrs = attrs.instances[i];
+        Endpoint local_endpoint;
+        local_endpoint.host = attrs.ip;
+        if (instance_attrs.port < 0) {
+            const auto status = PickAvailablePort(local_endpoint.host, local_endpoint.port);
+            if (status != Status::Ok) {
+                UC_ERROR("[Transport][HIXL] pick available port failed: host={}",
+                         local_endpoint.host);
+                return status;
+            }
+        } else if (instance_attrs.port <=
+                   static_cast<int32_t>(std::numeric_limits<uint16_t>::max())) {
+            local_endpoint.port = static_cast<uint16_t>(instance_attrs.port);
+        } else {
+            UC_ERROR("[Transport][HIXL] invalid port: port={}", instance_attrs.port);
+            return Status::InvalidArgument;
+        }
+        UC_DEBUG("[Transport][HIXL] init instance={} endpoint={} device={} options={}", i,
+                 local_endpoint.ToString(), instance_attrs.device_id,
+                 instance_attrs.options.size());
+
+        instances_.push_back(
+            std::make_unique<HixlInstance>(std::move(local_endpoint), instance_attrs.device_id));
     }
 
-    std::map<hixl::AscendString, hixl::AscendString> hixl_options;
-    for (const auto& item : options.options) {
-        hixl_options.emplace(item.first.c_str(), item.second.c_str());
-    }
-    const auto init_status = hixl_.Initialize(options.local_engine.c_str(), hixl_options);
-    if (init_status != hixl::SUCCESS) {
-        UC_ERROR("transport hixl init failed: Initialize(\"{}\") returned {}", options.local_engine,
-                 static_cast<int>(init_status));
-        if (previous_context != nullptr) { (void)aclrtSetCurrentContext(previous_context); }
-        return Status::Failed;
-    }
-    if (previous_context != nullptr && previous_context != context) {
-        const auto restore_status = aclrtSetCurrentContext(previous_context);
-        if (restore_status != ACL_ERROR_NONE) {
-            UC_ERROR("transport hixl restore context failed: aclrtSetCurrentContext returned {}",
-                     static_cast<int>(restore_status));
-            hixl_.Finalize();
-            return Status::Failed;
+    connect_timeout_ms_ = attrs.connect_timeout_ms;
+    transfer_timeout_ms_ = attrs.transfer_timeout_ms;
+
+    for (size_t i = 0; i < instances_.size(); ++i) {
+        const auto status = instances_[i]->Initialize(attrs.instances[i].options);
+        if (status != Status::Ok) {
+            for (auto& instance : instances_) { instance->Finalize(); }
+            instances_.clear();
+            return status;
         }
     }
-    local_engine_ = options.local_engine;
-    options_ = options.options;
-    context_ = context;
-    device_id_ = options.device_id;
-    connect_timeout_ms_ = options.connect_timeout_ms;
-    transfer_timeout_ms_ = options.transfer_timeout_ms;
+    UC_INFO("[Transport][HIXL] init success instances={}", instances_.size());
     return Status::Ok;
-}
-
-bool HixlTransport::ValidateMemory(uint64_t address, uint64_t length) const
-{
-    if (length == 0) { return false; }
-    for (const auto& item : memories_) {
-        const auto begin = detail::PtrToU64(item.second.region.addr);
-        if (address < begin) { continue; }
-        const auto offset = address - begin;
-        if (offset <= item.second.region.length && length <= item.second.region.length - offset) {
-            return true;
-        }
-    }
-    return false;
 }
 
 Status HixlTransport::Shutdown()
 {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
+    std::unique_lock<std::shared_mutex> lock(lifecycle_mutex_);
     Status result = Status::Ok;
-    if (!local_engine_.empty()) {
-        WithAclRuntimeContext context_guard(context_);
-        if (context_guard.status() != Status::Ok) { return context_guard.status(); }
-        for (const auto& item : peers_) {
-            const auto status =
-                hixl_.Disconnect(item.second.remote_engine.c_str(), connect_timeout_ms_);
-            if (status != hixl::SUCCESS) {
-                UC_WARN(
-                    "transport hixl disconnect during shutdown returned: Disconnect(\"{}\") "
-                    "returned {}",
-                    item.second.remote_engine, static_cast<int>(status));
-            }
-        }
-        for (const auto& item : memories_) {
-            if (item.second.native_handle != nullptr) {
-                const auto status = hixl_.DeregisterMem(item.second.native_handle);
-                if (status != hixl::SUCCESS) {
-                    UC_ERROR("transport hixl deregister memory failed: DeregisterMem returned {}",
-                             static_cast<int>(status));
-                    result = Status::Failed;
-                }
-            }
-        }
-        hixl_.Finalize();
-        context_ = nullptr;
-        device_id_ = -1;
-        local_engine_.clear();
+    for (auto& item : peers_) {
+        auto& peer = item.second;
+        if (peer.local_index >= instances_.size() || !peer.connected) { continue; }
+        const auto status = DisconnectRoute(peer, true);
+        if (status != Status::Ok && result == Status::Ok) { result = status; }
+        peer.connected = false;
     }
+
+    for (const auto& memory : memories_) {
+        for (const auto& handle : memory.second->native_handles) {
+            if (handle.first >= instances_.size() || handle.second == nullptr) { continue; }
+            const auto status = instances_[handle.first]->UnregisterMemory(handle.second);
+            if (status != Status::Ok && result == Status::Ok) { result = status; }
+        }
+    }
+
+    for (auto& instance : instances_) { instance->Finalize(); }
+    instances_.clear();
     peers_.clear();
     memories_.clear();
     pending_transfers_.clear();
@@ -159,228 +189,297 @@ Status HixlTransport::Shutdown()
 
 Status HixlTransport::RegisterMemory(const MemoryRegion& memory, MemoryHandle& handle)
 {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    WithAclRuntimeContext context_guard(context_);
-    if (context_guard.status() != Status::Ok) { return context_guard.status(); }
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
     handle = kInvalidMemoryHandle;
-    const auto address = detail::PtrToU64(memory.addr);
+    if (instances_.empty()) { return Status::Failed; }
 
-    LocalMemoryRecord record;
-    record.region = memory;
-    hixl::MemDesc desc{};
-    desc.addr = static_cast<uintptr_t>(address);
-    desc.len = static_cast<size_t>(memory.length);
-    hixl::MemHandle native_handle = nullptr;
-    const auto type = memory.type == MemoryType::Device ? hixl::MEM_DEVICE : hixl::MEM_HOST;
-    const auto status = hixl_.RegisterMem(desc, type, native_handle);
-    if (status != hixl::SUCCESS) {
-        UC_ERROR(
-            "transport hixl register memory failed: RegisterMem(addr=0x{:x}, length={}) returned "
-            "{}",
-            address, memory.length, static_cast<int>(status));
-        return Status::Failed;
+    std::unique_lock<std::shared_mutex> memory_lock(memories_mutex_);
+
+    auto record = std::make_unique<LocalMemoryRecord>();
+    record->region = memory;
+
+    for (size_t i = 0; i < instances_.size(); ++i) {
+        if (memory.type == MemoryType::Device && instances_[i]->DeviceId() != memory.device_id) {
+            continue;
+        }
+
+        hixl::MemHandle native_handle = nullptr;
+        const auto status = instances_[i]->RegisterMemory(memory, native_handle);
+        if (status != Status::Ok || native_handle == nullptr) {
+            for (const auto& item : record->native_handles) {
+                if (instances_[item.first]->UnregisterMemory(item.second) != Status::Ok) {
+                    UC_ERROR(
+                        "[Transport][HIXL] rollback memory registration failed: instance={} "
+                        "handle={}",
+                        item.first, item.second);
+                }
+            }
+            return status == Status::Ok ? Status::Failed : status;
+        }
+        record->native_handles.emplace(i, native_handle);
     }
-    record.native_handle = native_handle;
-    memories_.emplace(address, record);
-    handle = address;
+
+    if (record->native_handles.empty()) { return Status::InvalidArgument; }
+    handle = reinterpret_cast<MemoryHandle>(record.get());
+    memories_.emplace(handle, std::move(record));
     return Status::Ok;
 }
 
 Status HixlTransport::UnregisterMemory(MemoryHandle handle)
 {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    WithAclRuntimeContext context_guard(context_);
-    if (context_guard.status() != Status::Ok) { return context_guard.status(); }
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
     if (handle == kInvalidMemoryHandle) { return Status::InvalidArgument; }
-    const auto it = memories_.find(handle);
-    if (it == memories_.end()) { return Status::Failed; }
-    if (it->second.native_handle != nullptr) {
-        if (hixl_.DeregisterMem(it->second.native_handle) != hixl::SUCCESS) {
-            return Status::Failed;
-        }
-        it->second.native_handle = nullptr;
+
+    std::unique_lock<std::shared_mutex> memory_lock(memories_mutex_);
+    const auto record_it = memories_.find(handle);
+    if (record_it == memories_.end()) { return Status::Failed; }
+    auto& record = *record_it->second;
+    while (!record.native_handles.empty()) {
+        const auto item = *record.native_handles.begin();
+        if (item.first >= instances_.size() || item.second == nullptr) { return Status::Failed; }
+        const auto status = instances_[item.first]->UnregisterMemory(item.second);
+        if (status != Status::Ok) { return status; }
+        record.native_handles.erase(item.first);
     }
-    memories_.erase(it);
+    memories_.erase(record_it);
     return Status::Ok;
 }
 
 Status HixlTransport::ExportMetadata(const ManagerID&, Metadata& out)
 {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    return EncodeMetadata(HixlTransportMetadata{local_engine_}, out);
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    std::vector<HixlInstanceInfo> metadata;
+    metadata.reserve(instances_.size());
+    for (const auto& instance : instances_) {
+        metadata.push_back(HixlInstanceInfo{instance->LocalEndpoint(), instance->DeviceId()});
+    }
+    return EncodeMetadata(metadata, out);
 }
 
 Status HixlTransport::ImportMetadata(const ManagerID& manager_id, const Metadata& metadata)
 {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    WithAclRuntimeContext context_guard(context_);
-    if (context_guard.status() != Status::Ok) { return context_guard.status(); }
-    if (manager_id.empty()) { return Status::InvalidArgument; }
-    HixlTransportMetadata remote_meta;
-    const auto status = DecodeMetadata(metadata, remote_meta);
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    std::vector<HixlInstanceInfo> remote_instances;
+    const auto status = DecodeMetadata(metadata, remote_instances);
     if (status != Status::Ok) { return status; }
 
-    const auto peer_it = peers_.find(manager_id);
-    if (peer_it != peers_.end()) {
-        auto& peer = peer_it->second;
-        if (peer.metadata == metadata) { return Status::Ok; }
-        if (peer.remote_engine == remote_meta.local_engine) {
-            peer.metadata = metadata;
-            return Status::Ok;
-        }
-        if (peer.connected) {
-            const auto disconnect_status =
-                hixl_.Disconnect(peer.remote_engine.c_str(), connect_timeout_ms_);
-            if (disconnect_status != hixl::SUCCESS) {
-                UC_ERROR("transport hixl disconnect failed: Disconnect(\"{}\") returned {}",
-                         peer.remote_engine, static_cast<int>(disconnect_status));
-                return Status::Failed;
+    {
+        std::unique_lock<std::shared_mutex> peer_lock(peers_mutex_);
+        const auto peer_it = peers_.find(manager_id);
+        if (peer_it != peers_.end()) {
+            // A second metadata exchange means the previous remote instance has stopped, even
+            // when the new instance uses the same endpoint and device identifiers.
+            if (peer_it->second.connected && DisconnectRoute(peer_it->second, true) != Status::Ok) {
+                UC_ERROR("[Transport][HIXL] cleanup stale route failed: peer={}", manager_id);
             }
+            peers_.erase(peer_it);
         }
-    }
 
-    Peer peer_state;
-    peer_state.remote_engine = remote_meta.local_engine;
-    peer_state.metadata = metadata;
-    peers_[manager_id] = std::move(peer_state);
+        Peer peer_state;
+        peer_state.instances = std::move(remote_instances);
+        if (peer_state.instances.size() > 1) {
+            UC_DEBUG(
+                "[Transport][HIXL] import peer metadata with multiple remote instances: peer={} "
+                "remote_instances={}, use first instance for transfer route",
+                manager_id, peer_state.instances.size());
+        }
+        const auto route_status = BuildRouteLocked(manager_id, peer_state);
+        if (route_status != Status::Ok) { return route_status; }
+
+        peers_[manager_id] = std::move(peer_state);
+    }
     return Status::Ok;
 }
 
-Status HixlTransport::Connect(const ManagerID& peer)
+Status HixlTransport::BuildRouteLocked(const ManagerID& manager_id, Peer& peer)
 {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    WithAclRuntimeContext context_guard(context_);
-    if (context_guard.status() != Status::Ok) { return context_guard.status(); }
-    const auto peer_it = peers_.find(peer);
-    if (peer_it == peers_.end()) { return Status::Failed; }
-    auto& peer_state = peer_it->second;
-    if (peer_state.connected) { return Status::Ok; }
-    const auto connect_status =
-        hixl_.Connect(peer_state.remote_engine.c_str(), connect_timeout_ms_);
-    if (connect_status != hixl::SUCCESS) {
-        UC_ERROR("transport hixl connect failed: Connect(\"{}\") returned {}",
-                 peer_state.remote_engine, static_cast<int>(connect_status));
+    peer.local_index = SIZE_MAX;
+    peer.connected = false;
+    if (instances_.empty() || peer.instances.empty()) {
+        UC_ERROR("[Transport][HIXL] build route failed: peer={} remote_instances={}", manager_id,
+                 peer.instances.size());
+        return Status::InvalidArgument;
+    }
+
+    const auto local_count = instances_.size();
+    std::vector<size_t> load(local_count, 0);
+    for (const auto& item : peers_) {
+        if (item.first == manager_id) { continue; }
+        if (item.second.local_index < load.size()) { ++load[item.second.local_index]; }
+    }
+
+    const auto& remote = peer.instances.front();
+    std::vector<size_t> candidates;
+    size_t min_load = std::numeric_limits<size_t>::max();
+    for (size_t local_index = 0; local_index < local_count; ++local_index) {
+        if (instances_[local_index]->LocalEndpoint().host == remote.endpoint.host &&
+            instances_[local_index]->DeviceId() == remote.device_id) {
+            continue;
+        }
+        if (load[local_index] < min_load) {
+            candidates.clear();
+            min_load = load[local_index];
+        }
+        if (load[local_index] == min_load) { candidates.push_back(local_index); }
+    }
+    if (candidates.empty()) {
+        UC_ERROR(
+            "[Transport][HIXL] build route failed: no valid local instance for endpoint={} "
+            "device={}",
+            remote.endpoint.ToString(), remote.device_id);
         return Status::Failed;
     }
-    peer_state.connected = true;
+
+    const auto local_index = candidates.front();
+    peer.local_index = local_index;
+    UC_DEBUG(
+        "[Transport][HIXL] build route peer={} local_instance={} local_engine={} "
+        "local_device={} remote_engine={} remote_device={}",
+        manager_id, local_index, instances_[local_index]->LocalEndpoint().ToString(),
+        instances_[local_index]->DeviceId(), remote.endpoint.ToString(), remote.device_id);
     return Status::Ok;
 }
 
-Status HixlTransport::Disconnect(const ManagerID& peer)
+Status HixlTransport::DisconnectRoute(const Peer& peer, bool ignore_failure)
 {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    WithAclRuntimeContext context_guard(context_);
-    if (context_guard.status() != Status::Ok) { return context_guard.status(); }
-    const auto peer_it = peers_.find(peer);
+    if (peer.local_index >= instances_.size() || peer.instances.empty()) { return Status::Failed; }
+
+    const auto remote_engine = peer.instances.front().endpoint.ToString();
+    const auto status =
+        instances_[peer.local_index]->Disconnect(remote_engine, connect_timeout_ms_);
+    return ignore_failure ? Status::Ok : status;
+}
+
+Status HixlTransport::Connect(const ManagerID& manager_id)
+{
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    std::unique_lock<std::shared_mutex> peer_lock(peers_mutex_);
+    const auto peer_it = peers_.find(manager_id);
     if (peer_it == peers_.end()) { return Status::Failed; }
-    auto& peer_state = peer_it->second;
-    if (!peer_state.connected) { return Status::Ok; }
+    auto& peer = peer_it->second;
+    if (peer.local_index == SIZE_MAX || peer.instances.empty()) { return Status::Failed; }
+    if (peer.connected) { return Status::Ok; }
+    if (peer.local_index >= instances_.size()) { return Status::Failed; }
 
-    peer_state.connected = false;
-    const auto status = hixl_.Disconnect(peer_state.remote_engine.c_str(), connect_timeout_ms_);
-    if (status != hixl::SUCCESS) {
-        UC_WARN("transport hixl disconnect returned: Disconnect(\"{}\") returned {}",
-                peer_state.remote_engine, static_cast<int>(status));
-        return Status::Failed;
-    }
+    const auto remote_engine = peer.instances.front().endpoint.ToString();
+    const auto status = instances_[peer.local_index]->Connect(remote_engine, connect_timeout_ms_);
+    if (status != Status::Ok) { return status; }
+
+    peer.connected = true;
     return Status::Ok;
 }
 
-Status HixlTransport::BuildTransfer(const Operation& batch,
-                                    std::vector<hixl::TransferOpDesc>& descs)
+Status HixlTransport::Disconnect(const ManagerID& manager_id)
 {
-    if (batch.target_manager.empty() || batch.ops.empty()) { return Status::InvalidArgument; }
-    descs.clear();
-    descs.reserve(batch.ops.size());
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    std::unique_lock<std::shared_mutex> peer_lock(peers_mutex_);
+    const auto peer_it = peers_.find(manager_id);
+    if (peer_it == peers_.end()) { return Status::Failed; }
+    auto& peer = peer_it->second;
+    if (!peer.connected) { return Status::Ok; }
+    if (peer.local_index >= instances_.size() || peer.instances.empty()) { return Status::Failed; }
+
+    const auto status = DisconnectRoute(peer, false);
+    if (status != Status::Ok) { return status; }
+
+    peer.connected = false;
+    return Status::Ok;
+}
+
+Status HixlTransport::ValidateTransferLocked(const Operation& batch, size_t instance_index) const
+{
+    if (batch.target_manager.empty() || batch.ops.empty() || instance_index >= instances_.size()) {
+        return Status::InvalidArgument;
+    }
     for (const auto& item : batch.ops) {
-        const auto local_address = detail::PtrToU64(item.local_addr);
-        if (!ValidateMemory(local_address, item.length) || item.remote_addr == 0) {
+        if (item.local_addr == nullptr || item.length == 0 || item.remote_addr == 0) {
             return Status::InvalidArgument;
         }
-        descs.push_back(hixl::TransferOpDesc{
-            static_cast<uintptr_t>(local_address),
-            static_cast<uintptr_t>(item.remote_addr),
-            static_cast<size_t>(item.length),
-        });
+
+        const auto local_address = detail::PtrToU64(item.local_addr);
+        bool registered = false;
+        for (const auto& memory : memories_) {
+            const auto begin = detail::PtrToU64(memory.second->region.addr);
+            if (local_address < begin) { continue; }
+
+            const auto offset = local_address - begin;
+            if (offset <= memory.second->region.length &&
+                item.length <= memory.second->region.length - offset &&
+                memory.second->native_handles.find(instance_index) !=
+                    memory.second->native_handles.end()) {
+                registered = true;
+                break;
+            }
+        }
+        if (!registered) { return Status::InvalidArgument; }
     }
     return Status::Ok;
 }
 
 Status HixlTransport::ExecuteSync(const Operation& batch)
 {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    WithAclRuntimeContext context_guard(context_);
-    if (context_guard.status() != Status::Ok) { return context_guard.status(); }
-
-    const auto peer_it = peers_.find(batch.target_manager);
-    if (peer_it == peers_.end()) { return Status::Failed; }
-    if (!peer_it->second.connected) { return Status::Failed; }
-    auto& peer_state = peer_it->second;
-
-    std::vector<hixl::TransferOpDesc> descs;
-    const auto build_status = BuildTransfer(batch, descs);
-    if (build_status != Status::Ok) { return build_status; }
-
-    const auto op = batch.opcode == Opcode::Read ? hixl::READ : hixl::WRITE;
-    const auto transfer_status =
-        hixl_.TransferSync(peer_state.remote_engine.c_str(), op, descs, transfer_timeout_ms_);
-    if (transfer_status != hixl::SUCCESS) {
-        UC_ERROR(
-            "transport hixl operation failed: TransferSync(\"{}\", ops={}, timeout_ms={}) returned "
-            "{}",
-            peer_state.remote_engine, descs.size(), transfer_timeout_ms_,
-            static_cast<int>(transfer_status));
-        peer_state.connected = false;
-        const auto disconnect_status =
-            hixl_.Disconnect(peer_state.remote_engine.c_str(), connect_timeout_ms_);
-        if (disconnect_status != hixl::SUCCESS) {
-            UC_ERROR("transport hixl disconnect failed: Disconnect(\"{}\") returned {}",
-                     peer_state.remote_engine, static_cast<int>(disconnect_status));
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    size_t local_index = SIZE_MAX;
+    std::string remote_engine;
+    {
+        std::shared_lock<std::shared_mutex> peer_lock(peers_mutex_);
+        const auto peer_it = peers_.find(batch.target_manager);
+        if (peer_it == peers_.end()) { return Status::Failed; }
+        const auto& peer_state = peer_it->second;
+        if (peer_state.local_index >= instances_.size() || peer_state.instances.empty() ||
+            !peer_state.connected) {
+            return Status::Failed;
         }
-        return Status::Failed;
+        local_index = peer_state.local_index;
+        remote_engine = peer_state.instances.front().endpoint.ToString();
     }
-    return Status::Ok;
+
+    {
+        std::shared_lock<std::shared_mutex> memory_lock(memories_mutex_);
+        const auto transfer_status = ValidateTransferLocked(batch, local_index);
+        if (transfer_status != Status::Ok) { return transfer_status; }
+    }
+
+    return instances_[local_index]->TransferSync(remote_engine, batch.opcode, batch.ops,
+                                                 transfer_timeout_ms_);
 }
 
 Status HixlTransport::ExecuteAsync(const Operation& batch, TransferHandle& handle)
 {
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    WithAclRuntimeContext context_guard(context_);
-    if (context_guard.status() != Status::Ok) { return context_guard.status(); }
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
     handle = kInvalidTransferHandle;
-
-    const auto peer_it = peers_.find(batch.target_manager);
-    if (peer_it == peers_.end()) { return Status::Failed; }
-    if (!peer_it->second.connected) { return Status::Failed; }
-    auto& peer_state = peer_it->second;
-
-    std::vector<hixl::TransferOpDesc> descs;
-    const auto build_status = BuildTransfer(batch, descs);
-    if (build_status != Status::Ok) { return build_status; }
-
-    hixl::TransferReq request = nullptr;
-    hixl::TransferArgs args;
-    const auto op = batch.opcode == Opcode::Read ? hixl::READ : hixl::WRITE;
-    const auto transfer_status =
-        hixl_.TransferAsync(peer_state.remote_engine.c_str(), op, descs, args, request);
-    if (transfer_status != hixl::SUCCESS || request == nullptr) {
-        UC_ERROR(
-            "transport hixl async operation failed: TransferAsync(\"{}\", ops={}) returned "
-            "{} request={}",
-            peer_state.remote_engine, descs.size(), static_cast<int>(transfer_status), request);
-        peer_state.connected = false;
-        const auto disconnect_status =
-            hixl_.Disconnect(peer_state.remote_engine.c_str(), connect_timeout_ms_);
-        if (disconnect_status != hixl::SUCCESS) {
-            UC_ERROR("transport hixl disconnect failed: Disconnect(\"{}\") returned {}",
-                     peer_state.remote_engine, static_cast<int>(disconnect_status));
+    size_t local_index = SIZE_MAX;
+    std::string remote_engine;
+    {
+        std::shared_lock<std::shared_mutex> peer_lock(peers_mutex_);
+        const auto peer_it = peers_.find(batch.target_manager);
+        if (peer_it == peers_.end()) { return Status::Failed; }
+        const auto& peer_state = peer_it->second;
+        if (peer_state.local_index >= instances_.size() || peer_state.instances.empty() ||
+            !peer_state.connected) {
+            return Status::Failed;
         }
-        return Status::Failed;
+        local_index = peer_state.local_index;
+        remote_engine = peer_state.instances.front().endpoint.ToString();
     }
 
-    handle = next_transfer_handle_++;
-    if (handle == kInvalidTransferHandle) { handle = next_transfer_handle_++; }
-    pending_transfers_.emplace(handle, request);
+    {
+        std::shared_lock<std::shared_mutex> memory_lock(memories_mutex_);
+        const auto transfer_status = ValidateTransferLocked(batch, local_index);
+        if (transfer_status != Status::Ok) { return transfer_status; }
+    }
+
+    hixl::TransferReq request = nullptr;
+    const auto status =
+        instances_[local_index]->TransferAsync(remote_engine, batch.opcode, batch.ops, request);
+    if (status != Status::Ok) { return status; }
+
+    {
+        std::lock_guard<std::mutex> pending_lock(pending_mutex_);
+        handle = next_transfer_handle_++;
+        if (handle == kInvalidTransferHandle) { handle = next_transfer_handle_++; }
+        pending_transfers_.emplace(handle, PendingTransfer{local_index, request});
+    }
     return Status::Ok;
 }
 
@@ -388,23 +487,30 @@ Status HixlTransport::GetStatus(TransferHandle handle, TransferStatus& status)
 {
     status = TransferStatus::Failed;
     if (handle == kInvalidTransferHandle) { return Status::InvalidArgument; }
-    std::lock_guard<std::recursive_mutex> lock(mutex_);
-    WithAclRuntimeContext context_guard(context_);
-    if (context_guard.status() != Status::Ok) { return context_guard.status(); }
-    const auto it = pending_transfers_.find(handle);
-    if (it == pending_transfers_.end()) { return Status::Failed; }
-
-    hixl::TransferStatus transfer_status = hixl::TransferStatus::WAITING;
-    const auto query_status = hixl_.GetTransferStatus(it->second, transfer_status);
-    if (query_status != hixl::SUCCESS) {
-        UC_ERROR("transport hixl get transfer status failed: req={} returned {}", it->second,
-                 static_cast<int>(query_status));
-        status = TransferStatus::Failed;
-        pending_transfers_.erase(it);
-        return Status::Failed;
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    PendingTransfer pending;
+    {
+        std::lock_guard<std::mutex> pending_lock(pending_mutex_);
+        const auto it = pending_transfers_.find(handle);
+        if (it == pending_transfers_.end() || it->second.instance_index >= instances_.size()) {
+            return Status::Failed;
+        }
+        pending = it->second;
     }
-    status = ConvertTransferStatus(transfer_status);
-    if (status != TransferStatus::Waiting) { pending_transfers_.erase(it); }
+
+    TransferStatus transfer_status = TransferStatus::Waiting;
+    const auto query_status =
+        instances_[pending.instance_index]->GetTransferStatus(pending.request, transfer_status);
+    if (query_status != Status::Ok) {
+        std::lock_guard<std::mutex> pending_lock(pending_mutex_);
+        pending_transfers_.erase(handle);
+        return query_status;
+    }
+    status = transfer_status;
+    if (status != TransferStatus::Waiting) {
+        std::lock_guard<std::mutex> pending_lock(pending_mutex_);
+        pending_transfers_.erase(handle);
+    }
     return Status::Ok;
 }
 

--- a/ucm/transport/p2p/tests/e2e/hixl_e2e.cpp
+++ b/ucm/transport/p2p/tests/e2e/hixl_e2e.cpp
@@ -1,0 +1,574 @@
+#include <acl/acl.h>
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+#include "core/transport_manager.h"
+#include "test_common.h"
+
+using namespace transport;
+
+namespace {
+
+constexpr size_t kLen = 4 * 1024;
+
+const char* envText(const char* name, const char* fallback)
+{
+    const char* value = std::getenv(name);
+    return value == nullptr || *value == '\0' ? fallback : value;
+}
+
+int envInt(const char* name, int fallback)
+{
+    const char* text = std::getenv(name);
+    if (text == nullptr || *text == '\0') { return fallback; }
+    char* end = nullptr;
+    const auto value = std::strtol(text, &end, 10);
+    return end != nullptr && *end == '\0' ? static_cast<int>(value) : fallback;
+}
+
+int32_t envHixlPort(const char* name, int32_t fallback)
+{
+    const char* text = std::getenv(name);
+    if (text == nullptr || *text == '\0') { return fallback; }
+    char* end = nullptr;
+    const auto value = std::strtol(text, &end, 10);
+    if (end == nullptr || *end != '\0' || value < std::numeric_limits<int32_t>::min() ||
+        value > std::numeric_limits<int32_t>::max()) {
+        return fallback;
+    }
+    return static_cast<int32_t>(value);
+}
+
+std::vector<int> envIntList(const char* name, std::vector<int> fallback)
+{
+    const char* text = std::getenv(name);
+    if (text == nullptr || *text == '\0') { return fallback; }
+
+    std::vector<int> result;
+    std::istringstream iss(text);
+    std::string item;
+    while (std::getline(iss, item, ',')) {
+        if (item.empty()) { return fallback; }
+        char* end = nullptr;
+        const auto value = std::strtol(item.c_str(), &end, 10);
+        if (end == nullptr || *end != '\0') { return fallback; }
+        result.push_back(static_cast<int>(value));
+    }
+    return result.empty() ? fallback : result;
+}
+
+std::string joinDeviceIds(const std::vector<int>& device_ids)
+{
+    std::ostringstream oss;
+    for (size_t i = 0; i < device_ids.size(); ++i) {
+        if (i != 0) { oss << ','; }
+        oss << device_ids[i];
+    }
+    return oss.str();
+}
+
+struct Config {
+    std::string local_host =
+        envText("HIXL_TEST_LOCAL_HOST", envText("HIXL_TEST_HOST", "127.0.0.1"));
+    std::string peer_host = envText("HIXL_TEST_PEER_HOST", envText("HIXL_TEST_HOST", "127.0.0.1"));
+    uint16_t server_manager_port = test::envPort("TRANSPORT_TEST_PORT_A", 4501);
+    uint16_t client_manager_port = test::envPort("TRANSPORT_TEST_PORT_B", 4502);
+    uint16_t server_control_port = test::envPort("TRANSPORT_CONTROL_PORT_A", 4601);
+    uint16_t client_control_port = test::envPort("TRANSPORT_CONTROL_PORT_B", 4602);
+    int32_t server_hixl_port = envHixlPort("HIXL_TEST_PORT_A", -1);
+    int32_t client_hixl_port = envHixlPort("HIXL_TEST_PORT_B", -1);
+    int server_device_id = envInt("HIXL_TEST_DEVICE_A", 4);
+    int client_device_id = envInt("HIXL_TEST_DEVICE_B", 5);
+    std::vector<int> client_device_ids =
+        envIntList("HIXL_TEST_DEVICE_IDS_B",
+                   envIntList("HIXL_TEST_DEVICES_B", std::vector<int>{client_device_id}));
+    int connect_timeout_ms = envInt("HIXL_TEST_CONNECT_TIMEOUT_MS", 30000);
+    int transfer_timeout_ms = envInt("HIXL_TEST_TRANSFER_TIMEOUT_MS", 30000);
+    int wait_attempts = envInt("HIXL_TEST_WAIT_ATTEMPTS", 600);
+    int wait_interval_ms = envInt("HIXL_TEST_WAIT_RETRY_MS", 100);
+};
+
+class AclRuntime {
+public:
+    explicit AclRuntime(int device_id) : device_id_(device_id)
+    {
+        std::cerr << "[HIXL e2e] aclInit begin\n";
+        const auto init_status = aclInit(nullptr);
+        std::cerr << "[HIXL e2e] aclInit return " << static_cast<int>(init_status) << "\n";
+        if (init_status != ACL_ERROR_NONE) { return; }
+
+        ok_ = SetDevice(device_id_);
+    }
+
+    ~AclRuntime()
+    {
+        if (ok_) {
+            for (const auto device_id : device_ids_) { aclrtResetDevice(device_id); }
+            aclFinalize();
+        }
+    }
+
+    AclRuntime(const AclRuntime&) = delete;
+    AclRuntime& operator=(const AclRuntime&) = delete;
+
+    bool ok() const { return ok_; }
+
+    bool SetDevice(int device_id)
+    {
+        std::cerr << "[HIXL e2e] aclrtSetDevice(" << device_id << ") begin\n";
+        const auto set_device_status = aclrtSetDevice(device_id);
+        std::cerr << "[HIXL e2e] aclrtSetDevice(" << device_id << ") return "
+                  << static_cast<int>(set_device_status) << "\n";
+        if (set_device_status != ACL_ERROR_NONE) { return false; }
+        if (std::find(device_ids_.begin(), device_ids_.end(), device_id) == device_ids_.end()) {
+            device_ids_.push_back(device_id);
+        }
+        return true;
+    }
+
+private:
+    int device_id_ = 0;
+    std::vector<int> device_ids_;
+    bool ok_ = false;
+};
+
+ManagerID makeManagerID(const Config& config, bool server)
+{
+    return config.local_host + ":" +
+           std::to_string(server ? config.server_manager_port : config.client_manager_port);
+}
+
+ManagerID peerManagerID(const Config& config, bool server)
+{
+    return config.peer_host + ":" +
+           std::to_string(server ? config.client_manager_port : config.server_manager_port);
+}
+
+Endpoint peerEndpoint(const Config& config, bool server)
+{
+    return test::makeEndpoint(config.peer_host,
+                              server ? config.client_control_port : config.server_control_port);
+}
+
+HixlInitAttrs makeHixlAttrs(const Config& config, bool server)
+{
+    HixlInitAttrs attrs;
+    attrs.ip = config.local_host;
+    const auto device_ids =
+        server ? std::vector<int>{config.server_device_id} : config.client_device_ids;
+    const auto base_port = server ? config.server_hixl_port : config.client_hixl_port;
+    for (size_t i = 0; i < device_ids.size(); ++i) {
+        HixlInitAttrs::Instance instance;
+        const auto port_value = static_cast<int64_t>(base_port) + static_cast<int64_t>(i);
+        instance.port = base_port < 0 || port_value < std::numeric_limits<int32_t>::min() ||
+                                port_value > std::numeric_limits<int32_t>::max()
+                            ? -1
+                            : static_cast<int32_t>(port_value);
+        instance.device_id = device_ids[i];
+        attrs.instances.push_back(std::move(instance));
+    }
+    attrs.connect_timeout_ms = config.connect_timeout_ms;
+    attrs.transfer_timeout_ms = config.transfer_timeout_ms;
+    return attrs;
+}
+
+std::string describeHixlInstances(const HixlInitAttrs& attrs)
+{
+    std::ostringstream oss;
+    for (size_t i = 0; i < attrs.instances.size(); ++i) {
+        if (i != 0) { oss << ";"; }
+        oss << attrs.ip << ':' << attrs.instances[i].port
+            << "/device=" << attrs.instances[i].device_id;
+    }
+    return oss.str();
+}
+
+bool exchangeMetadataWithRetry(TransportManager& manager, const ManagerID& manager_id,
+                               const Config& config)
+{
+    for (int attempt = 1; attempt <= config.wait_attempts; ++attempt) {
+        if (manager.ExchangeMetadata(manager_id) == Status::Ok) { return true; }
+        std::this_thread::sleep_for(std::chrono::milliseconds(config.wait_interval_ms));
+    }
+    return false;
+}
+
+struct RemoteDeviceAddress {
+    int device_id = -1;
+    uint64_t address = 0;
+};
+
+struct LocalDeviceMemory {
+    int device_id = -1;
+    void* address = nullptr;
+    MemoryHandle handle = kInvalidMemoryHandle;
+};
+
+bool parseAddressMessage(const std::string& message, std::vector<RemoteDeviceAddress>& addresses)
+{
+    std::istringstream iss(message);
+    std::string tag;
+    iss >> tag;
+    addresses.clear();
+    if (tag == "ADDR") {
+        uint64_t address = 0;
+        iss >> std::hex >> address;
+        if (address == 0) { return false; }
+        addresses.push_back(RemoteDeviceAddress{-1, address});
+        return true;
+    }
+
+    if (tag != "ADDRS") { return false; }
+    size_t count = 0;
+    iss >> std::dec >> count;
+    if (count == 0) { return false; }
+    addresses.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        RemoteDeviceAddress item;
+        iss >> std::dec >> item.device_id >> std::hex >> item.address;
+        if (!iss || item.address == 0) { return false; }
+        addresses.push_back(item);
+    }
+    return addresses.size() == count;
+}
+
+bool sameHost(const Config& config)
+{
+    return config.local_host == config.peer_host ||
+           (config.local_host == "127.0.0.1" && config.peer_host == "localhost") ||
+           (config.local_host == "localhost" && config.peer_host == "127.0.0.1");
+}
+
+bool validateDeviceConfig(const Config& config)
+{
+    if (config.client_device_ids.empty()) {
+        std::cerr << "HIXL e2e invalid device config: client device list is empty\n";
+        return false;
+    }
+    if (config.server_device_id < 0 ||
+        std::any_of(
+            config.client_device_ids.begin(), config.client_device_ids.end(),
+            [](int device_id) { return device_id < 0; })) {
+        std::cerr << "HIXL e2e invalid device config: device id must be non-negative\n";
+        return false;
+    }
+    if (sameHost(config) &&
+        std::find(config.client_device_ids.begin(), config.client_device_ids.end(),
+                  config.server_device_id) != config.client_device_ids.end()) {
+        std::cerr << "HIXL e2e invalid device config: same-host two-process test cannot use the "
+                     "same device_id="
+                  << config.server_device_id
+                  << ". Set HIXL_TEST_DEVICE_A and HIXL_TEST_DEVICE_IDS_B to disjoint "
+                     "devices.\n";
+        return false;
+    }
+    return true;
+}
+
+bool verifyPattern(const unsigned char* data, const std::string& label)
+{
+    size_t first_error = kLen;
+    for (size_t i = 0; i < kLen; ++i) {
+        if (data[i] != static_cast<unsigned char>(i & 0xff)) {
+            first_error = i;
+            break;
+        }
+    }
+
+    if (first_error == kLen) {
+        std::cout << "[A] >>> VERIFY " << label << ": PASS <<<\n";
+        return true;
+    }
+
+    std::cerr << "[A] >>> VERIFY " << label << ": FAIL <<< at index " << first_error
+              << ", expect=" << int(first_error & 0xff) << ", actual=" << int(data[first_error])
+              << "\n";
+    return false;
+}
+
+bool executeAsync(TransportManager& manager, const Operation& batch,
+                  const std::string& submit_label, const std::string& wait_label)
+{
+    TransferHandle handle = kInvalidTransferHandle;
+    if (!test::expectOk(manager.ExecuteAsync(batch, handle), submit_label.c_str())) {
+        return false;
+    }
+
+    for (;;) {
+        TransferStatus status = TransferStatus::Failed;
+        if (!test::expectOk(manager.GetStatus(handle, status), wait_label.c_str())) {
+            return false;
+        }
+        if (status == TransferStatus::Completed) { return true; }
+        if (status == TransferStatus::Failed) {
+            std::cerr << wait_label << " failed: transfer failed\n";
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+}
+
+int runServer()
+{
+    Config config;
+    if (!validateDeviceConfig(config)) { return 1; }
+    std::cerr << "[HIXL e2e server] init standalone TCP listen " << config.local_host << ':'
+              << config.server_control_port << '\n';
+    TcpMessageChannel control;
+    if (!test::expectOk(
+            control.Init(test::makeEndpoint(config.local_host, config.server_control_port)),
+            "server init standalone TCP")) {
+        return 1;
+    }
+
+    std::cerr << "[HIXL e2e server] init ACL device " << config.server_device_id << '\n';
+    AclRuntime acl(config.server_device_id);
+    if (!test::expectTrue(acl.ok(), "server initialize ACL runtime")) { return 1; }
+
+    const auto manager_id = makeManagerID(config, true);
+    const auto hixl_attrs = makeHixlAttrs(config, true);
+    std::cerr << "[HIXL e2e server] manager_id=" << manager_id
+              << " peer_control=" << config.peer_host << ':' << config.client_control_port
+              << " hixl_instance=\"" << describeHixlInstances(hixl_attrs) << "\"\n";
+
+    TransportManager manager(manager_id);
+    if (!test::expectOk(manager.Init(), "server init manager") ||
+        !test::expectOk(manager.InstallTransport(TransportProtocol::Hixl, hixl_attrs),
+                        "server install HIXL")) {
+        return 1;
+    }
+
+    std::cerr << "[HIXL e2e server] allocate/register device memory\n";
+    LocalDeviceMemory device_memory;
+    device_memory.device_id = config.server_device_id;
+    if (!test::expectTrue(
+            aclrtMalloc(&device_memory.address, kLen, ACL_MEM_MALLOC_HUGE_ONLY) == ACL_ERROR_NONE,
+            "server allocate device memory") ||
+        !test::expectTrue(aclrtMemset(device_memory.address, kLen, 0, kLen) == ACL_ERROR_NONE,
+                          "server clear device memory")) {
+        return 1;
+    }
+
+    MemoryRegion device_region;
+    device_region.addr = device_memory.address;
+    device_region.length = kLen;
+    device_region.type = MemoryType::Device;
+    device_region.device_id = config.server_device_id;
+    if (!test::expectOk(manager.RegisterMemory(device_region, device_memory.handle),
+                        "server register device memory")) {
+        return 1;
+    }
+
+    std::cout << "[B] waiting READY from client on standalone TCP port "
+              << config.server_control_port << "\n";
+    Endpoint client_control;
+    std::string ready;
+    if (!test::receiveText(control, client_control, ready,
+                           "server receives client READY over standalone TCP") ||
+        ready != "READY") {
+        return 1;
+    }
+    std::cout << "[B] client READY from " << client_control.host << ':' << client_control.port
+              << "\n";
+
+    std::ostringstream address_message;
+    address_message << "ADDRS 1 " << std::dec << config.server_device_id << " " << std::hex
+                    << reinterpret_cast<uintptr_t>(device_memory.address);
+    if (!test::sendTextWithRetry(control, client_control, address_message.str(),
+                                 config.wait_attempts, config.wait_interval_ms,
+                                 "server sends device addresses over standalone TCP")) {
+        return 1;
+    }
+
+    std::cout << "[B] waiting DONE from client\n";
+    std::string done;
+    if (!test::receiveText(control, done, "server receives completion over standalone TCP") ||
+        done != "DONE") {
+        return 1;
+    }
+
+    unsigned char back[16] = {};
+    if (!test::expectTrue(aclrtMemcpy(back, sizeof(back), device_memory.address, sizeof(back),
+                                      ACL_MEMCPY_DEVICE_TO_HOST) == ACL_ERROR_NONE,
+                          "server copy final device bytes to host")) {
+        return 1;
+    }
+    std::cout << "[B] first bytes after A->B: ";
+    for (int i = 0; i < 16; ++i) { std::cout << int(back[i]) << " "; }
+    std::cout << "\n";
+
+    if (!test::expectOk(manager.Shutdown(), "server shutdown manager") ||
+        !test::expectOk(control.Shutdown(), "server shutdown standalone TCP")) {
+        return 1;
+    }
+    aclrtFree(device_memory.address);
+    return 0;
+}
+
+int runClient()
+{
+    Config config;
+    if (!validateDeviceConfig(config)) { return 1; }
+    std::cerr << "[HIXL e2e client] init standalone TCP listen " << config.local_host << ':'
+              << config.client_control_port << '\n';
+    TcpMessageChannel control;
+    if (!test::expectOk(
+            control.Init(test::makeEndpoint(config.local_host, config.client_control_port)),
+            "client init standalone TCP")) {
+        return 1;
+    }
+
+    if (!test::sendTextWithRetry(control, peerEndpoint(config, false), "READY",
+                                 config.wait_attempts, config.wait_interval_ms,
+                                 "client sends READY over standalone TCP")) {
+        return 1;
+    }
+
+    std::cerr << "[HIXL e2e client] init ACL device " << config.client_device_ids.front()
+              << " device_ids=" << joinDeviceIds(config.client_device_ids) << '\n';
+    AclRuntime acl(config.client_device_ids.front());
+    if (!test::expectTrue(acl.ok(), "client initialize ACL runtime")) { return 1; }
+
+    const auto manager_id = makeManagerID(config, false);
+    const auto hixl_attrs = makeHixlAttrs(config, false);
+    std::cerr << "[HIXL e2e client] manager_id=" << manager_id
+              << " peer_control=" << config.peer_host << ':' << config.server_control_port
+              << " hixl_instances=\"" << describeHixlInstances(hixl_attrs) << "\"\n";
+
+    TransportManager manager(manager_id);
+    if (!test::expectOk(manager.Init(), "client init manager") ||
+        !test::expectOk(manager.InstallTransport(TransportProtocol::Hixl, hixl_attrs),
+                        "client install HIXL")) {
+        return 1;
+    }
+
+    std::cerr << "[HIXL e2e client] allocate/register host memory\n";
+    void* host = nullptr;
+    if (!test::expectTrue(aclrtMallocHost(&host, kLen) == ACL_ERROR_NONE,
+                          "client allocate host memory")) {
+        return 1;
+    }
+    auto* p = static_cast<unsigned char*>(host);
+    for (size_t i = 0; i < kLen; ++i) { p[i] = static_cast<unsigned char>(i & 0xff); }
+
+    MemoryRegion host_region;
+    host_region.addr = host;
+    host_region.length = kLen;
+    host_region.type = MemoryType::Host;
+    MemoryHandle host_handle = kInvalidMemoryHandle;
+    if (!test::expectOk(manager.RegisterMemory(host_region, host_handle),
+                        "client register host memory")) {
+        return 1;
+    }
+
+    std::cout << "[A] waiting server device address on standalone TCP port "
+              << config.client_control_port << "\n";
+    std::string address_message;
+    std::vector<RemoteDeviceAddress> remote_devices;
+    if (!test::receiveText(control, address_message,
+                           "client receives device addresses over standalone TCP") ||
+        !test::expectTrue(parseAddressMessage(address_message, remote_devices),
+                          "client parses server device addresses")) {
+        return 1;
+    }
+    for (const auto& remote_device : remote_devices) {
+        std::cout << "[A] remote B device " << remote_device.device_id << " addr = 0x" << std::hex
+                  << remote_device.address << std::dec << "\n";
+    }
+
+    const auto peer_manager_id = peerManagerID(config, false);
+    if (!test::expectTrue(exchangeMetadataWithRetry(manager, peer_manager_id, config),
+                          "client exchanges HIXL metadata with server")) {
+        return 1;
+    }
+    if (!test::expectOk(manager.Connect(TransportProtocol::Hixl, peer_manager_id),
+                        "client connects HIXL peer")) {
+        return 1;
+    }
+
+    bool verify_ok = true;
+    for (const auto& remote_device : remote_devices) {
+        Operation batch;
+        batch.target_manager = peer_manager_id;
+        batch.direct = OperationDirect::RemoteDeviceHost;
+        batch.opcode = Opcode::Write;
+        batch.ops.push_back(Segment{host_region.addr, remote_device.address, kLen});
+
+        for (size_t i = 0; i < kLen; ++i) { p[i] = static_cast<unsigned char>(i & 0xff); }
+        std::cout << "[A] Host -> B Device " << remote_device.device_id << " WRITE sync\n";
+        if (!test::expectOk(manager.ExecuteSync(batch),
+                            "client manager routes HIXL host to remote device write sync")) {
+            return 1;
+        }
+        std::cout << "[A] H2D WRITE sync done device=" << remote_device.device_id << "\n";
+
+        std::memset(host, 0, kLen);
+        batch.opcode = Opcode::Read;
+        std::cout << "[A] B Device " << remote_device.device_id << " -> Host READ sync\n";
+        if (!test::expectOk(manager.ExecuteSync(batch),
+                            "client manager routes HIXL remote device to host read sync")) {
+            return 1;
+        }
+        std::cout << "[A] D2H READ sync done device=" << remote_device.device_id << "\n";
+        verify_ok =
+            verifyPattern(p, "sync device " + std::to_string(remote_device.device_id)) && verify_ok;
+
+        for (size_t i = 0; i < kLen; ++i) { p[i] = static_cast<unsigned char>(i & 0xff); }
+        batch.opcode = Opcode::Write;
+        std::cout << "[A] Host -> B Device " << remote_device.device_id << " WRITE async\n";
+        if (!executeAsync(manager, batch,
+                          "client manager submits HIXL host to remote device write async",
+                          "client manager waits HIXL host to remote device write async")) {
+            return 1;
+        }
+        std::cout << "[A] H2D WRITE async done device=" << remote_device.device_id << "\n";
+
+        std::memset(host, 0, kLen);
+        batch.opcode = Opcode::Read;
+        std::cout << "[A] B Device " << remote_device.device_id << " -> Host READ async\n";
+        if (!executeAsync(manager, batch,
+                          "client manager submits HIXL remote device to host read async",
+                          "client manager waits HIXL remote device to host read async")) {
+            return 1;
+        }
+        std::cout << "[A] D2H READ async done device=" << remote_device.device_id << "\n";
+
+        verify_ok = verifyPattern(p, "async device " + std::to_string(remote_device.device_id)) &&
+                    verify_ok;
+    }
+
+    if (!test::sendTextWithRetry(control, peerEndpoint(config, false), "DONE", config.wait_attempts,
+                                 config.wait_interval_ms,
+                                 "client sends completion over standalone TCP")) {
+        return 1;
+    }
+
+    if (!test::expectOk(manager.Shutdown(), "client shutdown manager") ||
+        !test::expectOk(control.Shutdown(), "client shutdown standalone TCP")) {
+        return 1;
+    }
+    aclrtFreeHost(host);
+    return verify_ok ? 0 : 1;
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    const std::string mode = argc > 1 ? argv[1] : envText("HIXL_TEST_ROLE", "");
+    if (mode == "server" || mode == "B") { return runServer(); }
+    if (mode == "client" || mode == "A") { return runClient(); }
+
+    std::cerr << "usage: " << argv[0] << " server|client\n";
+    return 1;
+}

--- a/ucm/transport/p2p/tests/e2e/test_common.h
+++ b/ucm/transport/p2p/tests/e2e/test_common.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <thread>
+#include "core/transport.h"
+#include "two_sided/tcp/tcp_message_channel.h"
+
+namespace transport::test {
+
+inline const char* statusName(Status status)
+{
+    switch (status) {
+        case Status::Ok: return "Ok";
+        case Status::InvalidArgument: return "InvalidArgument";
+        case Status::Failed: return "Failed";
+    }
+    return "Unknown";
+}
+
+inline bool expectOk(Status status, const char* step)
+{
+    if (status == Status::Ok) { return true; }
+    std::cerr << step << " failed: " << statusName(status) << '\n';
+    return false;
+}
+
+inline bool expectStatus(Status actual, Status expected, const char* step)
+{
+    if (actual == expected) { return true; }
+    std::cerr << step << " failed: got " << statusName(actual) << ", expected "
+              << statusName(expected) << '\n';
+    return false;
+}
+
+inline bool expectTrue(bool value, const char* step)
+{
+    if (value) { return true; }
+    std::cerr << step << " failed\n";
+    return false;
+}
+
+inline bool envEnabled(const char* name)
+{
+    const char* value = std::getenv(name);
+    return value != nullptr && std::string(value) == "1";
+}
+
+inline uint16_t envPort(const char* name, uint16_t fallback)
+{
+    const char* text = std::getenv(name);
+    if (text == nullptr || *text == '\0') { return fallback; }
+    const auto value = std::strtoul(text, nullptr, 10);
+    if (value == 0 || value > UINT16_MAX) { return fallback; }
+    return static_cast<uint16_t>(value);
+}
+
+inline Endpoint makeEndpoint(const std::string& host, uint16_t port)
+{
+    Endpoint result;
+    result.host = host;
+    result.port = port;
+    return result;
+}
+
+inline bool sendTextWithRetry(TcpMessageChannel& tcp, const Endpoint& peer, const std::string& text,
+                              int attempts, int interval_ms, const char* step)
+{
+    for (int attempt = 1; attempt <= attempts; ++attempt) {
+        if (tcp.Send(peer, text.data(), text.size()) == Status::Ok) { return true; }
+        std::this_thread::sleep_for(std::chrono::milliseconds(interval_ms));
+    }
+    std::cerr << step << " failed\n";
+    return false;
+}
+
+inline bool receiveText(TcpMessageChannel& tcp, Endpoint& peer, std::string& text, const char* step)
+{
+    Metadata data;
+    const auto status = tcp.Receive(peer, data);
+    if (status != Status::Ok) {
+        std::cerr << step << " failed: " << statusName(status) << '\n';
+        return false;
+    }
+    text.assign(data.begin(), data.end());
+    return true;
+}
+
+inline bool receiveText(TcpMessageChannel& tcp, std::string& text, const char* step)
+{
+    Endpoint peer;
+    return receiveText(tcp, peer, text, step);
+}
+
+}  // namespace transport::test


### PR DESCRIPTION
## Purpose
When HIXL communicates over RoCE, the underlying network resources are bound to the device/NIC associated with the current ACL runtime context. As a result, a single HIXL instance can only represent the resources of one device/NIC and cannot utilize multiple available NICs on the host process. 
This commit adds multi-instance support to the HIXL transport.

## Modifications 
* `HixlInitAttrs` now supports configuring multiple HIXL instances. Each instance creates an independent HIXL engine and runs in its own worker thread, where the corresponding ACL device context is initialized during thread startup.
* If an instance is configured with a port less than 0, an available local port is automatically selected during initialization.
* After importing peer metadata, the transport builds a route to that peer. Route selection will be further topology-aware in future updates. The current strategy is:

  * Avoid selecting a local instance that belongs to the same host and device as the remote instance.
  * Among the remaining candidates, randomly select one of the local instances with the fewest existing routes.
  * Use the selected route for all subsequent `Connect` and transfer operations to that peer.
* The current implementation assumes that the remote peer exports a single HIXL instance. If multiple remote instances are advertised, only the first one is used as a fallback.

