### PR TITLE
[Feat] Add DramPool process startup and runtime configuration

### DIFF
--- a/examples/drampool.yaml
+++ b/examples/drampool.yaml
@@ -2,7 +2,7 @@
 #
 # Launch parameters stay on the command line:
 #   --addr, --nics, --pool-size-gb, --kvcache-block-sizes,
-#   --kvcache-block-proportions, and --ttl-minutes.
+#   --kvcache-block-proportions, --ttl-minutes, and --config.
 
 transport:
   device_id: 0

--- a/examples/drampool.yaml
+++ b/examples/drampool.yaml
@@ -28,6 +28,10 @@ gc:
   interval_ms: 1000
 
 metadata:
+  # Policy used by periodic eviction; supported values: TTL, POSITION.
+  periodic_eviction_policy: TTL
+  # Policy used by deep eviction; supported values: TTL, POSITION.
+  deep_eviction_policy: POSITION
   # A lookup hit protects the entry from eviction for this duration.
   lease_time_ms: 5000
   # Fraction selected by ratio-based eviction policies; range: [0, 1].

--- a/examples/drampool.yaml
+++ b/examples/drampool.yaml
@@ -21,9 +21,7 @@ request_receiver:
   idle_wait_us: 100
 
 poller:
-  drain_budget: 64
-  scan_budget: 64
-  max_pending: 1048576
+  pending_depth: 64
 
 gc:
   enabled: true

--- a/examples/drampool.yaml
+++ b/examples/drampool.yaml
@@ -1,0 +1,47 @@
+# DramPool runtime configuration.
+#
+# Launch parameters stay on the command line:
+#   --addr, --nics, --pool-size-gb, --kvcache-block-sizes,
+#   --kvcache-block-proportions, and --ttl-minutes.
+
+transport:
+  device_id: 0
+  # Cluster-wide request-channel to transport-endpoint routing.
+  endpoints:
+    - two_sided: "127.0.0.1:9000"
+      one_sided: "127.0.0.1:4501"
+    - two_sided: "127.0.0.1:9001"
+      one_sided: "127.0.0.1:4502"
+
+queue:
+  request_depth: 65536
+  completion_depth: 65536
+
+request_receiver:
+  idle_wait_us: 100
+
+poller:
+  drain_budget: 64
+  scan_budget: 64
+  max_pending: 1048576
+
+gc:
+  enabled: true
+  interval_ms: 1000
+
+metadata:
+  # A lookup hit protects the entry from eviction for this duration.
+  lease_time_ms: 5000
+  # Fraction selected by ratio-based eviction policies; range: [0, 1].
+  default_evict_ratio: 0.0
+  # Keep internal metadata eviction deferred until buffer reclamation is wired.
+  evict_period_ms: 31536000000
+
+operation:
+  timeout_ms: 5000
+
+logger:
+  level: info
+  dir: ./logs
+  max_files: 10
+  max_size_mb: 5

--- a/ucm/store/dram/cc/drampool/drampool_config.h
+++ b/ucm/store/dram/cc/drampool/drampool_config.h
@@ -1,0 +1,96 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "core/transport.h"
+#include "status/status.h"
+
+namespace UC::DramPool {
+
+inline constexpr std::uint32_t kDefaultPollerDrainBudget = 64;
+inline constexpr std::uint32_t kDefaultPollerScanBudget = 64;
+inline constexpr std::uint32_t kDefaultPollerMaxPending = 1024 * 1024;
+inline constexpr std::uint64_t kBytesPerGiB = 1024ULL * 1024ULL * 1024ULL;
+inline constexpr std::uint64_t kMillisecondsPerMinute = 60'000;
+inline constexpr std::uint64_t kDefaultTtlMinutes = 120;
+inline constexpr std::uint64_t kDefaultDumpTtlMs = kDefaultTtlMinutes * kMillisecondsPerMinute;
+inline constexpr char kDefaultDramPoolRuntimeConfigPath[] = "examples/drampool.yaml";
+
+struct DramPoolConfig {
+    // Northbound KV control endpoint supplied by --addr.
+    transport::Endpoint addr{};
+    std::vector<std::string> nics{};
+    // --pool-size-gb follows the project convention: the unit is GiB.
+    std::uint64_t poolSizeGb{0};
+    std::vector<std::uint64_t> poolBlockSizes{};
+    std::vector<std::uint32_t> poolBlockProportions{};
+    // Resolved by ParseCommandLine from poolSizeGb, block sizes, and proportions.
+    std::vector<std::uint32_t> poolSlotCounts{};
+    std::uint64_t defaultDumpTtlMs{kDefaultDumpTtlMs};
+
+    // Transport internals are loaded from the runtime YAML file.
+    std::int32_t transportDeviceId{0};
+    // Cluster-wide routing from the request channel address to the transport identity.
+    std::unordered_map<std::string, transport::ManagerID> twoSidedToOneSided{};
+
+    // Bounded handoff from RequestReceiveLoop to TaskWorker.
+    std::uint32_t requestQueueDepth{65536};
+    // Bounded handoff from TaskWorker to CompletionPoller.
+    std::uint32_t completionQueueDepth{65536};
+    std::uint32_t requestReceiverIdleWaitUs{100};
+
+    std::uint32_t pollerDrainBudget{kDefaultPollerDrainBudget};
+    std::uint32_t pollerScanBudget{kDefaultPollerScanBudget};
+    std::uint32_t pollerMaxPending{kDefaultPollerMaxPending};
+
+    bool gcEnabled{true};
+    std::uint32_t gcIntervalMs{1000};
+
+    // MetadataManager internals are loaded from the runtime YAML file.
+    std::uint64_t metadataLeaseTimeMs{5000};
+    double metadataDefaultEvictRatio{0.0};
+    std::uint64_t metadataEvictPeriodMs{365ULL * 24ULL * 60ULL * 60ULL * 1000ULL};
+
+    std::uint32_t opTimeoutMs{5000};
+
+    std::string logLevel{"info"};
+    std::string logDir{"./logs"};
+    std::uint32_t logMaxFiles{10};
+    std::uint32_t logMaxSizeMb{5};
+};
+
+// One DramPool daemon runs in each process; startup sets this once before Server::Init().
+inline DramPoolConfig g_config{};
+
+std::string BuildUsage(const char* program);
+Status ParseCommandLine(int argc, char** argv, DramPoolConfig& config);
+Status ParseDramPoolEndpoint(const std::string& name, const std::string& value,
+                             transport::Endpoint& endpoint);
+Status ParseYamlConfig(const std::string& path, DramPoolConfig& config);
+
+}  // namespace UC::DramPool

--- a/ucm/store/dram/cc/drampool/drampool_config.h
+++ b/ucm/store/dram/cc/drampool/drampool_config.h
@@ -32,9 +32,7 @@
 
 namespace UC::DramPool {
 
-inline constexpr std::uint32_t kDefaultPollerDrainBudget = 64;
-inline constexpr std::uint32_t kDefaultPollerScanBudget = 64;
-inline constexpr std::uint32_t kDefaultPollerMaxPending = 1024 * 1024;
+inline constexpr std::uint32_t kDefaultPollerPendingDepth = 64;
 inline constexpr std::uint64_t kBytesPerGiB = 1024ULL * 1024ULL * 1024ULL;
 inline constexpr std::uint64_t kMillisecondsPerMinute = 60'000;
 inline constexpr std::uint64_t kDefaultTtlMinutes = 120;
@@ -64,9 +62,7 @@ struct DramPoolConfig {
     std::uint32_t completionQueueDepth{65536};
     std::uint32_t requestReceiverIdleWaitUs{100};
 
-    std::uint32_t pollerDrainBudget{kDefaultPollerDrainBudget};
-    std::uint32_t pollerScanBudget{kDefaultPollerScanBudget};
-    std::uint32_t pollerMaxPending{kDefaultPollerMaxPending};
+    std::uint32_t pollerPendingDepth{kDefaultPollerPendingDepth};
 
     bool gcEnabled{true};
     std::uint32_t gcIntervalMs{1000};

--- a/ucm/store/dram/cc/drampool/drampool_config.h
+++ b/ucm/store/dram/cc/drampool/drampool_config.h
@@ -28,6 +28,7 @@
 #include <unordered_map>
 #include <vector>
 #include "core/transport.h"
+#include "eviction_policy.h"
 #include "status/status.h"
 
 namespace UC::DramPool {
@@ -68,6 +69,8 @@ struct DramPoolConfig {
     std::uint32_t gcIntervalMs{1000};
 
     // MetadataManager internals are loaded from the runtime YAML file.
+    EvictionPolicyType metadataPeriodicEvictionPolicy{EvictionPolicyType::TTL};
+    EvictionPolicyType metadataDeepEvictionPolicy{EvictionPolicyType::POSITION};
     std::uint64_t metadataLeaseTimeMs{5000};
     double metadataDefaultEvictRatio{0.0};
     std::uint64_t metadataEvictPeriodMs{365ULL * 24ULL * 60ULL * 60ULL * 1000ULL};

--- a/ucm/store/dram/cc/drampool/drampool_config.h
+++ b/ucm/store/dram/cc/drampool/drampool_config.h
@@ -41,6 +41,7 @@ inline constexpr std::uint64_t kDefaultDumpTtlMs = kDefaultTtlMinutes * kMillise
 inline constexpr char kDefaultDramPoolRuntimeConfigPath[] = "examples/drampool.yaml";
 
 struct DramPoolConfig {
+    std::string runtimeConfigPath{kDefaultDramPoolRuntimeConfigPath};
     // Northbound KV control endpoint supplied by --addr.
     transport::Endpoint addr{};
     std::vector<std::string> nics{};

--- a/ucm/store/dram/cc/drampool/drampool_config_utils.h
+++ b/ucm/store/dram/cc/drampool/drampool_config_utils.h
@@ -1,0 +1,43 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ */
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+
+namespace UC::DramPool::detail {
+
+inline std::string Trim(const std::string& value)
+{
+    const auto begin = value.find_first_not_of(" \t\r\n");
+    if (begin == std::string::npos) { return ""; }
+    const auto end = value.find_last_not_of(" \t\r\n");
+    return value.substr(begin, end - begin + 1);
+}
+
+inline std::uint64_t ParseUint64(const std::string& value)
+{
+    if (value.empty() || value.front() == '-') {
+        throw std::invalid_argument("expected an unsigned integer");
+    }
+    std::size_t parsed = 0;
+    const auto number = std::stoull(value, &parsed, 0);
+    if (parsed != value.size()) { throw std::invalid_argument("trailing characters"); }
+    return number;
+}
+
+inline std::uint32_t ParseUint32(const std::string& value)
+{
+    const auto number = ParseUint64(value);
+    if (number > std::numeric_limits<std::uint32_t>::max()) {
+        throw std::out_of_range("uint32 overflow");
+    }
+    return static_cast<std::uint32_t>(number);
+}
+
+}  // namespace UC::DramPool::detail

--- a/ucm/store/dram/cc/drampool/drampool_daemon.cpp
+++ b/ucm/store/dram/cc/drampool/drampool_daemon.cpp
@@ -1,0 +1,118 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "drampool_daemon.h"
+#include <chrono>
+#include <csignal>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <thread>
+#include "logger/logger.h"
+
+namespace UC::DramPool {
+int DramPoolDaemon::Run(int argc, char** argv)
+{
+    auto status = ParseCommandLine(argc, argv, g_config);
+    if (status.Failure()) {
+        std::cerr << status.ToString() << "\n" << BuildUsage(argc > 0 ? argv[0] : "drampool");
+        return 1;
+    }
+    status = ParseYamlConfig(kDefaultDramPoolRuntimeConfigPath, g_config);
+    if (status.Failure()) {
+        std::cerr << status.ToString() << "\n";
+        return 1;
+    }
+    status = SetupLogger();
+    if (status.Failure()) {
+        std::cerr << status.ToString() << "\n";
+        return 1;
+    }
+    status = SetupSignals();
+    if (status.Failure()) {
+        UC_ERROR_UNLIMITED("DramPool setup signals failed: {}", status);
+        return 1;
+    }
+
+    DramPoolServer server;
+    status = server.Init();
+    if (status.Failure()) {
+        UC_ERROR_UNLIMITED("DramPool server init failed: {}", status);
+        return 1;
+    }
+    status = server.Start();
+    if (status.Failure()) {
+        UC_ERROR_UNLIMITED("DramPool server start failed: {}", status);
+        return 1;
+    }
+
+    UC_INFO_UNLIMITED("DramPool service ready, addr={}", g_config.addr.ToString());
+    WaitForShutdown();
+    UC_INFO_UNLIMITED("DramPool shutdown requested");
+    server.Stop();
+    UC::Logger::Flush();
+    return 0;
+}
+
+Status DramPoolDaemon::SetupLogger()
+{
+    constexpr char kUcLoggerLevelEnv[] = "UC_LOGGER_LEVEL";
+
+    // UC::Logger reads its level once, when Setup creates the process logger.
+    if (::setenv(kUcLoggerLevelEnv, g_config.logLevel.c_str(), 1) != 0) {
+        return Status::OsApiError("failed to set UC_LOGGER_LEVEL");
+    }
+    UC::Logger::Setup(g_config.logDir, static_cast<int>(g_config.logMaxFiles),
+                      static_cast<int>(g_config.logMaxSizeMb));
+    return Status::OK();
+}
+
+Status DramPoolDaemon::SetupSignals()
+{
+    shutdownRequested_.store(false, std::memory_order_release);
+    if (std::signal(SIGINT, &DramPoolDaemon::HandleSignal) == SIG_ERR) {
+        return Status::OsApiError("failed to install SIGINT handler");
+    }
+    if (std::signal(SIGTERM, &DramPoolDaemon::HandleSignal) == SIG_ERR) {
+        return Status::OsApiError("failed to install SIGTERM handler");
+    }
+    return Status::OK();
+}
+
+void DramPoolDaemon::WaitForShutdown()
+{
+    constexpr auto kShutdownPollInterval = std::chrono::milliseconds(100);
+
+    while (!shutdownRequested_.load(std::memory_order_acquire)) {
+        std::this_thread::sleep_for(kShutdownPollInterval);
+    }
+}
+
+void DramPoolDaemon::HandleSignal(int signum)
+{
+    if (signum == SIGINT || signum == SIGTERM) {
+        shutdownRequested_.store(true, std::memory_order_release);
+    }
+}
+
+}  // namespace UC::DramPool

--- a/ucm/store/dram/cc/drampool/drampool_daemon.cpp
+++ b/ucm/store/dram/cc/drampool/drampool_daemon.cpp
@@ -38,7 +38,7 @@ int DramPoolDaemon::Run(int argc, char** argv)
         std::cerr << status.ToString() << "\n" << BuildUsage(argc > 0 ? argv[0] : "drampool");
         return 1;
     }
-    status = ParseYamlConfig(kDefaultDramPoolRuntimeConfigPath, g_config);
+    status = ParseYamlConfig(g_config.runtimeConfigPath, g_config);
     if (status.Failure()) {
         std::cerr << status.ToString() << "\n";
         return 1;

--- a/ucm/store/dram/cc/drampool/drampool_daemon.h
+++ b/ucm/store/dram/cc/drampool/drampool_daemon.h
@@ -1,0 +1,46 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <atomic>
+#include "drampool_config.h"
+#include "drampool_server.h"
+#include "status/status.h"
+
+namespace UC::DramPool {
+
+class DramPoolDaemon {
+public:
+    int Run(int argc, char** argv);
+
+private:
+    Status SetupLogger();
+    Status SetupSignals();
+    void WaitForShutdown();
+
+    static void HandleSignal(int signum);
+    inline static std::atomic_bool shutdownRequested_{false};
+};
+
+}  // namespace UC::DramPool

--- a/ucm/store/dram/cc/drampool/drampool_launch_config.cpp
+++ b/ucm/store/dram/cc/drampool/drampool_launch_config.cpp
@@ -1,0 +1,400 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <cstddef>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+#include "drampool_config.h"
+
+namespace UC::DramPool {
+namespace {
+
+// Must match the fixed slot layout used by BufferManager.
+constexpr std::size_t kSlotAlignment = 64;
+
+bool IsLongOption(const std::string& value)
+{
+    return value.size() > 2 && value.rfind("--", 0) == 0;
+}
+
+std::string Trim(const std::string& value)
+{
+    const auto begin = value.find_first_not_of(" \t\r\n");
+    if (begin == std::string::npos) { return ""; }
+    const auto end = value.find_last_not_of(" \t\r\n");
+    return value.substr(begin, end - begin + 1);
+}
+
+std::uint64_t ParseUint64(const std::string& value)
+{
+    if (value.empty() || value.front() == '-') {
+        throw std::invalid_argument("expected an unsigned integer");
+    }
+    std::size_t parsed = 0;
+    const auto number = std::stoull(value, &parsed, 0);
+    if (parsed != value.size()) { throw std::invalid_argument("trailing characters"); }
+    return number;
+}
+
+std::uint32_t ParseUint32(const std::string& value)
+{
+    const auto number = ParseUint64(value);
+    if (number > std::numeric_limits<std::uint32_t>::max()) {
+        throw std::out_of_range("uint32 overflow");
+    }
+    return static_cast<std::uint32_t>(number);
+}
+
+Status ReadSingleValue(const std::string& option, bool hasInlineValue,
+                       const std::string& inlineValue, int argc, char** argv, int& index,
+                       std::string& value)
+{
+    if (hasInlineValue) {
+        if (inlineValue.empty()) { return Status::InvalidParam("{} requires a value", option); }
+        value = inlineValue;
+        return Status::OK();
+    }
+
+    if (++index >= argc || argv[index] == nullptr || IsLongOption(argv[index])) {
+        return Status::InvalidParam("{} requires a value", option);
+    }
+    value = argv[index];
+    if (value.empty()) { return Status::InvalidParam("{} requires a value", option); }
+    return Status::OK();
+}
+
+Status ReadListValues(const std::string& option, bool hasInlineValue,
+                      const std::string& inlineValue, int argc, char** argv, int& index,
+                      std::vector<std::string>& values)
+{
+    values.clear();
+    if (hasInlineValue) {
+        if (inlineValue.empty()) {
+            return Status::InvalidParam("{} requires at least one value", option);
+        }
+        values.emplace_back(inlineValue);
+    }
+
+    while (index + 1 < argc && argv[index + 1] != nullptr && !IsLongOption(argv[index + 1])) {
+        const std::string value = argv[++index];
+        if (value.empty()) { return Status::InvalidParam("{} has an empty value", option); }
+        values.emplace_back(value);
+    }
+    if (values.empty()) { return Status::InvalidParam("{} requires at least one value", option); }
+    return Status::OK();
+}
+
+Status ParseBlockSizes(const std::vector<std::string>& values, std::vector<std::uint64_t>& sizes)
+{
+    try {
+        sizes.clear();
+        sizes.reserve(values.size());
+        for (const auto& value : values) { sizes.emplace_back(ParseUint64(value)); }
+    } catch (const std::exception& error) {
+        return Status::InvalidParam("invalid --kvcache-block-sizes value: {}", error.what());
+    }
+    return Status::OK();
+}
+
+Status ParseBlockProportions(const std::vector<std::string>& values,
+                             std::vector<std::uint32_t>& proportions)
+{
+    try {
+        proportions.clear();
+        proportions.reserve(values.size());
+        for (const auto& value : values) { proportions.emplace_back(ParseUint32(value)); }
+    } catch (const std::exception& error) {
+        return Status::InvalidParam("invalid --kvcache-block-proportions value: {}", error.what());
+    }
+    return Status::OK();
+}
+
+Status ValidateNics(const std::vector<std::string>& nics)
+{
+    for (const auto& nic : nics) {
+        if (Trim(nic).empty()) { return Status::InvalidParam("--nics contains an empty name"); }
+    }
+    return Status::OK();
+}
+
+Status ValidatePoolSize(std::uint64_t poolSizeGb)
+{
+    if (poolSizeGb == 0) {
+        return Status::InvalidParam("--pool-size-gb must be greater than zero");
+    }
+    if (poolSizeGb > std::numeric_limits<std::uint64_t>::max() / kBytesPerGiB) {
+        return Status::InvalidParam("--pool-size-gb is too large");
+    }
+    const auto totalBytes = poolSizeGb * kBytesPerGiB;
+    if (static_cast<std::uint64_t>(static_cast<std::size_t>(totalBytes)) != totalBytes) {
+        return Status::InvalidParam("--pool-size-gb exceeds addressable process memory");
+    }
+    return Status::OK();
+}
+
+Status ValidateBlockSizes(const std::vector<std::uint64_t>& blockSizes)
+{
+    for (const auto blockSize : blockSizes) {
+        const auto slotCapacity = static_cast<std::size_t>(blockSize);
+        if (blockSize == 0 || blockSize > std::numeric_limits<std::uint32_t>::max() ||
+            static_cast<std::uint64_t>(slotCapacity) != blockSize) {
+            return Status::InvalidParam("--kvcache-block-sizes item is unsupported");
+        }
+        if (slotCapacity > std::numeric_limits<std::size_t>::max() - (kSlotAlignment - 1)) {
+            return Status::InvalidParam("--kvcache-block-sizes item overflows slot alignment");
+        }
+    }
+    return Status::OK();
+}
+
+Status ValidateBlockProportions(const std::vector<std::uint32_t>& proportions)
+{
+    std::uint64_t totalProportion = 0;
+    for (const auto proportion : proportions) {
+        if (proportion == 0 ||
+            totalProportion > std::numeric_limits<std::uint32_t>::max() - proportion) {
+            return Status::InvalidParam("sum of --kvcache-block-proportions must be in [1, {}]",
+                                        std::numeric_limits<std::uint32_t>::max());
+        }
+        totalProportion += proportion;
+    }
+    return Status::OK();
+}
+
+Status ValidateBlockClassCount(const std::vector<std::uint64_t>& blockSizes,
+                               const std::vector<std::uint32_t>& proportions)
+{
+    if (blockSizes.size() != proportions.size()) {
+        return Status::InvalidParam(
+            "--kvcache-block-sizes and --kvcache-block-proportions must have the same length");
+    }
+    return Status::OK();
+}
+
+Status CalculatePoolSlotCounts(DramPoolConfig& config)
+{
+    config.poolSlotCounts.clear();
+    std::uint64_t totalProportion = 0;
+    for (const auto proportion : config.poolBlockProportions) { totalProportion += proportion; }
+
+    const auto totalBytes = config.poolSizeGb * kBytesPerGiB;
+    std::vector<std::uint32_t> slotCounts;
+    slotCounts.reserve(config.poolBlockSizes.size());
+    const auto wholeShare = totalBytes / totalProportion;
+    const auto remainder = totalBytes % totalProportion;
+    for (std::size_t index = 0; index < config.poolBlockSizes.size(); ++index) {
+        const auto slotCapacity = static_cast<std::size_t>(config.poolBlockSizes[index]);
+        const auto slotStride =
+            (slotCapacity + kSlotAlignment - 1) / kSlotAlignment * kSlotAlignment;
+        const auto proportion = static_cast<std::uint64_t>(config.poolBlockProportions[index]);
+        // totalProportion is bounded to uint32_t, so this remainder product cannot overflow.
+        const auto classBytes = wholeShare * proportion + remainder * proportion / totalProportion;
+        const auto slotCount = classBytes / slotStride;
+        if (slotCount == 0 || slotCount >= std::numeric_limits<std::uint32_t>::max()) {
+            return Status::InvalidParam(
+                "pool capacity for --kvcache-block-sizes item {} cannot form a valid slot pool",
+                index);
+        }
+        slotCounts.push_back(static_cast<std::uint32_t>(slotCount));
+    }
+
+    config.poolSlotCounts = std::move(slotCounts);
+    return Status::OK();
+}
+
+}  // namespace
+
+Status ParseDramPoolEndpoint(const std::string& name, const std::string& value,
+                             transport::Endpoint& endpoint)
+{
+    const auto normalized = Trim(value);
+    if (normalized.empty()) { return Status::InvalidParam("{} is required", name); }
+
+    const auto separator = normalized.rfind(':');
+    if (separator == std::string::npos || separator == 0 || separator + 1 >= normalized.size()) {
+        return Status::InvalidParam("{} must be <IP>:<PORT>", name);
+    }
+    try {
+        std::size_t parsed = 0;
+        const auto port = std::stoul(normalized.substr(separator + 1), &parsed, 10);
+        if (parsed != normalized.size() - separator - 1 || port == 0 ||
+            port > std::numeric_limits<std::uint16_t>::max()) {
+            return Status::InvalidParam("{} must have a valid port", name);
+        }
+        endpoint.host = normalized.substr(0, separator);
+        endpoint.port = static_cast<std::uint16_t>(port);
+    } catch (const std::exception&) {
+        return Status::InvalidParam("{} must have a valid port", name);
+    }
+    return Status::OK();
+}
+
+std::string BuildUsage(const char* program)
+{
+    const std::string name = program == nullptr ? "drampool" : program;
+    return "Usage: " + name +
+           " --addr <IP>:<PORT> --nics <NAME>... --pool-size-gb <SIZE>"
+           " --kvcache-block-sizes <SIZE>... [options]\n"
+           "Required options:\n"
+           "  --addr <IP>:<PORT>                 DramPool service address for KV control "
+           "messages.\n"
+           "  --nics <NAME>...                   RDMA NIC names for pinned memory registration.\n"
+           "  --pool-size-gb <SIZE>              Local DRAM capacity contributed to the pool.\n"
+           "  --kvcache-block-sizes <SIZE>...    Supported fixed KVCache block sizes.\n"
+           "Optional options:\n"
+           "  --kvcache-block-proportions <P>... Relative capacity per block size; defaults to "
+           "1:1.\n"
+           "  --ttl-minutes <MINUTES>            Absolute block lifetime; defaults to 120.\n";
+}
+
+Status ParseCommandLine(int argc, char** argv, DramPoolConfig& config)
+{
+    config = DramPoolConfig{};
+
+    bool hasAddr = false;
+    bool hasNics = false;
+    bool hasPoolSize = false;
+    bool hasBlockSizes = false;
+    bool hasBlockProportions = false;
+    bool hasTtl = false;
+
+    for (int index = 1; index < argc; ++index) {
+        const std::string argument = argv[index] == nullptr ? "" : argv[index];
+        if (!IsLongOption(argument)) {
+            return Status::InvalidParam("unexpected argument: {}", argument);
+        }
+
+        const auto equals = argument.find('=');
+        const std::string option = argument.substr(0, equals);
+        const bool hasInlineValue = equals != std::string::npos;
+        const std::string inlineValue =
+            hasInlineValue ? argument.substr(equals + 1) : std::string{};
+        std::string value;
+        std::vector<std::string> values;
+        auto status = Status::OK();
+
+        if (option == "--addr") {
+            if (hasAddr) { return Status::InvalidParam("--addr may be specified once"); }
+            status = ReadSingleValue(option, hasInlineValue, inlineValue, argc, argv, index, value);
+            if (status.Failure()) { return status; }
+            transport::Endpoint endpoint;
+            status = ParseDramPoolEndpoint("--addr", value, endpoint);
+            if (status.Failure()) { return status; }
+            config.addr = std::move(endpoint);
+            hasAddr = true;
+            continue;
+        }
+        if (option == "--nics") {
+            if (hasNics) { return Status::InvalidParam("--nics may be specified once"); }
+            status = ReadListValues(option, hasInlineValue, inlineValue, argc, argv, index, values);
+            if (status.Failure()) { return status; }
+            config.nics = std::move(values);
+            status = ValidateNics(config.nics);
+            if (status.Failure()) { return status; }
+            hasNics = true;
+            continue;
+        }
+        if (option == "--pool-size-gb") {
+            if (hasPoolSize) {
+                return Status::InvalidParam("--pool-size-gb may be specified once");
+            }
+            status = ReadSingleValue(option, hasInlineValue, inlineValue, argc, argv, index, value);
+            if (status.Failure()) { return status; }
+            try {
+                config.poolSizeGb = ParseUint64(value);
+            } catch (const std::exception& error) {
+                return Status::InvalidParam("invalid --pool-size-gb value: {}", error.what());
+            }
+            status = ValidatePoolSize(config.poolSizeGb);
+            if (status.Failure()) { return status; }
+            hasPoolSize = true;
+            continue;
+        }
+        if (option == "--kvcache-block-sizes") {
+            if (hasBlockSizes) {
+                return Status::InvalidParam("--kvcache-block-sizes may be specified once");
+            }
+            status = ReadListValues(option, hasInlineValue, inlineValue, argc, argv, index, values);
+            if (status.Failure()) { return status; }
+            status = ParseBlockSizes(values, config.poolBlockSizes);
+            if (status.Failure()) { return status; }
+            status = ValidateBlockSizes(config.poolBlockSizes);
+            if (status.Failure()) { return status; }
+            hasBlockSizes = true;
+            continue;
+        }
+        if (option == "--kvcache-block-proportions") {
+            if (hasBlockProportions) {
+                return Status::InvalidParam("--kvcache-block-proportions may be specified once");
+            }
+            status = ReadListValues(option, hasInlineValue, inlineValue, argc, argv, index, values);
+            if (status.Failure()) { return status; }
+            status = ParseBlockProportions(values, config.poolBlockProportions);
+            if (status.Failure()) { return status; }
+            status = ValidateBlockProportions(config.poolBlockProportions);
+            if (status.Failure()) { return status; }
+            hasBlockProportions = true;
+            continue;
+        }
+        if (option == "--ttl-minutes") {
+            if (hasTtl) { return Status::InvalidParam("--ttl-minutes may be specified once"); }
+            status = ReadSingleValue(option, hasInlineValue, inlineValue, argc, argv, index, value);
+            if (status.Failure()) { return status; }
+            try {
+                const auto ttlMinutes = ParseUint64(value);
+                if (ttlMinutes == 0 || ttlMinutes > std::numeric_limits<std::uint64_t>::max() /
+                                                        kMillisecondsPerMinute) {
+                    return Status::InvalidParam("--ttl-minutes must be a positive value");
+                }
+                config.defaultDumpTtlMs = ttlMinutes * kMillisecondsPerMinute;
+            } catch (const std::exception& error) {
+                return Status::InvalidParam("invalid --ttl-minutes value: {}", error.what());
+            }
+            hasTtl = true;
+            continue;
+        }
+        return Status::InvalidParam("unknown argument: {}", argument);
+    }
+
+    if (!hasAddr || !hasNics || !hasPoolSize || !hasBlockSizes) {
+        return Status::InvalidParam(
+            "--addr, --nics, --pool-size-gb, and --kvcache-block-sizes are required");
+    }
+    if (!hasBlockProportions) {
+        // Each configured block size receives an equal capacity share by default.
+        config.poolBlockProportions.assign(config.poolBlockSizes.size(), 1);
+    }
+    if (const auto status =
+            ValidateBlockClassCount(config.poolBlockSizes, config.poolBlockProportions);
+        status.Failure()) {
+        return status;
+    }
+    // Options are order-independent; all pool inputs are complete only here.
+    if (const auto status = CalculatePoolSlotCounts(config); status.Failure()) { return status; }
+    return Status::OK();
+}
+
+}  // namespace UC::DramPool

--- a/ucm/store/dram/cc/drampool/drampool_launch_config.cpp
+++ b/ucm/store/dram/cc/drampool/drampool_launch_config.cpp
@@ -28,6 +28,7 @@
 #include <utility>
 #include <vector>
 #include "drampool_config.h"
+#include "drampool_config_utils.h"
 
 namespace UC::DramPool {
 namespace {
@@ -35,37 +36,13 @@ namespace {
 // Must match the fixed slot layout used by BufferManager.
 constexpr std::size_t kSlotAlignment = 64;
 
+using detail::ParseUint32;
+using detail::ParseUint64;
+using detail::Trim;
+
 bool IsLongOption(const std::string& value)
 {
     return value.size() > 2 && value.rfind("--", 0) == 0;
-}
-
-std::string Trim(const std::string& value)
-{
-    const auto begin = value.find_first_not_of(" \t\r\n");
-    if (begin == std::string::npos) { return ""; }
-    const auto end = value.find_last_not_of(" \t\r\n");
-    return value.substr(begin, end - begin + 1);
-}
-
-std::uint64_t ParseUint64(const std::string& value)
-{
-    if (value.empty() || value.front() == '-') {
-        throw std::invalid_argument("expected an unsigned integer");
-    }
-    std::size_t parsed = 0;
-    const auto number = std::stoull(value, &parsed, 0);
-    if (parsed != value.size()) { throw std::invalid_argument("trailing characters"); }
-    return number;
-}
-
-std::uint32_t ParseUint32(const std::string& value)
-{
-    const auto number = ParseUint64(value);
-    if (number > std::numeric_limits<std::uint32_t>::max()) {
-        throw std::out_of_range("uint32 overflow");
-    }
-    return static_cast<std::uint32_t>(number);
 }
 
 Status ReadSingleValue(const std::string& option, bool hasInlineValue,
@@ -265,6 +242,9 @@ std::string BuildUsage(const char* program)
            "  --pool-size-gb <SIZE>              Local DRAM capacity contributed to the pool.\n"
            "  --kvcache-block-sizes <SIZE>...    Supported fixed KVCache block sizes.\n"
            "Optional options:\n"
+           "  --config <PATH>                    Runtime YAML path; defaults to " +
+           kDefaultDramPoolRuntimeConfigPath +
+           ".\n"
            "  --kvcache-block-proportions <P>... Relative capacity per block size; defaults to "
            "1:1.\n"
            "  --ttl-minutes <MINUTES>            Absolute block lifetime; defaults to 120.\n";
@@ -280,6 +260,7 @@ Status ParseCommandLine(int argc, char** argv, DramPoolConfig& config)
     bool hasBlockSizes = false;
     bool hasBlockProportions = false;
     bool hasTtl = false;
+    bool hasConfig = false;
 
     for (int index = 1; index < argc; ++index) {
         const std::string argument = argv[index] == nullptr ? "" : argv[index];
@@ -296,6 +277,15 @@ Status ParseCommandLine(int argc, char** argv, DramPoolConfig& config)
         std::vector<std::string> values;
         auto status = Status::OK();
 
+        if (option == "--config") {
+            if (hasConfig) { return Status::InvalidParam("--config may be specified once"); }
+            status = ReadSingleValue(option, hasInlineValue, inlineValue, argc, argv, index, value);
+            if (status.Failure()) { return status; }
+            if (Trim(value).empty()) { return Status::InvalidParam("--config must not be blank"); }
+            config.runtimeConfigPath = std::move(value);
+            hasConfig = true;
+            continue;
+        }
         if (option == "--addr") {
             if (hasAddr) { return Status::InvalidParam("--addr may be specified once"); }
             status = ReadSingleValue(option, hasInlineValue, inlineValue, argc, argv, index, value);

--- a/ucm/store/dram/cc/drampool/drampool_server.cpp
+++ b/ucm/store/dram/cc/drampool/drampool_server.cpp
@@ -28,10 +28,10 @@
 #include <string>
 #include <type_traits>
 #include <utility>
-#include "buffer_manager.h"
 #include "core/transport_manager.h"
 #include "logger/logger.h"
 #include "metadata.h"
+#include "pool/buffer_pool.h"
 #include "task_worker.h"
 #include "two_sided/tcp/tcp_message_channel.h"
 
@@ -159,15 +159,15 @@ Status DramPoolServer::InitializeAclRuntime()
 
 Status DramPoolServer::InitMemoryPool()
 {
-    constexpr char kBufferManagerNamePrefix[] = "drampool-kvcache-";
+    constexpr char kBufferPoolNamePrefix[] = "drampool-kvcache-";
     for (std::size_t index = 0; index < g_config.poolBlockSizes.size(); ++index) {
-        auto bufferManager = std::make_unique<UC::ASU::BufferManager>();
-        const auto status = bufferManager->Init(
-            kBufferManagerNamePrefix + std::to_string(index), UC::ASU::MemoryType::HOST,
+        auto bufferPool = std::make_unique<UC::BufferPool>();
+        const auto status = bufferPool->Init(
+            kBufferPoolNamePrefix + std::to_string(index), UC::BufferPool::MemoryType::HOST,
             static_cast<std::size_t>(g_config.poolBlockSizes[index]),
-            static_cast<std::size_t>(g_config.poolSlotCounts[index]), nullptr);
-        if (!status.ok()) { return Status::Error("BufferManager::Init failed: " + status.message); }
-        bufferManagers_.push_back(std::move(bufferManager));
+            static_cast<std::size_t>(g_config.poolSlotCounts[index]));
+        if (status.Failure()) { return status; }
+        bufferPools_.push_back(std::move(bufferPool));
     }
     return Status::OK();
 }
@@ -215,7 +215,7 @@ Status DramPoolServer::StartTransportService()
     if (!transportManager_) {
         return Status::InvalidParam("DramPool transport manager is not initialized");
     }
-    if (bufferManagers_.empty()) { return Status::InvalidParam("memory pool is not initialized"); }
+    if (bufferPools_.empty()) { return Status::InvalidParam("memory pool is not initialized"); }
     const auto localControlId = g_config.addr.ToString();
     const auto localEndpoint = g_config.twoSidedToOneSided.find(localControlId);
     if (localEndpoint == g_config.twoSidedToOneSided.end()) {
@@ -269,13 +269,13 @@ Status DramPoolServer::CreateRuntimeContext()
     if (!metadataManager_ || !protocolManager_ || !transportManager_) {
         return Status::InvalidParam("DramPool runtime dependencies are not initialized");
     }
-    if (bufferManagers_.empty()) {
-        return Status::InvalidParam("DramPool buffer managers are not initialized");
+    if (bufferPools_.empty()) {
+        return Status::InvalidParam("DramPool buffer pools are not initialized");
     }
     try {
-        runtime_ = std::make_unique<DramPoolRuntime>(*metadataManager_, bufferManagers_,
-                                                     *transportManager_, *protocolManager_,
-                                                     requestQueue_, completionQueue_);
+        runtime_ =
+            std::make_unique<DramPoolRuntime>(*metadataManager_, bufferPools_, *transportManager_,
+                                              *protocolManager_, requestQueue_, completionQueue_);
     } catch (const std::exception& error) {
         return Status::Error(std::string{"failed to create DramPool runtime: "} + error.what());
     }
@@ -505,7 +505,7 @@ void DramPoolServer::ResetInitializedComponents()
     protocolManager_.reset();
     metadataManager_.reset();
     tcpMessageChannel_.reset();
-    bufferManagers_.clear();
+    bufferPools_.clear();
     transportManager_.reset();
     if (aclRuntimeOwned_) {
         (void)aclrtResetDevice(g_config.transportDeviceId);

--- a/ucm/store/dram/cc/drampool/drampool_server.cpp
+++ b/ucm/store/dram/cc/drampool/drampool_server.cpp
@@ -1,0 +1,517 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "drampool_server.h"
+#include <acl/acl.h>
+#include <chrono>
+#include <exception>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include "buffer_manager.h"
+#include "core/transport_manager.h"
+#include "logger/logger.h"
+#include "metadata.h"
+#include "task_worker.h"
+#include "two_sided/tcp/tcp_message_channel.h"
+
+namespace UC::DramPool {
+namespace {
+
+template <typename Callback>
+class ScopeExit final {
+public:
+    explicit ScopeExit(Callback callback) : callback_(std::move(callback)) {}
+    ~ScopeExit()
+    {
+        if (active_) { callback_(); }
+    }
+
+    ScopeExit(const ScopeExit&) = delete;
+    ScopeExit& operator=(const ScopeExit&) = delete;
+
+    ScopeExit(ScopeExit&& other) noexcept(std::is_nothrow_move_constructible_v<Callback>)
+        : callback_(std::move(other.callback_)), active_(std::exchange(other.active_, false))
+    {
+    }
+
+    void Release() noexcept { active_ = false; }
+
+private:
+    Callback callback_;
+    bool active_{true};
+};
+
+template <typename Callback>
+auto MakeScopeExit(Callback&& callback)
+{
+    return ScopeExit<std::decay_t<Callback>>(std::forward<Callback>(callback));
+}
+
+}  // namespace
+
+DramPoolServer::DramPoolServer() = default;
+
+DramPoolServer::~DramPoolServer() { Stop(); }
+
+Status DramPoolServer::Init()
+{
+    if (state_ != ServerState::New) {
+        return Status::InvalidParam("DramPoolServer cannot be initialized in its current state");
+    }
+
+    // Build runtime dependencies without starting transport services or listeners.
+    auto rollback = MakeScopeExit([this]() { ResetInitializedComponents(); });
+    try {
+        if (auto status = InitializeAclRuntime(); status.Failure()) { return status; }
+        if (auto status = InitMemoryPool(); status.Failure()) { return status; }
+        if (auto status = InitMetadata(); status.Failure()) { return status; }
+        if (auto status = InitProtocol(); status.Failure()) { return status; }
+        if (auto status = InitQueues(); status.Failure()) { return status; }
+        if (auto status = InitTransportManager(); status.Failure()) { return status; }
+        if (auto status = CreateRuntimeContext(); status.Failure()) { return status; }
+    } catch (const std::exception& error) {
+        return Status::Error(std::string{"DramPoolServer initialization failed: "} + error.what());
+    }
+
+    state_ = ServerState::Initialized;
+    rollback.Release();
+    return Status::OK();
+}
+
+Status DramPoolServer::Start()
+{
+    if (state_ != ServerState::Initialized) {
+        return Status::InvalidParam("DramPoolServer is not ready to start");
+    }
+
+    auto rollback = MakeScopeExit([this]() { Stop(); });
+    try {
+        if (auto status = StartCompletionPoller(); status.Failure()) { return status; }
+        if (auto status = StartTaskWorker(); status.Failure()) { return status; }
+        if (auto status = StartGCThread(); status.Failure()) { return status; }
+        if (auto status = StartRequestReceiver(); status.Failure()) { return status; }
+        // Start transport listeners only after every request consumer is ready.
+        if (auto status = StartTransportService(); status.Failure()) { return status; }
+        if (auto status = StartTcpMessageChannel(); status.Failure()) { return status; }
+        state_ = ServerState::Running;
+    } catch (const std::exception& error) {
+        return Status::Error(std::string{"DramPoolServer start failed: "} + error.what());
+    }
+    rollback.Release();
+    return Status::OK();
+}
+
+void DramPoolServer::Stop()
+{
+    if (state_ == ServerState::New || state_ == ServerState::Stopped) { return; }
+    // Close ingress, stop its receiver, then let TaskWorker drain accepted tasks.
+    StopRequestReceiver();
+    StopTaskWorker();
+    MarkInflightTransportsFailed();
+    StopCompletionPoller();
+    StopGCThread();
+    StopTransportService();
+    // Object destruction is shared with Init() rollback and happens only after
+    // every active thread and transport service has stopped.
+    ResetInitializedComponents();
+    state_ = ServerState::Stopped;
+}
+
+Status DramPoolServer::InitializeAclRuntime()
+{
+    const auto initStatus = aclInit(nullptr);
+    if (initStatus == ACL_SUCCESS) {
+        aclRuntimeOwned_ = true;
+    } else if (initStatus != ACL_ERROR_REPEAT_INITIALIZE) {
+        return Status::Error("aclInit failed: " + std::to_string(initStatus));
+    }
+
+    const auto setDeviceStatus = aclrtSetDevice(g_config.transportDeviceId);
+    if (setDeviceStatus == ACL_SUCCESS) { return Status::OK(); }
+
+    if (aclRuntimeOwned_) {
+        (void)aclFinalize();
+        aclRuntimeOwned_ = false;
+    }
+    return Status::Error("aclrtSetDevice failed: " + std::to_string(setDeviceStatus));
+}
+
+Status DramPoolServer::InitMemoryPool()
+{
+    constexpr char kBufferManagerNamePrefix[] = "drampool-kvcache-";
+    for (std::size_t index = 0; index < g_config.poolBlockSizes.size(); ++index) {
+        auto bufferManager = std::make_unique<UC::ASU::BufferManager>();
+        const auto status = bufferManager->Init(
+            kBufferManagerNamePrefix + std::to_string(index), UC::ASU::MemoryType::HOST,
+            static_cast<std::size_t>(g_config.poolBlockSizes[index]),
+            static_cast<std::size_t>(g_config.poolSlotCounts[index]), nullptr);
+        if (!status.ok()) { return Status::Error("BufferManager::Init failed: " + status.message); }
+        bufferManagers_.push_back(std::move(bufferManager));
+    }
+    return Status::OK();
+}
+
+Status DramPoolServer::InitMetadata()
+{
+    // Metadata eviction settings come from the process-wide runtime configuration.
+    const UC::DramPool::MetadataConfig config{
+        UC::DramPool::EvictionPolicyType::TTL,
+        UC::DramPool::EvictionPolicyType::POSITION,
+        std::chrono::milliseconds(g_config.metadataLeaseTimeMs),
+        g_config.metadataDefaultEvictRatio,
+        std::chrono::milliseconds(g_config.metadataEvictPeriodMs),
+    };
+    metadataManager_ = std::make_unique<UC::DramPool::MetadataManager>(config);
+    return Status::OK();
+}
+
+Status DramPoolServer::InitProtocol()
+{
+    protocolManager_ = std::make_unique<ProtocolManager>();
+    return Status::OK();
+}
+
+Status DramPoolServer::InitQueues()
+{
+    requestQueue_.Setup(g_config.requestQueueDepth);
+    completionQueue_.Setup(g_config.completionQueueDepth);
+    return Status::OK();
+}
+
+Status DramPoolServer::InitTransportManager()
+{
+    const auto localEndpoint = g_config.twoSidedToOneSided.find(g_config.addr.ToString());
+    if (localEndpoint == g_config.twoSidedToOneSided.end()) {
+        return Status::InvalidParam("local static transport endpoint is not configured");
+    }
+    transportManager_ = std::make_unique<transport::TransportManager>(localEndpoint->second);
+    tcpMessageChannel_ = std::make_unique<transport::TcpMessageChannel>();
+    return Status::OK();
+}
+
+Status DramPoolServer::StartTransportService()
+{
+    if (!transportManager_) {
+        return Status::InvalidParam("DramPool transport manager is not initialized");
+    }
+    if (bufferManagers_.empty()) { return Status::InvalidParam("memory pool is not initialized"); }
+    const auto localControlId = g_config.addr.ToString();
+    const auto localEndpoint = g_config.twoSidedToOneSided.find(localControlId);
+    if (localEndpoint == g_config.twoSidedToOneSided.end()) {
+        return Status::InvalidParam("local static transport endpoint is not configured");
+    }
+    transport::HixlInitAttrs attrs;
+    // A -1 port lets HIXL allocate its internal endpoint without occupying the
+    // TransportManager metadata listener port.
+    transport::Endpoint managerEndpoint;
+    if (auto status = ParseDramPoolEndpoint("transport local one_sided", localEndpoint->second,
+                                            managerEndpoint);
+        status.Failure()) {
+        return status;
+    }
+    const bool isIpv6 = managerEndpoint.host.find(':') != std::string::npos;
+    attrs.local_engine = (isIpv6 ? "[" + managerEndpoint.host + "]" : managerEndpoint.host) + ":-1";
+    attrs.device_id = g_config.transportDeviceId;
+    attrs.connect_timeout_ms = static_cast<std::int32_t>(g_config.opTimeoutMs);
+    attrs.transfer_timeout_ms = static_cast<std::int32_t>(g_config.opTimeoutMs);
+    auto status = transportManager_->InstallTransport(transport::TransportProtocol::Hixl, attrs);
+    if (status != transport::Status::Ok) {
+        return ToUcStatus(status, "TransportManager::InstallTransport");
+    }
+    // Accept metadata exchanges initiated by DramStore. DramPool peer routing remains
+    // static and does not actively call ExchangeMetadata().
+    status = transportManager_->Init();
+    if (status != transport::Status::Ok) { return ToUcStatus(status, "TransportManager::Init"); }
+    return Status::OK();
+}
+
+Status DramPoolServer::StartTcpMessageChannel()
+{
+    if (!tcpMessageChannel_) {
+        return Status::InvalidParam("DramPool TCP message channel is not initialized");
+    }
+
+    const auto channelStatus = tcpMessageChannel_->Init(g_config.addr);
+    if (channelStatus != transport::Status::Ok) {
+        return ToUcStatus(channelStatus, "TcpMessageChannel::Init");
+    }
+    {
+        std::lock_guard<std::mutex> waitGuard(requestReceiverWaitMutex_);
+        tcpMessageChannelReady_ = true;
+    }
+    requestReceiverWaitCv_.notify_one();
+    return Status::OK();
+}
+
+Status DramPoolServer::CreateRuntimeContext()
+{
+    if (!metadataManager_ || !protocolManager_ || !transportManager_) {
+        return Status::InvalidParam("DramPool runtime dependencies are not initialized");
+    }
+    if (bufferManagers_.empty()) {
+        return Status::InvalidParam("DramPool buffer managers are not initialized");
+    }
+    try {
+        runtime_ = std::make_unique<DramPoolRuntime>(*metadataManager_, bufferManagers_,
+                                                     *transportManager_, *protocolManager_,
+                                                     requestQueue_, completionQueue_);
+    } catch (const std::exception& error) {
+        return Status::Error(std::string{"failed to create DramPool runtime: "} + error.what());
+    }
+    return Status::OK();
+}
+
+Status DramPoolServer::StartCompletionPoller()
+{
+    if (!runtime_) { return Status::InvalidParam("DramPool runtime is not initialized"); }
+    try {
+        completionPoller_ = std::make_unique<CompletionPoller>(*runtime_);
+        completionPollerStop_.store(false, std::memory_order_release);
+        completionPollerThread_ = std::thread(&DramPoolServer::CompletionPollerLoop, this);
+    } catch (const std::exception& e) {
+        completionPollerStop_.store(true, std::memory_order_release);
+        completionPoller_.reset();
+        return Status::Error(std::string{"failed to start CompletionPoller: "} + e.what());
+    }
+    return Status::OK();
+}
+
+Status DramPoolServer::StartTaskWorker()
+{
+    if (!runtime_) { return Status::InvalidParam("DramPool runtime is not initialized"); }
+    try {
+        taskWorker_ = std::make_unique<TaskWorker>(*runtime_);
+        taskWorkerStop_.store(false, std::memory_order_release);
+        taskWorkerThread_ = std::thread(&DramPoolServer::TaskWorkerLoop, this);
+    } catch (const std::exception& e) {
+        taskWorkerStop_.store(true, std::memory_order_release);
+        taskWorker_.reset();
+        return Status::Error(std::string{"failed to start TaskWorker: "} + e.what());
+    }
+    return Status::OK();
+}
+
+Status DramPoolServer::StartRequestReceiver()
+{
+    if (!runtime_ || !tcpMessageChannel_) {
+        return Status::InvalidParam("DramPool RequestReceiver dependencies are not initialized");
+    }
+    try {
+        {
+            std::lock_guard<std::mutex> waitGuard(requestReceiverWaitMutex_);
+            requestReceiverStop_.store(false, std::memory_order_release);
+        }
+        requestReceiverThread_ = std::thread(&DramPoolServer::RequestReceiveLoop, this);
+    } catch (const std::exception& e) {
+        requestReceiverStop_.store(true, std::memory_order_release);
+        return Status::Error(std::string{"failed to start RequestReceiver: "} + e.what());
+    }
+    return Status::OK();
+}
+
+Status DramPoolServer::StartGCThread()
+{
+    if (!g_config.gcEnabled) { return Status::OK(); }
+    try {
+        gcThreadStop_.store(false, std::memory_order_release);
+        gcThread_ = std::thread(&DramPoolServer::GCThreadLoop, this);
+    } catch (const std::exception& e) {
+        gcThreadStop_.store(true, std::memory_order_release);
+        return Status::Error(std::string{"failed to start GCThread: "} + e.what());
+    }
+    return Status::OK();
+}
+
+void DramPoolServer::StopTcpMessageChannel()
+{
+    {
+        std::lock_guard<std::mutex> waitGuard(requestReceiverWaitMutex_);
+        tcpMessageChannelReady_ = false;
+    }
+    if (tcpMessageChannel_) {
+        const auto status = tcpMessageChannel_->Shutdown();
+        if (status != transport::Status::Ok) {
+            UC_ERROR_UNLIMITED("DramPool TCP message channel shutdown failed");
+        }
+    }
+}
+
+void DramPoolServer::StopRequestReceiver()
+{
+    {
+        std::lock_guard<std::mutex> waitGuard(requestReceiverWaitMutex_);
+        requestReceiverStop_.store(true, std::memory_order_release);
+    }
+    requestReceiverWaitCv_.notify_one();
+    StopTcpMessageChannel();
+    if (requestReceiverThread_.joinable()) { requestReceiverThread_.join(); }
+}
+
+void DramPoolServer::StopTaskWorker()
+{
+    taskWorkerStop_.store(true, std::memory_order_release);
+    if (taskWorkerThread_.joinable()) { taskWorkerThread_.join(); }
+}
+
+void DramPoolServer::MarkInflightTransportsFailed()
+{
+    if (completionPoller_) { completionPoller_->RequestDrainAllAsFailed(); }
+}
+
+void DramPoolServer::StopCompletionPoller()
+{
+    completionPollerStop_.store(true, std::memory_order_release);
+    if (completionPollerThread_.joinable()) { completionPollerThread_.join(); }
+}
+
+void DramPoolServer::StopGCThread()
+{
+    gcThreadStop_.store(true, std::memory_order_release);
+    stopWaitCv_.notify_one();
+    if (gcThread_.joinable()) { gcThread_.join(); }
+}
+
+void DramPoolServer::StopTransportService()
+{
+    if (transportManager_) {
+        const auto status = transportManager_->Shutdown();
+        if (status != transport::Status::Ok) {
+            UC_ERROR_UNLIMITED("DramPool TransportManager shutdown failed");
+        }
+    }
+}
+
+void DramPoolServer::TaskWorkerLoop()
+{
+    UC_INFO_UNLIMITED("DramPool TaskWorker started");
+    taskWorker_->Run(taskWorkerStop_);
+    UC_INFO_UNLIMITED("DramPool TaskWorker stopped");
+}
+
+void DramPoolServer::RequestReceiveLoop()
+{
+    UC_INFO_UNLIMITED("DramPool RequestReceiver started, addr={}", g_config.addr.ToString());
+    if (!WaitForChannelReady()) {
+        UC_INFO_UNLIMITED("DramPool RequestReceiver stopped before TCP channel became ready");
+        return;
+    }
+
+    const auto idleWait = std::chrono::microseconds(g_config.requestReceiverIdleWaitUs);
+    while (!requestReceiverStop_.load(std::memory_order_acquire)) {
+        transport::Endpoint controlPeer;
+        transport::Metadata received;
+        const auto receiveStatus = tcpMessageChannel_->Receive(controlPeer, received);
+        if (requestReceiverStop_.load(std::memory_order_acquire)) { break; }
+        if (receiveStatus != transport::Status::Ok) {
+            UC_ERROR("RequestReceiver TCP message channel stopped unexpectedly");
+            break;
+        }
+
+        RequestPtr request;
+        const auto unpackStatus =
+            runtime_->protocol.UnpackRequest(received.data(), received.size(), request);
+        if (unpackStatus.Failure()) {
+            UC_WARN("RequestReceiver rejected KV request from {}: {}", controlPeer.ToString(),
+                    unpackStatus);
+            continue;
+        }
+
+        const auto controlPeerId = controlPeer.ToString();
+        const auto peerIt = g_config.twoSidedToOneSided.find(controlPeerId);
+        if (peerIt == g_config.twoSidedToOneSided.end()) {
+            UC_WARN("RequestReceiver rejected unconfigured control peer {}", controlPeerId);
+            continue;
+        }
+
+        auto task = std::make_unique<RequestTask>();
+        task->request = std::move(request);
+        task->peer_one_sided_id = peerIt->second;
+        // This bounded handoff keeps transport I/O separate from potentially slow request handling.
+        bool queueFullLogged = false;
+        while (!requestReceiverStop_.load(std::memory_order_acquire)) {
+            if (requestQueue_.TryPush(std::move(task))) { break; }
+            if (!queueFullLogged) {
+                UC_WARN("RequestReceiver queue is full, depth={}, retry_wait_us={}",
+                        g_config.requestQueueDepth, g_config.requestReceiverIdleWaitUs);
+                queueFullLogged = true;
+            }
+            std::this_thread::sleep_for(idleWait);
+        }
+    }
+    UC_INFO_UNLIMITED("DramPool RequestReceiver stopped");
+}
+
+bool DramPoolServer::WaitForChannelReady()
+{
+    std::unique_lock<std::mutex> waitLock(requestReceiverWaitMutex_);
+    requestReceiverWaitCv_.wait(waitLock, [this]() {
+        return tcpMessageChannelReady_ || requestReceiverStop_.load(std::memory_order_acquire);
+    });
+    return tcpMessageChannelReady_ && !requestReceiverStop_.load(std::memory_order_acquire);
+}
+
+void DramPoolServer::CompletionPollerLoop()
+{
+    UC_INFO_UNLIMITED("DramPool CompletionPoller started");
+    completionPoller_->Run(completionPollerStop_);
+    UC_INFO_UNLIMITED("DramPool CompletionPoller stopped");
+}
+
+void DramPoolServer::GCThreadLoop()
+{
+    UC_INFO_UNLIMITED("DramPool GCThread started, interval_ms={}", g_config.gcIntervalMs);
+    const auto interval = std::chrono::milliseconds(g_config.gcIntervalMs);
+    const auto stopRequested = [this]() { return gcThreadStop_.load(std::memory_order_acquire); };
+    while (true) {
+        std::unique_lock<std::mutex> waitLock(stopWaitMutex_);
+        if (stopWaitCv_.wait_for(waitLock, interval, stopRequested)) { break; }
+        waitLock.unlock();
+        // TODO: Run periodic eviction after MetadataManager exposes a production API
+        // that returns each victim Entry (including its buffer slot). GC must release
+        // the BufferManager slot before removing the metadata entry; the current
+        // metadata eviction path only returns keys and does not release DRAM buffers.
+    }
+    UC_INFO_UNLIMITED("DramPool GCThread stopped");
+}
+
+void DramPoolServer::ResetInitializedComponents()
+{
+    // Dependents must be destroyed before the non-owning runtime context and
+    // the components referenced by that context.
+    completionPoller_.reset();
+    taskWorker_.reset();
+    runtime_.reset();
+    protocolManager_.reset();
+    metadataManager_.reset();
+    tcpMessageChannel_.reset();
+    bufferManagers_.clear();
+    transportManager_.reset();
+    if (aclRuntimeOwned_) {
+        (void)aclrtResetDevice(g_config.transportDeviceId);
+        (void)aclFinalize();
+        aclRuntimeOwned_ = false;
+    }
+}
+
+}  // namespace UC::DramPool

--- a/ucm/store/dram/cc/drampool/drampool_server.cpp
+++ b/ucm/store/dram/cc/drampool/drampool_server.cpp
@@ -176,8 +176,8 @@ Status DramPoolServer::InitMetadata()
 {
     // Metadata eviction settings come from the process-wide runtime configuration.
     const UC::DramPool::MetadataConfig config{
-        UC::DramPool::EvictionPolicyType::TTL,
-        UC::DramPool::EvictionPolicyType::POSITION,
+        g_config.metadataPeriodicEvictionPolicy,
+        g_config.metadataDeepEvictionPolicy,
         std::chrono::milliseconds(g_config.metadataLeaseTimeMs),
         g_config.metadataDefaultEvictRatio,
         std::chrono::milliseconds(g_config.metadataEvictPeriodMs),

--- a/ucm/store/dram/cc/drampool/drampool_server.cpp
+++ b/ucm/store/dram/cc/drampool/drampool_server.cpp
@@ -239,10 +239,32 @@ Status DramPoolServer::StartTransportService()
     if (status != transport::Status::Ok) {
         return ToUcStatus(status, "TransportManager::InstallTransport");
     }
+    if (auto registerStatus = RegisterBufferPools(); registerStatus.Failure()) {
+        return registerStatus;
+    }
     // Accept metadata exchanges initiated by DramStore. DramPool peer routing remains
     // static and does not actively call ExchangeMetadata().
     status = transportManager_->Init();
     if (status != transport::Status::Ok) { return ToUcStatus(status, "TransportManager::Init"); }
+    return Status::OK();
+}
+
+Status DramPoolServer::RegisterBufferPools()
+{
+    bufferPoolMemoryHandles_.reserve(bufferPools_.size());
+    for (const auto& bufferPool : bufferPools_) {
+        transport::MemoryRegion memory;
+        memory.addr = bufferPool->GetLocalAddr();
+        memory.length = bufferPool->GetTotalSize();
+        memory.type = transport::MemoryType::Host;
+
+        transport::MemoryHandle handle = transport::kInvalidMemoryHandle;
+        const auto status = transportManager_->RegisterMemory(memory, handle);
+        if (status != transport::Status::Ok) {
+            return ToUcStatus(status, "TransportManager::RegisterMemory");
+        }
+        bufferPoolMemoryHandles_.push_back(handle);
+    }
     return Status::OK();
 }
 
@@ -395,11 +417,24 @@ void DramPoolServer::StopGCThread()
 void DramPoolServer::StopTransportService()
 {
     if (transportManager_) {
+        UnregisterBufferPools();
         const auto status = transportManager_->Shutdown();
         if (status != transport::Status::Ok) {
             UC_ERROR_UNLIMITED("DramPool TransportManager shutdown failed");
         }
     }
+}
+
+void DramPoolServer::UnregisterBufferPools()
+{
+    for (auto iter = bufferPoolMemoryHandles_.rbegin(); iter != bufferPoolMemoryHandles_.rend();
+         ++iter) {
+        const auto status = transportManager_->UnregisterMemory(*iter);
+        if (status != transport::Status::Ok) {
+            UC_ERROR_UNLIMITED("DramPool buffer pool memory unregister failed, handle={}", *iter);
+        }
+    }
+    bufferPoolMemoryHandles_.clear();
 }
 
 void DramPoolServer::TaskWorkerLoop()
@@ -505,6 +540,7 @@ void DramPoolServer::ResetInitializedComponents()
     protocolManager_.reset();
     metadataManager_.reset();
     tcpMessageChannel_.reset();
+    bufferPoolMemoryHandles_.clear();
     bufferPools_.clear();
     transportManager_.reset();
     if (aclRuntimeOwned_) {

--- a/ucm/store/dram/cc/drampool/drampool_server.h
+++ b/ucm/store/dram/cc/drampool/drampool_server.h
@@ -74,6 +74,7 @@ private:
     Status CreateRuntimeContext();
 
     Status StartTransportService();
+    Status RegisterBufferPools();
     Status StartTcpMessageChannel();
     Status StartCompletionPoller();
     Status StartTaskWorker();
@@ -86,6 +87,7 @@ private:
     void MarkInflightTransportsFailed();
     void StopCompletionPoller();
     void StopGCThread();
+    void UnregisterBufferPools();
     void StopTransportService();
 
     void RequestReceiveLoop();
@@ -111,6 +113,7 @@ private:
     std::unique_ptr<transport::TransportManager> transportManager_;
     std::unique_ptr<transport::TcpMessageChannel> tcpMessageChannel_;
     BufferPoolList bufferPools_;
+    std::vector<transport::MemoryHandle> bufferPoolMemoryHandles_;
     std::unique_ptr<UC::DramPool::MetadataManager> metadataManager_;
     std::unique_ptr<ProtocolManager> protocolManager_;
     std::unique_ptr<DramPoolRuntime> runtime_;

--- a/ucm/store/dram/cc/drampool/drampool_server.h
+++ b/ucm/store/dram/cc/drampool/drampool_server.h
@@ -1,0 +1,128 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+#include "completion_poller.h"
+#include "drampool_config.h"
+#include "drampool_types.h"
+#include "kv_protocol.h"
+#include "status/status.h"
+
+namespace transport {
+class TcpMessageChannel;
+}
+
+namespace UC::DramPool {
+
+class TaskWorker;
+
+class DramPoolServer {
+public:
+    DramPoolServer();
+    ~DramPoolServer();
+
+    DramPoolServer(const DramPoolServer&) = delete;
+    DramPoolServer& operator=(const DramPoolServer&) = delete;
+
+    Status Init();
+    Status Start();
+    void Stop();
+
+private:
+    enum class ServerState {
+        New = 0,
+        Initialized,
+        Running,
+        Stopped,
+    };
+
+    Status InitializeAclRuntime();
+    Status InitMemoryPool();
+    Status InitMetadata();
+    Status InitProtocol();
+    Status InitQueues();
+    Status InitTransportManager();
+    Status CreateRuntimeContext();
+
+    Status StartTransportService();
+    Status StartTcpMessageChannel();
+    Status StartCompletionPoller();
+    Status StartTaskWorker();
+    Status StartRequestReceiver();
+    Status StartGCThread();
+
+    void StopTcpMessageChannel();
+    void StopRequestReceiver();
+    void StopTaskWorker();
+    void MarkInflightTransportsFailed();
+    void StopCompletionPoller();
+    void StopGCThread();
+    void StopTransportService();
+
+    void RequestReceiveLoop();
+    bool WaitForChannelReady();
+    void TaskWorkerLoop();
+    void CompletionPollerLoop();
+    void GCThreadLoop();
+    void ResetInitializedComponents();
+
+    std::atomic_bool requestReceiverStop_{true};
+    std::atomic_bool taskWorkerStop_{true};
+    std::atomic_bool completionPollerStop_{true};
+    std::atomic_bool gcThreadStop_{true};
+    bool tcpMessageChannelReady_{false};
+
+    std::thread requestReceiverThread_;
+    std::thread taskWorkerThread_;
+    std::thread completionPollerThread_;
+    std::thread gcThread_;
+
+    RequestQueue requestQueue_;
+    CompletionQueue completionQueue_;
+    std::unique_ptr<transport::TransportManager> transportManager_;
+    std::unique_ptr<transport::TcpMessageChannel> tcpMessageChannel_;
+    BufferManagerList bufferManagers_;
+    std::unique_ptr<UC::DramPool::MetadataManager> metadataManager_;
+    std::unique_ptr<ProtocolManager> protocolManager_;
+    std::unique_ptr<DramPoolRuntime> runtime_;
+    std::unique_ptr<TaskWorker> taskWorker_;
+    std::unique_ptr<CompletionPoller> completionPoller_;
+    bool aclRuntimeOwned_{false};
+
+    ServerState state_{ServerState::New};
+    std::mutex requestReceiverWaitMutex_;
+    std::condition_variable requestReceiverWaitCv_;
+    std::mutex stopWaitMutex_;
+    std::condition_variable stopWaitCv_;
+};
+
+}  // namespace UC::DramPool

--- a/ucm/store/dram/cc/drampool/drampool_server.h
+++ b/ucm/store/dram/cc/drampool/drampool_server.h
@@ -110,7 +110,7 @@ private:
     CompletionQueue completionQueue_;
     std::unique_ptr<transport::TransportManager> transportManager_;
     std::unique_ptr<transport::TcpMessageChannel> tcpMessageChannel_;
-    BufferManagerList bufferManagers_;
+    BufferPoolList bufferPools_;
     std::unique_ptr<UC::DramPool::MetadataManager> metadataManager_;
     std::unique_ptr<ProtocolManager> protocolManager_;
     std::unique_ptr<DramPoolRuntime> runtime_;

--- a/ucm/store/dram/cc/drampool/drampool_yaml_config.cpp
+++ b/ucm/store/dram/cc/drampool/drampool_yaml_config.cpp
@@ -54,9 +54,7 @@ constexpr const char* kRequiredRuntimeConfigKeys[] = {
     "queue.request_depth",
     "queue.completion_depth",
     "request_receiver.idle_wait_us",
-    "poller.drain_budget",
-    "poller.scan_budget",
-    "poller.max_pending",
+    "poller.pending_depth",
     "gc.enabled",
     "gc.interval_ms",
     "metadata.lease_time_ms",
@@ -275,14 +273,8 @@ Status ApplyRuntimeConfigValue(DramPoolConfig& config, const std::string& key,
     if (key == "request_receiver.idle_wait_us") {
         return ParseUint32Value(key, value, config.requestReceiverIdleWaitUs);
     }
-    if (key == "poller.drain_budget") {
-        return ParseUint32Value(key, value, config.pollerDrainBudget);
-    }
-    if (key == "poller.scan_budget") {
-        return ParseUint32Value(key, value, config.pollerScanBudget);
-    }
-    if (key == "poller.max_pending") {
-        return ParseUint32Value(key, value, config.pollerMaxPending);
+    if (key == "poller.pending_depth") {
+        return ParseUint32Value(key, value, config.pollerPendingDepth);
     }
     if (key == "gc.enabled") { return ParseBoolValue(key, value, config.gcEnabled); }
     if (key == "gc.interval_ms") { return ParseUint32Value(key, value, config.gcIntervalMs); }
@@ -335,13 +327,8 @@ Status ValidateRuntimeConfig(const DramPoolConfig& config)
     if (config.requestReceiverIdleWaitUs == 0) {
         return Status::InvalidParam("request_receiver.idle_wait_us must be greater than zero");
     }
-    if (config.pollerDrainBudget == 0 || config.pollerScanBudget == 0 ||
-        config.pollerMaxPending == 0) {
-        return Status::InvalidParam("poller values must be greater than zero");
-    }
-    if (config.pollerMaxPending < config.pollerDrainBudget ||
-        config.pollerMaxPending < config.pollerScanBudget) {
-        return Status::InvalidParam("poller.max_pending must cover both poller budgets");
+    if (config.pollerPendingDepth == 0) {
+        return Status::InvalidParam("poller.pending_depth must be greater than zero");
     }
     if (config.gcEnabled && config.gcIntervalMs == 0) {
         return Status::InvalidParam("gc.interval_ms must be greater than zero when GC is enabled");

--- a/ucm/store/dram/cc/drampool/drampool_yaml_config.cpp
+++ b/ucm/store/dram/cc/drampool/drampool_yaml_config.cpp
@@ -57,6 +57,8 @@ constexpr const char* kRequiredRuntimeConfigKeys[] = {
     "poller.pending_depth",
     "gc.enabled",
     "gc.interval_ms",
+    "metadata.periodic_eviction_policy",
+    "metadata.deep_eviction_policy",
     "metadata.lease_time_ms",
     "metadata.default_evict_ratio",
     "metadata.evict_period_ms",
@@ -204,6 +206,21 @@ Status ParseBoolValue(const std::string& key, const std::string& value, bool& ou
     return Status::InvalidParam("invalid YAML boolean for {}", key);
 }
 
+Status ParseEvictionPolicyValue(const std::string& key, const std::string& value,
+                                EvictionPolicyType& output)
+{
+    const auto normalized = ToLower(value);
+    if (normalized == "ttl") {
+        output = EvictionPolicyType::TTL;
+        return Status::OK();
+    }
+    if (normalized == "position") {
+        output = EvictionPolicyType::POSITION;
+        return Status::OK();
+    }
+    return Status::InvalidParam("unsupported eviction policy for {}: {}", key, value);
+}
+
 Status ApplyEndpointEntryValue(EndpointEntry& entry, const std::string& key,
                                const std::string& value, std::uint32_t lineNumber)
 {
@@ -278,6 +295,12 @@ Status ApplyRuntimeConfigValue(DramPoolConfig& config, const std::string& key,
     }
     if (key == "gc.enabled") { return ParseBoolValue(key, value, config.gcEnabled); }
     if (key == "gc.interval_ms") { return ParseUint32Value(key, value, config.gcIntervalMs); }
+    if (key == "metadata.periodic_eviction_policy") {
+        return ParseEvictionPolicyValue(key, value, config.metadataPeriodicEvictionPolicy);
+    }
+    if (key == "metadata.deep_eviction_policy") {
+        return ParseEvictionPolicyValue(key, value, config.metadataDeepEvictionPolicy);
+    }
     if (key == "metadata.lease_time_ms") {
         return ParseUint64Value(key, value, config.metadataLeaseTimeMs);
     }

--- a/ucm/store/dram/cc/drampool/drampool_yaml_config.cpp
+++ b/ucm/store/dram/cc/drampool/drampool_yaml_config.cpp
@@ -1,0 +1,513 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <exception>
+#include <fstream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+#include "drampool_config.h"
+
+namespace UC::DramPool {
+namespace {
+
+struct YamlSection {
+    std::size_t indent{0};
+    std::string key;
+};
+
+struct EndpointEntry {
+    std::string twoSided;
+    std::string oneSided;
+    bool hasTwoSided{false};
+    bool hasOneSided{false};
+};
+
+constexpr const char* kRequiredRuntimeConfigKeys[] = {
+    "transport.device_id",
+    "queue.request_depth",
+    "queue.completion_depth",
+    "request_receiver.idle_wait_us",
+    "poller.drain_budget",
+    "poller.scan_budget",
+    "poller.max_pending",
+    "gc.enabled",
+    "gc.interval_ms",
+    "metadata.lease_time_ms",
+    "metadata.default_evict_ratio",
+    "metadata.evict_period_ms",
+    "operation.timeout_ms",
+    "logger.level",
+    "logger.dir",
+    "logger.max_files",
+    "logger.max_size_mb",
+};
+
+std::string Trim(const std::string& value)
+{
+    const auto begin = value.find_first_not_of(" \t\r\n");
+    if (begin == std::string::npos) { return ""; }
+    const auto end = value.find_last_not_of(" \t\r\n");
+    return value.substr(begin, end - begin + 1);
+}
+
+std::string ToLower(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char character) {
+        return static_cast<char>(std::tolower(character));
+    });
+    return value;
+}
+
+std::string BuildSectionPath(const std::vector<YamlSection>& sections)
+{
+    std::string path;
+    for (const auto& section : sections) {
+        if (!path.empty()) { path += '.'; }
+        path += section.key;
+    }
+    return path;
+}
+
+std::string StripYamlComment(const std::string& line)
+{
+    char quote = '\0';
+    for (std::size_t index = 0; index < line.size(); ++index) {
+        const char character = line[index];
+        if (quote != '\0') {
+            if (character == quote) { quote = '\0'; }
+            continue;
+        }
+        if (character == '\'' || character == '"') {
+            quote = character;
+        } else if (character == '#') {
+            return line.substr(0, index);
+        }
+    }
+    return line;
+}
+
+Status ParseYamlScalar(const std::string& key, std::string value, std::string& output)
+{
+    value = Trim(value);
+    if (value.size() >= 2 && ((value.front() == '"' && value.back() == '"') ||
+                              (value.front() == '\'' && value.back() == '\''))) {
+        value = value.substr(1, value.size() - 2);
+    } else if ((!value.empty() && (value.front() == '"' || value.front() == '\'')) ||
+               (!value.empty() && (value.back() == '"' || value.back() == '\''))) {
+        return Status::InvalidParam("unmatched quote in YAML key {}", key);
+    }
+    output = std::move(value);
+    return Status::OK();
+}
+
+Status ParseUint32Value(const std::string& key, const std::string& value, std::uint32_t& output)
+{
+    try {
+        if (value.empty() || value.front() == '-') {
+            throw std::invalid_argument("expected an unsigned integer");
+        }
+        std::size_t parsed = 0;
+        const auto number = std::stoull(value, &parsed, 0);
+        if (parsed != value.size() || number > std::numeric_limits<std::uint32_t>::max()) {
+            throw std::out_of_range("outside uint32 range");
+        }
+        output = static_cast<std::uint32_t>(number);
+    } catch (const std::exception& error) {
+        return Status::InvalidParam("invalid YAML value for {}: {}", key, error.what());
+    }
+    return Status::OK();
+}
+
+Status ParseUint64Value(const std::string& key, const std::string& value, std::uint64_t& output)
+{
+    try {
+        if (value.empty() || value.front() == '-') {
+            throw std::invalid_argument("expected an unsigned integer");
+        }
+        std::size_t parsed = 0;
+        const auto number = std::stoull(value, &parsed, 0);
+        if (parsed != value.size()) { throw std::invalid_argument("unexpected trailing data"); }
+        output = number;
+    } catch (const std::exception& error) {
+        return Status::InvalidParam("invalid YAML value for {}: {}", key, error.what());
+    }
+    return Status::OK();
+}
+
+Status ParseDoubleValue(const std::string& key, const std::string& value, double& output)
+{
+    try {
+        std::size_t parsed = 0;
+        const auto number = std::stod(value, &parsed);
+        if (parsed != value.size() || !std::isfinite(number)) {
+            throw std::invalid_argument("expected a finite number");
+        }
+        output = number;
+    } catch (const std::exception& error) {
+        return Status::InvalidParam("invalid YAML value for {}: {}", key, error.what());
+    }
+    return Status::OK();
+}
+
+Status ParseInt32Value(const std::string& key, const std::string& value, std::int32_t& output)
+{
+    try {
+        std::size_t parsed = 0;
+        const auto number = std::stoll(value, &parsed, 0);
+        if (parsed != value.size() || number < std::numeric_limits<std::int32_t>::min() ||
+            number > std::numeric_limits<std::int32_t>::max()) {
+            throw std::out_of_range("outside int32 range");
+        }
+        output = static_cast<std::int32_t>(number);
+    } catch (const std::exception& error) {
+        return Status::InvalidParam("invalid YAML value for {}: {}", key, error.what());
+    }
+    return Status::OK();
+}
+
+Status ParseBoolValue(const std::string& key, const std::string& value, bool& output)
+{
+    const auto normalized = ToLower(value);
+    if (normalized == "true" || normalized == "yes" || normalized == "on" || normalized == "1") {
+        output = true;
+        return Status::OK();
+    }
+    if (normalized == "false" || normalized == "no" || normalized == "off" || normalized == "0") {
+        output = false;
+        return Status::OK();
+    }
+    return Status::InvalidParam("invalid YAML boolean for {}", key);
+}
+
+Status ApplyEndpointEntryValue(EndpointEntry& entry, const std::string& key,
+                               const std::string& value, std::uint32_t lineNumber)
+{
+    if (key == "two_sided") {
+        if (entry.hasTwoSided) {
+            return Status::InvalidParam("duplicate transport endpoint two_sided at line {}",
+                                        lineNumber);
+        }
+        entry.twoSided = value;
+        entry.hasTwoSided = true;
+        return Status::OK();
+    }
+    if (key == "one_sided") {
+        if (entry.hasOneSided) {
+            return Status::InvalidParam("duplicate transport endpoint one_sided at line {}",
+                                        lineNumber);
+        }
+        entry.oneSided = value;
+        entry.hasOneSided = true;
+        return Status::OK();
+    }
+    return Status::InvalidParam("unknown transport endpoint key at line {}: {}", lineNumber, key);
+}
+
+Status CommitEndpointEntry(EndpointEntry& entry, DramPoolConfig& config,
+                           std::unordered_set<std::string>& oneSidedIds)
+{
+    if (!entry.hasTwoSided || !entry.hasOneSided) {
+        return Status::InvalidParam("each transport endpoint requires two_sided and one_sided");
+    }
+    transport::Endpoint twoSided;
+    transport::Endpoint oneSided;
+    if (auto status =
+            ParseDramPoolEndpoint("transport.endpoints.two_sided", entry.twoSided, twoSided);
+        status.Failure()) {
+        return status;
+    }
+    if (auto status =
+            ParseDramPoolEndpoint("transport.endpoints.one_sided", entry.oneSided, oneSided);
+        status.Failure()) {
+        return status;
+    }
+    const auto twoSidedId = twoSided.ToString();
+    const auto oneSidedId = oneSided.ToString();
+    if (!config.twoSidedToOneSided.emplace(twoSidedId, oneSidedId).second) {
+        return Status::InvalidParam("duplicate transport two_sided endpoint: {}", twoSidedId);
+    }
+    if (!oneSidedIds.insert(oneSidedId).second) {
+        return Status::InvalidParam("duplicate transport one_sided endpoint: {}", oneSidedId);
+    }
+    entry = EndpointEntry{};
+    return Status::OK();
+}
+
+Status ApplyRuntimeConfigValue(DramPoolConfig& config, const std::string& key,
+                               const std::string& value)
+{
+    if (key == "transport.device_id") {
+        return ParseInt32Value(key, value, config.transportDeviceId);
+    }
+    if (key == "queue.request_depth") {
+        return ParseUint32Value(key, value, config.requestQueueDepth);
+    }
+    if (key == "queue.completion_depth") {
+        return ParseUint32Value(key, value, config.completionQueueDepth);
+    }
+    if (key == "request_receiver.idle_wait_us") {
+        return ParseUint32Value(key, value, config.requestReceiverIdleWaitUs);
+    }
+    if (key == "poller.drain_budget") {
+        return ParseUint32Value(key, value, config.pollerDrainBudget);
+    }
+    if (key == "poller.scan_budget") {
+        return ParseUint32Value(key, value, config.pollerScanBudget);
+    }
+    if (key == "poller.max_pending") {
+        return ParseUint32Value(key, value, config.pollerMaxPending);
+    }
+    if (key == "gc.enabled") { return ParseBoolValue(key, value, config.gcEnabled); }
+    if (key == "gc.interval_ms") { return ParseUint32Value(key, value, config.gcIntervalMs); }
+    if (key == "metadata.lease_time_ms") {
+        return ParseUint64Value(key, value, config.metadataLeaseTimeMs);
+    }
+    if (key == "metadata.default_evict_ratio") {
+        return ParseDoubleValue(key, value, config.metadataDefaultEvictRatio);
+    }
+    if (key == "metadata.evict_period_ms") {
+        return ParseUint64Value(key, value, config.metadataEvictPeriodMs);
+    }
+    if (key == "operation.timeout_ms") { return ParseUint32Value(key, value, config.opTimeoutMs); }
+    if (key == "logger.level") {
+        config.logLevel = ToLower(value);
+        return Status::OK();
+    }
+    if (key == "logger.dir") {
+        config.logDir = value;
+        return Status::OK();
+    }
+    if (key == "logger.max_files") { return ParseUint32Value(key, value, config.logMaxFiles); }
+    if (key == "logger.max_size_mb") { return ParseUint32Value(key, value, config.logMaxSizeMb); }
+    return Status::InvalidParam("unknown DramPool runtime YAML key: {}", key);
+}
+
+Status ValidateRuntimeConfig(const DramPoolConfig& config)
+{
+    if (config.twoSidedToOneSided.empty()) {
+        return Status::InvalidParam("transport.endpoints must not be empty");
+    }
+    const auto localControlId = config.addr.ToString();
+    const auto localEndpoint = config.twoSidedToOneSided.find(localControlId);
+    if (localEndpoint == config.twoSidedToOneSided.end()) {
+        return Status::InvalidParam("transport.endpoints has no two_sided entry for --addr {}",
+                                    localControlId);
+    }
+    for (const auto& endpoint : config.twoSidedToOneSided) {
+        if (config.twoSidedToOneSided.find(endpoint.second) != config.twoSidedToOneSided.end()) {
+            return Status::InvalidParam(
+                "transport endpoint cannot be both two_sided and one_sided: {}", endpoint.second);
+        }
+    }
+    if (config.transportDeviceId < 0) {
+        return Status::InvalidParam("transport.device_id must not be negative");
+    }
+    if (config.requestQueueDepth < 2 || config.completionQueueDepth < 2) {
+        return Status::InvalidParam("queue depths must be at least 2");
+    }
+    if (config.requestReceiverIdleWaitUs == 0) {
+        return Status::InvalidParam("request_receiver.idle_wait_us must be greater than zero");
+    }
+    if (config.pollerDrainBudget == 0 || config.pollerScanBudget == 0 ||
+        config.pollerMaxPending == 0) {
+        return Status::InvalidParam("poller values must be greater than zero");
+    }
+    if (config.pollerMaxPending < config.pollerDrainBudget ||
+        config.pollerMaxPending < config.pollerScanBudget) {
+        return Status::InvalidParam("poller.max_pending must cover both poller budgets");
+    }
+    if (config.gcEnabled && config.gcIntervalMs == 0) {
+        return Status::InvalidParam("gc.interval_ms must be greater than zero when GC is enabled");
+    }
+    if (config.metadataLeaseTimeMs == 0) {
+        return Status::InvalidParam("metadata.lease_time_ms must be greater than zero");
+    }
+    if (config.metadataLeaseTimeMs >
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max())) {
+        return Status::InvalidParam("metadata.lease_time_ms is too large");
+    }
+    if (config.metadataDefaultEvictRatio < 0.0 || config.metadataDefaultEvictRatio > 1.0) {
+        return Status::InvalidParam("metadata.default_evict_ratio must be in [0, 1]");
+    }
+    if (config.metadataEvictPeriodMs == 0) {
+        return Status::InvalidParam("metadata.evict_period_ms must be greater than zero");
+    }
+    if (config.metadataEvictPeriodMs >
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max())) {
+        return Status::InvalidParam("metadata.evict_period_ms is too large");
+    }
+    if (config.opTimeoutMs == 0) {
+        return Status::InvalidParam("operation.timeout_ms must be greater than zero");
+    }
+    if (config.logLevel != "trace" && config.logLevel != "debug" && config.logLevel != "info" &&
+        config.logLevel != "warn" && config.logLevel != "error" && config.logLevel != "critical") {
+        return Status::InvalidParam("unsupported logger.level: {}", config.logLevel);
+    }
+    if (Trim(config.logDir).empty()) {
+        return Status::InvalidParam("logger.dir must not be empty");
+    }
+    if (config.logMaxFiles == 0 || config.logMaxSizeMb == 0 ||
+        config.logMaxFiles > static_cast<std::uint32_t>(std::numeric_limits<int>::max()) ||
+        config.logMaxSizeMb > static_cast<std::uint32_t>(std::numeric_limits<int>::max())) {
+        return Status::InvalidParam("logger rotation values must fit positive int values");
+    }
+    return Status::OK();
+}
+
+Status ValidateRequiredRuntimeConfigKeys(const std::unordered_set<std::string>& configuredKeys)
+{
+    for (const char* key : kRequiredRuntimeConfigKeys) {
+        if (configuredKeys.find(key) == configuredKeys.end()) {
+            return Status::InvalidParam("DramPool runtime YAML is missing required key: {}", key);
+        }
+    }
+    return Status::OK();
+}
+
+}  // namespace
+
+Status ParseYamlConfig(const std::string& path, DramPoolConfig& config)
+{
+    std::ifstream input{path};
+    if (!input.is_open()) {
+        return Status::Error("failed to open DramPool runtime YAML, path=" + path);
+    }
+
+    // Keep the caller's launch configuration intact if YAML parsing fails.
+    DramPoolConfig loadedConfig = config;
+    loadedConfig.twoSidedToOneSided.clear();
+    std::vector<YamlSection> sections;
+    std::unordered_set<std::string> configuredKeys;
+    std::unordered_set<std::string> oneSidedIds;
+    EndpointEntry endpointEntry;
+    bool endpointEntryActive = false;
+    bool endpointsSectionSeen = false;
+    std::string line;
+    std::uint32_t lineNumber = 0;
+    while (std::getline(input, line)) {
+        ++lineNumber;
+        line = StripYamlComment(line);
+        if (Trim(line).empty()) { continue; }
+        if (line.find('\t') != std::string::npos) {
+            return Status::InvalidParam("YAML line {} uses a tab for indentation", lineNumber);
+        }
+
+        const auto firstContent = line.find_first_not_of(' ');
+        const auto indent = firstContent == std::string::npos ? 0 : firstContent;
+        auto content = Trim(line.substr(indent));
+        while (!sections.empty() && sections.back().indent >= indent) { sections.pop_back(); }
+        auto sectionPath = BuildSectionPath(sections);
+        if (endpointEntryActive && sectionPath != "transport.endpoints") {
+            if (auto status = CommitEndpointEntry(endpointEntry, loadedConfig, oneSidedIds);
+                status.Failure()) {
+                return status;
+            }
+            endpointEntryActive = false;
+        }
+
+        if (content.rfind("- ", 0) == 0) {
+            if (sectionPath != "transport.endpoints") {
+                return Status::InvalidParam("YAML sequence is unsupported at line {}", lineNumber);
+            }
+            if (endpointEntryActive) {
+                if (auto status = CommitEndpointEntry(endpointEntry, loadedConfig, oneSidedIds);
+                    status.Failure()) {
+                    return status;
+                }
+            }
+            endpointEntryActive = true;
+            endpointsSectionSeen = true;
+            content = Trim(content.substr(2));
+        }
+
+        const auto separator = content.find(':');
+        if (separator == std::string::npos || separator == 0) {
+            return Status::InvalidParam("invalid YAML mapping at line {}", lineNumber);
+        }
+
+        const auto key = Trim(content.substr(0, separator));
+        if (key.empty() || key.find_first_of(" \t") != std::string::npos) {
+            return Status::InvalidParam("invalid YAML key at line {}", lineNumber);
+        }
+        const auto scalarToken = content.substr(separator + 1);
+        const bool hasScalar = !Trim(scalarToken).empty();
+        std::string value;
+        auto status = ParseYamlScalar(key, scalarToken, value);
+        if (status.Failure()) { return status; }
+
+        if (sectionPath == "transport.endpoints") {
+            if (!endpointEntryActive || !hasScalar) {
+                return Status::InvalidParam("invalid transport endpoint at line {}", lineNumber);
+            }
+            status = ApplyEndpointEntryValue(endpointEntry, key, value, lineNumber);
+            if (status.Failure()) { return status; }
+            continue;
+        }
+        if (!hasScalar) {
+            sections.push_back(YamlSection{indent, key});
+            if (BuildSectionPath(sections) == "transport.endpoints") {
+                endpointsSectionSeen = true;
+            }
+            continue;
+        }
+
+        std::string fullKey;
+        for (const auto& section : sections) {
+            if (!fullKey.empty()) { fullKey += '.'; }
+            fullKey += section.key;
+        }
+        if (!fullKey.empty()) { fullKey += '.'; }
+        fullKey += key;
+        if (!configuredKeys.insert(fullKey).second) {
+            return Status::InvalidParam("duplicate YAML key: {}", fullKey);
+        }
+        status = ApplyRuntimeConfigValue(loadedConfig, fullKey, value);
+        if (status.Failure()) { return status; }
+    }
+    if (endpointEntryActive) {
+        if (auto status = CommitEndpointEntry(endpointEntry, loadedConfig, oneSidedIds);
+            status.Failure()) {
+            return status;
+        }
+    }
+    if (!endpointsSectionSeen) {
+        return Status::InvalidParam("DramPool runtime YAML is missing transport.endpoints");
+    }
+    if (const auto status = ValidateRequiredRuntimeConfigKeys(configuredKeys); status.Failure()) {
+        return status;
+    }
+    if (const auto status = ValidateRuntimeConfig(loadedConfig); status.Failure()) {
+        return status;
+    }
+    config = std::move(loadedConfig);
+    return Status::OK();
+}
+
+}  // namespace UC::DramPool

--- a/ucm/store/dram/cc/drampool/drampool_yaml_config.cpp
+++ b/ucm/store/dram/cc/drampool/drampool_yaml_config.cpp
@@ -33,9 +33,12 @@
 #include <utility>
 #include <vector>
 #include "drampool_config.h"
+#include "drampool_config_utils.h"
 
 namespace UC::DramPool {
 namespace {
+
+using detail::Trim;
 
 struct YamlSection {
     std::size_t indent{0};
@@ -68,14 +71,6 @@ constexpr const char* kRequiredRuntimeConfigKeys[] = {
     "logger.max_files",
     "logger.max_size_mb",
 };
-
-std::string Trim(const std::string& value)
-{
-    const auto begin = value.find_first_not_of(" \t\r\n");
-    if (begin == std::string::npos) { return ""; }
-    const auto end = value.find_last_not_of(" \t\r\n");
-    return value.substr(begin, end - begin + 1);
-}
 
 std::string ToLower(std::string value)
 {
@@ -130,15 +125,7 @@ Status ParseYamlScalar(const std::string& key, std::string value, std::string& o
 Status ParseUint32Value(const std::string& key, const std::string& value, std::uint32_t& output)
 {
     try {
-        if (value.empty() || value.front() == '-') {
-            throw std::invalid_argument("expected an unsigned integer");
-        }
-        std::size_t parsed = 0;
-        const auto number = std::stoull(value, &parsed, 0);
-        if (parsed != value.size() || number > std::numeric_limits<std::uint32_t>::max()) {
-            throw std::out_of_range("outside uint32 range");
-        }
-        output = static_cast<std::uint32_t>(number);
+        output = detail::ParseUint32(value);
     } catch (const std::exception& error) {
         return Status::InvalidParam("invalid YAML value for {}: {}", key, error.what());
     }
@@ -148,13 +135,7 @@ Status ParseUint32Value(const std::string& key, const std::string& value, std::u
 Status ParseUint64Value(const std::string& key, const std::string& value, std::uint64_t& output)
 {
     try {
-        if (value.empty() || value.front() == '-') {
-            throw std::invalid_argument("expected an unsigned integer");
-        }
-        std::size_t parsed = 0;
-        const auto number = std::stoull(value, &parsed, 0);
-        if (parsed != value.size()) { throw std::invalid_argument("unexpected trailing data"); }
-        output = number;
+        output = detail::ParseUint64(value);
     } catch (const std::exception& error) {
         return Status::InvalidParam("invalid YAML value for {}: {}", key, error.what());
     }

--- a/ucm/store/dram/cc/drampool/main.cpp
+++ b/ucm/store/dram/cc/drampool/main.cpp
@@ -1,0 +1,7 @@
+#include "drampool_daemon.h"
+
+int main(int argc, char** argv)
+{
+    UC::DramPool::DramPoolDaemon daemon;
+    return daemon.Run(argc, argv);
+}

--- a/ucm/transport/kv/dramstore/test/drampool_startup_test.cpp
+++ b/ucm/transport/kv/dramstore/test/drampool_startup_test.cpp
@@ -291,6 +291,8 @@ TEST(DramPoolRuntimeConfigTest, LoadsRepositoryExample)
     EXPECT_EQ(config.completionQueueDepth, 65536U);
     EXPECT_EQ(config.requestReceiverIdleWaitUs, 100U);
     EXPECT_EQ(config.pollerPendingDepth, 64U);
+    EXPECT_EQ(config.metadataPeriodicEvictionPolicy, EvictionPolicyType::TTL);
+    EXPECT_EQ(config.metadataDeepEvictionPolicy, EvictionPolicyType::POSITION);
     EXPECT_EQ(config.metadataLeaseTimeMs, 5000U);
     EXPECT_DOUBLE_EQ(config.metadataDefaultEvictRatio, 0.0);
     EXPECT_EQ(config.metadataEvictPeriodMs, 31'536'000'000ULL);

--- a/ucm/transport/kv/dramstore/test/drampool_startup_test.cpp
+++ b/ucm/transport/kv/dramstore/test/drampool_startup_test.cpp
@@ -1,0 +1,569 @@
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+#if defined(UCM_DRAMPOOL_RUNTIME_INTEGRATION_TESTS) && !defined(_WIN32)
+#include <arpa/inet.h>
+#include <chrono>
+#include <csignal>
+#include <sys/socket.h>
+#include <sys/wait.h>
+#include <thread>
+#include <unistd.h>
+#endif
+#include "drampool_config.h"
+#include "drampool_daemon.h"
+#include "drampool_server.h"
+
+namespace UC::DramPool {
+namespace {
+
+std::filesystem::path RepositoryRuntimeConfigPath();
+
+class ScopedCurrentPath {
+public:
+    explicit ScopedCurrentPath(const std::filesystem::path& path)
+        : previous_(std::filesystem::current_path())
+    {
+        std::filesystem::current_path(path);
+    }
+
+    ~ScopedCurrentPath() { std::filesystem::current_path(previous_); }
+
+private:
+    std::filesystem::path previous_;
+};
+
+#if defined(UCM_DRAMPOOL_RUNTIME_INTEGRATION_TESTS)
+std::uint16_t FindAvailableTcpPort()
+{
+#if !defined(_WIN32)
+    const int socket = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (socket < 0) { throw std::runtime_error("failed to create test socket"); }
+    sockaddr_in address{};
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    address.sin_port = 0;
+    socklen_t addressLength = sizeof(address);
+    if (::bind(socket, reinterpret_cast<sockaddr*>(&address), sizeof(address)) != 0 ||
+        ::getsockname(socket, reinterpret_cast<sockaddr*>(&address), &addressLength) != 0) {
+        ::close(socket);
+        throw std::runtime_error("failed to reserve an available test port");
+    }
+    ::close(socket);
+    return ntohs(address.sin_port);
+#else
+    static std::uint16_t nextPort = 19000;
+    return nextPort++;
+#endif
+}
+
+std::uint16_t FindDistinctTcpPort(std::uint16_t first, std::uint16_t second = 0)
+{
+    std::uint16_t port = 0;
+    do {
+        port = FindAvailableTcpPort();
+    } while (port == first || port == second);
+    return port;
+}
+
+DramPoolConfig MakeValidConfig()
+{
+    const char* argv[] = {
+        "drampool",
+        "--addr",
+        "127.0.0.1:9000",
+        "--nics",
+        "mlx5_0",
+        "mlx5_1",
+        "--pool-size-gb",
+        "1",
+        "--kvcache-block-sizes",
+        "4096",
+        "8192",
+        "--kvcache-block-proportions",
+        "70",
+        "30",
+    };
+    DramPoolConfig config;
+    if (const auto status = ParseCommandLine(14, const_cast<char**>(argv), config);
+        status.Failure()) {
+        throw std::runtime_error(status.ToString());
+    }
+
+    if (const auto status = ParseYamlConfig(RepositoryRuntimeConfigPath().string(), config);
+        status.Failure()) {
+        throw std::runtime_error(status.ToString());
+    }
+    const auto originalLocalId = config.addr.ToString();
+    config.addr.port = FindAvailableTcpPort();
+    const auto oneSidedPort = FindDistinctTcpPort(config.addr.port);
+    config.twoSidedToOneSided.erase(originalLocalId);
+    config.twoSidedToOneSided.emplace(config.addr.ToString(),
+                                      "127.0.0.1:" + std::to_string(oneSidedPort));
+    return config;
+}
+
+class ScopedDramPoolConfig {
+public:
+    explicit ScopedDramPoolConfig(DramPoolConfig config) : previous_(g_config)
+    {
+        g_config = std::move(config);
+    }
+
+    ~ScopedDramPoolConfig() { g_config = std::move(previous_); }
+
+    ScopedDramPoolConfig(const ScopedDramPoolConfig&) = delete;
+    ScopedDramPoolConfig& operator=(const ScopedDramPoolConfig&) = delete;
+
+private:
+    DramPoolConfig previous_;
+};
+
+#if !defined(_WIN32)
+class ScopedListeningPort {
+public:
+    explicit ScopedListeningPort(std::uint16_t port)
+    {
+        socket_ = ::socket(AF_INET, SOCK_STREAM, 0);
+        if (socket_ < 0) { throw std::runtime_error("failed to create test socket"); }
+        sockaddr_in address{};
+        address.sin_family = AF_INET;
+        address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        address.sin_port = htons(port);
+        if (::bind(socket_, reinterpret_cast<sockaddr*>(&address), sizeof(address)) != 0 ||
+            ::listen(socket_, 1) != 0) {
+            ::close(socket_);
+            throw std::runtime_error("failed to occupy test port");
+        }
+    }
+
+    ~ScopedListeningPort() { ::close(socket_); }
+
+private:
+    int socket_{-1};
+};
+
+bool CanConnectTo(std::uint16_t port)
+{
+    const int socket = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (socket < 0) { return false; }
+    sockaddr_in address{};
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    address.sin_port = htons(port);
+    const bool connected =
+        ::connect(socket, reinterpret_cast<sockaddr*>(&address), sizeof(address)) == 0;
+    ::close(socket);
+    return connected;
+}
+
+template <typename Scenario>
+int RunInIsolatedProcess(Scenario scenario)
+{
+    const auto child = ::fork();
+    if (child < 0) { return -1; }
+    if (child == 0) { ::_exit(scenario()); }
+    int status = 0;
+    if (::waitpid(child, &status, 0) != child || !WIFEXITED(status)) { return -1; }
+    return WEXITSTATUS(status);
+}
+
+std::filesystem::path CreateDaemonRuntimeDirectory(std::uint16_t servicePort,
+                                                   std::uint16_t oneSidedPort)
+{
+    const auto directory =
+        std::filesystem::temp_directory_path() / ("drampool_daemon_" + std::to_string(::getpid()));
+    std::filesystem::create_directories(directory / "examples");
+    std::ifstream input(RepositoryRuntimeConfigPath());
+    std::string yaml((std::istreambuf_iterator<char>(input)), std::istreambuf_iterator<char>());
+    const auto replacePort = [&yaml](const std::string& original, std::uint16_t replacement) {
+        const auto replacementText = std::to_string(replacement);
+        auto position = yaml.find(original);
+        if (position == std::string::npos) {
+            throw std::runtime_error("expected endpoint missing from test runtime YAML");
+        }
+        while (position != std::string::npos) {
+            yaml.replace(position, original.size(), replacementText);
+            position = yaml.find(original, position + replacementText.size());
+        }
+    };
+    replacePort("4501", oneSidedPort);
+    replacePort("9000", servicePort);
+    std::ofstream output(directory / "examples" / "drampool.yaml");
+    output << yaml;
+    return directory;
+}
+#endif
+#endif
+
+std::filesystem::path RepositoryRuntimeConfigPath()
+{
+    auto path = std::filesystem::path{__FILE__}.parent_path();
+    for (int depth = 0; depth < 5; ++depth) { path = path.parent_path(); }
+    return path / "examples" / "drampool.yaml";
+}
+
+}  // namespace
+
+TEST(DramPoolConfigTest, ParsesLaunchOptions)
+{
+    const char* argv[] = {
+        "drampool",
+        "--addr",
+        "127.0.0.1:9000",
+        "--nics",
+        "mlx5_0",
+        "mlx5_1",
+        "--pool-size-gb",
+        "128",
+        "--kvcache-block-sizes",
+        "4096",
+        "8192",
+        "--kvcache-block-proportions",
+        "1",
+        "3",
+        "--ttl-minutes=30",
+    };
+    DramPoolConfig config;
+
+    const auto status = ParseCommandLine(15, const_cast<char**>(argv), config);
+
+    ASSERT_TRUE(status.Success()) << status.ToString();
+    EXPECT_EQ(config.addr.host, "127.0.0.1");
+    EXPECT_EQ(config.addr.port, 9000U);
+    EXPECT_EQ(config.nics, (std::vector<std::string>{"mlx5_0", "mlx5_1"}));
+    EXPECT_EQ(config.poolSizeGb, 128U);
+    EXPECT_EQ(config.poolBlockSizes, (std::vector<std::uint64_t>{4096, 8192}));
+    EXPECT_EQ(config.poolBlockProportions, (std::vector<std::uint32_t>{1, 3}));
+    EXPECT_EQ(config.poolSlotCounts, (std::vector<std::uint32_t>{8'388'608, 12'582'912}));
+    EXPECT_EQ(config.defaultDumpTtlMs, 30U * kMillisecondsPerMinute);
+}
+
+TEST(DramPoolConfigTest, DefaultsBlockProportionsAndTtl)
+{
+    const char* argv[] = {
+        "drampool",          "--addr=127.0.0.1:9000",      "--nics=mlx5_0",
+        "--pool-size-gb=64", "--kvcache-block-sizes=4096", "8192",
+    };
+    DramPoolConfig config;
+
+    const auto status = ParseCommandLine(6, const_cast<char**>(argv), config);
+
+    ASSERT_TRUE(status.Success()) << status.ToString();
+    EXPECT_EQ(config.poolBlockProportions, (std::vector<std::uint32_t>{1, 1}));
+    EXPECT_EQ(config.defaultDumpTtlMs, kDefaultDumpTtlMs);
+}
+
+TEST(DramPoolConfigTest, ResolvesGiBSlotCountsWithAlignedStride)
+{
+    const char* argv[] = {
+        "drampool",         "--addr=127.0.0.1:9000",      "--nics=mlx5_0",
+        "--pool-size-gb=1", "--kvcache-block-sizes=4097",
+    };
+    DramPoolConfig config;
+
+    const auto status = ParseCommandLine(5, const_cast<char**>(argv), config);
+
+    ASSERT_TRUE(status.Success()) << status.ToString();
+    EXPECT_EQ(config.poolSlotCounts, (std::vector<std::uint32_t>{258'111}));
+}
+
+TEST(DramPoolRuntimeConfigTest, LoadsRepositoryExample)
+{
+    const char* argv[] = {
+        "drampool",       "--addr", "127.0.0.1:9000",        "--nics", "mlx5_0",
+        "--pool-size-gb", "1",      "--kvcache-block-sizes", "4096",
+    };
+    DramPoolConfig config;
+    ASSERT_TRUE(ParseCommandLine(9, const_cast<char**>(argv), config).Success());
+
+    const auto status = ParseYamlConfig(RepositoryRuntimeConfigPath().string(), config);
+
+    ASSERT_TRUE(status.Success()) << status.ToString();
+    ASSERT_EQ(config.twoSidedToOneSided.size(), 2U);
+    EXPECT_EQ(config.twoSidedToOneSided.at("127.0.0.1:9000"), "127.0.0.1:4501");
+    EXPECT_EQ(config.requestQueueDepth, 65536U);
+    EXPECT_EQ(config.completionQueueDepth, 65536U);
+    EXPECT_EQ(config.requestReceiverIdleWaitUs, 100U);
+    EXPECT_EQ(config.pollerScanBudget, 64U);
+    EXPECT_EQ(config.metadataLeaseTimeMs, 5000U);
+    EXPECT_DOUBLE_EQ(config.metadataDefaultEvictRatio, 0.0);
+    EXPECT_EQ(config.metadataEvictPeriodMs, 31'536'000'000ULL);
+    EXPECT_EQ(config.logLevel, "info");
+}
+
+TEST(DramPoolConfigTest, RejectsInvalidCommandLines)
+{
+    {
+        const char* argv[] = {"drampool", "--help"};
+        DramPoolConfig config;
+        EXPECT_TRUE(ParseCommandLine(2, const_cast<char**>(argv), config).Failure());
+    }
+    {
+        const char* argv[] = {"drampool"};
+        DramPoolConfig config;
+        EXPECT_TRUE(ParseCommandLine(1, const_cast<char**>(argv), config).Failure());
+    }
+    {
+        const char* argv[] = {
+            "drampool", "--addr", "127.0.0.1:9000", "--pool-size-gb", "1", "--kvcache-block-sizes",
+            "4096"};
+        DramPoolConfig config;
+        EXPECT_TRUE(ParseCommandLine(7, const_cast<char**>(argv), config).Failure());
+    }
+    {
+        const char* argv[] = {"drampool", "--config", "legacy.conf"};
+        DramPoolConfig config;
+        EXPECT_TRUE(ParseCommandLine(3, const_cast<char**>(argv), config).Failure());
+    }
+    {
+        const char* argv[] = {
+            "drampool",
+            "--addr",
+            "127.0.0.1:9000",
+            "--nics",
+            "mlx5_0",
+            "--pool-size-gb",
+            "1",
+            "--kvcache-block-sizes",
+            "4096",
+            "8192",
+            "--kvcache-block-proportions",
+            "1",
+            "--ttl-minutes",
+            "0",
+        };
+        DramPoolConfig config;
+        EXPECT_TRUE(ParseCommandLine(14, const_cast<char**>(argv), config).Failure());
+    }
+    {
+        const char* argv[] = {
+            "drampool",
+            "--addr",
+            "127.0.0.1:9000",
+            "--nics",
+            "mlx5_0",
+            "--pool-size-gb=-1",
+            "--kvcache-block-sizes",
+            "4096",
+        };
+        DramPoolConfig config;
+        EXPECT_TRUE(ParseCommandLine(8, const_cast<char**>(argv), config).Failure());
+    }
+    {
+        const char* argv[] = {"drampool", "--pool-size-gb", "0"};
+        DramPoolConfig config;
+        EXPECT_TRUE(ParseCommandLine(3, const_cast<char**>(argv), config).Failure());
+    }
+    {
+        const char* argv[] = {"drampool", "--kvcache-block-sizes", "0"};
+        DramPoolConfig config;
+        EXPECT_TRUE(ParseCommandLine(3, const_cast<char**>(argv), config).Failure());
+    }
+    {
+        const char* argv[] = {"drampool", "--kvcache-block-proportions", "0"};
+        DramPoolConfig config;
+        EXPECT_TRUE(ParseCommandLine(3, const_cast<char**>(argv), config).Failure());
+    }
+    {
+        const char* argv[] = {
+            "drampool",
+            "--pool-size-gb",
+            "18446744073709551615",
+            "--unknown",
+        };
+        DramPoolConfig config;
+        const auto status = ParseCommandLine(4, const_cast<char**>(argv), config);
+        EXPECT_TRUE(status.Failure());
+        EXPECT_NE(status.ToString().find("--pool-size-gb is too large"), std::string::npos);
+    }
+    {
+        const char* argv[] = {
+            "drampool",
+            "--addr",
+            "127.0.0.1:9000",
+            "--nics",
+            "mlx5_0",
+            "--pool-size-gb",
+            "1",
+            "--kvcache-block-proportions",
+            "1",
+            "--kvcache-block-sizes",
+            "4096",
+            "8192",
+        };
+        DramPoolConfig config;
+        const auto status = ParseCommandLine(12, const_cast<char**>(argv), config);
+        EXPECT_TRUE(status.Failure());
+        EXPECT_NE(status.ToString().find("must have the same length"), std::string::npos);
+    }
+    {
+        const char* argv[] = {
+            "drampool",       "--addr", "127.0.0.1:bad",         "--nics", "mlx5_0",
+            "--pool-size-gb", "1",      "--kvcache-block-sizes", "4096",
+        };
+        DramPoolConfig config;
+        EXPECT_TRUE(ParseCommandLine(9, const_cast<char**>(argv), config).Failure());
+    }
+}
+
+TEST(DramPoolServerTest, RejectsCallsOutsideValidState)
+{
+    DramPoolServer server;
+    EXPECT_TRUE(server.Start().Failure());
+    server.Stop();
+    server.Stop();
+}
+
+#if defined(UCM_DRAMPOOL_RUNTIME_INTEGRATION_TESTS)
+#if !defined(_WIN32)
+TEST(DramPoolServerTest, StartsAndStopsService)
+{
+    EXPECT_EQ(RunInIsolatedProcess([]() {
+                  ScopedDramPoolConfig configScope(MakeValidConfig());
+                  DramPoolServer server;
+                  if (server.Init().Failure()) { return 1; }
+                  if (server.Init().Success()) { return 2; }
+                  if (server.Start().Failure()) { return 3; }
+                  if (server.Start().Success()) { return 4; }
+                  server.Stop();
+                  server.Stop();
+                  if (server.Init().Success()) { return 5; }
+                  if (server.Start().Success()) { return 6; }
+                  return 0;
+              }),
+              0);
+}
+
+TEST(DramPoolServerTest, RejectsDuplicateInitializationAndCleansUpWithoutStart)
+{
+    EXPECT_EQ(RunInIsolatedProcess([]() {
+                  ScopedDramPoolConfig configScope(MakeValidConfig());
+                  DramPoolServer server;
+                  if (server.Init().Failure()) { return 1; }
+                  return server.Init().Failure() ? 0 : 2;
+              }),
+              0);
+}
+
+TEST(DramPoolServerTest, StartFailureRollsBackStartedComponents)
+{
+    EXPECT_EQ(RunInIsolatedProcess([]() {
+                  auto config = MakeValidConfig();
+                  ScopedListeningPort occupiedServicePort(config.addr.port);
+                  ScopedDramPoolConfig configScope(std::move(config));
+                  DramPoolServer server;
+                  if (server.Init().Failure()) { return 1; }
+                  if (server.Start().Success()) { return 2; }
+                  server.Stop();
+                  return server.Start().Failure() ? 0 : 3;
+              }),
+              0);
+}
+
+TEST(DramPoolServerTest, StartsAndStopsWithGcDisabled)
+{
+    EXPECT_EQ(RunInIsolatedProcess([]() {
+                  auto config = MakeValidConfig();
+                  config.gcEnabled = false;
+                  config.gcIntervalMs = 0;
+                  ScopedDramPoolConfig configScope(std::move(config));
+                  DramPoolServer server;
+                  if (server.Init().Failure()) { return 1; }
+                  if (server.Start().Failure()) { return 2; }
+                  server.Stop();
+                  return 0;
+              }),
+              0);
+}
+#endif
+#endif
+
+TEST(DramPoolDaemonTest, ReturnsForInvalidArguments)
+{
+    const std::vector<std::vector<const char*>> cases = {
+        {"drampool"},
+        {"drampool", "--help"},
+        {"drampool", "--config", "legacy.conf"},
+    };
+    for (const auto& arguments : cases) {
+        std::vector<char*> argv;
+        argv.reserve(arguments.size());
+        for (const auto* argument : arguments) { argv.push_back(const_cast<char*>(argument)); }
+        DramPoolDaemon daemon;
+        EXPECT_EQ(daemon.Run(static_cast<int>(argv.size()), argv.data()), 1);
+    }
+}
+
+TEST(DramPoolDaemonTest, ReturnsWhenRuntimeYamlIsMissing)
+{
+    const auto emptyDirectory = std::filesystem::temp_directory_path() / "drampool_no_yaml";
+    std::filesystem::create_directories(emptyDirectory);
+    {
+        ScopedCurrentPath pathScope(emptyDirectory);
+        const char* argv[] = {
+            "drampool",       "--addr", "127.0.0.1:19000",       "--nics", "mlx5_0",
+            "--pool-size-gb", "1",      "--kvcache-block-sizes", "4096",
+        };
+        DramPoolDaemon daemon;
+
+        EXPECT_EQ(daemon.Run(9, const_cast<char**>(argv)), 1);
+    }
+    std::filesystem::remove(emptyDirectory);
+}
+
+#if defined(UCM_DRAMPOOL_RUNTIME_INTEGRATION_TESTS) && !defined(_WIN32)
+TEST(DramPoolDaemonTest, RunsUntilSigtermAndShutsDownCleanly)
+{
+    const auto servicePort = FindAvailableTcpPort();
+    const auto oneSidedPort = FindDistinctTcpPort(servicePort);
+    const auto runtimeDirectory = CreateDaemonRuntimeDirectory(servicePort, oneSidedPort);
+    const auto child = ::fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        std::filesystem::current_path(runtimeDirectory);
+        const auto serviceEndpoint = "127.0.0.1:" + std::to_string(servicePort);
+        std::vector<std::string> arguments = {
+            "drampool",       "--addr", serviceEndpoint,         "--nics", "mlx5_0",
+            "--pool-size-gb", "1",      "--kvcache-block-sizes", "4096",
+        };
+        std::vector<char*> argv;
+        argv.reserve(arguments.size());
+        for (auto& argument : arguments) { argv.push_back(argument.data()); }
+        DramPoolDaemon daemon;
+        const int result = daemon.Run(static_cast<int>(argv.size()), argv.data());
+        ::_exit(result);
+    }
+
+    bool ready = false;
+    bool exitedEarly = false;
+    int childStatus = 0;
+    for (int attempt = 0; attempt < 200; ++attempt) {
+        if (::waitpid(child, &childStatus, WNOHANG) == child) {
+            exitedEarly = true;
+            break;
+        }
+        if (CanConnectTo(servicePort)) {
+            ready = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    if (!exitedEarly) {
+        EXPECT_EQ(::kill(child, SIGTERM), 0);
+        EXPECT_EQ(::waitpid(child, &childStatus, 0), child);
+    }
+    std::filesystem::remove_all(runtimeDirectory);
+    ASSERT_TRUE(ready) << "daemon did not open its service listener";
+    ASSERT_TRUE(WIFEXITED(childStatus));
+    EXPECT_EQ(WEXITSTATUS(childStatus), 0);
+}
+#endif
+
+}  // namespace UC::DramPool

--- a/ucm/transport/kv/dramstore/test/drampool_startup_test.cpp
+++ b/ucm/transport/kv/dramstore/test/drampool_startup_test.cpp
@@ -290,7 +290,7 @@ TEST(DramPoolRuntimeConfigTest, LoadsRepositoryExample)
     EXPECT_EQ(config.requestQueueDepth, 65536U);
     EXPECT_EQ(config.completionQueueDepth, 65536U);
     EXPECT_EQ(config.requestReceiverIdleWaitUs, 100U);
-    EXPECT_EQ(config.pollerScanBudget, 64U);
+    EXPECT_EQ(config.pollerPendingDepth, 64U);
     EXPECT_EQ(config.metadataLeaseTimeMs, 5000U);
     EXPECT_DOUBLE_EQ(config.metadataDefaultEvictRatio, 0.0);
     EXPECT_EQ(config.metadataEvictPeriodMs, 31'536'000'000ULL);

--- a/ucm/transport/kv/dramstore/test/drampool_startup_test.cpp
+++ b/ucm/transport/kv/dramstore/test/drampool_startup_test.cpp
@@ -228,10 +228,11 @@ TEST(DramPoolConfigTest, ParsesLaunchOptions)
         "1",
         "3",
         "--ttl-minutes=30",
+        "--config=/tmp/drampool-custom.yaml",
     };
     DramPoolConfig config;
 
-    const auto status = ParseCommandLine(15, const_cast<char**>(argv), config);
+    const auto status = ParseCommandLine(16, const_cast<char**>(argv), config);
 
     ASSERT_TRUE(status.Success()) << status.ToString();
     EXPECT_EQ(config.addr.host, "127.0.0.1");
@@ -242,6 +243,7 @@ TEST(DramPoolConfigTest, ParsesLaunchOptions)
     EXPECT_EQ(config.poolBlockProportions, (std::vector<std::uint32_t>{1, 3}));
     EXPECT_EQ(config.poolSlotCounts, (std::vector<std::uint32_t>{8'388'608, 12'582'912}));
     EXPECT_EQ(config.defaultDumpTtlMs, 30U * kMillisecondsPerMinute);
+    EXPECT_EQ(config.runtimeConfigPath, "/tmp/drampool-custom.yaml");
 }
 
 TEST(DramPoolConfigTest, DefaultsBlockProportionsAndTtl)
@@ -257,6 +259,8 @@ TEST(DramPoolConfigTest, DefaultsBlockProportionsAndTtl)
     ASSERT_TRUE(status.Success()) << status.ToString();
     EXPECT_EQ(config.poolBlockProportions, (std::vector<std::uint32_t>{1, 1}));
     EXPECT_EQ(config.defaultDumpTtlMs, kDefaultDumpTtlMs);
+    EXPECT_EQ(config.runtimeConfigPath, kDefaultDramPoolRuntimeConfigPath);
+    EXPECT_NE(BuildUsage("drampool").find("--config <PATH>"), std::string::npos);
 }
 
 TEST(DramPoolConfigTest, ResolvesGiBSlotCountsWithAlignedStride)
@@ -319,9 +323,34 @@ TEST(DramPoolConfigTest, RejectsInvalidCommandLines)
         EXPECT_TRUE(ParseCommandLine(7, const_cast<char**>(argv), config).Failure());
     }
     {
-        const char* argv[] = {"drampool", "--config", "legacy.conf"};
+        const char* argv[] = {"drampool", "--config"};
         DramPoolConfig config;
-        EXPECT_TRUE(ParseCommandLine(3, const_cast<char**>(argv), config).Failure());
+        EXPECT_TRUE(ParseCommandLine(2, const_cast<char**>(argv), config).Failure());
+    }
+    {
+        const char* argv[] = {
+            "drampool",
+            "--addr=127.0.0.1:9000",
+            "--nics=mlx5_0",
+            "--pool-size-gb=1",
+            "--kvcache-block-sizes=4096",
+            "--config=first.yaml",
+            "--config=second.yaml",
+        };
+        DramPoolConfig config;
+        const auto status = ParseCommandLine(7, const_cast<char**>(argv), config);
+        EXPECT_TRUE(status.Failure());
+        EXPECT_NE(status.ToString().find("--config may be specified once"), std::string::npos);
+    }
+    {
+        const char* argv[] = {
+            "drampool",         "--addr=127.0.0.1:9000",      "--nics=mlx5_0",
+            "--pool-size-gb=1", "--kvcache-block-sizes=4096", "--config=   ",
+        };
+        DramPoolConfig config;
+        const auto status = ParseCommandLine(6, const_cast<char**>(argv), config);
+        EXPECT_TRUE(status.Failure());
+        EXPECT_NE(status.ToString().find("--config must not be blank"), std::string::npos);
     }
     {
         const char* argv[] = {
@@ -491,7 +520,7 @@ TEST(DramPoolDaemonTest, ReturnsForInvalidArguments)
     const std::vector<std::vector<const char*>> cases = {
         {"drampool"},
         {"drampool", "--help"},
-        {"drampool", "--config", "legacy.conf"},
+        {"drampool", "--config"},
     };
     for (const auto& arguments : cases) {
         std::vector<char*> argv;
@@ -519,20 +548,40 @@ TEST(DramPoolDaemonTest, ReturnsWhenRuntimeYamlIsMissing)
     std::filesystem::remove(emptyDirectory);
 }
 
+TEST(DramPoolDaemonTest, ReturnsWhenConfiguredRuntimeYamlIsMissing)
+{
+    const auto missingPath =
+        (std::filesystem::temp_directory_path() / "drampool_missing_explicit.yaml").string();
+    std::vector<std::string> arguments = {
+        "drampool",       "--addr", "127.0.0.1:19000",       "--nics", "mlx5_0",
+        "--pool-size-gb", "1",      "--kvcache-block-sizes", "4096",   "--config",
+        missingPath,
+    };
+    std::vector<char*> argv;
+    argv.reserve(arguments.size());
+    for (auto& argument : arguments) { argv.push_back(argument.data()); }
+    DramPoolDaemon daemon;
+
+    EXPECT_EQ(daemon.Run(static_cast<int>(argv.size()), argv.data()), 1);
+    EXPECT_EQ(g_config.runtimeConfigPath, missingPath);
+}
+
 #if defined(UCM_DRAMPOOL_RUNTIME_INTEGRATION_TESTS) && !defined(_WIN32)
 TEST(DramPoolDaemonTest, RunsUntilSigtermAndShutsDownCleanly)
 {
     const auto servicePort = FindAvailableTcpPort();
     const auto oneSidedPort = FindDistinctTcpPort(servicePort);
     const auto runtimeDirectory = CreateDaemonRuntimeDirectory(servicePort, oneSidedPort);
+    const auto runtimeConfigPath = (runtimeDirectory / "examples" / "drampool.yaml").string();
     const auto child = ::fork();
     ASSERT_GE(child, 0);
     if (child == 0) {
         std::filesystem::current_path(runtimeDirectory);
         const auto serviceEndpoint = "127.0.0.1:" + std::to_string(servicePort);
         std::vector<std::string> arguments = {
-            "drampool",       "--addr", serviceEndpoint,         "--nics", "mlx5_0",
-            "--pool-size-gb", "1",      "--kvcache-block-sizes", "4096",
+            "drampool",        "--addr", serviceEndpoint,         "--nics", "mlx5_0",
+            "--pool-size-gb",  "1",      "--kvcache-block-sizes", "4096",   "--config",
+            runtimeConfigPath,
         };
         std::vector<char*> argv;
         argv.reserve(arguments.size());

--- a/ucm/transport/kv/dramstore/test/drampool_yaml_config_test.cpp
+++ b/ucm/transport/kv/dramstore/test/drampool_yaml_config_test.cpp
@@ -1,0 +1,197 @@
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <string>
+#include <utility>
+#include <vector>
+#include "drampool_config.h"
+
+namespace UC::DramPool {
+namespace {
+
+class RuntimeYamlFile {
+public:
+    explicit RuntimeYamlFile(const std::string& contents)
+        : path_(std::filesystem::temp_directory_path() /
+                ("drampool_runtime_" + std::to_string(sequence_++) + ".yaml"))
+    {
+        std::ofstream output(path_);
+        output << contents;
+    }
+
+    ~RuntimeYamlFile()
+    {
+        std::error_code error;
+        std::filesystem::remove(path_, error);
+    }
+
+    const std::filesystem::path& Path() const { return path_; }
+
+private:
+    inline static std::uint64_t sequence_{0};
+    std::filesystem::path path_;
+};
+
+std::string ValidRuntimeYaml()
+{
+    return R"(transport:
+  device_id: 0
+  endpoints:
+    - two_sided: "127.0.0.1:9000"
+      one_sided: "127.0.0.1:4501"
+    - two_sided: "127.0.0.1:9001"
+      one_sided: "127.0.0.1:4502"
+queue:
+  request_depth: 65536
+  completion_depth: 65536
+request_receiver:
+  idle_wait_us: 100
+poller:
+  drain_budget: 64
+  scan_budget: 64
+  max_pending: 1048576
+gc:
+  enabled: true
+  interval_ms: 1000
+metadata:
+  lease_time_ms: 5000
+  default_evict_ratio: 0.0
+  evict_period_ms: 31536000000
+operation:
+  timeout_ms: 5000
+logger:
+  level: info
+  dir: ./logs
+  max_files: 10
+  max_size_mb: 5
+)";
+}
+
+std::string ReplaceOnce(std::string text, const std::string& from, const std::string& to)
+{
+    const auto position = text.find(from);
+    EXPECT_NE(position, std::string::npos);
+    if (position != std::string::npos) { text.replace(position, from.size(), to); }
+    return text;
+}
+
+DramPoolConfig LaunchConfig()
+{
+    DramPoolConfig config;
+    config.addr.host = "127.0.0.1";
+    config.addr.port = 9000;
+    config.poolSizeGb = 7;
+    config.nics = {"mlx5_0"};
+    return config;
+}
+
+struct InvalidYamlCase {
+    const char* name;
+    const char* original;
+    const char* replacement;
+    const char* expected;
+};
+
+class InvalidRuntimeYamlTest : public testing::TestWithParam<InvalidYamlCase> {};
+
+TEST(DramPoolRuntimeYamlTest, LoadsEveryRuntimeFieldAndPreservesLaunchFields)
+{
+    auto config = LaunchConfig();
+    RuntimeYamlFile yaml(ValidRuntimeYaml());
+
+    const auto status = ParseYamlConfig(yaml.Path().string(), config);
+
+    ASSERT_TRUE(status.Success()) << status.ToString();
+    EXPECT_EQ(config.addr.port, 9000U);
+    EXPECT_EQ(config.poolSizeGb, 7U);
+    EXPECT_EQ(config.nics, (std::vector<std::string>{"mlx5_0"}));
+    ASSERT_EQ(config.twoSidedToOneSided.size(), 2U);
+    EXPECT_EQ(config.twoSidedToOneSided.at("127.0.0.1:9000"), "127.0.0.1:4501");
+    EXPECT_EQ(config.twoSidedToOneSided.at("127.0.0.1:9001"), "127.0.0.1:4502");
+    EXPECT_EQ(config.transportDeviceId, 0);
+    EXPECT_EQ(config.requestQueueDepth, 65536U);
+    EXPECT_EQ(config.completionQueueDepth, 65536U);
+    EXPECT_EQ(config.requestReceiverIdleWaitUs, 100U);
+    EXPECT_EQ(config.pollerDrainBudget, 64U);
+    EXPECT_EQ(config.pollerScanBudget, 64U);
+    EXPECT_EQ(config.pollerMaxPending, 1048576U);
+    EXPECT_TRUE(config.gcEnabled);
+    EXPECT_EQ(config.gcIntervalMs, 1000U);
+    EXPECT_EQ(config.metadataLeaseTimeMs, 5000U);
+    EXPECT_DOUBLE_EQ(config.metadataDefaultEvictRatio, 0.0);
+    EXPECT_EQ(config.metadataEvictPeriodMs, 31'536'000'000ULL);
+    EXPECT_EQ(config.opTimeoutMs, 5000U);
+    EXPECT_EQ(config.logLevel, "info");
+    EXPECT_EQ(config.logDir, "./logs");
+    EXPECT_EQ(config.logMaxFiles, 10U);
+    EXPECT_EQ(config.logMaxSizeMb, 5U);
+}
+
+TEST(DramPoolRuntimeYamlTest, RejectsMissingUnknownAndDuplicateKeys)
+{
+    const std::vector<std::pair<std::string, std::string>> cases = {
+        {ReplaceOnce(ValidRuntimeYaml(), "  max_size_mb: 5\n", ""), "missing required key"},
+        {ValidRuntimeYaml() + "unknown: 1\n", "unknown DramPool runtime YAML key"},
+        {ValidRuntimeYaml() + "transport:\n  device_id: 0\n", "duplicate YAML key"},
+    };
+    for (const auto& item : cases) {
+        auto config = LaunchConfig();
+        RuntimeYamlFile yaml(item.first);
+        const auto status = ParseYamlConfig(yaml.Path().string(), config);
+        EXPECT_TRUE(status.Failure());
+        EXPECT_NE(status.ToString().find(item.second), std::string::npos) << status.ToString();
+    }
+}
+
+TEST(DramPoolRuntimeYamlTest, FailureDoesNotPartiallyModifyConfiguration)
+{
+    auto config = LaunchConfig();
+    config.transportDeviceId = 37;
+    RuntimeYamlFile yaml(ReplaceOnce(ValidRuntimeYaml(), "  max_size_mb: 5", "  max_size_mb: 0"));
+
+    EXPECT_TRUE(ParseYamlConfig(yaml.Path().string(), config).Failure());
+
+    EXPECT_EQ(config.transportDeviceId, 37);
+    EXPECT_TRUE(config.twoSidedToOneSided.empty());
+    EXPECT_EQ(config.poolSizeGb, 7U);
+}
+
+TEST_P(InvalidRuntimeYamlTest, RejectsInvalidValue)
+{
+    const auto& item = GetParam();
+    auto config = LaunchConfig();
+    RuntimeYamlFile yaml(ReplaceOnce(ValidRuntimeYaml(), item.original, item.replacement));
+
+    const auto status = ParseYamlConfig(yaml.Path().string(), config);
+
+    EXPECT_TRUE(status.Failure());
+    EXPECT_NE(status.ToString().find(item.expected), std::string::npos) << status.ToString();
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Validation, InvalidRuntimeYamlTest,
+    testing::Values(
+        InvalidYamlCase{"MissingLocalEndpoint", "two_sided: \"127.0.0.1:9000\"",
+                        "two_sided: \"127.0.0.1:9010\"", "no two_sided entry for --addr"},
+        InvalidYamlCase{"DuplicateTwoSided", "two_sided: \"127.0.0.1:9001\"",
+                        "two_sided: \"127.0.0.1:9000\"", "duplicate transport two_sided"},
+        InvalidYamlCase{"DuplicateOneSided", "one_sided: \"127.0.0.1:4502\"",
+                        "one_sided: \"127.0.0.1:4501\"", "duplicate transport one_sided"},
+        InvalidYamlCase{"EndpointInBothRoles", "one_sided: \"127.0.0.1:4502\"",
+                        "one_sided: \"127.0.0.1:9000\"", "both two_sided and one_sided"},
+        InvalidYamlCase{"NegativeDevice", "device_id: 0", "device_id: -1", "must not be negative"},
+        InvalidYamlCase{"QueueTooShallow", "request_depth: 65536", "request_depth: 1",
+                        "at least 2"},
+        InvalidYamlCase{"PollerBudgetExceedsPending", "max_pending: 1048576", "max_pending: 1",
+                        "cover both"},
+        InvalidYamlCase{"EnabledGcHasZeroInterval", "interval_ms: 1000", "interval_ms: 0",
+                        "when GC is enabled"},
+        InvalidYamlCase{"EvictRatioAboveOne", "default_evict_ratio: 0.0",
+                        "default_evict_ratio: 1.1", "must be in [0, 1]"},
+        InvalidYamlCase{"UnsupportedLogLevel", "level: info", "level: verbose", "unsupported"},
+        InvalidYamlCase{"EmptyLogDirectory", "dir: ./logs", "dir: ''", "must not be empty"}),
+    [](const testing::TestParamInfo<InvalidYamlCase>& info) { return info.param.name; });
+
+}  // namespace
+}  // namespace UC::DramPool

--- a/ucm/transport/kv/dramstore/test/drampool_yaml_config_test.cpp
+++ b/ucm/transport/kv/dramstore/test/drampool_yaml_config_test.cpp
@@ -53,6 +53,8 @@ gc:
   enabled: true
   interval_ms: 1000
 metadata:
+  periodic_eviction_policy: TTL
+  deep_eviction_policy: POSITION
   lease_time_ms: 5000
   default_evict_ratio: 0.0
   evict_period_ms: 31536000000
@@ -114,6 +116,8 @@ TEST(DramPoolRuntimeYamlTest, LoadsEveryRuntimeFieldAndPreservesLaunchFields)
     EXPECT_EQ(config.pollerPendingDepth, 64U);
     EXPECT_TRUE(config.gcEnabled);
     EXPECT_EQ(config.gcIntervalMs, 1000U);
+    EXPECT_EQ(config.metadataPeriodicEvictionPolicy, EvictionPolicyType::TTL);
+    EXPECT_EQ(config.metadataDeepEvictionPolicy, EvictionPolicyType::POSITION);
     EXPECT_EQ(config.metadataLeaseTimeMs, 5000U);
     EXPECT_DOUBLE_EQ(config.metadataDefaultEvictRatio, 0.0);
     EXPECT_EQ(config.metadataEvictPeriodMs, 31'536'000'000ULL);
@@ -122,6 +126,22 @@ TEST(DramPoolRuntimeYamlTest, LoadsEveryRuntimeFieldAndPreservesLaunchFields)
     EXPECT_EQ(config.logDir, "./logs");
     EXPECT_EQ(config.logMaxFiles, 10U);
     EXPECT_EQ(config.logMaxSizeMb, 5U);
+}
+
+TEST(DramPoolRuntimeYamlTest, LoadsConfiguredEvictionPoliciesCaseInsensitively)
+{
+    auto yamlText = ReplaceOnce(ValidRuntimeYaml(), "periodic_eviction_policy: TTL",
+                                "periodic_eviction_policy: position");
+    yamlText = ReplaceOnce(std::move(yamlText), "deep_eviction_policy: POSITION",
+                           "deep_eviction_policy: ttl");
+    auto config = LaunchConfig();
+    RuntimeYamlFile yaml(yamlText);
+
+    const auto status = ParseYamlConfig(yaml.Path().string(), config);
+
+    ASSERT_TRUE(status.Success()) << status.ToString();
+    EXPECT_EQ(config.metadataPeriodicEvictionPolicy, EvictionPolicyType::POSITION);
+    EXPECT_EQ(config.metadataDeepEvictionPolicy, EvictionPolicyType::TTL);
 }
 
 TEST(DramPoolRuntimeYamlTest, RejectsMissingUnknownAndDuplicateKeys)
@@ -183,6 +203,10 @@ INSTANTIATE_TEST_SUITE_P(
                         "greater than zero"},
         InvalidYamlCase{"EnabledGcHasZeroInterval", "interval_ms: 1000", "interval_ms: 0",
                         "when GC is enabled"},
+        InvalidYamlCase{"UnsupportedPeriodicEvictionPolicy", "periodic_eviction_policy: TTL",
+                        "periodic_eviction_policy: LRU", "unsupported eviction policy"},
+        InvalidYamlCase{"UnsupportedDeepEvictionPolicy", "deep_eviction_policy: POSITION",
+                        "deep_eviction_policy: LFU", "unsupported eviction policy"},
         InvalidYamlCase{"EvictRatioAboveOne", "default_evict_ratio: 0.0",
                         "default_evict_ratio: 1.1", "must be in [0, 1]"},
         InvalidYamlCase{"UnsupportedLogLevel", "level: info", "level: verbose", "unsupported"},

--- a/ucm/transport/kv/dramstore/test/drampool_yaml_config_test.cpp
+++ b/ucm/transport/kv/dramstore/test/drampool_yaml_config_test.cpp
@@ -79,6 +79,7 @@ std::string ReplaceOnce(std::string text, const std::string& from, const std::st
 DramPoolConfig LaunchConfig()
 {
     DramPoolConfig config;
+    config.runtimeConfigPath = "launch-selected.yaml";
     config.addr.host = "127.0.0.1";
     config.addr.port = 9000;
     config.poolSizeGb = 7;
@@ -103,6 +104,7 @@ TEST(DramPoolRuntimeYamlTest, LoadsEveryRuntimeFieldAndPreservesLaunchFields)
     const auto status = ParseYamlConfig(yaml.Path().string(), config);
 
     ASSERT_TRUE(status.Success()) << status.ToString();
+    EXPECT_EQ(config.runtimeConfigPath, "launch-selected.yaml");
     EXPECT_EQ(config.addr.port, 9000U);
     EXPECT_EQ(config.poolSizeGb, 7U);
     EXPECT_EQ(config.nics, (std::vector<std::string>{"mlx5_0"}));

--- a/ucm/transport/kv/dramstore/test/drampool_yaml_config_test.cpp
+++ b/ucm/transport/kv/dramstore/test/drampool_yaml_config_test.cpp
@@ -48,9 +48,7 @@ queue:
 request_receiver:
   idle_wait_us: 100
 poller:
-  drain_budget: 64
-  scan_budget: 64
-  max_pending: 1048576
+  pending_depth: 64
 gc:
   enabled: true
   interval_ms: 1000
@@ -113,9 +111,7 @@ TEST(DramPoolRuntimeYamlTest, LoadsEveryRuntimeFieldAndPreservesLaunchFields)
     EXPECT_EQ(config.requestQueueDepth, 65536U);
     EXPECT_EQ(config.completionQueueDepth, 65536U);
     EXPECT_EQ(config.requestReceiverIdleWaitUs, 100U);
-    EXPECT_EQ(config.pollerDrainBudget, 64U);
-    EXPECT_EQ(config.pollerScanBudget, 64U);
-    EXPECT_EQ(config.pollerMaxPending, 1048576U);
+    EXPECT_EQ(config.pollerPendingDepth, 64U);
     EXPECT_TRUE(config.gcEnabled);
     EXPECT_EQ(config.gcIntervalMs, 1000U);
     EXPECT_EQ(config.metadataLeaseTimeMs, 5000U);
@@ -183,8 +179,8 @@ INSTANTIATE_TEST_SUITE_P(
         InvalidYamlCase{"NegativeDevice", "device_id: 0", "device_id: -1", "must not be negative"},
         InvalidYamlCase{"QueueTooShallow", "request_depth: 65536", "request_depth: 1",
                         "at least 2"},
-        InvalidYamlCase{"PollerBudgetExceedsPending", "max_pending: 1048576", "max_pending: 1",
-                        "cover both"},
+        InvalidYamlCase{"ZeroPollerPendingDepth", "pending_depth: 64", "pending_depth: 0",
+                        "greater than zero"},
         InvalidYamlCase{"EnabledGcHasZeroInterval", "interval_ms: 1000", "interval_ms: 0",
                         "when GC is enabled"},
         InvalidYamlCase{"EvictRatioAboveOne", "default_evict_ratio: 0.0",


### PR DESCRIPTION
## Purpose

* Add the DramPool daemon entrypoint and process lifecycle
* Add launch and runtime configuration for cluster endpoints

## Modifications

* Add command-line and YAML configuration parsing
* Add daemon signal handling and DramPoolServer Init/Start/Stop lifecycle
* Add the cluster-wide two-sided to one-sided endpoint mapping

## Test

* Add launch and runtime configuration validation tests
* Add daemon and server lifecycle tests
