### PR TITLE
[Feat] Add register KV cache regions in UCM connector and ASU store

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -401,6 +401,9 @@ class UCMDirectConnector(KVConnectorBase_V1):
         )
 
         self.store = self._create_store(self.kv_cache_layout, store_cores)
+        if self.store.need_register_kv_caches():
+            registrations = self._collect_kv_cache_registrations()
+            self.store.register_kv_caches(registrations)
 
         if worker_cores:
             try:
@@ -411,6 +414,41 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
         if self.device is None:
             raise RuntimeError(f"Unsupported device platform for UCMDirectConnector.")
+
+    def _collect_kv_cache_registrations(self):
+        registrations: list[tuple[int, int]] = []
+        unique_registrations: set[tuple[int, int]] = set()
+
+        def add_tensor(tensor: torch.Tensor) -> None:
+            addr = tensor.data_ptr()
+            size = tensor.numel() * tensor.element_size()
+            registration = (addr, size)
+            if addr == 0 or size <= 0 or registration in unique_registrations:
+                return
+            registrations.append(registration)
+            unique_registrations.add(registration)
+
+        for kv_layer in self.kv_caches.values():
+            if isinstance(kv_layer, torch.Tensor):
+                if kv_layer.dim() == 5:
+                    add_tensor(kv_layer[0])
+                    add_tensor(kv_layer[1])
+                elif kv_layer.dim() == 3:
+                    add_tensor(kv_layer)
+                else:
+                    raise ValueError(
+                        f"Unsupported kv cache tensor shape: {kv_layer.shape}"
+                    )
+            elif isinstance(kv_layer, Tuple):
+                for tensor in kv_layer:
+                    add_tensor(tensor)
+            else:
+                raise TypeError(f"Unsupported kv cache type: {type(kv_layer)}")
+
+        return np.array(
+            registrations,
+            dtype=[("addr", np.uintp), ("size", np.uintp)],
+        )
 
     def get_num_new_matched_tokens(
         self,

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -467,6 +467,13 @@ public:
         return ConvertStatus(result.status);
     }
 
+    bool NeedRegisterKVCaches() const override { return true; }
+
+    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
+    {
+        return Status::OK();
+    }
+
 private:
     using SubmitFunc = AsuStatus (AsuBackend::*)(const std::vector<UC::ASU::KVBuffer>&,
                                                  UC::ASU::TaskId&);

--- a/ucm/store/cache/cc/cache_store.cc
+++ b/ucm/store/cache/cc/cache_store.cc
@@ -99,6 +99,11 @@ public:
         if (s.Failure()) [[unlikely]] { UC_ERROR("Failed({}) to wait task({}).", s, taskId); }
         return s;
     }
+    bool NeedRegisterKVCaches() const override { return false; }
+    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
+    {
+        return Status::OK();
+    }
 
 private:
     Config ParseConfig(const Detail::Dictionary& config)

--- a/ucm/store/compress/cc/compressor.h
+++ b/ucm/store/compress/cc/compressor.h
@@ -20,6 +20,11 @@ public:
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override;
     Expected<bool> Check(Detail::TaskHandle taskId) override;
     Status Wait(Detail::TaskHandle taskId) override;
+    bool NeedRegisterKVCaches() const override { return false; }
+    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
+    {
+        return Status::OK();
+    }
 
 private:
     std::shared_ptr<CompressorImpl> impl_;

--- a/ucm/store/ds3fs/cc/ds3fs_store.h
+++ b/ucm/store/ds3fs/cc/ds3fs_store.h
@@ -41,6 +41,11 @@ public:
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override;
     Expected<bool> Check(Detail::TaskHandle taskId) override;
     Status Wait(Detail::TaskHandle taskId) override;
+    bool NeedRegisterKVCaches() const override { return false; }
+    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
+    {
+        return Status::OK();
+    }
 
 private:
     std::shared_ptr<Ds3fsStoreImpl> impl_;

--- a/ucm/store/empty/cc/empty_store.cc
+++ b/ucm/store/empty/cc/empty_store.cc
@@ -42,6 +42,11 @@ public:
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) { return NextId(); }
     Expected<bool> Check(Detail::TaskHandle taskId) { return true; }
     Status Wait(Detail::TaskHandle taskId) { return Status::OK(); }
+    bool NeedRegisterKVCaches() const override { return false; }
+    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
+    {
+        return Status::OK();
+    }
 
 private:
     static Detail::TaskHandle NextId() noexcept

--- a/ucm/store/fake/cc/fake_store.cc
+++ b/ucm/store/fake/cc/fake_store.cc
@@ -82,6 +82,11 @@ public:
     }
     Expected<bool> Check(Detail::TaskHandle taskId) override { return true; }
     Status Wait(Detail::TaskHandle taskId) override { return Status::OK(); }
+    bool NeedRegisterKVCaches() const override { return false; }
+    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
+    {
+        return Status::OK();
+    }
 
 private:
     static Detail::TaskHandle NextId() noexcept

--- a/ucm/store/pcstore/pcstore_connector_v1.py
+++ b/ucm/store/pcstore/pcstore_connector_v1.py
@@ -255,3 +255,9 @@ class UcmPcStoreV1(UcmKVStoreBaseV1):
             ``True`` if the task has finished, ``False`` if still in-flight.
         """
         return self.store.Check(task.task_id)
+
+    def need_register_kv_caches(self) -> bool:
+        return False
+
+    def register_kv_caches(self, registrations: np.ndarray) -> None:
+        return

--- a/ucm/store/pipeline/connector.py
+++ b/ucm/store/pipeline/connector.py
@@ -157,6 +157,12 @@ class UcmPipelineStore(UcmKVStoreBaseV1):
     def check(self, task: Task) -> bool:
         return self.store_.Check(task.task_id)
 
+    def need_register_kv_caches(self) -> bool:
+        return self.store_.NeedRegisterKVCaches()
+
+    def register_kv_caches(self, registrations: np.ndarray) -> None:
+        self.store_.RegisterKVCaches(registrations)
+
 
 def _cache_ds3fs_pipeline_builder(
     config: Dict[str, object], pipeline: ucmpipelinestore.PipelineStore

--- a/ucm/store/pipeline/cpy/pipeline_store.py.cc
+++ b/ucm/store/pipeline/cpy/pipeline_store.py.cc
@@ -168,6 +168,12 @@ public:
         }
         ThrowIfFailed(status);
     }
+    bool NeedRegisterKVCaches() const { return StoreBack()->NeedRegisterKVCaches(); }
+    void RegisterKVCaches(const pybind11::buffer& registrations)
+    {
+        BufferArrayView<KVCacheRegistration> registrationArr{registrations};
+        ThrowIfFailed(StoreBack()->RegisterKVCaches(registrationArr.data, registrationArr.num));
+    }
 };
 
 }  // namespace UC::PipelineStore
@@ -192,4 +198,7 @@ PYBIND11_MODULE(ucmpipelinestore, m)
           py::arg("addrs").noconvert(), py::arg("prerequisite_handle") = 0);
     s.def("Check", &PipelineStore::Check);
     s.def("Wait", &PipelineStore::Wait);
+    s.def("NeedRegisterKVCaches", &PipelineStore::NeedRegisterKVCaches);
+    s.def("RegisterKVCaches", &PipelineStore::RegisterKVCaches,
+          py::arg("registrations").noconvert());
 }

--- a/ucm/store/posix/cc/posix_store.cc
+++ b/ucm/store/posix/cc/posix_store.cc
@@ -97,6 +97,11 @@ public:
         if (s.Failure()) [[unlikely]] { UC_ERROR("Failed({}) to wait task({}).", s, taskId); }
         return s;
     }
+    bool NeedRegisterKVCaches() const override { return false; }
+    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
+    {
+        return Status::OK();
+    }
 
 private:
     Config ParseConfig(const Detail::Dictionary& inConfig)

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -704,3 +704,14 @@ TEST(UCAsuStoreTest, UsesNonLayerwiseGqaKeyValueOffsets)
         EXPECT_EQ(state->lastStoreEntries[index].offset, expectedOffsets[index]);
     }
 }
+
+TEST(UCAsuStoreTest, KvCacheRegistrationIsCurrentlyNoOp)
+{
+    UC::AsuStore::AsuStore store;
+    const UC::KVCacheRegistration registrations[]{
+        {0x1000, 1024}
+    };
+
+    EXPECT_TRUE(store.NeedRegisterKVCaches());
+    EXPECT_TRUE(store.RegisterKVCaches(registrations, std::size(registrations)).Success());
+}

--- a/ucm/store/test/case/detail/mock_store.h
+++ b/ucm/store/test/case/detail/mock_store.h
@@ -44,6 +44,11 @@ public:
                 (override));
     MOCK_METHOD((UC::Expected<bool>), Check, (UC::Detail::TaskHandle taskId), (override));
     MOCK_METHOD((UC::Status), Wait, (UC::Detail::TaskHandle taskId), (override));
+    bool NeedRegisterKVCaches() const override { return false; }
+    Status RegisterKVCaches(const UC::KVCacheRegistration*, std::size_t) override
+    {
+        return Status::OK();
+    }
 };
 
 }  // namespace UC::Test::Detail

--- a/ucm/store/ucmstore_v1.h
+++ b/ucm/store/ucmstore_v1.h
@@ -24,11 +24,20 @@
 #ifndef UNIFIEDCACHE_STORE_V1_H
 #define UNIFIEDCACHE_STORE_V1_H
 
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
 #include "status/status.h"
 #include "type/dictionary.h"
 #include "type/types.h"
 
 namespace UC {
+
+struct KVCacheRegistration {
+    std::uintptr_t addr{0};
+    std::size_t size{0};
+};
 
 /**
  * @brief Abstract interface for a key-value store that supports
@@ -146,6 +155,11 @@ public:
      *         describing the failure.
      */
     virtual Status Wait(Detail::TaskHandle taskId) = 0;
+
+    virtual bool NeedRegisterKVCaches() const = 0;
+
+    virtual Status RegisterKVCaches(const KVCacheRegistration* registrations,
+                                    std::size_t count) = 0;
 
 protected:
     /**

--- a/ucm/store/ucmstore_v1.py
+++ b/ucm/store/ucmstore_v1.py
@@ -202,3 +202,13 @@ class UcmKVStoreBaseV1(ABC):
             ``True`` if the task has finished, ``False`` if still in-flight.
         """
         pass
+
+    @abstractmethod
+    def need_register_kv_caches(self) -> bool:
+        """Return whether this store requires KV-cache registration."""
+        pass
+
+    @abstractmethod
+    def register_kv_caches(self, registrations: np.ndarray) -> None:
+        """Register pre-collected KV-cache memory regions for this store."""
+        pass


### PR DESCRIPTION
## Purpose
Enable the vLLM UCM connector to collect and register KV-cache memory regions with ASU pipeline stores.
## Modifications
Update UCMDirectConnector to collect KV-cache memory regions after pipeline-store initialization.
Register K and V cache tensors as separate regions when the pipeline store requires KV-cache registration.
Support supported KV-cache tensor layouts, skip empty or duplicate regions, and reject unsupported cache types or tensor shapes.
Add NeedRegisterKVCaches and RegisterKVCaches to the UCM store interface.
Expose KV-cache registration through the pipeline-store C++ and Python bindings.
Make ASU stores opt in to registration; other stores report that it is not required.
## Test
Added an ASU store test confirming KV-cache registration is enabled and currently succeeds as a no-op.
Verified Python syntax for the updated connector and pipeline-store wrapper.