### PR TITLE
[Feat] Unify ASU memory registration APIs and harden ASU transport registration and endpoint handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(UCM_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 option(BUILD_UCM_STORE "build ucm store module." ON)
 option(BUILD_UCM_SPARSE "build ucm sparse module." OFF)
-option(BUILD_UCM_ASU "build ucm ASU transport module." OFF)
+option(BUILD_UCM_ASU "build ucm ASU transport module." ON)
 option(BUILD_UCM_MINDIE "build ucm MindIE integration module." OFF)
 option(BUILD_UNIT_TESTS "build all unit test suits." OFF)
 option(BUILD_NUMA "build numactl library." OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(UCM_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 option(BUILD_UCM_STORE "build ucm store module." ON)
 option(BUILD_UCM_SPARSE "build ucm sparse module." OFF)
-option(BUILD_UCM_ASU "build ucm ASU transport module." ON)
+option(BUILD_UCM_ASU "build ucm ASU transport module." OFF)
 option(BUILD_UCM_MINDIE "build ucm MindIE integration module." OFF)
 option(BUILD_UNIT_TESTS "build all unit test suits." OFF)
 option(BUILD_NUMA "build numactl library." OFF)

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ PLATFORM = os.getenv("PLATFORM")
 ENABLE_SPARSE = os.getenv("ENABLE_SPARSE")
 BUILD_UCM_ASU = os.getenv("BUILD_UCM_ASU", "0") not in ("", "0", "false", "False")
 ENABLE_MINDIE = os.getenv("UCM_ENABLE_MINDIE", "0") not in ("", "0", "false", "False")
-
+BUILD_UCM_ASU_PROVIDER_AIV = os.getenv("BUILD_UCM_ASU_PROVIDER_AIV", "0") not in ("", "0", "false", "False")
 
 def get_abi_flag_from_env() -> str:
     v = os.environ.get("UCM_CXX11_ABI")

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,13 @@ PLATFORM = os.getenv("PLATFORM")
 ENABLE_SPARSE = os.getenv("ENABLE_SPARSE")
 BUILD_UCM_ASU = os.getenv("BUILD_UCM_ASU", "0") not in ("", "0", "false", "False")
 ENABLE_MINDIE = os.getenv("UCM_ENABLE_MINDIE", "0") not in ("", "0", "false", "False")
-BUILD_UCM_ASU_PROVIDER_AIV = os.getenv("BUILD_UCM_ASU_PROVIDER_AIV", "0") not in ("", "0", "false", "False")
+BUILD_UCM_ASU_PROVIDER_AIV = os.getenv("BUILD_UCM_ASU_PROVIDER_AIV", "0") not in (
+    "",
+    "0",
+    "false",
+    "False",
+)
+
 
 def get_abi_flag_from_env() -> str:
     v = os.environ.get("UCM_CXX11_ABI")

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -610,10 +610,6 @@ private:
             return Status::InvalidParam("invalid layerwise gqa tensor size count({})",
                                         config.tensorSizes.size());
         }
-        if (shardsPerBlock > 1 && config.tensorLayout == "mla" && config.tensorSizes.size() != 1) {
-            return Status::InvalidParam("invalid layerwise mla tensor size count({})",
-                                        config.tensorSizes.size());
-        }
         return Status::OK();
     }
 

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -188,6 +188,7 @@ UC::ASU::TransportConfig BuildTransportConfig(const Config& config, std::size_t 
     // Set for all backends including fake
     const auto kvNsIndex = config.uniqueId.find("_fawa_wa") == std::string::npos ? 0 : 1;
     transportConfig.attrs["kv_ns_id"] = std::to_string(config.kvNsIds[kvNsIndex]);
+    if (!config.asuLocalIp.empty()) { transportConfig.attrs["localIp"] = config.asuLocalIp; }
 
     if (!config.asuIps.empty()) {
         UC::ASU::AsuEndpoint endpoint;
@@ -482,6 +483,7 @@ private:
         inConfig.Get("asu_view_service_addrs", config.viewServiceAddrs);
         inConfig.GetNumbers("asu_ids", config.asuIds);
         inConfig.Get("asu_ips", config.asuIps);
+        inConfig.Get("asu_local_ip", config.asuLocalIp);
         inConfig.Get("asu_name_prefix", config.asuNamePrefix);
         inConfig.GetNumbers("kv_ns_ids", config.kvNsIds);
         ssize_t asuPort = 0;

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -18,6 +18,7 @@ struct Config {
     std::vector<std::string> viewServiceAddrs;
     std::vector<ssize_t> asuIds;
     std::vector<std::string> asuIps;
+    std::string asuLocalIp;
     std::string asuNamePrefix{"asu"};
     std::vector<std::uint32_t> kvNsIds;
     std::uint16_t asuPort{0};

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -45,6 +45,11 @@ struct CacheKeyHasher {
     }
 };
 
+UC::ASU::MRHandle MakeTestMrHandle(std::uintptr_t value)
+{
+    return reinterpret_cast<UC::ASU::MRHandle>(value);
+}
+
 struct FakeAsuBackendState {
     std::vector<UC::ASU::QueryMode> queryModes;
     std::vector<UC::AsuStore::Config> initConfigs;

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -575,6 +575,53 @@ TEST(UCAsuStoreTest, UsesLayerwiseMlaTensorOffsets)
     EXPECT_EQ(state->lastStoreEntries[0].offset, std::uint32_t{1024});
 }
 
+TEST(UCAsuStoreTest, UsesMultiSegmentLayerwiseMlaTensorOffsets)
+{
+    constexpr std::size_t shardIndex = 2;
+    constexpr std::size_t alignment = UC::ASU::kAsuAlignmentBytes;
+    constexpr std::size_t alignedShardSize = alignment * 2;
+
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeBackend(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_mode", std::string{"transport"});
+    config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("tensor_layout", std::string{"mla"});
+    config.SetNumber("tensor_size", std::size_t{0});
+    config.Set("tensor_size_list", std::vector<ssize_t>{128, 64});
+    config.SetNumber("shard_size", std::size_t{192});
+    config.SetNumber("block_size", std::size_t{576});
+
+    auto status = store.Setup(config);
+    ASSERT_TRUE(status.Success()) << status.ToString();
+
+    std::array<std::byte, alignment> mainCache{};
+    std::array<std::byte, alignment> ropeCache{};
+    const std::array<void*, 2> buffers{mainCache.data(), ropeCache.data()};
+    auto block = UC::Test::Detail::TypesHelper::MakeBlockId("e1b2c3d4e5f6789012345678901234ab");
+    UC::Detail::TaskDesc task;
+    task.brief = "asu-store-test";
+    task.push_back(UC::Detail::Shard{
+        block, shardIndex, {buffers[0], buffers[1]}
+    });
+
+    auto dump = store.Dump(task);
+    ASSERT_TRUE(dump.HasValue()) << dump.Error().ToString();
+    ASSERT_EQ(state->lastStoreEntries.size(), buffers.size());
+
+    const std::array<std::uint32_t, 2> expectedOffsets{
+        shardIndex * alignedShardSize,
+        shardIndex * alignedShardSize + alignment,
+    };
+    for (std::size_t index = 0; index < buffers.size(); ++index) {
+        EXPECT_EQ(state->lastStoreEntries[index].buffer.region.addr,
+                  reinterpret_cast<std::uint64_t>(buffers[index]));
+        EXPECT_EQ(state->lastStoreEntries[index].buffer.region.size, alignment);
+        EXPECT_EQ(state->lastStoreEntries[index].offset, expectedOffsets[index]);
+    }
+}
+
 TEST(UCAsuStoreTest, AlignsTensorSizeAndDerivesShardBlockSize)
 {
     UC::AsuStore::AsuStore store;

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -350,8 +350,6 @@ Status AsuClientImpl::RegisterRegionsOnce(const std::vector<MemoryRegion>& regio
         RegisteredMemory registeredRegion;
         registeredRegion.region = regions[index];
         registeredRegion.handle = results[index].handle;
-        registeredRegion.lkey = results[index].lkey;
-        registeredRegion.rkey = results[index].rkey;
         registeredRegion.tokenId = results[index].tokenId;
         registeredRegions.emplace_back(registeredRegion);
     }
@@ -917,8 +915,6 @@ Status AsuClientImpl::BindRegisteredResources(AsuId asuId,
         RegisteredMemory registeredRegion;
         registeredRegion.region = resource.region;
         registeredRegion.handle = resource.result.handle;
-        registeredRegion.lkey = resource.result.lkey;
-        registeredRegion.rkey = resource.result.rkey;
         registeredRegion.tokenId = resource.result.tokenId;
         registeredRegions.emplace_back(registeredRegion);
     }

--- a/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
@@ -32,6 +32,8 @@ static CacheKey MakeCacheKey(std::string_view text)
     return key;
 }
 
+MRHandle MakeTestMrHandle(std::uintptr_t value) { return static_cast<MRHandle>(value); }
+
 struct TestState {
     std::uint32_t createdTransports{0};
     std::unordered_map<AsuId, TransportConfig> initConfigs;
@@ -218,7 +220,7 @@ public:
         state_->registerCalls.emplace_back(config_.asuId);
         results.clear();
         for (std::size_t index = 0; index < regions.size(); ++index) {
-            results.emplace_back(RegisterResult{Status::OK(), 500 + index, 0, 0,
+            results.emplace_back(RegisterResult{Status::OK(), MakeTestMrHandle(500 + index),
                                                 900 + static_cast<std::uint32_t>(index)});
         }
         return Status::OK();
@@ -231,8 +233,7 @@ public:
         state_->boundRegions[config_.asuId] = regions;
         results.clear();
         for (const auto& region : regions) {
-            results.emplace_back(RegisterResult{Status::OK(), region.handle, region.lkey,
-                                                region.rkey, region.tokenId});
+            results.emplace_back(RegisterResult{Status::OK(), region.handle, region.tokenId});
         }
         return Status::OK();
     }
@@ -983,14 +984,14 @@ TEST(AsuClientImplTest, MemoryRegister_RegisterRegionsRegistersFirstTransportAnd
     EXPECT_EQ(state->registerCalls, std::vector<AsuId>({10}));
     EXPECT_EQ(state->bindCalls, std::vector<AsuId>({20, 30}));
     ASSERT_EQ(results.size(), std::size_t{2});
-    EXPECT_EQ(results[0].handle, MRHandle{500});
-    EXPECT_EQ(results[1].handle, MRHandle{501});
+    EXPECT_EQ(results[0].handle, MakeTestMrHandle(500));
+    EXPECT_EQ(results[1].handle, MakeTestMrHandle(501));
     EXPECT_EQ(results[0].tokenId, std::uint32_t{900});
     EXPECT_EQ(results[1].tokenId, std::uint32_t{901});
     ASSERT_EQ(state->boundRegions[20].size(), std::size_t{2});
-    EXPECT_EQ(state->boundRegions[20][0].handle, MRHandle{500});
+    EXPECT_EQ(state->boundRegions[20][0].handle, MakeTestMrHandle(500));
     EXPECT_EQ(state->boundRegions[20][0].tokenId, std::uint32_t{900});
-    EXPECT_EQ(state->boundRegions[20][1].handle, MRHandle{501});
+    EXPECT_EQ(state->boundRegions[20][1].handle, MakeTestMrHandle(501));
     EXPECT_EQ(state->boundRegions[20][1].tokenId, std::uint32_t{901});
     ASSERT_EQ(state->boundRegions[30].size(), std::size_t{2});
     EXPECT_EQ(state->boundRegions[30][0].tokenId, std::uint32_t{900});
@@ -1012,7 +1013,7 @@ TEST(AsuClientImplTest, MemoryRegister_PartialRegisterFailureDoesNotBindFollower
             results.clear();
             results.reserve(regions.size());
             if (!regions.empty()) {
-                results.emplace_back(RegisterResult{Status::OK(), 500, 0, 0, 900});
+                results.emplace_back(RegisterResult{Status::OK(), MakeTestMrHandle(500), 900});
             }
             if (regions.size() > 1) {
                 results.emplace_back(RegisterResult{
@@ -1602,7 +1603,7 @@ TEST(AsuClientImplTest, SnapshotRefresh_ReusesExistingTransportAndBindsResources
     EXPECT_EQ(state->createdTransports, std::uint32_t{2});
     EXPECT_EQ(state->bindCalls, std::vector<AsuId>({20}));
     ASSERT_EQ(state->boundRegions[20].size(), std::size_t{1});
-    EXPECT_EQ(state->boundRegions[20][0].handle, MRHandle{500});
+    EXPECT_EQ(state->boundRegions[20][0].handle, MakeTestMrHandle(500));
     EXPECT_EQ(state->boundRegions[20][0].tokenId, std::uint32_t{900});
 }
 

--- a/ucm/transport/kv/asu/test/case/asu_client_e2e_metrics_test.cc
+++ b/ucm/transport/kv/asu/test/case/asu_client_e2e_metrics_test.cc
@@ -67,6 +67,8 @@ struct CacheKeyHasher {
     }
 };
 
+MRHandle MakeTestMrHandle(std::uintptr_t value) { return static_cast<MRHandle>(value); }
+
 enum class OperationKind {
     QUERY,
     LOAD,
@@ -492,7 +494,7 @@ public:
     {
         results.clear();
         for (std::size_t index = 0; index < regions.size(); ++index) {
-            results.emplace_back(RegisterResult{Status::OK(), index + 1});
+            results.emplace_back(RegisterResult{Status::OK(), MakeTestMrHandle(index + 1)});
         }
         return Status::OK();
     }

--- a/ucm/transport/kv/asu/test/case/asu_smoke_test.cc
+++ b/ucm/transport/kv/asu/test/case/asu_smoke_test.cc
@@ -39,6 +39,8 @@ CacheKey MakeCacheKey(std::string_view text)
     return key;
 }
 
+MRHandle MakeTestMrHandle(std::uintptr_t value) { return static_cast<MRHandle>(value); }
+
 class StubTransport : public AsuTransport {
 public:
     Status Init(const TransportConfig& config) override
@@ -116,7 +118,7 @@ public:
     {
         results.clear();
         for (std::size_t i = 0; i < regions.size(); ++i) {
-            results.emplace_back(RegisterResult{Status::OK(), static_cast<MRHandle>(i + 1)});
+            results.emplace_back(RegisterResult{Status::OK(), MakeTestMrHandle(i + 1)});
         }
         return Status::OK();
     }

--- a/ucm/transport/kv/asu/test/case/buffer_manager_test.cc
+++ b/ucm/transport/kv/asu/test/case/buffer_manager_test.cc
@@ -415,8 +415,8 @@ public:
     {
         return {};
     }
-    Status RegisterMemory(ConnectionHandle, const std::vector<RegisterMemoryDesc>& descs,
-                          std::vector<MemHandle>& handles) override
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>& descs,
+                          std::vector<MRHandle>& handles) override
     {
         registerCount++;
         if (!descs.empty()) {
@@ -428,7 +428,7 @@ public:
         if (failRegister) {
             return Status::Error(StatusCode::INTERNAL_ERROR, "stub register failed");
         }
-        handles.push_back(reinterpret_cast<MemHandle>(static_cast<uintptr_t>(registerCount)));
+        handles.push_back(reinterpret_cast<MRHandle>(static_cast<uintptr_t>(registerCount)));
         return Status::OK();
     }
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& descs) override
@@ -441,7 +441,7 @@ public:
         return Status::OK();
     }
     std::vector<Status> FreeThread(const std::vector<ThreadHandle>&) override { return {}; }
-    Status GetMemTokenId(MemHandle, uint32_t& tokenId) override
+    Status GetMemTokenId(MRHandle, uint32_t& tokenId) override
     {
         if (failGetToken) {
             return Status::Error(StatusCode::INTERNAL_ERROR, "stub get token failed");

--- a/ucm/transport/kv/asu/test/case/connection_manager_test.cc
+++ b/ucm/transport/kv/asu/test/case/connection_manager_test.cc
@@ -64,14 +64,14 @@ public:
     {
         return {};
     }
-    Status RegisterMemory(ConnectionHandle, const std::vector<RegisterMemoryDesc>& descs,
-                          std::vector<MemHandle>& handles) override
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>& descs,
+                          std::vector<MRHandle>& handles) override
     {
         handles.clear();
         handles.reserve(descs.size());
         for (std::size_t index = 0; index < descs.size(); ++index) {
-            handles.push_back(reinterpret_cast<MemHandle>(static_cast<std::uintptr_t>(index) +
-                                                          static_cast<std::uintptr_t>(1)));
+            handles.push_back(reinterpret_cast<MRHandle>(static_cast<std::uintptr_t>(index) +
+                                                         static_cast<std::uintptr_t>(1)));
         }
         return Status::OK();
     }
@@ -84,7 +84,7 @@ public:
         return Status::OK();
     }
     std::vector<Status> FreeThread(const std::vector<ThreadHandle>&) override { return {}; }
-    Status GetMemTokenId(MemHandle, uint32_t& tokenId) override
+    Status GetMemTokenId(MRHandle, uint32_t& tokenId) override
     {
         tokenId = 1;
         return Status::OK();

--- a/ucm/transport/kv/asu/trans/include/aiv_transport/aiv_transport.h
+++ b/ucm/transport/kv/asu/trans/include/aiv_transport/aiv_transport.h
@@ -35,7 +35,6 @@ namespace UC::ASU {
 class AIVTransport {
 public:
     using ConnectionHandle = void*;
-    using MemHandle = void*;
 
     virtual ~AIVTransport() = default;
 
@@ -64,21 +63,20 @@ public:
         size_t size;
     };
 
-    virtual Status RegisterMemory(ConnectionHandle connectionHandle,
-                                  const std::vector<RegisterMemoryDesc>& memoryDescs,
-                                  std::vector<MemHandle>& memoryHandles) = 0;
+    virtual Status RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
+                                  std::vector<MRHandle>& mrHandles) = 0;
 
     struct UnregisterMemoryDesc {
-        ConnectionHandle connectionHandle;
-        MemHandle memoryHandle;
+        MRHandle mrHandle;
     };
 
     virtual std::vector<Status> UnregisterMemory(
         const std::vector<UnregisterMemoryDesc>& memoryDescs) = 0;
 
-    virtual Status GetMemTokenId(MemHandle memHandle, uint32_t& tokenId) = 0;
+    virtual Status GetMemTokenId(MRHandle mrHandle, uint32_t& tokenId) = 0;
 };
 
 std::unique_ptr<AIVTransport> CreateAIVTransProvider();
+std::unique_ptr<AIVTransport> CreateAIVTransProvider(uint32_t deviceId);
 
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/include/asu_transport/types.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/types.h
@@ -163,16 +163,12 @@ struct KVBuffer {
 struct RegisterResult {
     Status status;
     MRHandle handle{kInvalidMRHandle};
-    std::uint32_t lkey{0};
-    std::uint32_t rkey{0};
     std::uint32_t tokenId{0};
 };
 
 struct RegisteredMemory {  // 用于绑定已注册的内存
     MemoryRegion region;
     MRHandle handle{kInvalidMRHandle};
-    std::uint32_t lkey{0};
-    std::uint32_t rkey{0};
     std::uint32_t tokenId{0};
 };
 

--- a/ucm/transport/kv/asu/trans/src/aicpu_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/aicpu_trans_provider.h
@@ -22,8 +22,7 @@ public:
         return std::vector<Status>(ioBatches.size(), Status::OK());
     }
 
-    Status RegisterMemory(ConnectionHandle, const std::vector<RegisterMemoryDesc>&,
-                          std::vector<MemHandle>&) override
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>&, std::vector<MRHandle>&) override
     {
         return Status::OK();
     }
@@ -43,7 +42,7 @@ public:
         return std::vector<Status>(threads.size(), Status::OK());
     }
 
-    Status GetMemTokenId(MemHandle, uint32_t& tokenId) override
+    Status GetMemTokenId(MRHandle, uint32_t& tokenId) override
     {
         tokenId = 0;
         return Status::OK();

--- a/ucm/transport/kv/asu/trans/src/aiv_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/aiv_trans_provider.h
@@ -32,6 +32,7 @@ namespace UC::ASU {
 class AIVTransProviderAdapter : public TransProvider {
 public:
     AIVTransProviderAdapter() : impl_(CreateAIVTransProvider()) {}
+    explicit AIVTransProviderAdapter(uint32_t deviceId) : impl_(CreateAIVTransProvider(deviceId)) {}
 
     Status CreateConnection(const std::string& localIp, const std::string& remoteIp, uint32_t port,
                             uint32_t qpNum, uint32_t timeout,
@@ -58,9 +59,8 @@ public:
         return FromImpl(impl_->Send(batches, kernelCount, quietCount));
     }
 
-    Status RegisterMemory(ConnectionHandle connectionHandle,
-                          const std::vector<RegisterMemoryDesc>& memoryDescs,
-                          std::vector<MemHandle>& memoryHandles) override
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
+                          std::vector<MRHandle>& mrHandles) override
     {
         std::vector<AIVTransport::RegisterMemoryDesc> descs;
         descs.reserve(memoryDescs.size());
@@ -68,7 +68,7 @@ public:
             descs.push_back(
                 {static_cast<AIVTransport::MemType>(desc.memoryType), desc.addr, desc.size});
         }
-        return FromImpl(impl_->RegisterMemory(connectionHandle, descs, memoryHandles));
+        return FromImpl(impl_->RegisterMemory(descs, mrHandles));
     }
 
     std::vector<Status> UnregisterMemory(
@@ -76,9 +76,7 @@ public:
     {
         std::vector<AIVTransport::UnregisterMemoryDesc> descs;
         descs.reserve(memoryDescs.size());
-        for (const auto& desc : memoryDescs) {
-            descs.push_back({desc.connectionHandle, desc.memoryHandle});
-        }
+        for (const auto& desc : memoryDescs) { descs.push_back({desc.mrHandle}); }
         return FromImpl(impl_->UnregisterMemory(descs));
     }
 
@@ -92,9 +90,9 @@ public:
         return std::vector<Status>(threads.size(), Status::OK());
     }
 
-    Status GetMemTokenId(MemHandle memHandle, uint32_t& tokenId) override
+    Status GetMemTokenId(MRHandle mrHandle, uint32_t& tokenId) override
     {
-        return FromImpl(impl_->GetMemTokenId(memHandle, tokenId));
+        return FromImpl(impl_->GetMemTokenId(mrHandle, tokenId));
     }
 
 private:

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -150,7 +150,7 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
         auto s = connManager_->AddGroup(ep, qp_num);
         if (!s.ok()) {
             UC_DEBUG("AsuTransportImpl::Init AddGroup FAILED: {}", s.message);
-            (void)connManager_->Shutdown();
+            (void)Shutdown();
             return s;
         }
     }
@@ -160,12 +160,18 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
     auto status = sendBufferManager_.Init("asu send buffer", MemoryType::HOST_PINNED,
                                           config_.sendBufferSlotSize, config_.sendBufferSlotNum,
                                           transProvider_.get());
-    if (!status.ok()) { return status; }
+    if (!status.ok()) {
+        (void)Shutdown();
+        return status;
+    }
 
     status = flagBufferManager_.Init("asu flag buffer", MemoryType::HOST_PINNED,
                                      config_.flagBufferSlotSize, config_.flagBufferSlotNum,
                                      transProvider_.get());
-    if (!status.ok()) { return status; }
+    if (!status.ok()) {
+        (void)Shutdown();
+        return status;
+    }
     protocolManager_ = std::make_unique<ProtocolManager>();
 
     auto queueDepth = std::max<std::size_t>(2, static_cast<std::size_t>(config_.maxInflightTasks));
@@ -202,11 +208,9 @@ Status AsuTransportImpl::Shutdown()
     {
         std::lock_guard<std::mutex> lock(registeredRegionsMu_);
         std::vector<TransProvider::UnregisterMemoryDesc> descs;
-        descs.reserve(registeredRegionStates_.size());
-        for (const auto& item : registeredRegionStates_) {
-            const auto& state = item.second;
-            descs.push_back(
-                TransProvider::UnregisterMemoryDesc{state.connectionHandle, state.memHandle});
+        descs.reserve(ownedRegisteredRegionHandles_.size());
+        for (auto handle : ownedRegisteredRegionHandles_) {
+            descs.push_back(TransProvider::UnregisterMemoryDesc{handle});
         }
         if (!descs.empty() && transProvider_) {
             const auto statuses = transProvider_->UnregisterMemory(descs);
@@ -215,9 +219,11 @@ Status AsuTransportImpl::Shutdown()
             }
         }
         registeredRegions_.clear();
-        registeredRegionStates_.clear();
-        registeredRegionConnectionLeases_.clear();
+        ownedRegisteredRegionHandles_.clear();
     }
+    flagBufferManager_.Shutdown();
+    sendBufferManager_.Shutdown();
+
     if (connManager_) {
         auto status = connManager_->Shutdown();
         if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
@@ -355,24 +361,9 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
             {memType, static_cast<std::uintptr_t>(region.addr),
              static_cast<std::size_t>(region.size)}
         };
-        std::vector<TransProvider::MemHandle> memHandles;
-        auto connectionChannel =
-            memType == TransProvider::MemType::MEM_DEVICE && connManager_ != nullptr
-                ? connManager_->GetActiveConnection()
-                : nullptr;
-        const auto connectionHandle =
-            connectionChannel == nullptr ? nullptr : connectionChannel->GetConnection();
-        if (memType == TransProvider::MemType::MEM_DEVICE && connectionHandle == nullptr) {
-            hasFailure = true;
-            results.emplace_back(RegisterResult{
-                Status::Error(StatusCode::CONNECTION_ERROR,
-                              "transport register device memory requires an active connection"),
-                kInvalidMRHandle});
-            break;
-        }
-
-        auto status = transProvider_->RegisterMemory(connectionHandle, descs, memHandles);
-        if (!status.ok() || memHandles.empty()) {
+        std::vector<MRHandle> mrHandles;
+        auto status = transProvider_->RegisterMemory(descs, mrHandles);
+        if (!status.ok() || mrHandles.empty()) {
             hasFailure = true;
             results.emplace_back(RegisterResult{
                 status.ok() ? Status::Error(StatusCode::INTERNAL_ERROR,
@@ -382,14 +373,13 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
             break;
         }
 
-        auto handle = static_cast<MRHandle>(reinterpret_cast<std::uintptr_t>(memHandles[0]));
+        auto handle = mrHandles[0];
         uint32_t tokenId{0};
-        status = transProvider_->GetMemTokenId(memHandles[0], tokenId);
+        status = transProvider_->GetMemTokenId(mrHandles[0], tokenId);
         if (!status.ok()) {
             hasFailure = true;
-            (void)transProvider_->UnregisterMemory({
-                TransProvider::UnregisterMemoryDesc{connectionHandle, memHandles[0]}
-            });
+            (void)transProvider_->UnregisterMemory(
+                {TransProvider::UnregisterMemoryDesc{mrHandles[0]}});
             results.emplace_back(RegisterResult{status, kInvalidMRHandle});
             break;
         }
@@ -399,21 +389,16 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
         regMem.handle = handle;
         regMem.tokenId = tokenId;  // Only UB is supported for the current version.
         registeredRegions_[handle] = regMem;
-        registeredRegionStates_[handle] = RegisteredRegionState{connectionHandle, memHandles[0]};
-        if (connectionChannel != nullptr) {
-            registeredRegionConnectionLeases_[handle] = std::move(connectionChannel);
-        }
+        ownedRegisteredRegionHandles_.insert(handle);
         registeredHandles.emplace_back(handle);
-        registeredDescs.push_back(
-            TransProvider::UnregisterMemoryDesc{connectionHandle, memHandles[0]});
-        results.emplace_back(RegisterResult{Status::OK(), handle, 0, 0, tokenId});
+        registeredDescs.push_back(TransProvider::UnregisterMemoryDesc{mrHandles[0]});
+        results.emplace_back(RegisterResult{Status::OK(), handle, tokenId});
     }
     if (hasFailure) {
         if (!registeredDescs.empty()) { (void)transProvider_->UnregisterMemory(registeredDescs); }
         for (auto handle : registeredHandles) {
             registeredRegions_.erase(handle);
-            registeredRegionStates_.erase(handle);
-            registeredRegionConnectionLeases_.erase(handle);
+            ownedRegisteredRegionHandles_.erase(handle);
         }
         return Status::Error(StatusCode::PARTIAL_FAILED,
                              "one or more memory regions failed to register");
@@ -430,8 +415,7 @@ Status AsuTransportImpl::BindRegisteredRegions(const std::vector<RegisteredMemor
     std::lock_guard<std::mutex> lock(registeredRegionsMu_);
     for (const auto& region : regions) {
         registeredRegions_[region.handle] = region;
-        results.emplace_back(
-            RegisterResult{Status::OK(), region.handle, region.lkey, region.rkey, region.tokenId});
+        results.emplace_back(RegisterResult{Status::OK(), region.handle, region.tokenId});
     }
     return Status::OK();
 }
@@ -443,10 +427,10 @@ Status AsuTransportImpl::UnregisterRegions(const std::vector<MRHandle>& handles)
     descs.reserve(handles.size());
     for (auto handle : handles) {
         if (handle == kInvalidMRHandle) { continue; }
-        auto stateIter = registeredRegionStates_.find(handle);
-        if (stateIter == registeredRegionStates_.end()) { continue; }
-        descs.push_back(TransProvider::UnregisterMemoryDesc{stateIter->second.connectionHandle,
-                                                            stateIter->second.memHandle});
+        if (ownedRegisteredRegionHandles_.find(handle) == ownedRegisteredRegionHandles_.end()) {
+            continue;
+        }
+        descs.push_back(TransProvider::UnregisterMemoryDesc{handle});
     }
 
     if (!descs.empty()) {
@@ -457,8 +441,7 @@ Status AsuTransportImpl::UnregisterRegions(const std::vector<MRHandle>& handles)
     }
 
     for (auto handle : handles) { registeredRegions_.erase(handle); }
-    for (auto handle : handles) { registeredRegionStates_.erase(handle); }
-    for (auto handle : handles) { registeredRegionConnectionLeases_.erase(handle); }
+    for (auto handle : handles) { ownedRegisteredRegionHandles_.erase(handle); }
     return Status::OK();
 }
 

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -112,7 +112,8 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
 #endif
             case TransProviderType::AIV:
 #ifdef UCM_ASU_ENABLE_AIV_PROVIDER
-                transProvider_ = std::make_unique<AIVTransProviderAdapter>();
+                transProvider_ = std::make_unique<AIVTransProviderAdapter>(
+                    config_.endpoints.empty() ? -1 : config_.endpoints.front().deviceId);
                 break;
 #else
                 return Status::Error(
@@ -367,7 +368,7 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
                 Status::Error(StatusCode::CONNECTION_ERROR,
                               "transport register device memory requires an active connection"),
                 kInvalidMRHandle});
-            continue;
+            break;
         }
 
         auto status = transProvider_->RegisterMemory(connectionHandle, descs, memHandles);
@@ -378,18 +379,19 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
                                             "transport register memory returned no handle")
                             : status,
                 kInvalidMRHandle});
-            continue;
+            break;
         }
 
         auto handle = static_cast<MRHandle>(reinterpret_cast<std::uintptr_t>(memHandles[0]));
         uint32_t tokenId{0};
         status = transProvider_->GetMemTokenId(memHandles[0], tokenId);
         if (!status.ok()) {
+            hasFailure = true;
             (void)transProvider_->UnregisterMemory({
                 TransProvider::UnregisterMemoryDesc{connectionHandle, memHandles[0]}
             });
             results.emplace_back(RegisterResult{status, kInvalidMRHandle});
-            continue;
+            break;
         }
 
         RegisteredMemory regMem;

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
@@ -30,6 +30,7 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include "asu_transport/asu_transport.h"
 #include "buffer_manager.h"
@@ -121,11 +122,6 @@ private:
 
     void SetTransProvider(std::unique_ptr<TransProvider> provider);
 
-    struct RegisteredRegionState {
-        TransProvider::ConnectionHandle connectionHandle{nullptr};
-        TransProvider::MemHandle memHandle{nullptr};
-    };
-
     TransportConfig config_;
     IoScheduler ioScheduler_;
     std::unique_ptr<TransProvider> transProvider_;
@@ -144,11 +140,8 @@ private:
     std::atomic<std::uint16_t> nextRequestCid_{1};
 
     std::mutex registeredRegionsMu_;
-    std::atomic<MRHandle> nextMrHandle_{1};
     std::unordered_map<MRHandle, RegisteredMemory> registeredRegions_;
-    std::unordered_map<MRHandle, RegisteredRegionState> registeredRegionStates_;
-    std::unordered_map<MRHandle, std::shared_ptr<ConnectionChannel>>
-        registeredRegionConnectionLeases_;
+    std::unordered_set<MRHandle> ownedRegisteredRegionHandles_;
 };
 
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/buffer_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/buffer_manager.cpp
@@ -26,6 +26,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <limits>
+#include "logger.h"
 #include "trans/ascend/ascend_buffer.h"
 
 namespace UC::ASU {
@@ -99,14 +100,22 @@ bool IsTransportBufferReady(const ScatterGatherEntry& sge)
            sge.slot_index != UINT32_MAX;
 }
 
-BufferManager::~BufferManager()
+BufferManager::~BufferManager() { Shutdown(); }
+
+void BufferManager::Shutdown()
 {
-    if (provider_ && memHandle_) {
-        std::vector<TransProvider::UnregisterMemoryDesc> descs{
-            {nullptr, memHandle_}
-        };
-        provider_->UnregisterMemory(descs);
+    if (provider_ && mrHandle_) {
+        std::vector<TransProvider::UnregisterMemoryDesc> descs{{mrHandle_}};
+        const auto statuses = provider_->UnregisterMemory(descs);
+        for (const auto& status : statuses) {
+            if (!status.ok()) {
+                UC_WARN("Failed to unregister {} buffer memory: {}.", name_, status.message);
+            }
+        }
     }
+    provider_ = nullptr;
+    mrHandle_ = kInvalidMRHandle;
+    tokenId_ = 0;
     region_.Reset();
     slot_capacity_ = 0;
     slot_stride_ = 0;
@@ -172,24 +181,22 @@ Status BufferManager::RegisterMemory()
         {region_.providerMemType, reinterpret_cast<uintptr_t>(region_.deviceAddr), total,
          reinterpret_cast<uintptr_t>(region_.localAddr)}
     };
-    std::vector<TransProvider::MemHandle> memHandles;
-    auto regStatus = provider_->RegisterMemory(nullptr, descs, memHandles);
-    if (!regStatus.ok() || memHandles.empty()) {
+    std::vector<MRHandle> mrHandles;
+    auto regStatus = provider_->RegisterMemory(descs, mrHandles);
+    if (!regStatus.ok() || mrHandles.empty()) {
         return Status::Error(StatusCode::INTERNAL_ERROR,
                              name_ + ": failed to register memory: " + regStatus.message);
     }
 
-    auto tokenStatus = provider_->GetMemTokenId(memHandles[0], tokenId_);
+    auto tokenStatus = provider_->GetMemTokenId(mrHandles[0], tokenId_);
     if (!tokenStatus.ok()) {
-        std::vector<TransProvider::UnregisterMemoryDesc> unregDescs{
-            {nullptr, memHandles[0]}
-        };
+        std::vector<TransProvider::UnregisterMemoryDesc> unregDescs{{mrHandles[0]}};
         provider_->UnregisterMemory(unregDescs);
         return Status::Error(StatusCode::INTERNAL_ERROR,
                              name_ + ": failed to get token id: " + tokenStatus.message);
     }
 
-    memHandle_ = memHandles[0];
+    mrHandle_ = mrHandles[0];
     return Status::OK();
 }
 

--- a/ucm/transport/kv/asu/trans/src/buffer_manager.h
+++ b/ucm/transport/kv/asu/trans/src/buffer_manager.h
@@ -57,6 +57,7 @@ public:
 
     Status Init(std::string name, MemoryType type, std::size_t slot_capacity, std::size_t slot_num,
                 TransProvider* provider = nullptr);
+    void Shutdown();
 
     Status Allocate(std::size_t size, ScatterGatherEntry& sge);
     Status Free(std::uint32_t slot_index);
@@ -89,7 +90,7 @@ private:
     IndexPool index_pool_;
 
     TransProvider* provider_{nullptr};
-    TransProvider::MemHandle memHandle_{nullptr};
+    MRHandle mrHandle_{kInvalidMRHandle};
     std::uint32_t tokenId_{0};
 };
 

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
@@ -503,22 +503,20 @@ std::vector<Status> FakeTransProvider::Send(const std::vector<SendIoBatch>& ioBa
     return statuses;
 }
 
-Status FakeTransProvider::RegisterMemory(ConnectionHandle,
-                                         const std::vector<RegisterMemoryDesc>& memoryDescs,
-                                         std::vector<MemHandle>& memoryHandles)
+Status FakeTransProvider::RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
+                                         std::vector<MRHandle>& mrHandles)
 {
-    memoryHandles.clear();
-    memoryHandles.reserve(memoryDescs.size());
+    mrHandles.clear();
+    mrHandles.reserve(memoryDescs.size());
     std::lock_guard<std::mutex> lock(registeredMemoryMu_);
     for (const auto& desc : memoryDescs) {
-        auto handle = nextMemoryHandle_.fetch_add(1, std::memory_order_relaxed);
-        if (handle == 0) { handle = nextMemoryHandle_.fetch_add(1, std::memory_order_relaxed); }
-        auto memoryHandle = reinterpret_cast<MemHandle>(handle);
+        auto handle = nextMrHandle_.fetch_add(1, std::memory_order_relaxed);
+        if (handle == 0) { handle = nextMrHandle_.fetch_add(1, std::memory_order_relaxed); }
+        auto mrHandle = reinterpret_cast<MRHandle>(handle);
         if (desc.localAddr != 0) {
-            registeredMemories_[memoryHandle] =
-                RegisteredMemory{desc.addr, desc.localAddr, desc.size};
+            registeredMemories_[mrHandle] = RegisteredMemory{desc.addr, desc.localAddr, desc.size};
         }
-        memoryHandles.push_back(memoryHandle);
+        mrHandles.push_back(mrHandle);
     }
     return Status::OK();
 }
@@ -527,7 +525,7 @@ std::vector<Status> FakeTransProvider::UnregisterMemory(
     const std::vector<UnregisterMemoryDesc>& handles)
 {
     std::lock_guard<std::mutex> lock(registeredMemoryMu_);
-    for (const auto& desc : handles) { registeredMemories_.erase(desc.memoryHandle); }
+    for (const auto& desc : handles) { registeredMemories_.erase(desc.mrHandle); }
     return std::vector<Status>(handles.size(), Status::OK());
 }
 
@@ -542,7 +540,7 @@ std::vector<Status> FakeTransProvider::FreeThread(const std::vector<ThreadHandle
     return std::vector<Status>(threads.size(), Status::OK());
 }
 
-Status FakeTransProvider::GetMemTokenId(MemHandle, uint32_t& tokenId)
+Status FakeTransProvider::GetMemTokenId(MRHandle, uint32_t& tokenId)
 {
     tokenId = 1;
     return Status::OK();

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
@@ -98,7 +98,7 @@ std::filesystem::path KeyPath(const FakeTransProviderConfig& config, AsuId asuId
 }
 
 bool StoreBytes(const FakeTransProviderConfig& config, AsuId asuId, const CacheKey& key,
-                std::uint64_t addr, std::uint32_t length)
+                std::uint32_t offset, std::uint64_t addr, std::uint32_t length)
 {
     std::vector<char> buffer(length);
     auto ret = aclrtMemcpy(buffer.data(), buffer.size(), reinterpret_cast<const void*>(addr),
@@ -112,10 +112,22 @@ bool StoreBytes(const FakeTransProviderConfig& config, AsuId asuId, const CacheK
     }
 
     std::filesystem::create_directories(AsuRoot(config, asuId));
-    std::ofstream output(KeyPath(config, asuId, key), std::ios::binary | std::ios::trunc);
+    const auto path = KeyPath(config, asuId, key);
+    std::fstream output(path, std::ios::binary | std::ios::in | std::ios::out);
+    if (!output) {
+        std::ofstream create(path, std::ios::binary);
+        create.close();
+        output.open(path, std::ios::binary | std::ios::in | std::ios::out);
+    }
     if (!output) {
         UC_ERROR("ASU fake backend failed to open store file asuId={} key={} path={}.", asuId,
-                 CacheKeyToHex(key), KeyPath(config, asuId, key).string());
+                 CacheKeyToHex(key), path.string());
+        return false;
+    }
+    output.seekp(static_cast<std::streamoff>(offset), std::ios::beg);
+    if (!output) {
+        UC_ERROR("ASU fake backend failed to seek store file asuId={} key={} path={} offset={}.",
+                 asuId, CacheKeyToHex(key), path.string(), offset);
         return false;
     }
     output.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
@@ -123,19 +135,23 @@ bool StoreBytes(const FakeTransProviderConfig& config, AsuId asuId, const CacheK
 }
 
 bool LoadBytes(const FakeTransProviderConfig& config, AsuId asuId, const CacheKey& key,
-               std::uint64_t addr, std::uint32_t length)
+               std::uint32_t offset, std::uint64_t addr, std::uint32_t length)
 {
-    std::ifstream input(KeyPath(config, asuId, key), std::ios::binary);
+    const auto path = KeyPath(config, asuId, key);
+    std::ifstream input(path, std::ios::binary);
     if (!input) {
         UC_ERROR("ASU fake backend failed to open load file asuId={} key={} path={}.", asuId,
-                 CacheKeyToHex(key), KeyPath(config, asuId, key).string());
+                 CacheKeyToHex(key), path.string());
         return false;
     }
     std::vector<char> buffer(length, 0);
-    input.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
-    const auto readCount = input.gcount();
-    if (readCount < static_cast<std::streamsize>(length)) {
-        std::fill(buffer.begin() + readCount, buffer.end(), 0);
+    input.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
+    if (input) {
+        input.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        const auto readCount = input.gcount();
+        if (readCount < static_cast<std::streamsize>(length)) {
+            std::fill(buffer.begin() + readCount, buffer.end(), 0);
+        }
     }
     auto ret = aclrtMemcpy(reinterpret_cast<void*>(addr), length, buffer.data(), buffer.size(),
                            ACL_MEMCPY_HOST_TO_DEVICE);
@@ -191,6 +207,7 @@ void PackResultBuffer1Bit(std::uint32_t* resultData, const std::vector<std::uint
 
 struct BatchEntry {
     CacheKey key{};
+    std::uint32_t offset{0};
     std::uint64_t bufferAddr{0};
     std::uint32_t length{0};
 };
@@ -202,6 +219,7 @@ std::vector<BatchEntry> ReadBatchEntries(const std::uint32_t* request, std::uint
     for (std::uint16_t index = 0; index < batchNumber; ++index) {
         const auto* entry = request + kSqeDwordCount + index * kBatchEntryDwordCount;
         BatchEntry parsed;
+        parsed.offset = entry[0];
         parsed.key = ReadKey(entry + 1);
         parsed.bufferAddr = ReadU64(entry[5], entry[6]);
         parsed.length = entry[7] & 0xFFFFFF;
@@ -231,7 +249,7 @@ Status CompleteBatchStore(const FakeTransProviderConfig& config, AsuId asuId,
     const auto entries = ReadBatchEntries(request, batchNumber);
     for (std::size_t index = 0; index < entries.size(); ++index) {
         const auto& entry = entries[index];
-        if (!StoreBytes(config, asuId, entry.key, entry.bufferAddr, entry.length)) {
+        if (!StoreBytes(config, asuId, entry.key, entry.offset, entry.bufferAddr, entry.length)) {
             results[index] = kBatchEntryKeyNotFound;
         }
     }
@@ -254,7 +272,7 @@ Status CompleteBatchRetrieve(const FakeTransProviderConfig& config, AsuId asuId,
     const auto entries = ReadBatchEntries(request, batchNumber);
     for (std::size_t index = 0; index < entries.size(); ++index) {
         const auto& entry = entries[index];
-        if (!LoadBytes(config, asuId, entry.key, entry.bufferAddr, entry.length)) {
+        if (!LoadBytes(config, asuId, entry.key, entry.offset, entry.bufferAddr, entry.length)) {
             results[index] = kBatchEntryKeyNotFound;
         }
     }

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
@@ -50,8 +50,8 @@ public:
     std::vector<Status> Send(const std::vector<SendIoBatch>& ioBatches, uint32_t kernelCount,
                              uint32_t quietCount) override;
 
-    Status RegisterMemory(ConnectionHandle, const std::vector<RegisterMemoryDesc>& memoryDescs,
-                          std::vector<MemHandle>& memoryHandles) override;
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
+                          std::vector<MRHandle>& mrHandles) override;
 
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& handles) override;
 
@@ -59,7 +59,7 @@ public:
 
     std::vector<Status> FreeThread(const std::vector<ThreadHandle>& threads) override;
 
-    Status GetMemTokenId(MemHandle, uint32_t& tokenId) override;
+    Status GetMemTokenId(MRHandle, uint32_t& tokenId) override;
 
 private:
     struct RegisteredMemory {
@@ -72,9 +72,9 @@ private:
     Status ResolveLocalAddress(const void* providerAddr, std::size_t size, void*& localAddr);
 
     FakeTransProviderConfig config_;
-    std::atomic<std::uintptr_t> nextMemoryHandle_{1};
+    std::atomic<std::uintptr_t> nextMrHandle_{1};
     std::mutex registeredMemoryMu_;
-    std::unordered_map<MemHandle, RegisteredMemory> registeredMemories_;
+    std::unordered_map<MRHandle, RegisteredMemory> registeredMemories_;
 };
 
 FakeTransProviderConfig MakeFakeTransProviderConfig(const TransportConfig& config);

--- a/ucm/transport/kv/asu/trans/src/sqe_request.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.cpp
@@ -53,8 +53,9 @@ Status ResolveSqeMrKeys(const BatchView<KVBuffer>& entries,
         const auto handle = entries[index].buffer.handle;
         auto iter = registeredRegions.find(handle);
         if (iter == registeredRegions.end()) {
-            return Status::Error(StatusCode::BUFFER_NOT_REGISTERED,
-                                 "entry buffer is not registered");
+            // TODO: Replace the default MR key after memory registration is supported.
+            mrKeys.emplace_back(1);
+            continue;
         }
         mrKeys.emplace_back(iter->second.tokenId);
     }

--- a/ucm/transport/kv/asu/trans/src/trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/trans_provider.h
@@ -12,7 +12,6 @@ class TransProvider {
 public:
     using ConnectionHandle = void*;
     using ThreadHandle = void*;
-    using MemHandle = void*;
 
     virtual ~TransProvider() = default;
 
@@ -42,13 +41,11 @@ public:
         uintptr_t localAddr{0};
     };
 
-    virtual Status RegisterMemory(ConnectionHandle connectionHandle,
-                                  const std::vector<RegisterMemoryDesc>& memoryDescs,
-                                  std::vector<MemHandle>& memoryHandles) = 0;
+    virtual Status RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
+                                  std::vector<MRHandle>& mrHandles) = 0;
 
     struct UnregisterMemoryDesc {
-        ConnectionHandle connectionHandle;
-        MemHandle memoryHandle;
+        MRHandle mrHandle;
     };
 
     virtual std::vector<Status> UnregisterMemory(
@@ -59,7 +56,7 @@ public:
 
     virtual std::vector<Status> FreeThread(const std::vector<ThreadHandle>& threads) = 0;
 
-    virtual Status GetMemTokenId(MemHandle memHandle, uint32_t& tokenId) = 0;
+    virtual Status GetMemTokenId(MRHandle mrHandle, uint32_t& tokenId) = 0;
 };
 
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
@@ -46,7 +46,6 @@ public:
     std::uint32_t registerCount{0};
     std::uint32_t unregisterCount{0};
     std::uint32_t failRegisterAt{0};
-    std::function<void()> onUnregister;
 
     Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t qpNum,
                             uint32_t, std::vector<ConnectionHandle>& handles) override
@@ -70,20 +69,19 @@ public:
         return std::vector<Status>(ioBatches.size(), Status::OK());
     }
 
-    Status RegisterMemory(ConnectionHandle, const std::vector<RegisterMemoryDesc>&,
-                          std::vector<MemHandle>& handles) override
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>&,
+                          std::vector<MRHandle>& handles) override
     {
         ++registerCount;
         if (failRegisterAt != 0 && registerCount == failRegisterAt) {
             return Status::Error(StatusCode::INTERNAL_ERROR, "stub register failed");
         }
-        handles.push_back(reinterpret_cast<MemHandle>(static_cast<uintptr_t>(registerCount)));
+        handles.push_back(reinterpret_cast<MRHandle>(static_cast<uintptr_t>(registerCount)));
         return Status::OK();
     }
 
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& descs) override
     {
-        if (onUnregister) { onUnregister(); }
         unregisterCount += static_cast<std::uint32_t>(descs.size());
         return std::vector<Status>(descs.size(), Status::OK());
     }
@@ -95,7 +93,7 @@ public:
 
     std::vector<Status> FreeThread(const std::vector<ThreadHandle>&) override { return {}; }
 
-    Status GetMemTokenId(MemHandle, uint32_t& tokenId) override
+    Status GetMemTokenId(MRHandle, uint32_t& tokenId) override
     {
         tokenId = 1;
         return Status::OK();
@@ -179,13 +177,34 @@ TEST(AsuTransportRegisterTest, RegisterRegionsReturnsPartialFailedAndRollsBackSu
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_EQ(results.size(), std::size_t{2});
     EXPECT_TRUE(results[0].status.ok()) << results[0].status.message;
-    EXPECT_EQ(results[0].handle, MRHandle{1});
+    EXPECT_EQ(results[0].handle, reinterpret_cast<MRHandle>(std::uintptr_t{1}));
     EXPECT_EQ(results[1].status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_EQ(results[1].handle, kInvalidMRHandle);
     EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
     EXPECT_TRUE(transport.registeredRegions_.empty());
-    EXPECT_TRUE(transport.registeredRegionStates_.empty());
-    EXPECT_TRUE(transport.registeredRegionConnectionLeases_.empty());
+    EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
+}
+
+TEST(AsuTransportRegisterTest, RegisterDeviceRegionDoesNotRequireConnection)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    MemoryRegion region;
+    region.memoryType = MemoryType::ASCEND_DEVICE;
+    region.addr = 0x1000;
+    region.size = 4096;
+
+    std::vector<RegisterResult> results;
+    const auto status = transport.RegisterRegions({region}, results);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(results.size(), std::size_t{1});
+    EXPECT_TRUE(results[0].status.ok()) << results[0].status.message;
+    EXPECT_EQ(providerPtr->registerCount, std::uint32_t{1});
 }
 
 TEST(AsuTransportRegisterTest, RegisterRegionsStopsAtFirstFailure)
@@ -215,7 +234,7 @@ TEST(AsuTransportRegisterTest, RegisterRegionsStopsAtFirstFailure)
     EXPECT_EQ(providerPtr->registerCount, std::uint32_t{2});
     EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
     EXPECT_TRUE(transport.registeredRegions_.empty());
-    EXPECT_TRUE(transport.registeredRegionStates_.empty());
+    EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
 }
 
 TEST(AsuTransportRegisterTest, ShutdownUnregistersRegisteredRegions)
@@ -243,34 +262,7 @@ TEST(AsuTransportRegisterTest, ShutdownUnregistersRegisteredRegions)
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{2});
     EXPECT_TRUE(transport.registeredRegions_.empty());
-    EXPECT_TRUE(transport.registeredRegionStates_.empty());
-    EXPECT_TRUE(transport.registeredRegionConnectionLeases_.empty());
-}
-
-TEST(AsuTransportRegisterTest, UnregisterRegionReleasesConnectionLeaseAfterProviderCall)
-{
-    auto provider = std::make_unique<StubTransProvider>();
-    auto* providerPtr = provider.get();
-
-    AsuTransportImpl transport;
-    transport.SetTransProvider(std::move(provider));
-
-    constexpr MRHandle handle{7};
-    auto connection = std::make_shared<ConnectionChannel>(
-        0, nullptr, reinterpret_cast<TransProvider::ConnectionHandle>(1), providerPtr);
-    std::weak_ptr<ConnectionChannel> weakConnection = connection;
-    transport.registeredRegionStates_[handle] = AsuTransportImpl::RegisteredRegionState{
-        connection->GetConnection(), reinterpret_cast<TransProvider::MemHandle>(handle)};
-    transport.registeredRegionConnectionLeases_[handle] = std::move(connection);
-    providerPtr->onUnregister = [&weakConnection]() { EXPECT_FALSE(weakConnection.expired()); };
-
-    const auto status = transport.UnregisterRegions({handle});
-
-    EXPECT_TRUE(status.ok()) << status.message;
-    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
-    EXPECT_TRUE(transport.registeredRegionStates_.empty());
-    EXPECT_TRUE(transport.registeredRegionConnectionLeases_.empty());
-    EXPECT_TRUE(weakConnection.expired());
+    EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
 }
 
 TEST(AsuSubmitFlowTest, SendSubBatchBuffersReportsSendFailures)

--- a/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
@@ -188,6 +188,36 @@ TEST(AsuTransportRegisterTest, RegisterRegionsReturnsPartialFailedAndRollsBackSu
     EXPECT_TRUE(transport.registeredRegionConnectionLeases_.empty());
 }
 
+TEST(AsuTransportRegisterTest, RegisterRegionsStopsAtFirstFailure)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+    providerPtr->failRegisterAt = 2;
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    std::vector<MemoryRegion> regions(3);
+    regions[0].addr = 0x1000;
+    regions[0].size = 4096;
+    regions[1].addr = 0x2000;
+    regions[1].size = 4096;
+    regions[2].addr = 0x3000;
+    regions[2].size = 4096;
+
+    std::vector<RegisterResult> results;
+    auto status = transport.RegisterRegions(regions, results);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_EQ(results.size(), std::size_t{2});
+    EXPECT_TRUE(results[0].status.ok()) << results[0].status.message;
+    EXPECT_EQ(results[1].status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(providerPtr->registerCount, std::uint32_t{2});
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_TRUE(transport.registeredRegionStates_.empty());
+}
+
 TEST(AsuTransportRegisterTest, ShutdownUnregistersRegisteredRegions)
 {
     auto provider = std::make_unique<StubTransProvider>();

--- a/ucm/transport/kv/asu/trans/test/fake_trans_provider_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/fake_trans_provider_test.cpp
@@ -13,16 +13,16 @@ TEST(FakeTransProviderTest, RegisterMemoryReturnsUniqueHandlesAcrossCalls)
         {TransProvider::MemType::MEM_DEVICE, 0x2000, 4096}
     };
 
-    std::vector<TransProvider::MemHandle> firstHandles;
-    ASSERT_TRUE(provider.RegisterMemory(nullptr, descs, firstHandles).ok());
-    std::vector<TransProvider::MemHandle> secondHandles;
-    ASSERT_TRUE(provider.RegisterMemory(nullptr, descs, secondHandles).ok());
+    std::vector<MRHandle> firstHandles;
+    ASSERT_TRUE(provider.RegisterMemory(descs, firstHandles).ok());
+    std::vector<MRHandle> secondHandles;
+    ASSERT_TRUE(provider.RegisterMemory(descs, secondHandles).ok());
 
-    std::unordered_set<TransProvider::MemHandle> uniqueHandles;
+    std::unordered_set<MRHandle> uniqueHandles;
     uniqueHandles.insert(firstHandles.begin(), firstHandles.end());
     uniqueHandles.insert(secondHandles.begin(), secondHandles.end());
     EXPECT_EQ(uniqueHandles.size(), firstHandles.size() + secondHandles.size());
-    EXPECT_EQ(uniqueHandles.count(nullptr), 0);
+    EXPECT_EQ(uniqueHandles.count(kInvalidMRHandle), 0);
 }
 
 }  // namespace

--- a/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
@@ -67,10 +67,10 @@ public:
     {
         return {};
     }
-    Status RegisterMemory(ConnectionHandle, const std::vector<RegisterMemoryDesc>&,
-                          std::vector<MemHandle>& handles) override
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>&,
+                          std::vector<MRHandle>& handles) override
     {
-        handles.push_back(reinterpret_cast<MemHandle>(static_cast<uintptr_t>(1)));
+        handles.push_back(reinterpret_cast<MRHandle>(static_cast<uintptr_t>(1)));
         return Status::OK();
     }
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>&) override
@@ -82,7 +82,7 @@ public:
         return Status::OK();
     }
     std::vector<Status> FreeThread(const std::vector<ThreadHandle>&) override { return {}; }
-    Status GetMemTokenId(MemHandle, uint32_t& tokenId) override
+    Status GetMemTokenId(MRHandle, uint32_t& tokenId) override
     {
         tokenId = 1;
         return Status::OK();
@@ -305,7 +305,7 @@ TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
     EXPECT_EQ(PackedBatchEntryMrKey(sqe, 1), std::uint32_t{0x76540001});
 }
 
-TEST_F(SqeRequestTest, SubmitBatchStoreRejectsUnregisteredEntryBuffer)
+TEST_F(SqeRequestTest, SubmitBatchStoreUsesDefaultMrKeyForUnregisteredEntryBuffer)
 {
     auto entries = MakeEntries(1);
     IoScheduler::ScheduledIoBatch subBatch{
@@ -316,10 +316,11 @@ TEST_F(SqeRequestTest, SubmitBatchStoreRejectsUnregisteredEntryBuffer)
     const auto status = transport_->SubmitEntrySubBatchRequest(TransportOpType::BATCH_STORE,
                                                                subBatch, subBatchContext);
 
-    EXPECT_EQ(status.code, StatusCode::BUFFER_NOT_REGISTERED);
-    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
-    ASSERT_EQ(subBatchContext.entryStatus.size(), entries.size());
-    EXPECT_EQ(subBatchContext.entryStatus[0].code, StatusCode::BUFFER_NOT_REGISTERED);
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
+    const auto* sqe = reinterpret_cast<const std::uint32_t*>(subBatchContext.sendSge.local_addr);
+    ASSERT_NE(sqe, nullptr);
+    EXPECT_EQ(PackedBatchEntryMrKey(sqe, 0), std::uint32_t{1});
 }
 
 TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)

--- a/ucm/transport/kv/asu/trans/test/transport_task_completion_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/transport_task_completion_test.cpp
@@ -59,10 +59,10 @@ public:
     {
         return {};
     }
-    Status RegisterMemory(ConnectionHandle, const std::vector<RegisterMemoryDesc>&,
-                          std::vector<MemHandle>& handles) override
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>&,
+                          std::vector<MRHandle>& handles) override
     {
-        handles.push_back(reinterpret_cast<MemHandle>(static_cast<uintptr_t>(1)));
+        handles.push_back(reinterpret_cast<MRHandle>(static_cast<uintptr_t>(1)));
         return Status::OK();
     }
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>&) override
@@ -74,7 +74,7 @@ public:
         return Status::OK();
     }
     std::vector<Status> FreeThread(const std::vector<ThreadHandle>&) override { return {}; }
-    Status GetMemTokenId(MemHandle, uint32_t& tokenId) override
+    Status GetMemTokenId(MRHandle, uint32_t& tokenId) override
     {
         tokenId = 1;
         return Status::OK();


### PR DESCRIPTION
## Purpose
Unify ASU memory registration APIs and improve ASU transport and tensor-layout handling for device-aware registration and multi-segment MLA workloads.

## Modifications
- Standardize ASU memory registration interfaces on `MRHandle`.
- Remove connection handles from memory registration APIs to simplify ownership and lifecycle management.
- Add device-aware AIV provider creation for ASU registrations.
- Harden ASU transport registration validation and endpoint handling.
- Support multi-segment layerwise MLA tensor layouts in the ASU store path.
- Ensure aligned offsets across all MLA tensor segments are correctly registered and covered.

## Test 
**Use FakeBackend**

[2026-07-17 15:26:15.999171][UC][I] request_id: 0-a01097d0, total_blocks_num: 52, hit hbm: 0, hit external: 0
[2026-07-17 15:26:16.372395][UC][E] AsuTransportImpl::ProcessTask task_id=1 op_type=4 entries=2496 keys=0 sub_batches=23 done=false
[2026-07-17 15:26:16.375205][UC][E] AsuTransportImpl::ProcessTask task_id=1 op_type=4 entries=2496 keys=0 sub_batches=23 done=false
Processed prompts: 100%|██████████| 1/1 [00:00<00:00, 2.21it/s, input:14790 toks/s, output:6.65 toks/s]
Generated: '厦门大学', took 0.55s

Rendering prompts: 100%|██████████| 1/1 [00:00<00:00, 76.02it/s]
[2026-07-17 15:26:16.473541][UC][E] AsuTransportImpl::ProcessTask task_id=2 op_type=0 entries=0 keys=52 sub_batches=1 done=false
[2026-07-17 15:26:16.474048][UC][I] request_id: 1-a0bfa8cc, total_blocks_num: 52, hit hbm: 0, hit external: 52
[2026-07-17 15:26:16.642472][UC][E] AsuTransportImpl::ProcessTask task_id=2 op_type=3 entries=2496 keys=0 sub_batches=23 done=false
[2026-07-17 15:26:17.029629][UC][E] AsuTransportImpl::ProcessTask task_id=2 op_type=3 entries=2496 keys=0 sub_batches=23 done=false
Processed prompts: 100%|██████████| 1/1 [00:00<00:00, 1.54it/s, input:10259 toks/s, output:4.61 toks/s]
[2026-07-17 15:26:17.111887][UC][I] LLM engine is exiting.
Generated: '厦门大学', took 0.66s