### PR TITLE
[Bugfix] Fix FULL cudagraph bypass on partial cache hits for layerwise/hybrid connectors

### DIFF
--- a/ucm/integration/vllm/hla_connector.py
+++ b/ucm/integration/vllm/hla_connector.py
@@ -829,10 +829,29 @@ class UCMHybridLinearAttentionConnector(UCMDirectConnector, SupportsHMA):
         primary_full_attn = self.group_manager.full_attn_groups[0]
         primary_block_ids = group_ucm_block_ids[primary_full_attn.group_id]
 
+        # Pre-lookup reduction: leave at least recompute_tokens for vLLM to
+        # recompute, so the batch isn't dispatched as uniform decode into FULL
+        # cudagraph. For hybrid this also avoids looking up the last block(s)
+        # whose mamba state may not be valid in HBM at dump time.
+        recompute_tokens = self._get_full_hit_recompute_tokens()
+        max_hit_lcm_blocks = max(
+            0, (request.num_tokens - recompute_tokens) // lcm_block_size
+        )
+        total_lcm_blocks = request.num_tokens // lcm_block_size
+
+        if max_hit_lcm_blocks < total_lcm_blocks:
+            lookup_block_ids = []
+            for gid, group in enumerate(self.group_manager.groups_by_id):
+                ids = group_ucm_block_ids[gid]
+                group_max = max_hit_lcm_blocks * (lcm_block_size // group.block_size)
+                lookup_block_ids.append(ids[:group_max])
+        else:
+            lookup_block_ids = group_ucm_block_ids
+
         external_hit_tokens, external_hit_lcm_blocks, mamba_prefetch_hashes = (
             self.group_manager.lookup_external_hit_tokens(
                 num_computed_tokens,
-                group_ucm_block_ids,
+                lookup_block_ids,
                 lambda block_ids: self._rank_consistency.lookup_on_prefix(
                     self.store, block_ids
                 ),
@@ -870,13 +889,6 @@ class UCMHybridLinearAttentionConnector(UCMDirectConnector, SupportsHMA):
             self.store.prefetch(mamba_prefetch_hashes)
         self._prefetch_other_rank_hashes(all_hit_full_attn + mamba_prefetch_hashes)
 
-        logger.info_once(
-            f"request_id: {request.request_id}, "
-            f"total_lcm_blocks: {request.num_tokens // lcm_block_size}, "
-            f"hit hbm: {hbm_hit_block_num}, "
-            f"hit external: {external_hit_lcm_blocks}, "
-            f"total_tokens: {len(request.all_token_ids)}"
-        )
         if len(primary_block_ids) > 0:
             ucmmetrics.update_stats(
                 {
@@ -886,10 +898,18 @@ class UCMHybridLinearAttentionConnector(UCMDirectConnector, SupportsHMA):
                 },
             )
 
-        # Recompute last token when fully cached (vLLM needs logits).
+        # No post-lookup workaround: pre-lookup truncation already ensures
+        # total_hit_tokens == external_hit_tokens, and the mamba state at
+        # total_hit_tokens is a position the store actually verified.
         num_total_hit_tokens = total_hit_block_num * lcm_block_size
-        if num_total_hit_tokens == request.num_tokens and external_hit_tokens > 0:
-            external_hit_tokens -= 1
+
+        logger.info_once(
+            f"request_id: {request.request_id}, "
+            f"total_lcm_blocks: {request.num_tokens // lcm_block_size}, "
+            f"hit hbm: {hbm_hit_block_num}, "
+            f"hit external: {total_hit_block_num - hbm_hit_block_num}, "
+            f"total_tokens: {len(request.all_token_ids)}"
+        )
 
         self.requests_meta[request.request_id] = HLARequestMeta(
             ucm_block_ids=primary_block_ids,
@@ -1052,19 +1072,20 @@ class UCMHybridLinearAttentionConnector(UCMDirectConnector, SupportsHMA):
                         req_meta.group_vllm_block_ids[gid][start_blk:end_blk],
                     )
                 else:
-                    # Dump mamba state at each LCM boundary in range.
-                    if first_lcm_b > last_lcm_b:
+                    # Only dump when the chunk ends exactly at an LCM
+                    # boundary, so the state at last_lcm_b is the running
+                    # state. If dump_tok_end is not aligned, the HBM slot
+                    # at last_lcm_b may have been overwritten by the mamba
+                    # kernel's running state update for the partial block.
+                    if dump_tok_end != last_lcm_b or last_lcm_b < first_lcm_b:
                         continue
-                    b = first_lcm_b
-                    while b <= last_lcm_b:
-                        append_mamba_align_state_block(
-                            dump_ucm_block_ids,
-                            dump_vllm_block_ids,
-                            gid,
-                            b,
-                            "dump",
-                        )
-                        b += lcm_block_size
+                    append_mamba_align_state_block(
+                        dump_ucm_block_ids,
+                        dump_vllm_block_ids,
+                        gid,
+                        last_lcm_b,
+                        "dump",
+                    )
             req_meta.token_processed += new_tokens
 
         return RequestDispatchMeta(

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -844,7 +844,26 @@ class UCMDirectConnector(KVConnectorBase_V1):
         return self.block_size
 
     def _get_full_hit_recompute_tokens(self) -> int:
-        return 1
+        cached = getattr(self, "_recompute_tokens", None)
+        if cached is not None:
+            return cached
+        if not self.use_layerwise:
+            cached = 1
+        else:
+            speculative_config = getattr(self._vllm_config, "speculative_config", None)
+            if speculative_config is None:
+                cached = 2
+            else:
+                spec_token_num = getattr(
+                    speculative_config, "num_speculative_tokens", 0
+                )
+                try:
+                    spec_token_num = int(spec_token_num)
+                except (TypeError, ValueError):
+                    spec_token_num = 0
+                cached = max(spec_token_num, 0) + 2
+        self._recompute_tokens = cached
+        return cached
 
     @staticmethod
     def _record_counter(name: str, value: float = 1.0) -> None:
@@ -1124,14 +1143,15 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
         external_hit_tokens = external_hit_blocks * self.block_size
 
-        # When all the tokens are cached in ssd or hbm, recompute enough tokens
-        # to keep layerwise loads on the prefill path when speculative decode is
-        # enabled. This branch will be removed once vLLM scheduler provides a
-        # better solution in the future.
+        # Ensure vLLM recomputes enough tokens to avoid FULL cudagraph
+        # (which skips layerwise hooks). To be removed when vLLM scheduler
+        # handles this natively.
         num_total_hit_tokens = total_hit_block_num * self.block_size
-        if num_total_hit_tokens == request.num_tokens:
-            recompute_tokens = self._get_full_hit_recompute_tokens()
-            if external_hit_tokens < recompute_tokens:
+        recompute_tokens = self._get_full_hit_recompute_tokens()
+        actual_recompute_tokens = request.num_tokens - num_total_hit_tokens
+        if actual_recompute_tokens < recompute_tokens:
+            deficit = recompute_tokens - actual_recompute_tokens
+            if external_hit_tokens < deficit:
                 logger.error(
                     f"Full UCM cache hit fallback would make external hit tokens negative: "
                     f"request_id: {request.request_id}, "
@@ -1140,14 +1160,14 @@ class UCMDirectConnector(KVConnectorBase_V1):
                     f"num_total_hit_tokens: {num_total_hit_tokens}, "
                     f"request_tokens: {request.num_tokens}"
                 )
-            external_hit_tokens = max(0, external_hit_tokens - recompute_tokens)
+            external_hit_tokens = max(0, external_hit_tokens - deficit)
 
         self.requests_meta[request.request_id] = RequestMeta(
             ucm_block_ids=ucm_block_ids,
             hbm_hit_block_num=hbm_hit_block_num,
             total_hit_block_num=total_hit_block_num,
             num_token_ids=len(request.all_token_ids),
-            token_processed=num_total_hit_tokens,
+            token_processed=hbm_hit_block_num * self.block_size + external_hit_tokens,
         )
 
         return external_hit_tokens, False
@@ -1729,26 +1749,6 @@ class UCMLayerWiseConnector(UCMDirectConnector):
         self._mtp_layer_end: Optional[int] = None
         self._init_mtp_layerwise_dump_state()
         logger.info("Init UCMLayerWiseConnector.")
-
-    def _get_full_hit_recompute_tokens(self) -> int:
-        if not self.use_layerwise:
-            return super()._get_full_hit_recompute_tokens()
-
-        speculative_config = getattr(self._vllm_config, "speculative_config", None)
-        if speculative_config is None:
-            return 2
-
-        spec_token_num = getattr(speculative_config, "num_speculative_tokens", 0)
-        try:
-            spec_token_num = int(spec_token_num)
-        except (TypeError, ValueError):
-            logger.warning(
-                f"Invalid speculative token count: {spec_token_num}. "
-                "Fallback to recomputing two tokens on full layerwise UCM cache hit."
-            )
-            spec_token_num = 0
-
-        return max(spec_token_num, 0) + 2
 
     def _layerwise_batch_stats(
         self, total_end: float, save_tail_ms: Optional[float] = None


### PR DESCRIPTION
## Purpose

When a cache hit falls just a few tokens short of the full request length (e.g. request 8193 tokens, 8192 cached), vLLM dispatches the prefill as uniform decode into FULL cudagraph. FULL cudagraph replay skips `wait_for_layer_load` / `save_kv_layer`, breaking layerwise KV load/save. The previous workaround only fired on full hit (`num_total_hit_tokens == request.num_tokens`), missing the partial-hit case. For hybrid models, the old `external_hit_tokens -= 1` also left `total_hit_block_num` unchanged, causing the mamba-align state block to be loaded at a position beyond `num_computed_tokens` -- feeding the SSM a "future" state that already includes the recomputed positions. Additionally, the dump wrote mamba state at every LCM boundary within a chunk, but only the last boundary (chunk end) has a valid running state in HBM, leaving intermediate state entries as garbage in the store.

## Modifications

- **`UCMDirectConnector._get_full_hit_recompute_tokens`**: Consolidate the layerwise/non-layerwise logic here (check `self.use_layerwise`, return `2 + num_speculative_tokens` for layerwise, `1` otherwise). Remove the `UCMLayerWiseConnector` override -- both `UCMLayerWiseConnector` and the hybrid connectors now inherit directly.
- **`UCMDirectConnector.get_num_new_matched_tokens`** (non-hybrid): Change the workaround condition from `num_total_hit_tokens == request.num_tokens` (full hit only) to `actual_recompute_tokens < recompute_tokens`, so partial hits that would leave too few recompute tokens also trigger the workaround. Only the `deficit` is subtracted from `external_hit_tokens`; `total_hit_block_num` is unchanged.
- **`UCMHybridLinearAttentionConnector.get_num_new_matched_tokens`** (hybrid): Move the workaround BEFORE the lookup -- compute `max_hit_lcm_blocks = (request.num_tokens - recompute_tokens) // lcm_block_size` and truncate `lookup_block_ids` before querying the store. This ensures the last block(s) whose mamba state may not be valid are never looked up; if the state is absent, stage 2 of the lookup naturally degrades to a shorter hit instead of returning stale data. No post-lookup reduction is needed.
- **`_generate_hla_dispatch_meta`** (hybrid dump): Only dump the mamba-align state at `last_lcm_b` (the last LCM boundary in the chunk), not at every LCM boundary. Intermediate states within a chunk are not valid in HBM because the mamba kernel only keeps the running state at the current position. Dumping them wrote garbage data with valid keys into the store, which the lookup would later find and return as a hit.

## Test

### Non-hybrid: QwQ-32B (block_size=128, spec=3, recompute=5, max_num_batched_tokens=8192)

Send a first request of 8192 tokens to populate 64 blocks in the cache, then send a second request sharing the same 8192-token prefix:

| Case | Request B length | Hit tokens | actual_recompute | Workaround? | deficit | ext_hit_tokens returned | vLLM recompute |
|---|---|---|---|---|---|---|---|
| Full hit | 8192 | 8192 | 0 | Yes (0<5) | 5 | 8187 | 5 |
| 1 token short | 8193 | 8192 | 1 | Yes (1<5) | 4 | 8188 | 5 |
| 4 tokens short | 8196 | 8192 | 4 | Yes (4<5) | 1 | 8191 | 5 |
| Borderline (no workaround) | 8197 | 8192 | 5 | No (5<5 is False) | -- | 8192 | 5 |
| Enough new tokens | 8200 | 8192 | 8 | No | -- | 8192 | 8 |
| No hit | Different prompt | 0 | -- | No | -- | 0 | Full |

### Hybrid: Qwen3.5-35B-A3B (block_size=2048, spec=3, recompute=5)

#### With MTP (EAGLE pruning active)

EAGLE forces the last block into a separate chunk (`last_cache_position = num_tokens - block_size`), so an 8192-token request is chunked into 6144 + 2048. Each chunk boundary has a valid running state.

| Case | Request B length | max_hit_lcm_blocks | Truncated? | Blocks looked up | ext_hit_tokens | vLLM recompute |
|---|---|---|---|---|---|---|
| Full hit | 8192 | (8192-5)//2048=3 | Yes (4->3) | 3 | 6144 | 2048 |
| 1 token short | 8193 | (8193-5)//2048=3 | Yes (4->3) | 3 | 6144 | 2049 |
| 4 tokens short | 8196 | (8196-5)//2048=3 | Yes (4->3) | 3 | 6144 | 2052 |
| Borderline (no truncation) | 8197 | (8197-5)//2048=4 | No (4==4) | 4 | 8192 | 5 |
| Enough new tokens | 8200 | (8200-5)//2048=4 | No | 4 | 8192 | 8 |
| No hit | Different prompt | 0 | No | 0 | 0 | Full |

#### Without MTP (no EAGLE pruning)

Without MTP, `recompute_tokens = 2` (layerwise baseline). The request is a single chunk, so only the last block boundary has a valid mamba state. Pre-lookup truncation removes the last block; the backward scan finds no valid intermediate states and degrades to 0 hit. This is correct but sacrifices cache benefit.

| Case | Request B length | max_hit_lcm_blocks | Truncated? | ext_hit_tokens | vLLM recompute |
|---|---|---|---|---|---|
| Full hit | 8192 | (8192-2)//2048=3 | Yes (4->3) | 0 (graceful degradation) | 8192 |
| Borderline (no truncation) | 8194 | (8194-2)//2048=4 | No (4==4) | 8192 | 2 |
| Enough new tokens | 8200 | (8200-2)//2048=4 | No | 8192 | 8 |

> To maximize cache hit without MTP, set `max_num_batched_tokens = lcm_block_size` (2048) so each chunk = 1 block and every block boundary has a valid state.
