### PR TITLE
revert namespace in request_hash

### DIFF
--- a/test/test_ucm_connector_metrics.py
+++ b/test/test_ucm_connector_metrics.py
@@ -398,8 +398,7 @@ def test_other_rank_hashers_match_worker_hashes():
     rank0_block_id = b"rank-0-block-id"
 
     assert [hasher(rank0_block_id) for hasher in hashers] == [
-        RequestHasher(vllm_config, rank_id)(rank0_block_id)
-        for rank_id in range(1, 3)
+        RequestHasher(vllm_config, rank_id)(rank0_block_id) for rank_id in range(1, 3)
     ]
 
 

--- a/test/test_ucm_connector_metrics.py
+++ b/test/test_ucm_connector_metrics.py
@@ -361,6 +361,7 @@ from ucm.default_metrics_config import DEFAULT_METRICS_CONFIG
 from ucm.integration.vllm.metrics import UCMConnectorStats, UCMPromMetrics
 from ucm.integration.vllm.ucm_connector import (
     PendingDumpTask,
+    RequestHasher,
     UCMConnector,
     UCMDirectConnector,
 )
@@ -383,6 +384,23 @@ def _metric_types():
         FakeCounter: FakeCounter,
         FakeHistogram: FakeHistogram,
     }
+
+
+def test_other_rank_hashers_match_worker_hashes():
+    connector = object.__new__(UCMDirectConnector)
+    connector.is_mla = False
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(model="model-a", dtype="bf16"),
+        parallel_config=SimpleNamespace(tensor_parallel_size=3),
+    )
+
+    hashers = connector._make_other_rank_hashers(vllm_config)
+    rank0_block_id = b"rank-0-block-id"
+
+    assert [hasher(rank0_block_id) for hasher in hashers] == [
+        RequestHasher(vllm_config, rank_id)(rank0_block_id)
+        for rank_id in range(1, 3)
+    ]
 
 
 def _strip_yaml_comment(line):

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -365,11 +365,11 @@ class PendingDumpTask:
 class RequestHasher:
     """hash(md5) request to generate ucm block id"""
 
-    def __init__(self, vllm_config, rank_id, namespace: str = ""):
+    def __init__(self, vllm_config, rank_id):
         meta = (
             f"{vllm_config.model_config.model}:"
             f"{vllm_config.parallel_config.tensor_parallel_size}:"
-            f"{vllm_config.model_config.dtype}:{rank_id}:{namespace}"
+            f"{vllm_config.model_config.dtype}:{rank_id}"
         )
         self.meta_bytes = meta.encode("utf-8")
 
@@ -487,11 +487,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
             if not defer_scheduler_store:
                 self.store = self._create_store(None)
         else:
-            self.request_hasher = RequestHasher(
-                vllm_config,
-                self.tp_rank % self.tp_size,
-                self._request_hash_namespace(),
-            )
+            self.request_hasher = RequestHasher(vllm_config, self.tp_rank % self.tp_size)
             self._connector_worker_meta = UCMWorkerMetadata()
 
         self.persist_token_threshold = self.launch_config.get(
@@ -530,9 +526,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
                 "connector_load_invalid_blocks_total": float(len(new_invalid_blocks)),
             }
         )
-
-    def _request_hash_namespace(self) -> str:
-        return str(self.launch_config.get("request_hash_namespace", ""))
 
     def generate_hash(
         self, block_size: int, token_ids: List[int], parent_block_hash_value: bytes

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -487,7 +487,9 @@ class UCMDirectConnector(KVConnectorBase_V1):
             if not defer_scheduler_store:
                 self.store = self._create_store(None)
         else:
-            self.request_hasher = RequestHasher(vllm_config, self.tp_rank % self.tp_size)
+            self.request_hasher = RequestHasher(
+                vllm_config, self.tp_rank % self.tp_size
+            )
             self._connector_worker_meta = UCMWorkerMetadata()
 
         self.persist_token_threshold = self.launch_config.get(


### PR DESCRIPTION
## Purpose

Remove the unused `request_hash_namespace` logic and keep block hash generation consistent across the scheduler and TP workers.

## Modifications

- Removed the `namespace` parameter from `RequestHasher`.
- Removed the `request_hash_namespace` configuration handling.
- Restored the block hash metadata format to `model:tp_size:dtype:rank`.
- Added a unit test to verify that scheduler-generated hashes for other TP ranks match the hashes used by workers.