### PR TITLE
Add CPU Affinity Support for vLLM-Ascend v0.23.0rc1

### DIFF
--- a/docker/Dockerfile.ucm-vllm-ascend.a2-v0.23.0rc1
+++ b/docker/Dockerfile.ucm-vllm-ascend.a2-v0.23.0rc1
@@ -1,0 +1,36 @@
+# Set to other image if needed
+ARG IMAGE_SOURCE="quay.io/ascend"
+ARG IMAGE_NAME_VERSION="vllm-ascend:v0.23.0rc1"
+
+FROM ${IMAGE_SOURCE}/${IMAGE_NAME_VERSION}
+
+ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG INSTALL_MODE="source"
+
+WORKDIR /workspace
+
+# Install unified-cache-management
+COPY . /workspace/unified-cache-management
+
+RUN pip config set global.index-url ${PIP_INDEX_URL}
+
+ENV UCM_ENGINE_TYPE=vllm-ascend.a2
+
+# Build or link package
+RUN if [ "${INSTALL_MODE}" != "package" ]; then \
+        pip install --no-cache-dir build cmake && \
+        export WORKSPACE=/workspace SKIP_TAR=1 ENABLE_SPARSE=false && \
+        bash /workspace/unified-cache-management/scripts/build_ascend.sh; \
+    else \
+        ln -s /workspace/unified-cache-management /workspace/package; \
+    fi
+
+# Install UCM
+RUN pip install /workspace/package/uc_manager-*.whl
+
+# Run optional post-install hook
+RUN if [ -f /workspace/package/install.sh ]; then \
+        bash /workspace/package/install.sh; \
+    fi
+
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.ucm-vllm-ascend.a3-v0.23.0rc1
+++ b/docker/Dockerfile.ucm-vllm-ascend.a3-v0.23.0rc1
@@ -1,0 +1,36 @@
+# Set to other image if needed
+ARG IMAGE_SOURCE="quay.io/ascend"
+ARG IMAGE_NAME_VERSION="vllm-ascend:v0.23.0rc1-a3"
+
+FROM ${IMAGE_SOURCE}/${IMAGE_NAME_VERSION}
+
+ARG PIP_INDEX_URL="https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+ARG INSTALL_MODE="source"
+
+WORKDIR /workspace
+
+# Install unified-cache-management
+COPY . /workspace/unified-cache-management
+
+RUN pip config set global.index-url ${PIP_INDEX_URL}
+
+ENV UCM_ENGINE_TYPE=vllm-ascend.a3
+
+# Build or link package
+RUN if [ "${INSTALL_MODE}" != "package" ]; then \
+        pip install --no-cache-dir build cmake && \
+        export WORKSPACE=/workspace SKIP_TAR=1 ENABLE_SPARSE=false && \
+        bash /workspace/unified-cache-management/scripts/build_ascend.sh -p ascend-a3; \
+    else \
+        ln -s /workspace/unified-cache-management /workspace/package; \
+    fi
+
+# Install UCM
+RUN pip install /workspace/package/uc_manager-*.whl
+
+# Run optional post-install hook
+RUN if [ -f /workspace/package/install.sh ]; then \
+        bash /workspace/package/install.sh; \
+    fi
+
+CMD ["/bin/bash"]

--- a/ucm/integration/vllm/patch/apply_patch.py
+++ b/ucm/integration/vllm/patch/apply_patch.py
@@ -122,6 +122,7 @@ def get_supported_versions() -> list[str]:
         "0.20.2",
         "0.21.0",
         "0.22.1",
+        "0.23.0",
     ]
 
 
@@ -148,7 +149,13 @@ def apply_all_patches() -> None:
         ascend_version = get_vllm_ascend_version()
         # UCM PATCH: vllm-ascend registers UCMConnector as an alias for the
         # concrete UCMConnectorV1 class used by MultiConnector metrics.
-        if ascend_version in {"0.18.0", "0.19.1", "0.20.2", "0.22.1"}:
+        if ascend_version in {
+            "0.18.0",
+            "0.19.1",
+            "0.20.2",
+            "0.22.1",
+            "0.23.0",
+        }:
             logger.info("UCM patching vllm-ascend UCM connector metrics alias...")
             import ucm.integration.vllm.patch.ucm_connector_registration_patch
 
@@ -214,6 +221,9 @@ def apply_all_patches() -> None:
                 )
                 import ucm.integration.vllm.patch.v0221.vllm_ascend.ascend_hybrid_cache_patch
                 import ucm.integration.vllm.patch.v0221.vllm_ascend.cpu_binding_patch
+            case "0.23.0":
+                logger.info("UCM patching vllm-ascend 0.23.0 for CPU affinity...")
+                import ucm.integration.vllm.patch.v0230.vllm_ascend.cpu_binding_patch
             case _:
                 pass
 

--- a/ucm/integration/vllm/patch/v0230/__init__.py
+++ b/ucm/integration/vllm/patch/v0230/__init__.py
@@ -1,0 +1,1 @@
+"""Version-specific patches for vLLM-Ascend 0.23.0rc1."""

--- a/ucm/integration/vllm/patch/v0230/vllm_ascend/__init__.py
+++ b/ucm/integration/vllm/patch/v0230/vllm_ascend/__init__.py
@@ -1,0 +1,1 @@
+"""vLLM-Ascend 0.23.0rc1 patch package."""

--- a/ucm/integration/vllm/patch/v0230/vllm_ascend/cpu_binding/__init__.py
+++ b/ucm/integration/vllm/patch/v0230/vllm_ascend/cpu_binding/__init__.py
@@ -1,0 +1,1 @@
+"""CPU-binding replacements for vLLM-Ascend 0.23.0rc1."""

--- a/ucm/integration/vllm/patch/v0230/vllm_ascend/cpu_binding/bind_threads.py
+++ b/ucm/integration/vllm/patch/v0230/vllm_ascend/cpu_binding/bind_threads.py
@@ -1,0 +1,53 @@
+"""UCM-aware CPU role allocation for vLLM-Ascend 0.23.0rc1."""
+
+import psutil
+
+from ucm.integration.vllm.patch.cpu_binding_affinity_patch import (
+    assign_cpu_roles,
+)
+from ucm.integration.vllm.patch.cpu_binding_affinity_patch import (
+    bind_threads as bind_ucm_threads,
+)
+from ucm.integration.vllm.patch.cpu_binding_affinity_patch import (
+    print_plan as print_ucm_plan,
+)
+
+
+def allocate(self) -> None:
+    """Reserve UCM cores while retaining v0.23.0rc1 device-specific rules."""
+    if self._is_ascend_950():
+        # Ascend 950 supplies one topology-aware CPU cluster per NPU. Keep that
+        # cluster assignment, but partition the cluster so UCM I/O workers do
+        # not contend with the vLLM worker threads when affinity is enabled.
+        self.assign_ucm = {}
+        for npu, cpu_pool in self.npu_cpu_pool.items():
+            assign_cpu_roles(self, npu, cpu_pool, [], [])
+        return
+
+    self.assign_ucm = {}
+    reserve_irq_cpus = self._reserve_irq_cpus()
+    min_cpus_per_npu = self._min_cpus_per_npu()
+    for npu, cpu_pool in self.npu_cpu_pool.items():
+        if len(cpu_pool) < min_cpus_per_npu:
+            raise RuntimeError(
+                "The number of CPUs is insufficient. Each NPU requires at "
+                f"least {min_cpus_per_npu} CPUs."
+            )
+        main = cpu_pool[2:-2] if reserve_irq_cpus else cpu_pool[:-2]
+        assign_cpu_roles(self, npu, main, [cpu_pool[-2]], [cpu_pool[-1]])
+
+
+def print_plan(self) -> None:
+    """Print the worker/UCM split for every supported device."""
+    print_ucm_plan(self)
+
+
+def bind_threads(self) -> None:
+    """Bind UCM tasks and preserve Ascend 950 memory placement."""
+    if self._is_ascend_950():
+        bind_ucm_threads(self)
+        main_pid = str(psutil.Process().pid)
+        current_npu = self.device_info.running_npu_list[self.rank_id]
+        self.bind_memory(main_pid, current_npu)
+        return
+    bind_ucm_threads(self)

--- a/ucm/integration/vllm/patch/v0230/vllm_ascend/cpu_binding_patch.py
+++ b/ucm/integration/vllm/patch/v0230/vllm_ascend/cpu_binding_patch.py
@@ -1,0 +1,22 @@
+"""Install the UCM CPU-affinity patch for vLLM-Ascend 0.23.0rc1."""
+
+from ucm.integration.vllm.patch.cpu_binding_affinity_patch import (
+    install_cpu_binding_patch,
+)
+from ucm.integration.vllm.patch.utils import when_imported
+
+
+@when_imported("vllm_ascend.cpu_binding")
+def patch_cpu_binding(mod):
+    from ucm.integration.vllm.patch.v0230.vllm_ascend.cpu_binding.bind_threads import (
+        allocate,
+        bind_threads,
+        print_plan,
+    )
+
+    install_cpu_binding_patch(
+        mod,
+        allocate_func=allocate,
+        bind_threads_func=bind_threads,
+        print_plan_func=print_plan,
+    )


### PR DESCRIPTION
## Purpose
Extend UCM’s CPU-affinity integration to vLLM-Ascend v0.23.0rc1, including Ascend 950/A5 topology-aware CPU binding, so UCM I/O threads can run on dedicated CPU cores without competing with vLLM worker threads.
## Modifications 

- Added a version-specific v0.23.0 CPU-affinity patch and patch-package initialization files.
- Added v0.23.0 routing in apply_patch.py; the normalized version 0.23.0 covers installed 0.23.0rc1 packages.
- Added v0.23.0 to the supported-version list and UCM connector metrics-alias registration list.
- Reused the shared UCM CPU-affinity helpers to split each worker CPU pool into worker and UCM core subsets when VLLM_CPU_AFFINITY=1.
- Preserved v0.23.0rc1 Ascend 950/A5 topology-aware CPU-pool construction, UVB poll-window thread binding, and NUMA memory migration.
- Split each A5 per-NPU worker cluster into worker and UCM subsets, then bound ucm_* threads to the dedicated UCM subset.

## Test
