### PR TITLE
[Test] A2 scheduler probe 2

### DIFF
--- a/docs/a2-scheduler-probe-20260715-2.md
+++ b/docs/a2-scheduler-probe-20260715-2.md
@@ -1,0 +1,4 @@
+# A2 Scheduler Probe 2
+
+Temporary CI-only change used to verify that the A2 on-demand runner scheduler
+starts queued pull request jobs in the hourly execution window.


### PR DESCRIPTION
## What changed

Adds one temporary documentation-only probe file.

## Why

This PR is used to verify that the A2 on-demand scheduler detects queued PR gate jobs, splits card 7 during the hourly window, and starts available self-hosted runners.

## Impact

No product or runtime behavior changes. The PR and branch will be removed after scheduler validation.

## Verification

- `git diff --check origin/develop...HEAD`
- GitHub PR Gate, especially `test-e2e-pc-a2`
