### PR TITLE
fix: default SDMA Direct launch granularity to shard

### DIFF
--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -578,7 +578,6 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         )
         if config.get("posix_capacity_gb", None) is not None:
             config["posix_capacity_gb"] = int(config["posix_capacity_gb"]) // 2
-        self._apply_sdma_direct_launch_granularity(config)
         return name, module_path, config
 
     @staticmethod

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -519,13 +519,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
         tp_size = vllm_config.parallel_config.tensor_parallel_size
         return [RequestHasher(vllm_config, rank_id) for rank_id in range(1, tp_size)]
 
-    def _apply_sdma_direct_launch_granularity(self, config: dict[str, Any]) -> None:
-        if "cache_sdma_direct_launch_granularity" in config:
-            return
-        config["cache_sdma_direct_launch_granularity"] = (
-            "task" if self.use_layerwise else "shard"
-        )
-
     def _record_load_error(self, metric_name: str, block_ids: Any) -> None:
         invalid_blocks = set(block_ids)
         new_invalid_blocks = invalid_blocks - self._invalid_block_ids
@@ -668,8 +661,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
         config["posix_gc_enable"] = (
             self._role != KVConnectorRole.WORKER and dp_rank == 0
         )
-        self._apply_sdma_direct_launch_granularity(config)
-
         logger.info(f"create {name} with config: {config}")
         return UcmConnectorFactoryV1.create_connector(name, config, module_path)
 


### PR DESCRIPTION
## Purpose

Use shard-level submission as the default Cache SDMA Direct launch mode on Ascend A3.

CacheStore already defaults `cache_sdma_direct_launch_granularity` to `shard`. However, the vLLM integration previously injected `task` when layerwise mode was enabled, overriding the CacheStore default.

With task-level submission, H2D waits for multiple shards to become ready before submitting them as one batch. This couples H2D submission with S2H readiness and may break the overlap between the S2H and H2D stages.

With shard-level submission, each shard can enter H2D as soon as its S2H stage is ready, while the following shards continue S2H. This preserves the S2H/H2D pipeline and avoids unnecessary pipeline stalls.

## Modifications

- Remove the Python-side SDMA Direct launch granularity defaulting logic.
- Remove the default injection from the standard UCM and FAWA/HMA store creation paths.
- Let an omitted `cache_sdma_direct_launch_granularity` use CacheStore's native `shard` default.
- Preserve explicitly configured `task` and `shard` values.

Users who still need task-level submission can explicitly configure:

```yaml
cache_sdma_direct_launch_granularity: "task"
```

## Behavior

| Configuration | Effective launch granularity |
| --- | --- |
| Not configured | `shard` |
| Explicitly set to `shard` | `shard` |
| Explicitly set to `task` | `task` |

On Ascend A3, Cache SDMA Direct now uses shard-level submission by default, preserving the overlap between S2H and H2D.

## Test

Verified the configuration path without starting a vLLM service:

- Missing launch granularity:
  - `CacheSdmaDirect = true`
  - `SdmaDirectLaunchGranularity = shard`
- Explicit `task`:
  - `CacheSdmaDirect = true`
  - `SdmaDirectLaunchGranularity = task`
- Explicit `shard`:
  - `CacheSdmaDirect = true`
  - `SdmaDirectLaunchGranularity = shard`