### PR TITLE
[Feat] Adapt UCM connector to register KV cache regions

### DIFF
--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -30,12 +30,12 @@
 #include <cstring>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <numeric>
 #include <stdexcept>
 #include <string>
 #include <utility>
 #include "asu_client/asu_client.h"
-#include "asu_transport/asu_transport.h"
 #include "logger/logger.h"
 #include "ucmstore_v1.h"
 
@@ -281,71 +281,14 @@ public:
         return client_->Wait(taskId, timeoutMs, result);
     }
 
+    AsuStatus RegisterRegions(const std::vector<UC::ASU::MemoryRegion>& regions,
+                              std::vector<UC::ASU::RegisterResult>& results) override
+    {
+        return client_->RegisterRegions(regions, results);
+    }
+
 private:
     std::unique_ptr<UC::ASU::AsuClient> client_;
-};
-
-class TransportBackend final : public AsuBackend {
-public:
-    AsuStatus Init(const Config& config) override
-    {
-        transport_ = UC::ASU::CreateAsuTransport();
-        if (!transport_) {
-            return AsuStatus::Error(AsuStatusCode::INTERNAL_ERROR,
-                                    "ASU transport factory returned null");
-        }
-        return transport_->Init(BuildTransportConfig(config, 0));
-    }
-
-    AsuStatus Init(const std::string& configPath) override
-    {
-        transport_ = UC::ASU::CreateAsuTransport();
-        if (!transport_) {
-            return AsuStatus::Error(AsuStatusCode::INTERNAL_ERROR,
-                                    "ASU transport factory returned null");
-        }
-        return transport_->Init(configPath);
-    }
-
-    AsuStatus Shutdown() override { return transport_ ? transport_->Shutdown() : AsuStatus::OK(); }
-
-    AsuStatus Query(const std::vector<UC::ASU::CacheKey>& keys,
-                    const UC::ASU::QueryOptions& options, UC::ASU::QueryResult& result) override
-    {
-        return transport_->Query(keys, options, result);
-    }
-
-    AsuStatus LoadAsync(const std::vector<UC::ASU::KVBuffer>& entries,
-                        UC::ASU::TaskId& taskId) override
-    {
-        return transport_->LoadAsync(entries, taskId);
-    }
-
-    AsuStatus StoreAsync(const std::vector<UC::ASU::KVBuffer>& entries,
-                         UC::ASU::TaskId& taskId) override
-    {
-        return transport_->StoreAsync(entries, taskId);
-    }
-
-    AsuStatus DeleteAsync(const std::vector<UC::ASU::CacheKey>& keys,
-                          UC::ASU::TaskId& taskId) override
-    {
-        return transport_->DeleteAsync(keys, taskId);
-    }
-
-    AsuStatus Check(UC::ASU::TaskId taskId, UC::ASU::TaskResult& result) override
-    {
-        return transport_->Check(taskId, result);
-    }
-
-    AsuStatus Wait(UC::ASU::TaskId taskId, std::uint64_t timeoutMs,
-                   UC::ASU::TaskResult& result) override
-    {
-        return transport_->Wait(taskId, timeoutMs, result);
-    }
-
-private:
-    std::unique_ptr<UC::ASU::AsuTransport> transport_;
 };
 
 class AsuStore final : public StoreV1 {
@@ -426,6 +369,48 @@ public:
         (void)num;
     }
 
+    bool NeedRegisterKVCaches() const override { return true; }
+
+    Status RegisterKVCaches(const UC::KVCacheRegistration* registrations,
+                            std::size_t count) override
+    {
+        if (!backend_) { return Status::Error("ASU backend is not initialized"); }
+
+        const auto memoryType = ConfiguredMemoryType();
+        std::vector<UC::ASU::MemoryRegion> regions;
+        regions.reserve(count);
+        for (std::size_t index = 0; index < count; ++index) {
+            if (registrations[index].addr == 0 || registrations[index].size == 0) { continue; }
+            UC::ASU::MemoryRegion region;
+            region.memoryType = memoryType;
+            region.addr = static_cast<std::uint64_t>(registrations[index].addr);
+            region.size = static_cast<std::uint64_t>(registrations[index].size);
+            region.deviceId = config_.deviceId;
+            regions.emplace_back(region);
+        }
+        if (regions.empty()) { return Status::OK(); }
+
+        std::vector<UC::ASU::RegisterResult> results;
+        auto status = backend_->RegisterRegions(regions, results);
+        if (!status.ok()) {
+            LogAsuStatus("register persistent regions", status);
+            return ConvertStatus(status);
+        }
+        std::vector<RegisteredPersistentRegion> registered;
+        registered.reserve(regions.size());
+        for (std::size_t index = 0; index < regions.size(); ++index) {
+            registered.emplace_back(
+                RegisteredPersistentRegion{regions[index], results[index].handle});
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(persistentRegionsMu_);
+            persistentRegions_ = std::move(registered);
+        }
+        UC_INFO("ASU registered {} persistent KV cache region(s).", regions.size());
+        return Status::OK();
+    }
+
     Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override
     {
         return Submit(std::move(task), &AsuBackend::LoadAsync);
@@ -466,13 +451,6 @@ public:
         }
         LogAsuStatus("task result wait", result.status);
         return ConvertStatus(result.status);
-    }
-
-    bool NeedRegisterKVCaches() const override { return true; }
-
-    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
-    {
-        return Status::OK();
     }
 
 private:
@@ -627,7 +605,8 @@ private:
 #ifdef ASU_BUILD_TESTS
         if (backendFactory_) { return backendFactory_(config); }
 #endif
-        if (config.mode == "transport") { return std::make_unique<TransportBackend>(); }
+        // Keep asu_mode for configuration validation, but route all store operations through
+        // the ASU client backend.
         return std::make_unique<ClientBackend>();
     }
 
@@ -744,10 +723,7 @@ private:
     {
         std::vector<UC::ASU::KVBuffer> entries;
         entries.reserve(task.size() * config_.tensorSizes.size());
-        const auto memoryType = config_.memoryType.empty()
-                                    ? (config_.deviceId >= 0 ? UC::ASU::MemoryType::ASCEND_DEVICE
-                                                             : UC::ASU::MemoryType::HOST)
-                                    : ParseMemoryType(config_.memoryType);
+        const auto memoryType = ConfiguredMemoryType();
 
         for (const auto& shard : task) {
             if (shard.index >= ShardsPerBlock()) {
@@ -765,7 +741,10 @@ private:
                     reinterpret_cast<std::uint64_t>(shard.addrs[tensorIndex]);
                 entry.buffer.region.size = config_.tensorSizes[tensorIndex];
                 entry.buffer.region.deviceId = config_.deviceId;
-                entry.buffer.handle = UC::ASU::kInvalidMRHandle;
+                entry.buffer.handle = FindPersistentHandle(entry.buffer.region);
+                if (entry.buffer.handle == UC::ASU::kInvalidMRHandle) {
+                    return Status::Error("ASU KV buffer is outside registered persistent regions");
+                }
                 entry.offset = static_cast<std::uint32_t>(tensorOffsets[tensorIndex]);
                 entries.emplace_back(std::move(entry));
             }
@@ -793,9 +772,37 @@ private:
         UC_INFO("Set AsuStore::FakeBackendPath to {}.", config.fakeBackendPath);
     }
 
+    UC::ASU::MemoryType ConfiguredMemoryType() const
+    {
+        return config_.memoryType.empty()
+                   ? (config_.deviceId >= 0 ? UC::ASU::MemoryType::ASCEND_DEVICE
+                                            : UC::ASU::MemoryType::HOST)
+                   : ParseMemoryType(config_.memoryType);
+    }
+
+    UC::ASU::MRHandle FindPersistentHandle(const UC::ASU::MemoryRegion& region) const
+    {
+        std::lock_guard<std::mutex> lock(persistentRegionsMu_);
+        for (const auto& persistent : persistentRegions_) {
+            if (region.addr < persistent.region.addr || region.size > persistent.region.size) {
+                continue;
+            }
+            const auto offset = region.addr - persistent.region.addr;
+            if (offset <= persistent.region.size - region.size) { return persistent.handle; }
+        }
+        return UC::ASU::kInvalidMRHandle;
+    }
+
+    struct RegisteredPersistentRegion {
+        UC::ASU::MemoryRegion region;
+        UC::ASU::MRHandle handle{UC::ASU::kInvalidMRHandle};
+    };
+
     Config config_;
     TensorLayout tensorLayout_{TensorLayout::MLA};
     std::unique_ptr<AsuBackend> backend_;
+    mutable std::mutex persistentRegionsMu_;
+    std::vector<RegisteredPersistentRegion> persistentRegions_;
 #ifdef ASU_BUILD_TESTS
     BackendFactory backendFactory_;
 #endif

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -58,6 +58,8 @@ public:
     virtual UC::ASU::Status Check(UC::ASU::TaskId taskId, UC::ASU::TaskResult& result) = 0;
     virtual UC::ASU::Status Wait(UC::ASU::TaskId taskId, std::uint64_t timeoutMs,
                                  UC::ASU::TaskResult& result) = 0;
+    virtual UC::ASU::Status RegisterRegions(const std::vector<UC::ASU::MemoryRegion>& regions,
+                                            std::vector<UC::ASU::RegisterResult>& results) = 0;
 };
 
 }  // namespace UC::AsuStore

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -55,6 +55,7 @@ struct FakeAsuBackendState {
     std::vector<UC::AsuStore::Config> initConfigs;
     std::vector<UC::ASU::KVBuffer> lastLoadEntries;
     std::vector<UC::ASU::KVBuffer> lastStoreEntries;
+    std::vector<UC::ASU::MemoryRegion> registeredRegions;
 };
 
 class FakeAsuBackend final : public UC::AsuStore::AsuBackend {
@@ -147,6 +148,20 @@ public:
         return Check(taskId, result);
     }
 
+    UC::ASU::Status RegisterRegions(const std::vector<UC::ASU::MemoryRegion>& regions,
+                                    std::vector<UC::ASU::RegisterResult>& results) override
+    {
+        results.clear();
+        results.reserve(regions.size());
+        state_->registeredRegions.insert(state_->registeredRegions.end(), regions.begin(),
+                                         regions.end());
+        for (std::size_t index = 0; index < regions.size(); ++index) {
+            results.emplace_back(
+                UC::ASU::RegisterResult{UC::ASU::Status::OK(), MakeTestMrHandle(nextMrHandle_++)});
+        }
+        return UC::ASU::Status::OK();
+    }
+
 private:
     UC::ASU::Status Submit(const std::vector<UC::ASU::KVBuffer>& entries, UC::ASU::TaskId& taskId)
     {
@@ -176,6 +191,7 @@ private:
     std::shared_ptr<FakeAsuBackendState> state_;
     bool initialized_{false};
     UC::ASU::TaskId nextTaskId_{1};
+    std::uintptr_t nextMrHandle_{1};
     std::unordered_set<UC::ASU::CacheKey, CacheKeyHasher> storedKeys_;
     std::unordered_map<UC::ASU::TaskId, UC::ASU::TaskResult> taskResults_;
 };
@@ -215,6 +231,19 @@ UC::Detail::TaskDesc MakeTask(const UC::Detail::BlockId& block, void* addr)
     return task;
 }
 
+void RegisterPersistentRanges(UC::StoreV1& store,
+                              const std::vector<std::pair<void*, std::size_t>>& ranges)
+{
+    ASSERT_FALSE(ranges.empty());
+    std::vector<UC::KVCacheRegistration> registrations;
+    registrations.reserve(ranges.size());
+    for (const auto& [addr, size] : ranges) {
+        registrations.emplace_back(
+            UC::KVCacheRegistration{reinterpret_cast<std::uintptr_t>(addr), size});
+    }
+    ASSERT_TRUE(store.RegisterKVCaches(registrations.data(), registrations.size()).Success());
+}
+
 void ExpectLookupMiss(UC::StoreV1& store, const UC::Detail::BlockId& block)
 {
     auto lookup = store.Lookup(&block, 1);
@@ -229,7 +258,10 @@ void ExpectLookupMiss(UC::StoreV1& store, const UC::Detail::BlockId& block)
 
 void ExpectLoadDumpSmoke(UC::StoreV1& store, const UC::Detail::BlockId& block)
 {
-    std::array<std::byte, 64> buffer{};
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
+    RegisterPersistentRanges(store, {
+                                        {buffer.data(), buffer.size()}
+    });
     auto dump = store.Dump(MakeTask(block, buffer.data()));
     ASSERT_TRUE(dump.HasValue()) << dump.Error().ToString();
     ASSERT_TRUE(store.Wait(dump.Value()).Success());
@@ -337,6 +369,7 @@ TEST(UCAsuStoreTest, AllowsQueryOnlyConfigWithoutTensorSizes)
     auto config = MakeBaseConfig();
     config.SetNumber("tensor_size", std::size_t{0});
     config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("role", std::string{"scheduler"});
 
     auto status = store.Setup(config);
     ASSERT_TRUE(status.Success()) << status.ToString();
@@ -375,6 +408,100 @@ TEST(UCAsuStoreTest, WorkerRoleRequiresTensorSizes)
     auto status = store.Setup(config);
     ASSERT_TRUE(status.Failure());
 }
+TEST(UCAsuStoreTest, UsesPersistentRegionHandleBeforeSubmitAndKeepsItAfterWait)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeBackend(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    ASSERT_TRUE(store.Setup(config).Success());
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
+    RegisterPersistentRanges(store, {
+                                        {buffer.data(), buffer.size()}
+    });
+    auto block = UC::Test::Detail::TypesHelper::MakeBlockId("a2b2c3d4e5f6789012345678901234ab");
+    auto dump = store.Dump(MakeTask(block, buffer.data()));
+    ASSERT_TRUE(dump.HasValue()) << dump.Error().ToString();
+
+    ASSERT_EQ(state->lastStoreEntries.size(), std::size_t{1});
+    ASSERT_EQ(state->registeredRegions.size(), std::size_t{1});
+    EXPECT_NE(state->lastStoreEntries[0].buffer.handle, UC::ASU::kInvalidMRHandle);
+    ASSERT_TRUE(store.Wait(dump.Value()).Success());
+}
+
+TEST(UCAsuStoreTest, PersistentRegionHandleIsSharedByEntriesAndNotReleasedPerTask)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeBackend(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.SetNumber("tensor_size", std::size_t{0});
+    config.Set("tensor_size_list", std::vector<ssize_t>{64, 64});
+    config.SetNumber("shard_size", std::size_t{128});
+    config.SetNumber("block_size", std::size_t{128});
+    ASSERT_TRUE(store.Setup(config).Success());
+
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes * 2> buffer{};
+    const std::array<UC::KVCacheRegistration, 1> registrations{
+        UC::KVCacheRegistration{reinterpret_cast<std::uintptr_t>(buffer.data()), buffer.size()}
+    };
+    ASSERT_TRUE(store.RegisterKVCaches(registrations.data(), registrations.size()).Success());
+    ASSERT_EQ(state->registeredRegions.size(), std::size_t{1});
+
+    UC::Detail::TaskDesc task;
+    auto block = UC::Test::Detail::TypesHelper::MakeBlockId("c2b2c3d4e5f6789012345678901234ab");
+    task.push_back(UC::Detail::Shard{
+        block, 0, {buffer.data(), buffer.data() + UC::ASU::kAsuAlignmentBytes}
+    });
+
+    auto dump = store.Dump(std::move(task));
+    ASSERT_TRUE(dump.HasValue()) << dump.Error().ToString();
+    ASSERT_EQ(state->registeredRegions.size(), std::size_t{1});
+    ASSERT_EQ(state->lastStoreEntries.size(), std::size_t{2});
+    const auto sharedHandle = state->lastStoreEntries[0].buffer.handle;
+    EXPECT_NE(sharedHandle, UC::ASU::kInvalidMRHandle);
+    EXPECT_EQ(state->lastStoreEntries[1].buffer.handle, sharedHandle);
+
+    ASSERT_TRUE(store.Wait(dump.Value()).Success());
+}
+
+TEST(UCAsuStoreTest, ResolvesEachEntryToItsContainingPersistentRegion)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeBackend(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.SetNumber("tensor_size", std::size_t{0});
+    config.Set("tensor_size_list", std::vector<ssize_t>{64, 64});
+    config.SetNumber("shard_size", std::size_t{128});
+    config.SetNumber("block_size", std::size_t{128});
+    ASSERT_TRUE(store.Setup(config).Success());
+
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> firstBuffer{};
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> secondBuffer{};
+    const auto firstAddr = reinterpret_cast<std::uintptr_t>(firstBuffer.data());
+    const auto secondAddr = reinterpret_cast<std::uintptr_t>(secondBuffer.data());
+    const std::array<UC::KVCacheRegistration, 2> registrations{
+        UC::KVCacheRegistration{firstAddr,  UC::ASU::kAsuAlignmentBytes},
+        UC::KVCacheRegistration{secondAddr, UC::ASU::kAsuAlignmentBytes}
+    };
+    ASSERT_TRUE(store.RegisterKVCaches(registrations.data(), registrations.size()).Success());
+
+    UC::Detail::TaskDesc task;
+    auto block = UC::Test::Detail::TypesHelper::MakeBlockId("d2b2c3d4e5f6789012345678901234ab");
+    task.push_back(UC::Detail::Shard{
+        block, 0, {firstBuffer.data(), secondBuffer.data()}
+    });
+
+    auto dump = store.Dump(std::move(task));
+    ASSERT_TRUE(dump.HasValue()) << dump.Error().ToString();
+    ASSERT_EQ(state->registeredRegions.size(), std::size_t{2});
+    ASSERT_EQ(state->lastStoreEntries.size(), std::size_t{2});
+    EXPECT_NE(state->lastStoreEntries[0].buffer.handle, state->lastStoreEntries[1].buffer.handle);
+}
 
 TEST(UCAsuStoreTest, LookupOnPrefixUsesPrefixQueryMode)
 {
@@ -384,8 +511,10 @@ TEST(UCAsuStoreTest, LookupOnPrefixUsesPrefixQueryMode)
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1", "127.0.0.2"});
     config.Set("asu_ids", std::vector<ssize_t>{1001, 1002});
     ASSERT_TRUE(store.Setup(config).Success());
-
-    std::array<std::byte, 64> buffer{};
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
+    RegisterPersistentRanges(store, {
+                                        {buffer.data(), buffer.size()}
+    });
     std::vector<UC::Detail::BlockId> blocks{
         UC::Test::Detail::TypesHelper::MakeBlockId("e1b2c3d4e5f6789012345678901234ab"),
         UC::Test::Detail::TypesHelper::MakeBlockId("f1b2c3d4e5f6789012345678901234ab"),
@@ -490,9 +619,14 @@ TEST(UCAsuStoreTest, UsesNonLayerwiseMlaTensorOffsets)
     EXPECT_EQ(state->initConfigs.back().tensorSizes[1], std::size_t{512});
     EXPECT_EQ(state->initConfigs.back().tensorSizes[2], std::size_t{512});
 
-    std::array<std::byte, 140> first{};
-    std::array<std::byte, 140> second{};
-    std::array<std::byte, 140> third{};
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> first{};
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> second{};
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> third{};
+    RegisterPersistentRanges(store, {
+                                        {first.data(),  first.size() },
+                                        {second.data(), second.size()},
+                                        {third.data(),  third.size() }
+    });
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("d1b2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
@@ -529,6 +663,11 @@ TEST(UCAsuStoreTest, UsesHmaTensorOffsetsInConnectorOrder)
     ASSERT_TRUE(status.Success()) << status.ToString();
 
     std::array<std::array<std::byte, 512>, 3> buffers{};
+    RegisterPersistentRanges(store, {
+                                        {buffers[0].data(), buffers[0].size()},
+                                        {buffers[1].data(), buffers[1].size()},
+                                        {buffers[2].data(), buffers[2].size()}
+    });
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("f1b2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
@@ -565,7 +704,10 @@ TEST(UCAsuStoreTest, UsesLayerwiseMlaTensorOffsets)
     auto status = store.Setup(config);
     ASSERT_TRUE(status.Success()) << status.ToString();
 
-    std::array<std::byte, 128> buffer{};
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
+    RegisterPersistentRanges(store, {
+                                        {buffer.data(), buffer.size()}
+    });
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("e1b2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
@@ -604,6 +746,11 @@ TEST(UCAsuStoreTest, UsesMultiSegmentLayerwiseMlaTensorOffsets)
     std::array<std::byte, alignment> mainCache{};
     std::array<std::byte, alignment> ropeCache{};
     const std::array<void*, 2> buffers{mainCache.data(), ropeCache.data()};
+    RegisterPersistentRanges(
+        store, {
+                   {mainCache.data(), mainCache.size()},
+                   {ropeCache.data(), ropeCache.size()}
+    });
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("e1b2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
@@ -650,7 +797,10 @@ TEST(UCAsuStoreTest, AlignsTensorSizeAndDerivesShardBlockSize)
     EXPECT_EQ(state->initConfigs.back().blockSize,
               static_cast<std::size_t>(UC::ASU::kAsuAlignmentBytes) * 3);
 
-    std::array<std::byte, 100> buffer{};
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
+    RegisterPersistentRanges(store, {
+                                        {buffer.data(), buffer.size()}
+    });
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("abb2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
@@ -694,9 +844,12 @@ TEST(UCAsuStoreTest, UsesLayerwiseGqaKeyValueOffsets)
 
     auto status = store.Setup(config);
     ASSERT_TRUE(status.Success()) << status.ToString();
-
-    std::array<std::byte, 100> key{};
-    std::array<std::byte, 200> value{};
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> key{};
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> value{};
+    RegisterPersistentRanges(store, {
+                                        {key.data(),   key.size()  },
+                                        {value.data(), value.size()}
+    });
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("b1b2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
@@ -733,8 +886,10 @@ TEST(UCAsuStoreTest, UsesNonLayerwiseGqaKeyValueOffsets)
 
     auto status = store.Setup(config);
     ASSERT_TRUE(status.Success()) << status.ToString();
-
-    std::array<std::array<std::byte, 200>, 6> buffers{};
+    std::array<std::array<std::byte, UC::ASU::kAsuAlignmentBytes>, 6> buffers{};
+    std::vector<std::pair<void*, std::size_t>> ranges;
+    for (auto& buffer : buffers) { ranges.emplace_back(buffer.data(), buffer.size()); }
+    RegisterPersistentRanges(store, ranges);
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("c1b2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
@@ -757,13 +912,20 @@ TEST(UCAsuStoreTest, UsesNonLayerwiseGqaKeyValueOffsets)
     }
 }
 
-TEST(UCAsuStoreTest, KvCacheRegistrationIsCurrentlyNoOp)
+TEST(UCAsuStoreTest, RegistersKvCacheRegions)
 {
     UC::AsuStore::AsuStore store;
+    auto state = UseFakeBackend(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    ASSERT_TRUE(store.Setup(config).Success());
     const UC::KVCacheRegistration registrations[]{
         {0x1000, 1024}
     };
 
     EXPECT_TRUE(store.NeedRegisterKVCaches());
     EXPECT_TRUE(store.RegisterKVCaches(registrations, std::size(registrations)).Success());
+    ASSERT_EQ(state->registeredRegions.size(), std::size_t{1});
+    EXPECT_EQ(state->registeredRegions[0].addr, std::uint64_t{0x1000});
+    EXPECT_EQ(state->registeredRegions[0].size, std::uint64_t{1024});
 }

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -207,16 +207,12 @@ Status AsuTransportImpl::Shutdown()
     }
     {
         std::lock_guard<std::mutex> lock(registeredRegionsMu_);
-        std::vector<TransProvider::UnregisterMemoryDesc> descs;
-        descs.reserve(ownedRegisteredRegionHandles_.size());
-        for (auto handle : ownedRegisteredRegionHandles_) {
-            descs.push_back(TransProvider::UnregisterMemoryDesc{handle});
-        }
-        if (!descs.empty() && transProvider_) {
-            const auto statuses = transProvider_->UnregisterMemory(descs);
-            for (const auto& status : statuses) {
-                if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
-            }
+        std::vector<MRHandle> handles;
+        handles.reserve(ownedRegisteredRegionHandles_.size());
+        for (auto handle : ownedRegisteredRegionHandles_) { handles.push_back(handle); }
+        if (!handles.empty() && transProvider_) {
+            const auto status = UnregisterOwnedRegionHandles(handles);
+            if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
         }
         registeredRegions_.clear();
         ownedRegisteredRegionHandles_.clear();
@@ -346,62 +342,72 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
 {
     results.clear();
     results.reserve(regions.size());
+    if (regions.empty()) { return Status::OK(); }
 
     std::lock_guard<std::mutex> lock(registeredRegionsMu_);
-    bool hasFailure = false;
-    std::vector<MRHandle> registeredHandles;
-    std::vector<TransProvider::UnregisterMemoryDesc> registeredDescs;
-    registeredHandles.reserve(regions.size());
-    registeredDescs.reserve(regions.size());
+    std::vector<TransProvider::RegisterMemoryDesc> registerDescs;
+    registerDescs.reserve(regions.size());
     for (const auto& region : regions) {
         const auto memType = region.memoryType == MemoryType::ASCEND_DEVICE
                                  ? TransProvider::MemType::MEM_DEVICE
                                  : TransProvider::MemType::MEM_HOST;
-        std::vector<TransProvider::RegisterMemoryDesc> descs{
-            {memType, static_cast<std::uintptr_t>(region.addr),
-             static_cast<std::size_t>(region.size)}
-        };
-        std::vector<MRHandle> mrHandles;
-        auto status = transProvider_->RegisterMemory(descs, mrHandles);
-        if (!status.ok() || mrHandles.empty()) {
-            hasFailure = true;
-            results.emplace_back(RegisterResult{
-                status.ok() ? Status::Error(StatusCode::INTERNAL_ERROR,
-                                            "transport register memory returned no handle")
-                            : status,
-                kInvalidMRHandle});
-            break;
-        }
-
-        auto handle = mrHandles[0];
-        uint32_t tokenId{0};
-        status = transProvider_->GetMemTokenId(mrHandles[0], tokenId);
-        if (!status.ok()) {
-            hasFailure = true;
-            (void)transProvider_->UnregisterMemory(
-                {TransProvider::UnregisterMemoryDesc{mrHandles[0]}});
-            results.emplace_back(RegisterResult{status, kInvalidMRHandle});
-            break;
-        }
-
-        RegisteredMemory regMem;
-        regMem.region = region;
-        regMem.handle = handle;
-        regMem.tokenId = tokenId;  // Only UB is supported for the current version.
-        registeredRegions_[handle] = regMem;
-        ownedRegisteredRegionHandles_.insert(handle);
-        registeredHandles.emplace_back(handle);
-        registeredDescs.push_back(TransProvider::UnregisterMemoryDesc{mrHandles[0]});
-        results.emplace_back(RegisterResult{Status::OK(), handle, tokenId});
+        registerDescs.push_back({memType, static_cast<std::uintptr_t>(region.addr),
+                                 static_cast<std::size_t>(region.size)});
     }
-    if (hasFailure) {
-        if (!registeredDescs.empty()) { (void)transProvider_->UnregisterMemory(registeredDescs); }
-        for (auto handle : registeredHandles) {
-            registeredRegions_.erase(handle);
-            ownedRegisteredRegionHandles_.erase(handle);
+
+    std::vector<MRHandle> mrHandles;
+    auto status = transProvider_->RegisterMemory(registerDescs, mrHandles);
+    if (!status.ok()) {
+        ownedRegisteredRegionHandles_.insert(mrHandles.begin(), mrHandles.end());
+        const auto cleanupStatus = UnregisterOwnedRegionHandles(mrHandles);
+        results.assign(regions.size(), RegisterResult{status, kInvalidMRHandle});
+        const auto clearedStatus = Status::Error(
+            StatusCode::PARTIAL_FAILED, "registration was cleared after batch registration failed");
+        for (std::size_t index = 0; index < std::min(mrHandles.size(), results.size()); ++index) {
+            results[index].status = clearedStatus;
         }
         return Status::Error(StatusCode::PARTIAL_FAILED,
-                             "one or more memory regions failed to register");
+                             cleanupStatus.ok()
+                                 ? "one or more memory regions failed to register"
+                                 : "memory region registration failed and cleanup was incomplete");
+    }
+    if (mrHandles.size() != regions.size()) {
+        status = Status::Error(StatusCode::INTERNAL_ERROR,
+                               "register result count does not match region count");
+        ownedRegisteredRegionHandles_.insert(mrHandles.begin(), mrHandles.end());
+        const auto cleanupStatus = UnregisterOwnedRegionHandles(mrHandles);
+        results.assign(regions.size(), RegisterResult{status, kInvalidMRHandle});
+        return Status::Error(StatusCode::PARTIAL_FAILED,
+                             cleanupStatus.ok()
+                                 ? status.message
+                                 : "register result count mismatch and cleanup was incomplete");
+    }
+
+    std::vector<std::uint32_t> tokenIds(regions.size());
+    for (std::size_t index = 0; index < mrHandles.size(); ++index) {
+        status = transProvider_->GetMemTokenId(mrHandles[index], tokenIds[index]);
+        if (status.ok()) { continue; }
+
+        ownedRegisteredRegionHandles_.insert(mrHandles.begin(), mrHandles.end());
+        const auto cleanupStatus = UnregisterOwnedRegionHandles(mrHandles);
+        const auto rolledBackStatus = Status::Error(
+            StatusCode::PARTIAL_FAILED, "registration was cleared after token lookup failed");
+        results.assign(regions.size(), RegisterResult{rolledBackStatus, kInvalidMRHandle});
+        results[index].status = status;
+        return Status::Error(StatusCode::PARTIAL_FAILED,
+                             cleanupStatus.ok()
+                                 ? "one or more memory region token lookups failed"
+                                 : "memory region token lookup failed and cleanup was incomplete");
+    }
+
+    for (std::size_t index = 0; index < regions.size(); ++index) {
+        RegisteredMemory registeredMemory;
+        registeredMemory.region = regions[index];
+        registeredMemory.handle = mrHandles[index];
+        registeredMemory.tokenId = tokenIds[index];
+        registeredRegions_[mrHandles[index]] = registeredMemory;
+        ownedRegisteredRegionHandles_.insert(mrHandles[index]);
+        results.emplace_back(RegisterResult{Status::OK(), mrHandles[index], tokenIds[index]});
     }
     return Status::OK();
 }
@@ -423,26 +429,45 @@ Status AsuTransportImpl::BindRegisteredRegions(const std::vector<RegisteredMemor
 Status AsuTransportImpl::UnregisterRegions(const std::vector<MRHandle>& handles)
 {
     std::lock_guard<std::mutex> lock(registeredRegionsMu_);
-    std::vector<TransProvider::UnregisterMemoryDesc> descs;
-    descs.reserve(handles.size());
+    std::vector<MRHandle> ownedHandles;
+    ownedHandles.reserve(handles.size());
     for (auto handle : handles) {
         if (handle == kInvalidMRHandle) { continue; }
         if (ownedRegisteredRegionHandles_.find(handle) == ownedRegisteredRegionHandles_.end()) {
             continue;
         }
-        descs.push_back(TransProvider::UnregisterMemoryDesc{handle});
+        ownedHandles.push_back(handle);
+    }
+    return UnregisterOwnedRegionHandles(ownedHandles);
+}
+
+Status AsuTransportImpl::UnregisterOwnedRegionHandles(const std::vector<MRHandle>& handles)
+{
+    if (handles.empty()) { return Status::OK(); }
+
+    std::vector<TransProvider::UnregisterMemoryDesc> unregisterDescs;
+    unregisterDescs.reserve(handles.size());
+    for (const auto handle : handles) {
+        unregisterDescs.push_back(TransProvider::UnregisterMemoryDesc{handle});
     }
 
-    if (!descs.empty()) {
-        const auto statuses = transProvider_->UnregisterMemory(descs);
-        for (const auto& status : statuses) {
-            if (!status.ok()) { return status; }
+    const auto statuses = transProvider_->UnregisterMemory(unregisterDescs);
+    Status failure = statuses.size() == handles.size()
+                         ? Status::OK()
+                         : Status::Error(StatusCode::INTERNAL_ERROR,
+                                         "unregister result count does not match handle count");
+    for (std::size_t index = 0; index < handles.size(); ++index) {
+        if (index < statuses.size() && statuses[index].ok()) {
+            registeredRegions_.erase(handles[index]);
+            ownedRegisteredRegionHandles_.erase(handles[index]);
+        } else if (failure.ok()) {
+            failure = index < statuses.size()
+                          ? statuses[index]
+                          : Status::Error(StatusCode::INTERNAL_ERROR,
+                                          "unregister result count does not match handle count");
         }
     }
-
-    for (auto handle : handles) { registeredRegions_.erase(handle); }
-    for (auto handle : handles) { ownedRegisteredRegionHandles_.erase(handle); }
-    return Status::OK();
+    return failure;
 }
 
 std::uint16_t AsuTransportImpl::AllocateRequestCid()

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
@@ -121,6 +121,7 @@ private:
     void BuildResult(const TransportTaskContext& ctx, TaskResult& result);
 
     void SetTransProvider(std::unique_ptr<TransProvider> provider);
+    Status UnregisterOwnedRegionHandles(const std::vector<MRHandle>& handles);
 
     TransportConfig config_;
     IoScheduler ioScheduler_;

--- a/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
@@ -44,8 +44,13 @@ std::vector<Status> g_sendStatuses;
 class StubTransProvider : public TransProvider {
 public:
     std::uint32_t registerCount{0};
+    std::uint32_t registerCallCount{0};
     std::uint32_t unregisterCount{0};
     std::uint32_t failRegisterAt{0};
+    std::uint32_t tokenLookupCount{0};
+    std::uint32_t failTokenLookupAt{0};
+    std::uint32_t failUnregisterAt{0};
+    bool failUnregister{false};
 
     Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t qpNum,
                             uint32_t, std::vector<ConnectionHandle>& handles) override
@@ -69,21 +74,36 @@ public:
         return std::vector<Status>(ioBatches.size(), Status::OK());
     }
 
-    Status RegisterMemory(const std::vector<RegisterMemoryDesc>&,
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
                           std::vector<MRHandle>& handles) override
     {
-        ++registerCount;
-        if (failRegisterAt != 0 && registerCount == failRegisterAt) {
-            return Status::Error(StatusCode::INTERNAL_ERROR, "stub register failed");
+        ++registerCallCount;
+        handles.clear();
+        handles.reserve(memoryDescs.size());
+        for (std::size_t index = 0; index < memoryDescs.size(); ++index) {
+            ++registerCount;
+            if (failRegisterAt != 0 && registerCount == failRegisterAt) {
+                return Status::Error(StatusCode::INTERNAL_ERROR, "stub register failed");
+            }
+            handles.push_back(reinterpret_cast<MRHandle>(static_cast<uintptr_t>(registerCount)));
         }
-        handles.push_back(reinterpret_cast<MRHandle>(static_cast<uintptr_t>(registerCount)));
         return Status::OK();
     }
 
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& descs) override
     {
-        unregisterCount += static_cast<std::uint32_t>(descs.size());
-        return std::vector<Status>(descs.size(), Status::OK());
+        std::vector<Status> statuses;
+        statuses.reserve(descs.size());
+        for (std::size_t index = 0; index < descs.size(); ++index) {
+            ++unregisterCount;
+            if (failUnregister || (failUnregisterAt != 0 && unregisterCount == failUnregisterAt)) {
+                statuses.emplace_back(
+                    Status::Error(StatusCode::INTERNAL_ERROR, "stub unregister failed"));
+            } else {
+                statuses.emplace_back(Status::OK());
+            }
+        }
+        return statuses;
     }
 
     Status AllocThread(uint32_t, const std::vector<uint32_t>&, std::vector<ThreadHandle>&) override
@@ -95,6 +115,10 @@ public:
 
     Status GetMemTokenId(MRHandle, uint32_t& tokenId) override
     {
+        ++tokenLookupCount;
+        if (failTokenLookupAt != 0 && tokenLookupCount == failTokenLookupAt) {
+            return Status::Error(StatusCode::INTERNAL_ERROR, "stub token lookup failed");
+        }
         tokenId = 1;
         return Status::OK();
     }
@@ -176,10 +200,11 @@ TEST(AsuTransportRegisterTest, RegisterRegionsReturnsPartialFailedAndRollsBackSu
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_EQ(results.size(), std::size_t{2});
-    EXPECT_TRUE(results[0].status.ok()) << results[0].status.message;
-    EXPECT_EQ(results[0].handle, reinterpret_cast<MRHandle>(std::uintptr_t{1}));
+    EXPECT_EQ(results[0].status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_EQ(results[0].handle, kInvalidMRHandle);
     EXPECT_EQ(results[1].status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_EQ(results[1].handle, kInvalidMRHandle);
+    EXPECT_EQ(providerPtr->registerCallCount, std::uint32_t{1});
     EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
     EXPECT_TRUE(transport.registeredRegions_.empty());
     EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
@@ -207,7 +232,7 @@ TEST(AsuTransportRegisterTest, RegisterDeviceRegionDoesNotRequireConnection)
     EXPECT_EQ(providerPtr->registerCount, std::uint32_t{1});
 }
 
-TEST(AsuTransportRegisterTest, RegisterRegionsStopsAtFirstFailure)
+TEST(AsuTransportRegisterTest, RegisterRegionsReturnsAllResultsAfterBatchFailure)
 {
     auto provider = std::make_unique<StubTransProvider>();
     auto* providerPtr = provider.get();
@@ -228,11 +253,114 @@ TEST(AsuTransportRegisterTest, RegisterRegionsStopsAtFirstFailure)
     auto status = transport.RegisterRegions(regions, results);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
-    ASSERT_EQ(results.size(), std::size_t{2});
-    EXPECT_TRUE(results[0].status.ok()) << results[0].status.message;
+    ASSERT_EQ(results.size(), std::size_t{3});
+    EXPECT_EQ(results[0].status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_EQ(results[0].handle, kInvalidMRHandle);
     EXPECT_EQ(results[1].status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(results[2].status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(providerPtr->registerCallCount, std::uint32_t{1});
     EXPECT_EQ(providerPtr->registerCount, std::uint32_t{2});
     EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
+}
+
+TEST(AsuTransportRegisterTest, RegisterRegionsClearsBatchWhenTokenLookupFails)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+    providerPtr->failTokenLookupAt = 2;
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    std::vector<MemoryRegion> regions(3);
+    regions[0].addr = 0x1000;
+    regions[0].size = 4096;
+    regions[1].addr = 0x2000;
+    regions[1].size = 4096;
+    regions[2].addr = 0x3000;
+    regions[2].size = 4096;
+
+    std::vector<RegisterResult> results;
+    const auto status = transport.RegisterRegions(regions, results);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_EQ(results.size(), regions.size());
+    EXPECT_EQ(results[0].status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_EQ(results[1].status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(results[2].status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_EQ(providerPtr->registerCallCount, std::uint32_t{1});
+    EXPECT_EQ(providerPtr->registerCount, std::uint32_t{3});
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{3});
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
+}
+
+TEST(AsuTransportRegisterTest, RegisterRegionsRetainsHandlesWhenBatchCleanupFails)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+    providerPtr->failRegisterAt = 2;
+    providerPtr->failUnregister = true;
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    std::vector<MemoryRegion> regions(2);
+    regions[0].addr = 0x1000;
+    regions[0].size = 4096;
+    regions[1].addr = 0x2000;
+    regions[1].size = 4096;
+
+    std::vector<RegisterResult> results;
+    const auto status = transport.RegisterRegions(regions, results);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_NE(status.message.find("cleanup was incomplete"), std::string::npos);
+    ASSERT_EQ(results.size(), std::size_t{2});
+    EXPECT_EQ(results[0].status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_EQ(results[0].handle, kInvalidMRHandle);
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_EQ(transport.ownedRegisteredRegionHandles_.size(), std::size_t{1});
+    EXPECT_EQ(transport.ownedRegisteredRegionHandles_.count(
+                  reinterpret_cast<MRHandle>(std::uintptr_t{1})),
+              std::size_t{1});
+
+    providerPtr->failUnregister = false;
+    const auto cleanupStatus =
+        transport.UnregisterRegions({reinterpret_cast<MRHandle>(std::uintptr_t{1})});
+    EXPECT_TRUE(cleanupStatus.ok()) << cleanupStatus.message;
+    EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
+}
+
+TEST(AsuTransportRegisterTest, UnregisterRegionsRetainsOnlyHandlesThatFailToUnregister)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    std::vector<MemoryRegion> regions(2);
+    regions[0].addr = 0x1000;
+    regions[0].size = 4096;
+    regions[1].addr = 0x2000;
+    regions[1].size = 4096;
+
+    std::vector<RegisterResult> results;
+    ASSERT_TRUE(transport.RegisterRegions(regions, results).ok());
+    providerPtr->failUnregisterAt = 2;
+
+    const auto status = transport.UnregisterRegions({results[0].handle, results[1].handle});
+
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(transport.registeredRegions_.size(), std::size_t{1});
+    EXPECT_EQ(transport.ownedRegisteredRegionHandles_.size(), std::size_t{1});
+    EXPECT_EQ(transport.registeredRegions_.count(results[0].handle), std::size_t{0});
+    EXPECT_EQ(transport.registeredRegions_.count(results[1].handle), std::size_t{1});
+
+    EXPECT_TRUE(transport.UnregisterRegions({results[1].handle}).ok());
     EXPECT_TRUE(transport.registeredRegions_.empty());
     EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
 }


### PR DESCRIPTION
## Purpose

Integrate UCM KV-cache memory registration with the ASU store so ASU operations can reuse persistent memory-region handles and correctly support device-aware, multi-segment tensor layouts.

## Modifications

- Register K and V cache regions separately through the UCM connector and reuse persistent `MRHandle` values for ASU operations.
- Resolve KV buffers against their containing registered regions and validate that each buffer is fully covered.
- Support aligned multi-segment MLA tensor layouts while preserving correct GQA offset handling.
- Harden ASU transport memory registration and validation.

## Test

- Support ASU offline inference tests covering both AIV and FakeBackend, using the `multifieldqa_zh.jsonl` dataset.
- Verify successful offline inference for MLA models with both AIV and FakeBackend.
- Verify successful offline inference for GQA models with both AIV and FakeBackend.
