### PR TITLE
[Fix] dps on same machine share same shm

### DIFF
--- a/examples/ucm_config_example.yaml
+++ b/examples/ucm_config_example.yaml
@@ -8,7 +8,6 @@
 # for backward compatibility.
 
 # Connector name (e.g., "UcmNfsStore", "UcmPipelineStore")
-# Default cache_buffer_capacity_gb for CacheStore is 256GB.When use models like MLA you should make sure that /dev/shm has enough space, or you can set this parameter to a smaller value.
 # One important detail is that when multiple DP instances run on the same node, each of them creates its own CacheStore.
 ucm_connectors:
   - ucm_connector_name: "UcmPipelineStore"
@@ -16,7 +15,6 @@ ucm_connectors:
       store_pipeline: "Cache|Posix"
       storage_backends: "/mnt/test"
       io_direct: false
-      # cache_buffer_capacity_gb: 256
       # posix_capacity_gb: 1024
 
       # Enable GPUDirect RDMA transfers for CacheStore/PcStore H2D and D2H copies.

--- a/ucm/integration/vllm/hla_connector.py
+++ b/ucm/integration/vllm/hla_connector.py
@@ -1326,7 +1326,6 @@ class UCMHybridLinearAttentionLayerWiseConnector(UCMHybridLinearAttentionConnect
             tensor_size_list_override=row_tensor_size_list,
             shard_size_override=row_shard_size,
             block_size_override=row_shard_size * (max(self.row_ids) + 1),
-            compact_cache_buffer_capacity=True,
         )
 
         row_to_layers: dict[int, list[str]] = defaultdict(list)

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -675,6 +675,21 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
             config["posix_capacity_gb"] = int(config["posix_capacity_gb"]) // 2
         return name, module_path, config
 
+    def _set_default_shm_buffer_capacity(self, config: dict[str, object]) -> None:
+        if not bool(config.get("share_buffer_enable", False)):
+            return
+        if config.get("cache_buffer_capacity_gb") is not None:
+            return
+
+        # HMA creates two shared-buffer stores, FA and WA, so split the direct
+        # connector's 128GB shared-buffer default evenly between them.
+        config["cache_buffer_capacity_gb"] = 128 // 2
+        logger.info(
+            f"Set FAWA cache_buffer_capacity_gb to "
+            f"{config['cache_buffer_capacity_gb']}GB by splitting the direct "
+            "shared-buffer default 128GB across FA/WA stores."
+        )
+
     @staticmethod
     def _namespace_storage_backends(
         config: dict[str, object],
@@ -702,6 +717,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         """Instantiate one UCM store with worker tensor layout metadata."""
 
         name, module_path, config = self._base_store_config(store_suffix)
+        self._set_default_shm_buffer_capacity(config)
         if self._role == KVConnectorRole.WORKER:
             if tensor_size_list is None:
                 raise RuntimeError(f"Worker FAWA {label} store needs tensor sizes.")

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -3,6 +3,7 @@ import hashlib
 import math
 import os
 import pickle
+import re
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -77,6 +78,13 @@ _CACHE_STORE_DEFAULT_UNSHARED_BUFFER_CAPACITY_GB = 32
 _CACHE_STORE_COMPACT_CAPACITY_THRESHOLD_GB = 32
 _CACHE_STORE_MIN_BUFFER_NUMBER = 1024
 _CACHE_STORE_DEFAULT_LOAD_EXCLUSIVE_BUFFER_NUMBER = 1024
+_DP_ENGINE_ID_SUFFIX_RE = re.compile(r"_dp\d+$")
+
+
+def _strip_dp_suffix_from_engine_id(engine_id: str) -> str:
+    if not isinstance(engine_id, str):
+        return engine_id
+    return _DP_ENGINE_ID_SUFFIX_RE.sub("", engine_id)
 
 
 def _normalize_tensor_size_list(tensor_size_list: Any) -> list[int]:
@@ -470,7 +478,9 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self.requests_meta: dict[str, RequestMeta] = {}
 
         ucm_config = Config(vllm_config.kv_transfer_config)
-        self.engine_id = vllm_config.kv_transfer_config.engine_id
+        self.engine_id = _strip_dp_suffix_from_engine_id(
+            vllm_config.kv_transfer_config.engine_id
+        )
         self.launch_config = ucm_config.get_config()
         self.connector_configs = self.launch_config.get("ucm_connectors", [])
         self.enable_event_sync = self.launch_config.get("enable_event_sync", True)
@@ -2042,7 +2052,9 @@ class UCMConnector(KVConnectorBase_V1, SupportsHMA):
         )
         self.connector: KVConnectorBase_V1
         ucm_config = Config(vllm_config.kv_transfer_config)
-        self.engine_id = vllm_config.kv_transfer_config.engine_id
+        self.engine_id = _strip_dp_suffix_from_engine_id(
+            vllm_config.kv_transfer_config.engine_id
+        )
         self.launch_config = ucm_config.get_config()
         self._worker_rank = (
             get_world_group().rank

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -71,21 +71,6 @@ from ucm.sparse.state import has_ucm_sparse
 
 logger = init_logger(__name__)
 
-_GIB = 1 << 30
-_CACHE_BUFFER_CAPACITY_KEY = "cache_buffer_capacity_gb"
-_CACHE_STORE_DEFAULT_BUFFER_CAPACITY_GB = 256
-_CACHE_STORE_DEFAULT_UNSHARED_BUFFER_CAPACITY_GB = 32
-_CACHE_STORE_COMPACT_CAPACITY_THRESHOLD_GB = 32
-_CACHE_STORE_MIN_BUFFER_NUMBER = 1024
-_CACHE_STORE_DEFAULT_LOAD_EXCLUSIVE_BUFFER_NUMBER = 1024
-_DP_ENGINE_ID_SUFFIX_RE = re.compile(r"_dp\d+$")
-
-
-def _strip_dp_suffix_from_engine_id(engine_id: str) -> str:
-    if not isinstance(engine_id, str):
-        return engine_id
-    return _DP_ENGINE_ID_SUFFIX_RE.sub("", engine_id)
-
 
 def _normalize_tensor_size_list(tensor_size_list: Any) -> list[int]:
     if isinstance(tensor_size_list, np.ndarray):
@@ -93,79 +78,6 @@ def _normalize_tensor_size_list(tensor_size_list: Any) -> list[int]:
     if isinstance(tensor_size_list, (list, tuple)):
         return [int(v) for v in tensor_size_list]
     return [int(tensor_size_list)]
-
-
-def _cache_store_required_capacity_gb(
-    config: dict[str, Any],
-    shard_size: int,
-) -> tuple[int, int]:
-    try:
-        load_exclusive_buffer_number = int(
-            config.get(
-                "cache_load_exclusive_buffer_number",
-                _CACHE_STORE_DEFAULT_LOAD_EXCLUSIVE_BUFFER_NUMBER,
-            )
-        )
-    except (TypeError, ValueError):
-        load_exclusive_buffer_number = _CACHE_STORE_DEFAULT_LOAD_EXCLUSIVE_BUFFER_NUMBER
-
-    required_buffer_number = max(
-        _CACHE_STORE_MIN_BUFFER_NUMBER,
-        load_exclusive_buffer_number * 2,
-    )
-    required_capacity_bytes = int(shard_size) * required_buffer_number
-    return math.ceil(required_capacity_bytes / _GIB), required_buffer_number
-
-
-def _ensure_cache_store_buffer_capacity(
-    config: dict[str, Any], shard_size: int
-) -> None:
-    if shard_size <= 0:
-        return
-
-    required_capacity_gb, required_buffer_number = _cache_store_required_capacity_gb(
-        config, shard_size
-    )
-    required_capacity_bytes = required_capacity_gb * _GIB
-
-    configured_capacity = config.get(_CACHE_BUFFER_CAPACITY_KEY)
-    if configured_capacity is None:
-        share_buffer_enable = bool(config.get("share_buffer_enable", True))
-        current_capacity_gb = (
-            _CACHE_STORE_DEFAULT_BUFFER_CAPACITY_GB
-            if share_buffer_enable
-            else _CACHE_STORE_DEFAULT_UNSHARED_BUFFER_CAPACITY_GB
-        )
-        source = "default"
-    else:
-        try:
-            current_capacity_gb = int(configured_capacity)
-        except (TypeError, ValueError):
-            logger.warning(
-                f"Invalid {_CACHE_BUFFER_CAPACITY_KEY}={configured_capacity}; "
-                "skip automatic capacity adjustment."
-            )
-            return
-        source = "configured"
-
-    if current_capacity_gb * _GIB >= required_capacity_bytes:
-        return
-    if required_capacity_gb <= _CACHE_STORE_COMPACT_CAPACITY_THRESHOLD_GB:
-        logger.warning(
-            f"{_CACHE_BUFFER_CAPACITY_KEY}={source} {current_capacity_gb}GB "
-            f"is smaller than required {required_capacity_gb}GB for "
-            f"shard_size={shard_size}, required_buffer_number={required_buffer_number}; "
-            "keep it unchanged because the required capacity does not exceed "
-            f"{_CACHE_STORE_COMPACT_CAPACITY_THRESHOLD_GB}GB."
-        )
-        return
-
-    config[_CACHE_BUFFER_CAPACITY_KEY] = required_capacity_gb
-    logger.warning(
-        f"Increase {_CACHE_BUFFER_CAPACITY_KEY} from {source} "
-        f"{current_capacity_gb}GB to {required_capacity_gb}GB for "
-        f"shard_size={shard_size}, required_buffer_number={required_buffer_number}."
-    )
 
 
 def _short_list(values: list[int], limit: int = 12) -> list[int]:
@@ -478,8 +390,9 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self.requests_meta: dict[str, RequestMeta] = {}
 
         ucm_config = Config(vllm_config.kv_transfer_config)
-        self.engine_id = _strip_dp_suffix_from_engine_id(
-            vllm_config.kv_transfer_config.engine_id
+        dp_engine_id_suffix = re.compile(r"_dp\d+$")
+        self.engine_id = dp_engine_id_suffix.sub(
+            "", vllm_config.kv_transfer_config.engine_id
         )
         self.launch_config = ucm_config.get_config()
         self.connector_configs = self.launch_config.get("ucm_connectors", [])
@@ -566,6 +479,15 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
         return ret
 
+    def _set_default_shm_buffer_capacity(self, config: dict[str, Any]) -> None:
+        if not bool(config.get("share_buffer_enable", False)):
+            return
+        if config.get("cache_buffer_capacity_gb") is not None:
+            return
+
+        config["cache_buffer_capacity_gb"] = 128
+        logger.info("Set cache_buffer_capacity_gb to 128GB for shared-buffer store.")
+
     def _create_store(
         self,
         kv_cache_layout: Optional[KVCacheLayout],
@@ -573,7 +495,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
         shard_size_override: Optional[int] = None,
         block_size_override: Optional[int] = None,
         unique_id_suffix: str = "",
-        compact_cache_buffer_capacity: bool = False,
     ) -> UcmKVStoreBaseV1:
         if len(self.connector_configs) != 1:
             raise RuntimeError(
@@ -586,6 +507,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
         module_path = self.connector_configs[0].get("ucm_connector_module_path", None)
         config = copy.deepcopy(self.connector_configs[0]["ucm_connector_config"])
         config.setdefault("share_buffer_enable", self.is_mla)
+        self._set_default_shm_buffer_capacity(config)
         if "storage_backends" in config:
             backends = [path for path in config["storage_backends"].split(":")]
             config["storage_backends"] = backends
@@ -610,42 +532,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
             )
             config["shard_size"] = shard_size * self.blocks_per_chunk
             config["block_size"] = block_size * self.blocks_per_chunk
-            if compact_cache_buffer_capacity:
-                required_capacity_gb, required_buffer_number = (
-                    _cache_store_required_capacity_gb(config, config["shard_size"])
-                )
-                configured_capacity = config.get(_CACHE_BUFFER_CAPACITY_KEY)
-                if configured_capacity is None:
-                    config[_CACHE_BUFFER_CAPACITY_KEY] = (
-                        _CACHE_STORE_COMPACT_CAPACITY_THRESHOLD_GB
-                    )
-                    logger.info(
-                        f"Set {_CACHE_BUFFER_CAPACITY_KEY} to "
-                        f"{config[_CACHE_BUFFER_CAPACITY_KEY]}GB "
-                        f"for compact segmented shard_size={config['shard_size']}, "
-                        f"required_buffer_number={required_buffer_number}."
-                    )
-                else:
-                    try:
-                        configured_capacity_gb = int(configured_capacity)
-                    except (TypeError, ValueError):
-                        configured_capacity_gb = 0
-                    if (
-                        configured_capacity_gb
-                        > _CACHE_STORE_COMPACT_CAPACITY_THRESHOLD_GB
-                    ):
-                        config[_CACHE_BUFFER_CAPACITY_KEY] = max(
-                            _CACHE_STORE_COMPACT_CAPACITY_THRESHOLD_GB,
-                            required_capacity_gb,
-                        )
-                        logger.info(
-                            f"Adjust {_CACHE_BUFFER_CAPACITY_KEY} from "
-                            f"{configured_capacity_gb}GB to "
-                            f"{config[_CACHE_BUFFER_CAPACITY_KEY]}GB "
-                            f"for compact segmented shard_size={config['shard_size']}, "
-                            f"required_buffer_number={required_buffer_number}."
-                        )
-            _ensure_cache_store_buffer_capacity(config, config["shard_size"])
             config["local_rank_size"] = self.tp_size if self.is_mla else 1
             buffer_addrs = kv_cache_layout.base_ptrs.reshape(-1).tolist()
             buffer_sizes = kv_cache_layout.buffer_sizes.reshape(-1).tolist()
@@ -2052,8 +1938,9 @@ class UCMConnector(KVConnectorBase_V1, SupportsHMA):
         )
         self.connector: KVConnectorBase_V1
         ucm_config = Config(vllm_config.kv_transfer_config)
-        self.engine_id = _strip_dp_suffix_from_engine_id(
-            vllm_config.kv_transfer_config.engine_id
+        dp_engine_id_suffix = re.compile(r"_dp\d+$")
+        self.engine_id = dp_engine_id_suffix.sub(
+            "", vllm_config.kv_transfer_config.engine_id
         )
         self.launch_config = ucm_config.get_config()
         self._worker_rank = (


### PR DESCRIPTION
## Purpose

Fix the issue where multiple data-parallel (DP) instances running on the same machine create separate CacheStore shared-memory regions.
This change normalizes the engine ID by removing the DP suffix, allowing DP instances on the same machine to share the same CacheStore shared-memory region.

## Modifications

* ucm_connector.py: Add `_strip_dp_suffix_from_engine_id()` to remove a trailing `_dpN` suffix from the vLLM engine ID.
* Reduce the default CacheStore buffer capacity from 256 GB to 128 GB for MLA, each rank 32GB for non-MLA.
* ucm_config_example.yaml: Remove outdated _cache_buffer_capacity_gb_ and comments.

## Test
* Start vLLM with multiple DP instances on the same machine.
* Check the cache_buffer_capacity_gb when starting server
