### PR TITLE
[Opt] Move dram pool files and small fixes

### DIFF
--- a/ucm/store/dram/cc/drampool/entry.h
+++ b/ucm/store/dram/cc/drampool/entry.h
@@ -30,7 +30,7 @@
 #include "thread/lock.h"
 #include "type/types.h"
 
-namespace UC::DramStore {
+namespace UC::DramPool {
 
 using Spinlock = UC::SpinLock;
 using RwLock = UC::RwLock;
@@ -121,6 +121,6 @@ struct Entry {
 
 using EntryPtr = std::shared_ptr<Entry>;
 
-}  // namespace UC::DramStore
+}  // namespace UC::DramPool
 
 #endif

--- a/ucm/store/dram/cc/drampool/eviction_policy.h
+++ b/ucm/store/dram/cc/drampool/eviction_policy.h
@@ -30,7 +30,7 @@
 #include "entry.h"
 #include "status/status.h"
 
-namespace UC::DramStore {
+namespace UC::DramPool {
 
 enum class EvictionPolicyType {
     TTL = 0,
@@ -139,6 +139,6 @@ protected:
     std::unordered_map<BlockId, EntryIter, UC::Detail::BlockIdHasher> index_;
 };
 
-}  // namespace UC::DramStore
+}  // namespace UC::DramPool
 
 #endif

--- a/ucm/store/dram/cc/drampool/lru_eviction_policy.h
+++ b/ucm/store/dram/cc/drampool/lru_eviction_policy.h
@@ -35,7 +35,7 @@
 #include "eviction_policy.h"
 #include "logger/logger.h"
 
-namespace UC::DramStore {
+namespace UC::DramPool {
 
 /**
  * @brief Eviction policy that removes least-recently-used entries first.
@@ -105,6 +105,6 @@ private:
     std::unordered_map<BlockId, ListIter, UC::Detail::BlockIdHasher> index_;
 };
 
-}  // namespace UC::DramStore
+}  // namespace UC::DramPool
 
 #endif

--- a/ucm/store/dram/cc/drampool/metadata.cc
+++ b/ucm/store/dram/cc/drampool/metadata.cc
@@ -27,7 +27,7 @@
 #include "pos_eviction_policy.h"
 #include "ttl_eviction_policy.h"
 
-namespace UC::DramStore {
+namespace UC::DramPool {
 namespace {
 std::unique_ptr<EvictionPolicy> CreateEvictionPolicy(EvictionPolicyType type)
 {
@@ -53,8 +53,8 @@ Status ShardMetadata::StoreBegin(const BlockId& key, EntryPtr entry)
 {
     ReadWriteGuard lock(mtx_);
     if (metadata_.find(key) != metadata_.end()) {
-        UC_INFO("ShardMetadata StoreBegin: key already exists, skip.");
-        return Status::OK();
+        UC_INFO("ShardMetadata StoreBegin: key already exists.");
+        return Status::DuplicateKey();
     }
     if (entry == nullptr || !entry->IsInitial()) {
         UC_ERROR("ShardMetadata StoreBegin: entry not in initial state.");
@@ -84,15 +84,16 @@ Status ShardMetadata::StoreEnd(const BlockId& key)
     return entry->TryMarkReady() ? Status::OK() : Status::Error();
 }
 
-Status ShardMetadata::LoadBegin(const BlockId& key)
+Status ShardMetadata::LoadBegin(const BlockId& key, EntryPtr& entry)
 {
     ReadOnlyGuard lock(mtx_);
     auto it = metadata_.find(key);
     if (it == metadata_.end()) { return Status::NotFound(); }
-    auto& entry = it->second;
-    if (!entry->TryIncRef()) { return Status::Error(); }
+    auto& existingEntry = it->second;
+    if (!existingEntry->TryIncRef()) { return Status::Error(); }
     periodicEvictor_->AccessKey(key);
     deepEvictor_->AccessKey(key);
+    entry = existingEntry;
     return Status::OK();
 }
 
@@ -179,4 +180,4 @@ void MetadataManager::EvictOneShard(ShardMetadata& s, bool deep)
     for (const auto& k : victims) { s.Delete(k); }
 }
 
-}  // namespace UC::DramStore
+}  // namespace UC::DramPool

--- a/ucm/store/dram/cc/drampool/metadata.h
+++ b/ucm/store/dram/cc/drampool/metadata.h
@@ -39,7 +39,7 @@
 #include "eviction_policy.h"
 #include "status/status.h"
 
-namespace UC::DramStore {
+namespace UC::DramPool {
 
 struct MetadataConfig {
     EvictionPolicyType periodicType;
@@ -80,10 +80,11 @@ public:
     /**
      * @brief Begin a load: increment the entry's refCnt and notify both
      *        eviction policies of the access. Read-locks the shard.
+     * @param entry [out] Receives the entry associated with the key on success.
      * @return Status::OK() on success; Status::NotFound() if the key is
      *         missing; Status::Error() if the entry is not READY.
      */
-    Status LoadBegin(const BlockId& key);
+    Status LoadBegin(const BlockId& key, EntryPtr& entry);
 
     /**
      * @brief End a load: decrement the entry's refCnt. Read-locks the shard.
@@ -167,7 +168,10 @@ public:
 
     Status StoreBegin(const BlockId& key, EntryPtr entry);
     Status StoreEnd(const BlockId& key) { return ShardOf(key).StoreEnd(key); }
-    Status LoadBegin(const BlockId& key) { return ShardOf(key).LoadBegin(key); }
+    Status LoadBegin(const BlockId& key, EntryPtr& entry)
+    {
+        return ShardOf(key).LoadBegin(key, entry);
+    }
     Status LoadEnd(const BlockId& key) { return ShardOf(key).LoadEnd(key); }
     bool Exist(const BlockId& key) { return ShardOf(key).Exist(key); }
     bool Query(const BlockId& key) const { return ShardOf(key).Query(key); }
@@ -202,6 +206,6 @@ private:
     std::thread evictThread_;
 };
 
-}  // namespace UC::DramStore
+}  // namespace UC::DramPool
 
 #endif

--- a/ucm/store/dram/cc/drampool/pos_eviction_policy.h
+++ b/ucm/store/dram/cc/drampool/pos_eviction_policy.h
@@ -21,8 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  * */
-#ifndef UNIFIEDCACHE_DRAM_STORE_CC_TTL_EVICTION_POLICY_H
-#define UNIFIEDCACHE_DRAM_STORE_CC_TTL_EVICTION_POLICY_H
+#ifndef UNIFIEDCACHE_DRAM_STORE_CC_POS_EVICTION_POLICY_H
+#define UNIFIEDCACHE_DRAM_STORE_CC_POS_EVICTION_POLICY_H
 
 #include <chrono>
 #include <vector>
@@ -30,40 +30,46 @@
 #include "eviction_policy.h"
 #include "logger/logger.h"
 
-namespace UC::DramStore {
+namespace UC::DramPool {
 
-struct TtlEntryCmp {
+struct PosEntryCmp {
     bool operator()(const EntryPtr& a, const EntryPtr& b) const noexcept
     {
+        if (a->position != b->position) { return a->position > b->position; }
         return a->lifeTimeout < b->lifeTimeout;
     }
 };
 
 /**
- * @brief Eviction policy that removes all entries whose lifetime has expired.
+ * @brief Eviction policy that removes a fraction of entries selected by
+ *        position priority.
  *
- * Entries are ordered by lifeTimeout ascending. GetEvictionResults iterates
- * from the earliest-expiring entry and breaks at the first entry whose
- * lifeTimeout is still in the future.
+ * Position represents the absolute position of the current metadata's KV
+ * cache within the inference request. Entries are ordered by position
+ * descending, tiebroken by lifeTimeout ascending. GetEvictionResults evicts
+ * up to evict_ratio * size() entries from the front of the ordering.
  */
-class TtlEvictionPolicy : public OrderedEvictionPolicy<TtlEntryCmp> {
+class PosEvictionPolicy : public OrderedEvictionPolicy<PosEntryCmp> {
 public:
-    std::vector<BlockId> GetEvictionResults(double /*evict_ratio*/) override
+    std::vector<BlockId> GetEvictionResults(double evict_ratio) override
     {
         std::vector<BlockId> victims;
         const auto now = std::chrono::system_clock::now();
+        std::size_t target =
+            static_cast<std::size_t>(static_cast<double>(entries_.size()) * evict_ratio);
+        if (target > entries_.size()) { target = entries_.size(); }
         for (const auto& entry : entries_) {
-            if (entry->lifeTimeout > now) { break; }
+            if (victims.size() >= target) { break; }
             if (!entry->TryMarkEvicting(now)) { continue; }
             victims.push_back(entry->key);
         }
         if (!victims.empty()) {
-            UC_INFO("TtlEvictionPolicy evict {} of {} entries.", victims.size(), entries_.size());
+            UC_INFO("PosEvictionPolicy evict {} of {} entries.", victims.size(), entries_.size());
         }
         return victims;
     }
 };
 
-}  // namespace UC::DramStore
+}  // namespace UC::DramPool
 
 #endif

--- a/ucm/store/dram/cc/drampool/ttl_eviction_policy.h
+++ b/ucm/store/dram/cc/drampool/ttl_eviction_policy.h
@@ -21,8 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  * */
-#ifndef UNIFIEDCACHE_DRAM_STORE_CC_POS_EVICTION_POLICY_H
-#define UNIFIEDCACHE_DRAM_STORE_CC_POS_EVICTION_POLICY_H
+#ifndef UNIFIEDCACHE_DRAM_STORE_CC_TTL_EVICTION_POLICY_H
+#define UNIFIEDCACHE_DRAM_STORE_CC_TTL_EVICTION_POLICY_H
 
 #include <chrono>
 #include <vector>
@@ -30,46 +30,40 @@
 #include "eviction_policy.h"
 #include "logger/logger.h"
 
-namespace UC::DramStore {
+namespace UC::DramPool {
 
-struct PosEntryCmp {
+struct TtlEntryCmp {
     bool operator()(const EntryPtr& a, const EntryPtr& b) const noexcept
     {
-        if (a->position != b->position) { return a->position > b->position; }
         return a->lifeTimeout < b->lifeTimeout;
     }
 };
 
 /**
- * @brief Eviction policy that removes a fraction of entries selected by
- *        position priority.
+ * @brief Eviction policy that removes all entries whose lifetime has expired.
  *
- * Position represents the absolute position of the current metadata's KV
- * cache within the inference request. Entries are ordered by position
- * descending, tiebroken by lifeTimeout ascending. GetEvictionResults evicts
- * up to evict_ratio * size() entries from the front of the ordering.
+ * Entries are ordered by lifeTimeout ascending. GetEvictionResults iterates
+ * from the earliest-expiring entry and breaks at the first entry whose
+ * lifeTimeout is still in the future.
  */
-class PosEvictionPolicy : public OrderedEvictionPolicy<PosEntryCmp> {
+class TtlEvictionPolicy : public OrderedEvictionPolicy<TtlEntryCmp> {
 public:
-    std::vector<BlockId> GetEvictionResults(double evict_ratio) override
+    std::vector<BlockId> GetEvictionResults(double /*evict_ratio*/) override
     {
         std::vector<BlockId> victims;
         const auto now = std::chrono::system_clock::now();
-        std::size_t target =
-            static_cast<std::size_t>(static_cast<double>(entries_.size()) * evict_ratio);
-        if (target > entries_.size()) { target = entries_.size(); }
         for (const auto& entry : entries_) {
-            if (victims.size() >= target) { break; }
+            if (entry->lifeTimeout > now) { break; }
             if (!entry->TryMarkEvicting(now)) { continue; }
             victims.push_back(entry->key);
         }
         if (!victims.empty()) {
-            UC_INFO("PosEvictionPolicy evict {} of {} entries.", victims.size(), entries_.size());
+            UC_INFO("TtlEvictionPolicy evict {} of {} entries.", victims.size(), entries_.size());
         }
         return victims;
     }
 };
 
-}  // namespace UC::DramStore
+}  // namespace UC::DramPool
 
 #endif

--- a/ucm/store/test/case/dram/dram_test_common.h
+++ b/ucm/store/test/case/dram/dram_test_common.h
@@ -28,16 +28,16 @@
 #include <cstdint>
 #include <memory>
 #include "detail/types_helper.h"
-#include "dram/cc/entry.h"
+#include "dram/cc/drampool/entry.h"
 
 namespace UC::Test::Dram {
 
 using Clock = std::chrono::system_clock;
 using TimePoint = Clock::time_point;
 
-using UC::DramStore::Entry;
-using UC::DramStore::EntryPtr;
-using UC::DramStore::EntryStatus;
+using UC::DramPool::Entry;
+using UC::DramPool::EntryPtr;
+using UC::DramPool::EntryStatus;
 
 inline EntryPtr MakeEntry(UC::Detail::BlockId key, uint32_t position = 0,
                           TimePoint lifeTimeout = TimePoint{},

--- a/ucm/store/test/case/dram/drampool/dram_lru_eviction_policy_test.cc
+++ b/ucm/store/test/case/dram/drampool/dram_lru_eviction_policy_test.cc
@@ -24,10 +24,11 @@
 #include <chrono>
 #include <gtest/gtest.h>
 #include <limits>
-#include "dram/cc/lru_eviction_policy.h"
-#include "dram_test_common.h"
+#include "dram/cc/drampool/lru_eviction_policy.h"
+#include "dram/dram_test_common.h"
 
-using UC::DramStore::LruEvictionPolicy;
+using UC::Status;
+using UC::DramPool::LruEvictionPolicy;
 using UC::Test::Dram::Clock;
 using UC::Test::Dram::EntryStatus;
 using UC::Test::Dram::KeyFromHex;
@@ -50,14 +51,14 @@ TEST_F(UCLruEvictionPolicyTest, AddKeyDuplicateReturnsDuplicateKey)
 {
     auto key = KeyFromHex("a1");
     ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key)).Success());
-    ASSERT_FALSE(policy_.AddKey(key, MakeEntry(key)).Success());
+    ASSERT_EQ(policy_.AddKey(key, MakeEntry(key)), Status::DuplicateKey());
 }
 
 TEST_F(UCLruEvictionPolicyTest, AddKeyNullptrReturnsInvalidParam)
 {
     auto key = KeyFromHex("a1");
     auto st = policy_.AddKey(key, nullptr);
-    ASSERT_FALSE(st.Success());
+    ASSERT_EQ(st, Status::InvalidParam());
 }
 
 TEST_F(UCLruEvictionPolicyTest, DeleteKeyReturnsOkAndSecondIsNotFound)
@@ -65,13 +66,13 @@ TEST_F(UCLruEvictionPolicyTest, DeleteKeyReturnsOkAndSecondIsNotFound)
     auto key = KeyFromHex("a1");
     ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key)).Success());
     ASSERT_TRUE(policy_.DeleteKey(key).Success());
-    ASSERT_FALSE(policy_.DeleteKey(key).Success());
+    ASSERT_EQ(policy_.DeleteKey(key), Status::NotFound());
 }
 
 TEST_F(UCLruEvictionPolicyTest, AccessKeyReturnsNotFoundForMissingKey)
 {
     auto key = KeyFromHex("a1");
-    ASSERT_FALSE(policy_.AccessKey(key).Success());
+    ASSERT_EQ(policy_.AccessKey(key), Status::NotFound());
 }
 
 TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsEmptyWhenNoEntries)

--- a/ucm/store/test/case/dram/drampool/dram_metadata_test.cc
+++ b/ucm/store/test/case/dram/drampool/dram_metadata_test.cc
@@ -27,17 +27,18 @@
 #include <set>
 #include <string>
 #include <vector>
-#include "dram/cc/entry.h"
-#include "dram/cc/metadata.h"
-#include "dram_test_common.h"
+#include "dram/cc/drampool/entry.h"
+#include "dram/cc/drampool/metadata.h"
+#include "dram/dram_test_common.h"
 
+using UC::Status;
 using UC::Detail::BlockId;
-using UC::DramStore::EntryPtr;
-using UC::DramStore::EntryStatus;
-using UC::DramStore::EvictionPolicyType;
-using UC::DramStore::MetadataConfig;
-using UC::DramStore::MetadataManager;
-using UC::DramStore::ShardMetadata;
+using UC::DramPool::EntryPtr;
+using UC::DramPool::EntryStatus;
+using UC::DramPool::EvictionPolicyType;
+using UC::DramPool::MetadataConfig;
+using UC::DramPool::MetadataManager;
+using UC::DramPool::ShardMetadata;
 using UC::Test::Dram::Clock;
 using UC::Test::Dram::KeyFromHex;
 using UC::Test::Dram::MakeEntry;
@@ -67,12 +68,13 @@ TEST_F(UCShardMetadataTest, StoreBeginReturnsOk)
     EXPECT_TRUE(md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED)).Success());
 }
 
-TEST_F(UCShardMetadataTest, StoreBeginDuplicateReturnsOkAndKeepsSingleEntry)
+TEST_F(UCShardMetadataTest, StoreBeginDuplicateReturnsDuplicateKeyAndKeepsSingleEntry)
 {
     ShardMetadata md(MakeConfig());
     auto k = KeyFromHex("a1");
     EXPECT_TRUE(md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED)).Success());
-    EXPECT_TRUE(md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED)).Success());
+    EXPECT_EQ(md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED)),
+              Status::DuplicateKey());
     EXPECT_EQ(md.GetKeyCnt(), 1UL);
 }
 
@@ -80,22 +82,22 @@ TEST_F(UCShardMetadataTest, StoreBeginNullptrReturnsInvalidParam)
 {
     ShardMetadata md(MakeConfig());
     auto k = KeyFromHex("a1");
-    EXPECT_FALSE(md.StoreBegin(k, nullptr).Success());
+    EXPECT_EQ(md.StoreBegin(k, nullptr), Status::InvalidParam());
 }
 
 TEST_F(UCShardMetadataTest, StoreBeginRejectsReadyEntry)
 {
     ShardMetadata md(MakeConfig());
     auto k = KeyFromHex("a1");
-    EXPECT_FALSE(md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::READY)).Success());
+    EXPECT_EQ(md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::READY)), Status::InvalidParam());
 }
 
 TEST_F(UCShardMetadataTest, StoreBeginRejectsNonZeroRefCnt)
 {
     ShardMetadata md(MakeConfig());
     auto k = KeyFromHex("a1");
-    EXPECT_FALSE(
-        md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED, /*refCnt=*/1)).Success());
+    EXPECT_EQ(md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED, /*refCnt=*/1)),
+              Status::InvalidParam());
 }
 
 TEST_F(UCShardMetadataTest, StoreEndMarksInitializedAsReady)
@@ -116,19 +118,20 @@ TEST_F(UCShardMetadataTest, StoreEndReturnsErrorWhenNotInitialized)
     auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
     md.StoreBegin(k, entry);
     ASSERT_TRUE(md.StoreEnd(k).Success());
-    EXPECT_FALSE(md.StoreEnd(k).Success());
+    EXPECT_EQ(md.StoreEnd(k), Status::Error());
 }
 
 TEST_F(UCShardMetadataTest, StoreEndReturnsNotFoundWhenMissing)
 {
     ShardMetadata md(MakeConfig());
-    EXPECT_FALSE(md.StoreEnd(KeyFromHex("a1")).Success());
+    EXPECT_EQ(md.StoreEnd(KeyFromHex("a1")), Status::NotFound());
 }
 
 TEST_F(UCShardMetadataTest, LoadBeginReturnsNotFoundWhenMissing)
 {
     ShardMetadata md(MakeConfig());
-    EXPECT_FALSE(md.LoadBegin(KeyFromHex("a1")).Success());
+    EntryPtr out;
+    EXPECT_EQ(md.LoadBegin(KeyFromHex("a1"), out), Status::NotFound());
 }
 
 TEST_F(UCShardMetadataTest, LoadBeginIncrementsRefCnt)
@@ -140,8 +143,10 @@ TEST_F(UCShardMetadataTest, LoadBeginIncrementsRefCnt)
     md.StoreBegin(k, entry);
     md.StoreEnd(k);
     EXPECT_EQ(entry->refCnt, 0U);
-    EXPECT_TRUE(md.LoadBegin(k).Success());
+    EntryPtr out;
+    EXPECT_TRUE(md.LoadBegin(k, out).Success());
     EXPECT_EQ(entry->refCnt, 1U);
+    EXPECT_EQ(out.get(), entry.get());
 }
 
 TEST_F(UCShardMetadataTest, LoadBeginReturnsErrorWhenNotReady)
@@ -150,14 +155,15 @@ TEST_F(UCShardMetadataTest, LoadBeginReturnsErrorWhenNotReady)
     auto k = KeyFromHex("a1");
     auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
     md.StoreBegin(k, entry);
-    EXPECT_FALSE(md.LoadBegin(k).Success());
+    EntryPtr out;
+    EXPECT_EQ(md.LoadBegin(k, out), Status::Error());
     EXPECT_EQ(entry->refCnt, 0U);
 }
 
 TEST_F(UCShardMetadataTest, LoadEndReturnsNotFoundWhenMissing)
 {
     ShardMetadata md(MakeConfig());
-    EXPECT_FALSE(md.LoadEnd(KeyFromHex("a1")).Success());
+    EXPECT_EQ(md.LoadEnd(KeyFromHex("a1")), Status::NotFound());
 }
 
 TEST_F(UCShardMetadataTest, LoadEndDecrementsRefCnt)
@@ -167,7 +173,8 @@ TEST_F(UCShardMetadataTest, LoadEndDecrementsRefCnt)
     auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
     md.StoreBegin(k, entry);
     md.StoreEnd(k);
-    md.LoadBegin(k);
+    EntryPtr out;
+    md.LoadBegin(k, out);
     ASSERT_EQ(entry->refCnt, 1U);
     EXPECT_TRUE(md.LoadEnd(k).Success());
     EXPECT_EQ(entry->refCnt, 0U);
@@ -179,7 +186,7 @@ TEST_F(UCShardMetadataTest, LoadEndReturnsErrorWhenRefCntIsZero)
     auto k = KeyFromHex("a1");
     md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED));
     md.StoreEnd(k);
-    EXPECT_FALSE(md.LoadEnd(k).Success());
+    EXPECT_EQ(md.LoadEnd(k), Status::Error());
 }
 
 TEST_F(UCShardMetadataTest, ExistReturnsTrueAndRefreshesLeaseWhenReady)
@@ -230,7 +237,7 @@ TEST_F(UCShardMetadataTest, DeleteReturnsOkAndSecondIsNotFound)
     auto k = KeyFromHex("a1");
     EXPECT_TRUE(md.StoreBegin(k, MakeEntry(k, 0, past_, EntryStatus::INITIALIZED)).Success());
     EXPECT_TRUE(md.Delete(k).Success());
-    EXPECT_FALSE(md.Delete(k).Success());
+    EXPECT_EQ(md.Delete(k), Status::NotFound());
 }
 
 TEST_F(UCShardMetadataTest, GetKeyCntReflectsAddsAndDeletes)
@@ -254,10 +261,17 @@ TEST_F(UCShardMetadataTest, FullLifecycleStoreStoreEndLoadExist)
     auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
     EXPECT_TRUE(md.StoreBegin(k, entry).Success());
     EXPECT_EQ(entry->status, EntryStatus::INITIALIZED);
-    EXPECT_FALSE(md.LoadBegin(k).Success());
+    {
+        EntryPtr out;
+        EXPECT_EQ(md.LoadBegin(k, out), Status::Error());
+    }
     EXPECT_TRUE(md.StoreEnd(k).Success());
     EXPECT_EQ(entry->status, EntryStatus::READY);
-    EXPECT_TRUE(md.LoadBegin(k).Success());
+    {
+        EntryPtr out;
+        EXPECT_TRUE(md.LoadBegin(k, out).Success());
+        EXPECT_EQ(out.get(), entry.get());
+    }
     EXPECT_EQ(entry->refCnt, 1U);
     EXPECT_TRUE(md.Exist(k));
     EXPECT_GT(entry->leaseTimeout, Clock::now());
@@ -310,7 +324,11 @@ TEST_F(UCMetadataManagerTest, PerKeyOpsDispatchAndRoundtrip)
     EXPECT_FALSE(mgr.Query(KeyFromHex("a2")));
     EXPECT_TRUE(mgr.Exist(k));
     EXPECT_GT(entry->leaseTimeout, Clock::now());
-    EXPECT_TRUE(mgr.LoadBegin(k).Success());
+    {
+        EntryPtr out;
+        EXPECT_TRUE(mgr.LoadBegin(k, out).Success());
+        EXPECT_EQ(out.get(), entry.get());
+    }
     EXPECT_EQ(entry->refCnt, 1U);
     EXPECT_TRUE(mgr.LoadEnd(k).Success());
     EXPECT_EQ(entry->refCnt, 0U);

--- a/ucm/store/test/case/dram/drampool/dram_pos_eviction_policy_test.cc
+++ b/ucm/store/test/case/dram/drampool/dram_pos_eviction_policy_test.cc
@@ -24,11 +24,12 @@
 #include <chrono>
 #include <gtest/gtest.h>
 #include <memory>
-#include "dram/cc/entry.h"
-#include "dram/cc/pos_eviction_policy.h"
-#include "dram_test_common.h"
+#include "dram/cc/drampool/entry.h"
+#include "dram/cc/drampool/pos_eviction_policy.h"
+#include "dram/dram_test_common.h"
 
-using UC::DramStore::PosEvictionPolicy;
+using UC::Status;
+using UC::DramPool::PosEvictionPolicy;
 using UC::Test::Dram::Clock;
 using UC::Test::Dram::EntryStatus;
 using UC::Test::Dram::KeyFromHex;
@@ -52,13 +53,13 @@ TEST_F(UCPosEvictionPolicyTest, AddKeyDuplicateReturnsDuplicateKey)
 {
     auto key = KeyFromHex("a1");
     ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
-    ASSERT_FALSE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
+    ASSERT_EQ(policy_.AddKey(key, MakeEntry(key, 0, past_)), Status::DuplicateKey());
 }
 
 TEST_F(UCPosEvictionPolicyTest, AddKeyNullptrReturnsInvalidParam)
 {
     auto key = KeyFromHex("a1");
-    ASSERT_FALSE(policy_.AddKey(key, nullptr).Success());
+    ASSERT_EQ(policy_.AddKey(key, nullptr), Status::InvalidParam());
 }
 
 TEST_F(UCPosEvictionPolicyTest, DeleteKeyReturnsOkAndSecondIsNotFound)
@@ -66,7 +67,7 @@ TEST_F(UCPosEvictionPolicyTest, DeleteKeyReturnsOkAndSecondIsNotFound)
     auto key = KeyFromHex("a1");
     ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
     ASSERT_TRUE(policy_.DeleteKey(key).Success());
-    ASSERT_FALSE(policy_.DeleteKey(key).Success());
+    ASSERT_EQ(policy_.DeleteKey(key), Status::NotFound());
 }
 
 TEST_F(UCPosEvictionPolicyTest, AccessKeyReturnsOk)

--- a/ucm/store/test/case/dram/drampool/dram_ttl_eviction_policy_test.cc
+++ b/ucm/store/test/case/dram/drampool/dram_ttl_eviction_policy_test.cc
@@ -24,11 +24,12 @@
 #include <chrono>
 #include <gtest/gtest.h>
 #include <memory>
-#include "dram/cc/entry.h"
-#include "dram/cc/ttl_eviction_policy.h"
-#include "dram_test_common.h"
+#include "dram/cc/drampool/entry.h"
+#include "dram/cc/drampool/ttl_eviction_policy.h"
+#include "dram/dram_test_common.h"
 
-using UC::DramStore::TtlEvictionPolicy;
+using UC::Status;
+using UC::DramPool::TtlEvictionPolicy;
 using UC::Test::Dram::Clock;
 using UC::Test::Dram::EntryStatus;
 using UC::Test::Dram::KeyFromHex;
@@ -52,14 +53,14 @@ TEST_F(UCTtlEvictionPolicyTest, AddKeyDuplicateReturnsDuplicateKey)
 {
     auto key = KeyFromHex("a1");
     ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
-    ASSERT_FALSE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
+    ASSERT_EQ(policy_.AddKey(key, MakeEntry(key, 0, past_)), Status::DuplicateKey());
 }
 
 TEST_F(UCTtlEvictionPolicyTest, AddKeyNullptrReturnsInvalidParam)
 {
     auto key = KeyFromHex("a1");
     auto st = policy_.AddKey(key, nullptr);
-    ASSERT_FALSE(st.Success());
+    ASSERT_EQ(st, Status::InvalidParam());
 }
 
 TEST_F(UCTtlEvictionPolicyTest, DeleteKeyReturnsOkAndSecondIsNotFound)
@@ -67,7 +68,7 @@ TEST_F(UCTtlEvictionPolicyTest, DeleteKeyReturnsOkAndSecondIsNotFound)
     auto key = KeyFromHex("a1");
     ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, 0, past_)).Success());
     ASSERT_TRUE(policy_.DeleteKey(key).Success());
-    ASSERT_FALSE(policy_.DeleteKey(key).Success());
+    ASSERT_EQ(policy_.DeleteKey(key), Status::NotFound());
 }
 
 TEST_F(UCTtlEvictionPolicyTest, AccessKeyReturnsOk)


### PR DESCRIPTION
## Purpose
Move all dram pool related files to drampool directory. Fix some issue of `ShardMetadata`.

## Modifications 
1. Move all dram pool related files from `store/dram/cc` to `store/dram/cc/drampool`.
2. Move all dram pool related test files from `store/test/case/dram` to `store/test/case/dram/drampool`.
3. In `StoreBegin` function, if the key already exists, return `DuplicateKey`.
4. In `LoadBegin` function, add a new param entry as an output if the key exists.
5. Fix all the related test cases to expect for specific error code.

## Test
```
        Start  83: UCShardMetadataTest.StoreBeginReturnsOk
 83/166 Test  #83: UCShardMetadataTest.StoreBeginReturnsOk ...........................................................   Passed    0.01 sec
        Start  84: UCShardMetadataTest.StoreBeginDuplicateReturnsDuplicateKeyAndKeepsSingleEntry
 84/166 Test  #84: UCShardMetadataTest.StoreBeginDuplicateReturnsDuplicateKeyAndKeepsSingleEntry .....................   Passed    0.01 sec
        Start  85: UCShardMetadataTest.StoreBeginNullptrReturnsInvalidParam
 85/166 Test  #85: UCShardMetadataTest.StoreBeginNullptrReturnsInvalidParam ..........................................   Passed    0.01 sec
        Start  86: UCShardMetadataTest.StoreBeginRejectsReadyEntry
 86/166 Test  #86: UCShardMetadataTest.StoreBeginRejectsReadyEntry ...................................................   Passed    0.01 sec
        Start  87: UCShardMetadataTest.StoreBeginRejectsNonZeroRefCnt
 87/166 Test  #87: UCShardMetadataTest.StoreBeginRejectsNonZeroRefCnt ................................................   Passed    0.01 sec
        Start  88: UCShardMetadataTest.StoreEndMarksInitializedAsReady
 88/166 Test  #88: UCShardMetadataTest.StoreEndMarksInitializedAsReady ...............................................   Passed    0.01 sec
        Start  89: UCShardMetadataTest.StoreEndReturnsErrorWhenNotInitialized
 89/166 Test  #89: UCShardMetadataTest.StoreEndReturnsErrorWhenNotInitialized ........................................   Passed    0.01 sec
        Start  90: UCShardMetadataTest.StoreEndReturnsNotFoundWhenMissing
 90/166 Test  #90: UCShardMetadataTest.StoreEndReturnsNotFoundWhenMissing ............................................   Passed    0.01 sec
        Start  91: UCShardMetadataTest.LoadBeginReturnsNotFoundWhenMissing
 91/166 Test  #91: UCShardMetadataTest.LoadBeginReturnsNotFoundWhenMissing ...........................................   Passed    0.01 sec
        Start  92: UCShardMetadataTest.LoadBeginIncrementsRefCnt
 92/166 Test  #92: UCShardMetadataTest.LoadBeginIncrementsRefCnt .....................................................   Passed    0.01 sec
        Start  93: UCShardMetadataTest.LoadBeginReturnsErrorWhenNotReady
 93/166 Test  #93: UCShardMetadataTest.LoadBeginReturnsErrorWhenNotReady .............................................   Passed    0.01 sec
        Start  94: UCShardMetadataTest.LoadEndReturnsNotFoundWhenMissing
 94/166 Test  #94: UCShardMetadataTest.LoadEndReturnsNotFoundWhenMissing .............................................   Passed    0.01 sec
        Start  95: UCShardMetadataTest.LoadEndDecrementsRefCnt
 95/166 Test  #95: UCShardMetadataTest.LoadEndDecrementsRefCnt .......................................................   Passed    0.01 sec
        Start  96: UCShardMetadataTest.LoadEndReturnsErrorWhenRefCntIsZero
 96/166 Test  #96: UCShardMetadataTest.LoadEndReturnsErrorWhenRefCntIsZero ...........................................   Passed    0.01 sec
        Start  97: UCShardMetadataTest.ExistReturnsTrueAndRefreshesLeaseWhenReady
 97/166 Test  #97: UCShardMetadataTest.ExistReturnsTrueAndRefreshesLeaseWhenReady ....................................   Passed    0.01 sec
        Start  98: UCShardMetadataTest.ExistReturnsFalseWhenNotReady
 98/166 Test  #98: UCShardMetadataTest.ExistReturnsFalseWhenNotReady .................................................   Passed    0.01 sec
        Start  99: UCShardMetadataTest.ExistReturnsFalseWhenMissing
 99/166 Test  #99: UCShardMetadataTest.ExistReturnsFalseWhenMissing ..................................................   Passed    0.01 sec
        Start 100: UCShardMetadataTest.QueryReturnsTrueAfterAdd
100/166 Test #100: UCShardMetadataTest.QueryReturnsTrueAfterAdd ......................................................   Passed    0.01 sec
        Start 101: UCShardMetadataTest.QueryReturnsFalseWhenMissing
101/166 Test #101: UCShardMetadataTest.QueryReturnsFalseWhenMissing ..................................................   Passed    0.01 sec
        Start 102: UCShardMetadataTest.DeleteReturnsOkAndSecondIsNotFound
102/166 Test #102: UCShardMetadataTest.DeleteReturnsOkAndSecondIsNotFound ............................................   Passed    0.01 sec
        Start 103: UCShardMetadataTest.GetKeyCntReflectsAddsAndDeletes
103/166 Test #103: UCShardMetadataTest.GetKeyCntReflectsAddsAndDeletes ...............................................   Passed    0.01 sec
        Start 104: UCShardMetadataTest.FullLifecycleStoreStoreEndLoadExist
104/166 Test #104: UCShardMetadataTest.FullLifecycleStoreStoreEndLoadExist ...........................................   Passed    0.01 sec
```