### PR TITLE
[feat]Adapt GLM5.2

### DIFF
--- a/test/suites/Unit/test_kv_cache_layout.py
+++ b/test/suites/Unit/test_kv_cache_layout.py
@@ -8,7 +8,6 @@ from typing import List, Tuple
 
 import numpy as np
 
-
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CONNECTOR_PATH = REPO_ROOT / "ucm" / "integration" / "vllm" / "ucm_connector.py"
 
@@ -36,8 +35,11 @@ class FakeTorch:
 
 
 class FakeLogger:
+    def __init__(self):
+        self.messages = []
+
     def info(self, *_args, **_kwargs):
-        pass
+        self.messages.append(_args[0] % _args[1:] if len(_args) > 1 else _args[0])
 
 
 def _extract_layer_index(name: str) -> int:
@@ -156,6 +158,23 @@ class KVCacheLayoutTest(unittest.TestCase):
                 [[83968, 16384, 256], [83968, 32768], [83968]],
                 use_layerwise=True,
             )
+
+    def test_layerwise_layout_logs_padding_details(self):
+        logger = FakeLogger()
+        previous_logger = KVCacheLayout.__init__.__globals__["logger"]
+        KVCacheLayout.__init__.__globals__["logger"] = logger
+        try:
+            _build_layout([[8, 4, 2], [8]], use_layerwise=True)
+        finally:
+            KVCacheLayout.__init__.__globals__["logger"] = previous_logger
+
+        padding_log = next(
+            message for message in logger.messages if "uses padding" in message
+        )
+        self.assertIn("max_tensors_per_layer=3", padding_log)
+        self.assertIn("padded_layers=1", padding_log)
+        self.assertIn("ghost_slots=2", padding_log)
+        self.assertIn("tensor_counts_per_layer=[3, 1]", padding_log)
 
 
 if __name__ == "__main__":

--- a/test/suites/Unit/test_kv_cache_layout.py
+++ b/test/suites/Unit/test_kv_cache_layout.py
@@ -41,9 +41,6 @@ class FakeLogger:
     def info(self, *_args, **_kwargs):
         self.messages.append(_args[0] % _args[1:] if len(_args) > 1 else _args[0])
 
-    def debug(self, *_args, **_kwargs):
-        self.messages.append(_args[0] % _args[1:] if len(_args) > 1 else _args[0])
-
 
 def _extract_layer_index(name: str) -> int:
     match = re.search(r"layers\.(\d+)", name)
@@ -77,11 +74,7 @@ def _load_kv_cache_layout_class():
 KVCacheLayout = _load_kv_cache_layout_class()
 
 
-def _build_layout(
-    row_strides: list[list[int]],
-    use_layerwise: bool,
-    kv_cache_config=None,
-):
+def _build_layout(row_strides: list[list[int]], use_layerwise: bool):
     next_ptr = 0x1000
     kvcaches = {}
     for layer_id, strides in enumerate(row_strides):
@@ -97,7 +90,7 @@ def _build_layout(
             hf_text_config=SimpleNamespace(num_hidden_layers=len(row_strides))
         ),
     )
-    kv_cache_config = kv_cache_config or SimpleNamespace(num_blocks=2)
+    kv_cache_config = SimpleNamespace(num_blocks=2)
     return KVCacheLayout(
         kvcaches,
         {"use_layerwise": use_layerwise},
@@ -183,51 +176,6 @@ class KVCacheLayoutTest(unittest.TestCase):
         self.assertIn("padded_layers=1", padding_log)
         self.assertIn("ghost_slots=2", padding_log)
         self.assertIn("tensor_counts_per_layer=[3, 1]", padding_log)
-
-    def test_logs_effective_sparse_c8_config_per_indexer_layer(self):
-        sfa_c8_li_c8_spec = SimpleNamespace(
-            sparse_head_dim=(656, 0, 128),
-            cache_sparse_sfa_c8=True,
-            cache_sparse_li_c8=True,
-        )
-        sfa_c8_bf16_li_spec = SimpleNamespace(
-            sparse_head_dim=(656, 0, 128),
-            cache_sparse_sfa_c8=True,
-            cache_sparse_li_c8=False,
-        )
-        kv_cache_config = SimpleNamespace(
-            num_blocks=2,
-            kv_cache_tensors=[SimpleNamespace(size=1024)],
-            kv_cache_groups=[
-                SimpleNamespace(
-                    layer_names=["model.layers.0.self_attn"],
-                    kv_cache_spec=sfa_c8_bf16_li_spec,
-                ),
-                SimpleNamespace(
-                    layer_names=["model.layers.1.self_attn"],
-                    kv_cache_spec=sfa_c8_li_c8_spec,
-                ),
-            ],
-        )
-        logger = FakeLogger()
-        previous_logger = KVCacheLayout.__init__.__globals__["logger"]
-        KVCacheLayout.__init__.__globals__["logger"] = logger
-        try:
-            _build_layout(
-                [[8, 4], [8, 4]],
-                use_layerwise=True,
-                kv_cache_config=kv_cache_config,
-            )
-        finally:
-            KVCacheLayout.__init__.__globals__["logger"] = previous_logger
-
-        summary_log = next(
-            message for message in logger.messages if "config summary" in message
-        )
-        self.assertIn("tensor_sizes=[1024]", summary_log)
-        self.assertIn("effective_sfa_c8_counts={False: 0, True: 2}", summary_log)
-        self.assertIn("li_c8_enabled_layer_ids=[1]", summary_log)
-        self.assertIn("li_c8_disabled_layer_ids=[0]", summary_log)
 
 
 if __name__ == "__main__":

--- a/test/suites/Unit/test_kv_cache_layout.py
+++ b/test/suites/Unit/test_kv_cache_layout.py
@@ -41,6 +41,9 @@ class FakeLogger:
     def info(self, *_args, **_kwargs):
         self.messages.append(_args[0] % _args[1:] if len(_args) > 1 else _args[0])
 
+    def debug(self, *_args, **_kwargs):
+        self.messages.append(_args[0] % _args[1:] if len(_args) > 1 else _args[0])
+
 
 def _extract_layer_index(name: str) -> int:
     match = re.search(r"layers\.(\d+)", name)
@@ -74,7 +77,11 @@ def _load_kv_cache_layout_class():
 KVCacheLayout = _load_kv_cache_layout_class()
 
 
-def _build_layout(row_strides: list[list[int]], use_layerwise: bool):
+def _build_layout(
+    row_strides: list[list[int]],
+    use_layerwise: bool,
+    kv_cache_config=None,
+):
     next_ptr = 0x1000
     kvcaches = {}
     for layer_id, strides in enumerate(row_strides):
@@ -90,7 +97,7 @@ def _build_layout(row_strides: list[list[int]], use_layerwise: bool):
             hf_text_config=SimpleNamespace(num_hidden_layers=len(row_strides))
         ),
     )
-    kv_cache_config = SimpleNamespace(num_blocks=2)
+    kv_cache_config = kv_cache_config or SimpleNamespace(num_blocks=2)
     return KVCacheLayout(
         kvcaches,
         {"use_layerwise": use_layerwise},
@@ -152,7 +159,8 @@ class KVCacheLayoutTest(unittest.TestCase):
             ValueError,
             r"`use_layerwise: true` in ucm_config.yaml:.*"
             r"column 1 must have an identical block stride, but got "
-            r"\[16384, 32768\].*`use_layerwise: false`",
+            r"\[16384, 32768\]; stride_to_layer_ids="
+            r"\{16384: \[0\], 32768: \[1\]\}.*`use_layerwise: false`",
         ):
             _build_layout(
                 [[83968, 16384, 256], [83968, 32768], [83968]],
@@ -175,6 +183,51 @@ class KVCacheLayoutTest(unittest.TestCase):
         self.assertIn("padded_layers=1", padding_log)
         self.assertIn("ghost_slots=2", padding_log)
         self.assertIn("tensor_counts_per_layer=[3, 1]", padding_log)
+
+    def test_logs_effective_sparse_c8_config_per_indexer_layer(self):
+        sfa_c8_li_c8_spec = SimpleNamespace(
+            sparse_head_dim=(656, 0, 128),
+            cache_sparse_sfa_c8=True,
+            cache_sparse_li_c8=True,
+        )
+        sfa_c8_bf16_li_spec = SimpleNamespace(
+            sparse_head_dim=(656, 0, 128),
+            cache_sparse_sfa_c8=True,
+            cache_sparse_li_c8=False,
+        )
+        kv_cache_config = SimpleNamespace(
+            num_blocks=2,
+            kv_cache_tensors=[SimpleNamespace(size=1024)],
+            kv_cache_groups=[
+                SimpleNamespace(
+                    layer_names=["model.layers.0.self_attn"],
+                    kv_cache_spec=sfa_c8_bf16_li_spec,
+                ),
+                SimpleNamespace(
+                    layer_names=["model.layers.1.self_attn"],
+                    kv_cache_spec=sfa_c8_li_c8_spec,
+                ),
+            ],
+        )
+        logger = FakeLogger()
+        previous_logger = KVCacheLayout.__init__.__globals__["logger"]
+        KVCacheLayout.__init__.__globals__["logger"] = logger
+        try:
+            _build_layout(
+                [[8, 4], [8, 4]],
+                use_layerwise=True,
+                kv_cache_config=kv_cache_config,
+            )
+        finally:
+            KVCacheLayout.__init__.__globals__["logger"] = previous_logger
+
+        summary_log = next(
+            message for message in logger.messages if "config summary" in message
+        )
+        self.assertIn("tensor_sizes=[1024]", summary_log)
+        self.assertIn("effective_sfa_c8_counts={False: 0, True: 2}", summary_log)
+        self.assertIn("li_c8_enabled_layer_ids=[1]", summary_log)
+        self.assertIn("li_c8_disabled_layer_ids=[0]", summary_log)
 
 
 if __name__ == "__main__":

--- a/test/suites/Unit/test_kv_cache_layout.py
+++ b/test/suites/Unit/test_kv_cache_layout.py
@@ -1,0 +1,162 @@
+import ast
+import math
+import re
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import List, Tuple
+
+import numpy as np
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONNECTOR_PATH = REPO_ROOT / "ucm" / "integration" / "vllm" / "ucm_connector.py"
+
+
+class FakeTensor:
+    def __init__(self, ptr: int, block_stride: int, num_blocks: int = 2):
+        self._ptr = ptr
+        self.shape = (num_blocks, 1, 1, block_stride)
+
+    def __getitem__(self, _index):
+        return self
+
+    def data_ptr(self):
+        return self._ptr
+
+    def dim(self):
+        return len(self.shape)
+
+    def element_size(self):
+        return 1
+
+
+class FakeTorch:
+    Tensor = FakeTensor
+
+
+class FakeLogger:
+    def info(self, *_args, **_kwargs):
+        pass
+
+
+def _extract_layer_index(name: str) -> int:
+    match = re.search(r"layers\.(\d+)", name)
+    assert match is not None
+    return int(match.group(1))
+
+
+def _load_kv_cache_layout_class():
+    source = CONNECTOR_PATH.read_text(encoding="utf-8-sig")
+    tree = ast.parse(source)
+    class_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "KVCacheLayout"
+    )
+    module = ast.Module(body=[class_node], type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {
+        "List": List,
+        "Tuple": Tuple,
+        "extract_layer_index": _extract_layer_index,
+        "logger": FakeLogger(),
+        "math": math,
+        "np": np,
+        "torch": FakeTorch,
+    }
+    exec(compile(module, str(CONNECTOR_PATH), "exec"), namespace)
+    return namespace["KVCacheLayout"]
+
+
+KVCacheLayout = _load_kv_cache_layout_class()
+
+
+def _build_layout(row_strides: list[list[int]], use_layerwise: bool):
+    next_ptr = 0x1000
+    kvcaches = {}
+    for layer_id, strides in enumerate(row_strides):
+        tensors = []
+        for stride in strides:
+            tensors.append(FakeTensor(next_ptr, stride))
+            next_ptr += 0x1000
+        kvcaches[f"model.layers.{layer_id}.self_attn"] = tuple(tensors)
+
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(pipeline_parallel_size=1),
+        model_config=SimpleNamespace(
+            hf_text_config=SimpleNamespace(num_hidden_layers=len(row_strides))
+        ),
+    )
+    kv_cache_config = SimpleNamespace(num_blocks=2)
+    return KVCacheLayout(
+        kvcaches,
+        {"use_layerwise": use_layerwise},
+        vllm_config,
+        kv_cache_config,
+    )
+
+
+class KVCacheLayoutTest(unittest.TestCase):
+    def test_direct_layout_flattens_only_real_tensors_without_padding(self):
+        layout = _build_layout([[8, 4, 2], [8]], use_layerwise=False)
+
+        self.assertEqual(layout.base_ptrs.shape, (4,))
+        self.assertEqual(layout.tensor_size_list, [8, 4, 2, 8])
+        self.assertEqual(layout.buffer_sizes.tolist(), [16, 8, 4, 16])
+        self.assertTrue(layout.valid_mask.all())
+        self.assertEqual(layout.shard_size, 22)
+        self.assertEqual(layout.block_size, 22)
+
+        addrs = layout.extract_block_addrs([0, 1])
+        self.assertEqual(addrs.shape, (2, 4))
+        np.testing.assert_array_equal(
+            addrs[1], layout.base_ptrs + layout.block_stride_lists
+        )
+        with self.assertRaisesRegex(ValueError, "layer_first=True"):
+            layout.extract_block_addrs([0], layer_first=True)
+
+    def test_layerwise_layout_accepts_consistent_columns(self):
+        cases = [
+            (
+                [[131072, 16384, 32768], [131072, 16384]],
+                [131072, 16384, 32768],
+            ),
+            (
+                [[131072, 16384, 16384, 256], [131072, 16384]],
+                [131072, 16384, 16384, 256],
+            ),
+            ([[83968, 32768], [83968]], [83968, 32768]),
+            ([[83968, 16384, 256], [83968]], [83968, 16384, 256]),
+        ]
+
+        for row_strides, expected_sizes in cases:
+            with self.subTest(row_strides=row_strides):
+                layout = _build_layout(row_strides, use_layerwise=True)
+
+                self.assertEqual(layout.base_ptrs.shape, (2, len(expected_sizes)))
+                self.assertEqual(layout.tensor_size_list, expected_sizes)
+                self.assertEqual(
+                    layout.tensor_size_lists.tolist(),
+                    [expected_sizes, expected_sizes],
+                )
+
+                addrs = layout.extract_block_addrs([0, 1], layer_first=True)
+                self.assertEqual(addrs.shape, (2, 2, len(expected_sizes)))
+                self.assertTrue(np.all(addrs[1, :, len(row_strides[1]) :] == 0))
+
+    def test_layerwise_layout_rejects_inconsistent_real_strides_in_a_column(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            r"`use_layerwise: true` in ucm_config.yaml:.*"
+            r"column 1 must have an identical block stride, but got "
+            r"\[16384, 32768\].*`use_layerwise: false`",
+        ):
+            _build_layout(
+                [[83968, 16384, 256], [83968, 32768], [83968]],
+                use_layerwise=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -148,16 +148,14 @@ class KVCacheLayout:
         vllm_config: "VllmConfig",
         kv_cache_config: "KVCacheConfig",
     ) -> None:
-        # each row is a layer, each column is a tensor_size/ptr in the layer (e.g., k, v, rope, k_index)
-        self.base_ptrs: np.ndarray  # (n_layers, n_ptrs）
-        self.buffer_sizes: np.ndarray  # (n_layers, n_ptrs)
-        self.tensor_size_lists: np.ndarray  # (n_layers, n_tensor_sizes)
-        self.block_stride_lists: np.ndarray  # (n_layers, n_tensor_strides)
-        # True where the (layer, ptr) slot is real; False where zero-padded
-        # (ghost). Ghost slots get a zero base_ptr (so their computed address is
-        # masked to 0) but a column-broadcast tensor_size, letting the store's
-        # single tensorSizes_ cover every layer including the widest one.
-        self.valid_mask: np.ndarray  # (n_layers, n_ptrs) bool
+        # Direct mode stores only real tensors in flat arrays. Layerwise mode
+        # stores a padded [layer, tensor_slot] matrix because the store uses one
+        # tensor-size list for every layer.
+        self.base_ptrs: np.ndarray
+        self.buffer_sizes: np.ndarray
+        self.tensor_size_lists: np.ndarray
+        self.block_stride_lists: np.ndarray
+        self.valid_mask: np.ndarray
         self.use_layerwise = ucm_config.get("use_layerwise", False)
         self.kv_cache_config = kv_cache_config
         self.vllm_config = vllm_config
@@ -217,12 +215,34 @@ class KVCacheLayout:
             stride_rows[local_layer_id].extend(strides)
             buffer_size_rows[local_layer_id].extend(buffer_sizes)
 
-        # Layers may hold a different number of tensors (e.g. some layers carry
-        # an extra rope/k_index tensor). Pad every row to the widest one with 0
-        # so np.asarray yields a regular 2D array. The padded (ghost) slots are
-        # handled by masking their computed address to 0 (extract_block_addrs)
-        # so the C++ copy streams skip them via addr==nullptr.
+        if not self.use_layerwise:
+            # A direct transfer copies one whole KV-cache block. Keep only real
+            # tensors and flatten all layers into that block; padding would add
+            # fake tensors to the store metadata and copy path.
+            self.base_ptrs = np.asarray(
+                [ptr for row in raw_ptr_rows for ptr in row], dtype=np.uint64
+            )
+            self.tensor_size_lists = np.asarray(
+                [stride for row in stride_rows for stride in row], dtype=np.uint64
+            )
+            self.buffer_sizes = np.asarray(
+                [size for row in buffer_size_rows for size in row], dtype=np.uint64
+            )
+            self.block_stride_lists = self.tensor_size_lists
+            self.valid_mask = np.ones(self.base_ptrs.shape, dtype=bool)
+            logger.info(
+                f"base_ptrs: {self.base_ptrs.shape}, "
+                f"tensor_size_lists: {self.tensor_size_lists.shape}"
+            )
+            return
+
+        # A layerwise transfer uses one fixed tensor-size list for all layers.
+        # Pad shorter rows to the widest row, then verify that every real tensor
+        # in a column has the same block stride. This derives compatibility from
+        # the actual tensor layout without exposing model-specific C8 flags.
         max_ptrs = max((len(r) for r in raw_ptr_rows), default=0)
+        if max_ptrs == 0:
+            raise ValueError("KV cache layout must contain at least one tensor")
         for rows in (raw_ptr_rows, stride_rows, buffer_size_rows):
             for r in rows:
                 r.extend([0] * (max_ptrs - len(r)))
@@ -230,18 +250,29 @@ class KVCacheLayout:
         self.base_ptrs = np.asarray(raw_ptr_rows, dtype=np.uint64)
         self.tensor_size_lists = np.asarray(stride_rows, dtype=np.uint64)
         self.buffer_sizes = np.asarray(buffer_size_rows, dtype=np.uint64)
-        # base_ptr is 0 only for padding (real device addresses are never 0),
-        # so base_ptr != 0 precisely marks the real (layer, ptr) slots.
         self.valid_mask = self.base_ptrs != 0
-        # Column-broadcast tensor sizes: within a column all real strides are
-        # equal (same num_head/head_dim/block_size across layers), so fill each
-        # ghost (0) slot with its column's real value. This keeps shard_size /
-        # tensor_size_list consistent across layers so the store's single
-        # tensorSizes_ fits every layer (incl. the widest) in the layerwise path.
-        col_vals = self.tensor_size_lists.max(axis=0)  # (max_ptrs,)
-        self.tensor_size_lists = np.where(
-            self.valid_mask, self.tensor_size_lists, col_vals[None, :]
-        ).astype(np.uint64)
+
+        column_strides = np.zeros(max_ptrs, dtype=np.uint64)
+        for column_id in range(max_ptrs):
+            real_strides = self.tensor_size_lists[
+                self.valid_mask[:, column_id], column_id
+            ]
+            unique_strides = np.unique(real_strides)
+            if unique_strides.size != 1:
+                raise ValueError(
+                    "Invalid KV cache layout for `use_layerwise: true` in "
+                    "ucm_config.yaml: all real tensors in column "
+                    f"{column_id} must have an identical block stride, but got "
+                    f"{unique_strides.tolist()}. Set `use_layerwise: false` or "
+                    "make the tensor layout consistent across layers."
+                )
+            column_strides[column_id] = unique_strides[0]
+
+        # Ghost slots use the canonical column stride in store metadata, while
+        # their computed addresses remain zero and are skipped by copy streams.
+        self.tensor_size_lists = np.broadcast_to(
+            column_strides, self.base_ptrs.shape
+        ).copy()
         self.block_stride_lists = self.tensor_size_lists
 
         logger.info(
@@ -252,6 +283,16 @@ class KVCacheLayout:
         self, vllm_block_ids: List[int], layer_first: bool = False
     ) -> np.ndarray:
         vllm_block_ids_np = np.array(vllm_block_ids, np.uint64)
+        if not self.use_layerwise:
+            if layer_first:
+                raise ValueError(
+                    "layer_first=True requires a layerwise KV cache layout"
+                )
+            return (
+                vllm_block_ids_np[:, None] * self.block_stride_lists[None, :]
+                + self.base_ptrs[None, :]
+            )
+
         if layer_first:
             # (n_layers, num_blocks, n_ptrs)
             addrs = (
@@ -274,6 +315,10 @@ class KVCacheLayout:
     def extract_block_addrs_for_row(
         self, vllm_block_ids: List[int], row_id: int
     ) -> np.ndarray:
+        if not self.use_layerwise:
+            raise ValueError(
+                "Row address extraction requires a layerwise KV cache layout"
+            )
         vllm_block_ids_np = np.asarray(vllm_block_ids, dtype=np.uint64)
         addrs = (
             vllm_block_ids_np[:, None] * self.block_stride_lists[row_id][None, :]
@@ -577,6 +622,10 @@ class UCMDirectConnector(KVConnectorBase_V1):
             gpu_kv_buffer_addrs = []
             gpu_kv_buffer_sizes = []
             for addr, size in zip(buffer_addrs, buffer_sizes):
+                # Layerwise padding is store metadata only. Never register a
+                # ghost (nullptr, zero-sized) slot as a real device buffer.
+                if int(addr) == 0 or int(size) == 0:
+                    continue
                 key = (int(addr), int(size))
                 if key in gpu_kv_buffer_set:
                     continue

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -198,56 +198,7 @@ class KVCacheLayout:
         }
         self.first_layer_id = next(iter(self.layer_name_to_id.values()))
         self.num_blocks = self.kv_cache_config.num_blocks
-        self._log_kv_cache_config()
         self._build_layout(kvcaches)
-
-    def _log_kv_cache_config(self) -> None:
-        logger.debug(f"kv_cache_config: {self.kv_cache_config!r}")
-
-        kv_cache_groups = getattr(self.kv_cache_config, "kv_cache_groups", [])
-        kv_cache_tensors = getattr(self.kv_cache_config, "kv_cache_tensors", [])
-        layer_specs = {}
-        for group in kv_cache_groups:
-            group_spec = getattr(group, "kv_cache_spec", None)
-            per_layer_specs = getattr(group_spec, "kv_cache_specs", None)
-            if isinstance(per_layer_specs, dict):
-                layer_specs.update(per_layer_specs)
-                continue
-            for layer_name in getattr(group, "layer_names", []):
-                layer_specs[layer_name] = group_spec
-
-        sparse_layer_count = 0
-        sfa_c8_counts = {False: 0, True: 0}
-        indexer_layer_count = 0
-        li_c8_layer_ids = {False: [], True: []}
-        for layer_name, spec in layer_specs.items():
-            sparse_head_dim = getattr(spec, "sparse_head_dim", None)
-            if sparse_head_dim is None or len(sparse_head_dim) != 3:
-                continue
-
-            sparse_layer_count += 1
-            sfa_c8_counts[bool(getattr(spec, "cache_sparse_sfa_c8", False))] += 1
-            if sparse_head_dim[2] <= 0:
-                continue
-
-            indexer_layer_count += 1
-            li_c8_enabled = bool(getattr(spec, "cache_sparse_li_c8", False))
-            try:
-                layer_id = extract_layer_index(layer_name)
-            except (AssertionError, AttributeError, IndexError, TypeError, ValueError):
-                layer_id = layer_name
-            li_c8_layer_ids[li_c8_enabled].append(layer_id)
-
-        tensor_sizes = [getattr(tensor, "size", None) for tensor in kv_cache_tensors]
-        logger.info(
-            "KV cache config summary: "
-            f"num_blocks={self.num_blocks}, groups={len(kv_cache_groups)}, "
-            f"tensor_sizes={tensor_sizes}, sparse_layers={sparse_layer_count}, "
-            f"effective_sfa_c8_counts={sfa_c8_counts}, "
-            f"indexer_layers={indexer_layer_count}, "
-            f"li_c8_enabled_layer_ids={li_c8_layer_ids[True]}, "
-            f"li_c8_disabled_layer_ids={li_c8_layer_ids[False]}"
-        )
 
     def _build_layout(self, kvcaches):
 

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -198,7 +198,56 @@ class KVCacheLayout:
         }
         self.first_layer_id = next(iter(self.layer_name_to_id.values()))
         self.num_blocks = self.kv_cache_config.num_blocks
+        self._log_kv_cache_config()
         self._build_layout(kvcaches)
+
+    def _log_kv_cache_config(self) -> None:
+        logger.debug(f"kv_cache_config: {self.kv_cache_config!r}")
+
+        kv_cache_groups = getattr(self.kv_cache_config, "kv_cache_groups", [])
+        kv_cache_tensors = getattr(self.kv_cache_config, "kv_cache_tensors", [])
+        layer_specs = {}
+        for group in kv_cache_groups:
+            group_spec = getattr(group, "kv_cache_spec", None)
+            per_layer_specs = getattr(group_spec, "kv_cache_specs", None)
+            if isinstance(per_layer_specs, dict):
+                layer_specs.update(per_layer_specs)
+                continue
+            for layer_name in getattr(group, "layer_names", []):
+                layer_specs[layer_name] = group_spec
+
+        sparse_layer_count = 0
+        sfa_c8_counts = {False: 0, True: 0}
+        indexer_layer_count = 0
+        li_c8_layer_ids = {False: [], True: []}
+        for layer_name, spec in layer_specs.items():
+            sparse_head_dim = getattr(spec, "sparse_head_dim", None)
+            if sparse_head_dim is None or len(sparse_head_dim) != 3:
+                continue
+
+            sparse_layer_count += 1
+            sfa_c8_counts[bool(getattr(spec, "cache_sparse_sfa_c8", False))] += 1
+            if sparse_head_dim[2] <= 0:
+                continue
+
+            indexer_layer_count += 1
+            li_c8_enabled = bool(getattr(spec, "cache_sparse_li_c8", False))
+            try:
+                layer_id = extract_layer_index(layer_name)
+            except (AssertionError, AttributeError, IndexError, TypeError, ValueError):
+                layer_id = layer_name
+            li_c8_layer_ids[li_c8_enabled].append(layer_id)
+
+        tensor_sizes = [getattr(tensor, "size", None) for tensor in kv_cache_tensors]
+        logger.info(
+            "KV cache config summary: "
+            f"num_blocks={self.num_blocks}, groups={len(kv_cache_groups)}, "
+            f"tensor_sizes={tensor_sizes}, sparse_layers={sparse_layer_count}, "
+            f"effective_sfa_c8_counts={sfa_c8_counts}, "
+            f"indexer_layers={indexer_layer_count}, "
+            f"li_c8_enabled_layer_ids={li_c8_layer_ids[True]}, "
+            f"li_c8_disabled_layer_ids={li_c8_layer_ids[False]}"
+        )
 
     def _build_layout(self, kvcaches):
 
@@ -206,6 +255,7 @@ class KVCacheLayout:
         raw_ptr_rows = [[] for _ in range(num_rows)]
         stride_rows = [[] for _ in range(num_rows)]
         buffer_size_rows = [[] for _ in range(num_rows)]
+        row_layer_ids = [None for _ in range(num_rows)]
 
         for layer_name, kv_layer in kvcaches.items():
             ptrs = []
@@ -239,6 +289,7 @@ class KVCacheLayout:
                 raise TypeError(f"Unsupported kv cache type: {type(kv_layer)}")
 
             local_layer_id = self.layer_name_to_id[layer_name] - self.first_layer_id
+            row_layer_ids[local_layer_id] = self.layer_name_to_id[layer_name]
             raw_ptr_rows[local_layer_id].extend(ptrs)
             stride_rows[local_layer_id].extend(strides)
             buffer_size_rows[local_layer_id].extend(buffer_sizes)
@@ -297,11 +348,18 @@ class KVCacheLayout:
             ]
             unique_strides = np.unique(real_strides)
             if unique_strides.size != 1:
+                stride_to_layer_ids = {}
+                for row_id in np.flatnonzero(self.valid_mask[:, column_id]):
+                    stride = int(self.tensor_size_lists[row_id, column_id])
+                    stride_to_layer_ids.setdefault(stride, []).append(
+                        row_layer_ids[row_id]
+                    )
                 raise ValueError(
                     "Invalid KV cache layout for `use_layerwise: true` in "
                     "ucm_config.yaml: all real tensors in column "
                     f"{column_id} must have an identical block stride, but got "
-                    f"{unique_strides.tolist()}. Set `use_layerwise: false` or "
+                    f"{unique_strides.tolist()}; stride_to_layer_ids="
+                    f"{dict(stride_to_layer_ids)}. Set `use_layerwise: false` or "
                     "make the tensor layout consistent across layers."
                 )
             column_strides[column_id] = unique_strides[0]

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -153,6 +153,11 @@ class KVCacheLayout:
         self.buffer_sizes: np.ndarray  # (n_layers, n_ptrs)
         self.tensor_size_lists: np.ndarray  # (n_layers, n_tensor_sizes)
         self.block_stride_lists: np.ndarray  # (n_layers, n_tensor_strides)
+        # True where the (layer, ptr) slot is real; False where zero-padded
+        # (ghost). Ghost slots get a zero base_ptr (so their computed address is
+        # masked to 0) but a column-broadcast tensor_size, letting the store's
+        # single tensorSizes_ cover every layer including the widest one.
+        self.valid_mask: np.ndarray  # (n_layers, n_ptrs) bool
         self.use_layerwise = ucm_config.get("use_layerwise", False)
         self.kv_cache_config = kv_cache_config
         self.vllm_config = vllm_config
@@ -212,9 +217,31 @@ class KVCacheLayout:
             stride_rows[local_layer_id].extend(strides)
             buffer_size_rows[local_layer_id].extend(buffer_sizes)
 
+        # Layers may hold a different number of tensors (e.g. some layers carry
+        # an extra rope/k_index tensor). Pad every row to the widest one with 0
+        # so np.asarray yields a regular 2D array. The padded (ghost) slots are
+        # handled by masking their computed address to 0 (extract_block_addrs)
+        # so the C++ copy streams skip them via addr==nullptr.
+        max_ptrs = max((len(r) for r in raw_ptr_rows), default=0)
+        for rows in (raw_ptr_rows, stride_rows, buffer_size_rows):
+            for r in rows:
+                r.extend([0] * (max_ptrs - len(r)))
+
         self.base_ptrs = np.asarray(raw_ptr_rows, dtype=np.uint64)
         self.tensor_size_lists = np.asarray(stride_rows, dtype=np.uint64)
         self.buffer_sizes = np.asarray(buffer_size_rows, dtype=np.uint64)
+        # base_ptr is 0 only for padding (real device addresses are never 0),
+        # so base_ptr != 0 precisely marks the real (layer, ptr) slots.
+        self.valid_mask = self.base_ptrs != 0
+        # Column-broadcast tensor sizes: within a column all real strides are
+        # equal (same num_head/head_dim/block_size across layers), so fill each
+        # ghost (0) slot with its column's real value. This keeps shard_size /
+        # tensor_size_list consistent across layers so the store's single
+        # tensorSizes_ fits every layer (incl. the widest) in the layerwise path.
+        col_vals = self.tensor_size_lists.max(axis=0)  # (max_ptrs,)
+        self.tensor_size_lists = np.where(
+            self.valid_mask, self.tensor_size_lists, col_vals[None, :]
+        ).astype(np.uint64)
         self.block_stride_lists = self.tensor_size_lists
 
         logger.info(
@@ -227,23 +254,34 @@ class KVCacheLayout:
         vllm_block_ids_np = np.array(vllm_block_ids, np.uint64)
         if layer_first:
             # (n_layers, num_blocks, n_ptrs)
-            return (
+            addrs = (
                 self.block_stride_lists[:, None, :] * vllm_block_ids_np[None, :, None]
                 + self.base_ptrs[:, None, :]
             )
-        return (
+            if not self.valid_mask.all():
+                # zero out ghost (padded) slots so the C++ copy stream skips
+                # them via addr==nullptr (size is non-zero after col-broadcast).
+                addrs = addrs * self.valid_mask[:, None, :].astype(np.uint64)
+            return addrs
+        addrs = (
             vllm_block_ids_np[:, None, None] * self.block_stride_lists[None, :, :]
             + self.base_ptrs[None, :, :]
         )  # (num_blocks, n_layers, n_ptrs)
+        if not self.valid_mask.all():
+            addrs = addrs * self.valid_mask[None, :, :].astype(np.uint64)
+        return addrs
 
     def extract_block_addrs_for_row(
         self, vllm_block_ids: List[int], row_id: int
     ) -> np.ndarray:
         vllm_block_ids_np = np.asarray(vllm_block_ids, dtype=np.uint64)
-        return (
+        addrs = (
             vllm_block_ids_np[:, None] * self.block_stride_lists[row_id][None, :]
             + self.base_ptrs[row_id][None, :]
         )
+        if not self.valid_mask[row_id].all():
+            addrs = addrs * self.valid_mask[row_id][None, :].astype(np.uint64)
+        return addrs
 
     @property
     def tensor_size_list(self) -> list[int]:

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -72,6 +72,34 @@ from ucm.sparse.state import has_ucm_sparse
 logger = init_logger(__name__)
 
 
+def _validate_layerwise_sparse_c8_config(
+    vllm_config: "VllmConfig", launch_config: dict
+) -> None:
+    use_layerwise = bool((launch_config or {}).get("use_layerwise", False))
+    if not use_layerwise:
+        return
+
+    additional_config = getattr(vllm_config, "additional_config", None) or {}
+    enable_sparse_sfa_c8 = bool(additional_config.get("enable_sparse_sfa_c8", False))
+    enable_sparse_li_c8 = bool(additional_config.get("enable_sparse_li_c8", False))
+    if enable_sparse_sfa_c8 == enable_sparse_li_c8:
+        return
+
+    raise ValueError(
+        "Invalid UCM layerwise KV cache configuration: `use_layerwise: true` "
+        "is set in ucm_config.yaml, but the C8 options from "
+        "`--additional-config` are inconsistent. Layerwise mode currently "
+        "requires `enable_sparse_sfa_c8` and `enable_sparse_li_c8` to have "
+        "the same value. Supported combinations are (false, false) and "
+        "(true, true); received "
+        f"(enable_sparse_sfa_c8={enable_sparse_sfa_c8}, "
+        f"enable_sparse_li_c8={enable_sparse_li_c8}). Either set "
+        "`use_layerwise: false` in ucm_config.yaml, or configure both C8 "
+        "options to the same boolean value. Non-layerwise mode supports all "
+        "four C8 combinations."
+    )
+
+
 def _normalize_tensor_size_list(tensor_size_list: Any) -> list[int]:
     if isinstance(tensor_size_list, np.ndarray):
         return [int(v) for v in tensor_size_list.reshape(-1).tolist()]
@@ -243,6 +271,16 @@ class KVCacheLayout:
         max_ptrs = max((len(r) for r in raw_ptr_rows), default=0)
         if max_ptrs == 0:
             raise ValueError("KV cache layout must contain at least one tensor")
+        tensor_counts_per_layer = [len(row) for row in raw_ptr_rows]
+        ghost_slots = sum(max_ptrs - count for count in tensor_counts_per_layer)
+        if ghost_slots > 0:
+            padded_layers = sum(count < max_ptrs for count in tensor_counts_per_layer)
+            logger.info(
+                "Layerwise KV cache layout uses padding: "
+                f"num_layers={num_rows}, max_tensors_per_layer={max_ptrs}, "
+                f"padded_layers={padded_layers}, ghost_slots={ghost_slots}, "
+                f"tensor_counts_per_layer={tensor_counts_per_layer}"
+            )
         for rows in (raw_ptr_rows, stride_rows, buffer_size_rows):
             for r in rows:
                 r.extend([0] * (max_ptrs - len(r)))
@@ -375,10 +413,14 @@ class RequestHasher:
             spec_method = getattr(speculative_config, "method", "") or ""
             spec_tokens = getattr(speculative_config, "num_speculative_tokens", 0)
             spec_info = f":{spec_method}:{spec_tokens}"
+        additional_config = getattr(vllm_config, "additional_config", None) or {}
+        sparse_sfa_c8 = bool(additional_config.get("enable_sparse_sfa_c8", False))
+        sparse_li_c8 = bool(additional_config.get("enable_sparse_li_c8", False))
+        sparse_c8_info = f":sfa_c8={int(sparse_sfa_c8)}:li_c8={int(sparse_li_c8)}"
         meta = (
             f"{vllm_config.model_config.model}:"
             f"{vllm_config.parallel_config.tensor_parallel_size}:"
-            f"{vllm_config.model_config.dtype}:{rank_id}{spec_info}"
+            f"{vllm_config.model_config.dtype}:{rank_id}{spec_info}{sparse_c8_info}"
         )
         self.meta_bytes = meta.encode("utf-8")
 
@@ -478,6 +520,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
             "", vllm_config.kv_transfer_config.engine_id
         )
         self.launch_config = ucm_config.get_config()
+        _validate_layerwise_sparse_c8_config(vllm_config, self.launch_config)
         self.connector_configs = self.launch_config.get("ucm_connectors", [])
         self.enable_event_sync = self.launch_config.get("enable_event_sync", True)
         self.enable_record_traces = self.launch_config.get(
@@ -2038,6 +2081,7 @@ class UCMConnector(KVConnectorBase_V1, SupportsHMA):
         self._setup_ucm_metrics(vllm_config, role)
         logger.info(f"self.launch_config: {self.launch_config}")
 
+        _validate_layerwise_sparse_c8_config(vllm_config, self.launch_config)
         use_layerwise = (
             self.launch_config.get("use_layerwise", False)
             if self.launch_config is not None

--- a/ucm/shared/trans/ascend/sdma_direct/ascend_sdma_direct_copier.cc
+++ b/ucm/shared/trans/ascend/sdma_direct/ascend_sdma_direct_copier.cc
@@ -135,11 +135,10 @@ Status AscendSdmaDirectCopier::BuildHostToDeviceSpecs(const void* hostDevicePtr,
     specs.reserve(specs.size() + sizes.size());
     size_t offset = 0;
     for (size_t i = 0; i < sizes.size(); ++i) {
-        if (sizes[i] == 0 || devices[i] == nullptr) {
-            return Status::InvalidParam("invalid Cache SDMA Direct H2D tensor({})", i);
+        if (sizes[i] != 0 && devices[i] != nullptr) {
+            auto* src = static_cast<const std::byte*>(hostDevicePtr) + offset;
+            specs.push_back({devices[i], src, sizes[i]});
         }
-        auto* src = static_cast<const std::byte*>(hostDevicePtr) + offset;
-        specs.push_back({devices[i], src, sizes[i]});
         offset += sizes[i];
     }
     return Status::OK();
@@ -157,11 +156,10 @@ Status AscendSdmaDirectCopier::BuildDeviceToHostSpecs(void** devices, void* host
     specs.reserve(specs.size() + sizes.size());
     size_t offset = 0;
     for (size_t i = 0; i < sizes.size(); ++i) {
-        if (sizes[i] == 0 || devices[i] == nullptr) {
-            return Status::InvalidParam("invalid Cache SDMA Direct D2H tensor({})", i);
+        if (sizes[i] != 0 && devices[i] != nullptr) {
+            auto* dst = static_cast<std::byte*>(hostDevicePtr) + offset;
+            specs.push_back({dst, devices[i], sizes[i]});
         }
-        auto* dst = static_cast<std::byte*>(hostDevicePtr) + offset;
-        specs.push_back({dst, devices[i], sizes[i]});
         offset += sizes[i];
     }
     return Status::OK();

--- a/ucm/shared/trans/stream.h
+++ b/ucm/shared/trans/stream.h
@@ -54,8 +54,12 @@ public:
         size_t offset = 0;
         for (size_t i = 0; i < sizes.size(); ++i) {
             auto* pHost = static_cast<void*>(static_cast<int8_t*>(host) + offset);
-            auto s = HostToDeviceAsync(pHost, device[i], sizes[i]);
-            if (s.Failure()) [[unlikely]] { return s; }
+            // skip zero-padded ghost slots (addr==nullptr or size==0) but
+            // still advance offset so the host layout matches tensorSizes_.
+            if (sizes[i] != 0 && device[i] != nullptr) {
+                auto s = HostToDeviceAsync(pHost, device[i], sizes[i]);
+                if (s.Failure()) [[unlikely]] { return s; }
+            }
             offset += sizes[i];
         }
         return Status::OK();
@@ -78,8 +82,12 @@ public:
         size_t offset = 0;
         for (size_t i = 0; i < sizes.size(); ++i) {
             auto* pHost = static_cast<void*>(static_cast<int8_t*>(host) + offset);
-            auto s = DeviceToHostAsync(device[i], pHost, sizes[i]);
-            if (s.Failure()) [[unlikely]] { return s; }
+            // skip zero-padded ghost slots (addr==nullptr or size==0) but
+            // still advance offset so the host layout matches tensorSizes_.
+            if (sizes[i] != 0 && device[i] != nullptr) {
+                auto s = DeviceToHostAsync(device[i], pHost, sizes[i]);
+                if (s.Failure()) [[unlikely]] { return s; }
+            }
             offset += sizes[i];
         }
         return Status::OK();

--- a/ucm/store/mooncakestore/cc/dump_queue.cc
+++ b/ucm/store/mooncakestore/cc/dump_queue.cc
@@ -303,19 +303,11 @@ void DumpQueue::BackendDumpStage()
 Status DumpQueue::DeviceToHostGatherAsync(std::shared_ptr<Trans::Stream> stream, void** device,
                                           void* host)
 {
-    const auto number = tensorSizes_.size();
-    for (size_t i = 0, offset = 0; i < number; i++) {
-        auto pDevice = device[i];
-        auto pHost = (void*)(((int8_t*)host) + offset);
-        auto size = tensorSizes_[i];
-        auto s = stream->DeviceToHostAsync(pDevice, pHost, size);
-        if (s.Failure()) [[unlikely]] {
-            UC_ERROR("Failed({}) to do D2H({}) batch({}/{}) async.", s, size, i, number);
-            return s;
-        }
-        offset += size;
+    auto s = stream->DeviceToHostAsync(device, host, tensorSizes_);
+    if (s.Failure()) [[unlikely]] {
+        UC_ERROR("Failed({}) to do D2H gather async for {} tensors.", s, tensorSizes_.size());
     }
-    return Status::OK();
+    return s;
 }
 
 size_t DumpQueue::BlockBytes() const

--- a/ucm/store/mooncakestore/cc/load_queue.cc
+++ b/ucm/store/mooncakestore/cc/load_queue.cc
@@ -298,19 +298,11 @@ void LoadQueue::TransferOneTask(CopyStream& stream, ShardTask&& task)
 Status LoadQueue::HostToDeviceScatterAsync(std::shared_ptr<Trans::Stream> stream, void* host,
                                            void** device)
 {
-    const auto number = tensorSizes_.size();
-    for (size_t i = 0, offset = 0; i < number; i++) {
-        auto pHost = (void*)(((int8_t*)host) + offset);
-        auto pDevice = device[i];
-        auto size = tensorSizes_[i];
-        auto s = stream->HostToDeviceAsync(pHost, pDevice, size);
-        if (s.Failure()) [[unlikely]] {
-            UC_ERROR("Failed({}) to do H2D({}) batch({}/{}) async.", s, size, i, number);
-            return s;
-        }
-        offset += size;
+    auto s = stream->HostToDeviceAsync(host, device, tensorSizes_);
+    if (s.Failure()) [[unlikely]] {
+        UC_ERROR("Failed({}) to do H2D scatter async for {} tensors.", s, tensorSizes_.size());
     }
-    return Status::OK();
+    return s;
 }
 
 size_t LoadQueue::BlockBytes() const

--- a/ucm/store/mooncakestore/cc/share_load_queue.cc
+++ b/ucm/store/mooncakestore/cc/share_load_queue.cc
@@ -323,19 +323,11 @@ void ShareLoadQueue::HandleBackendComplete(BlockTask& task, Trans::Stream& strea
 
 Status ShareLoadQueue::HostToDeviceScatterAsync(Trans::Stream& stream, void* host, void** device)
 {
-    const auto number = tensorSizes_.size();
-    for (size_t i = 0, offset = 0; i < number; i++) {
-        auto pHost = (void*)(((int8_t*)host) + offset);
-        auto pDevice = device[i];
-        auto size = tensorSizes_[i];
-        auto s = stream.HostToDeviceAsync(pHost, pDevice, size);
-        if (s.Failure()) [[unlikely]] {
-            UC_ERROR("Failed({}) to do H2D({}) batch({}/{}) async.", s, size, i, number);
-            return s;
-        }
-        offset += size;
+    auto s = stream.HostToDeviceAsync(host, device, tensorSizes_);
+    if (s.Failure()) [[unlikely]] {
+        UC_ERROR("Failed({}) to do H2D scatter async for {} tensors.", s, tensorSizes_.size());
     }
-    return Status::OK();
+    return s;
 }
 
 size_t ShareLoadQueue::BlockBytes() const


### PR DESCRIPTION
## Purpose

适配 GLM-5.2 等不同层 KV Cache tensor 数量或大小不一致的场景，避免 UCM 在构建 KV Cache 地址矩阵时因不规则数组初始化失败。

同时分别支持：

- 非 Layerwise：按完整 KV Cache block 传输。
- Layerwise：按层传输，并兼容不同层 tensor 数量不同的情况。
- 根据实际 tensor 布局判断 Layerwise 是否可用，不依赖或暴露模型侧的 C8 配置参数。

## Modification

1. **非 Layerwise 模式**

   - 将所有层的真实 tensor pointer、block stride 和 buffer size 直接拍平成一维数组。
   - 不进行 padding，不产生 ghost tensor。
   - 支持各层 tensor 数量不同的 KV Cache 布局。

2. **Layerwise 模式**

   - 按最大 tensor 数量对各层进行 padding。
   - 使用 `valid_mask` 区分真实 tensor 和 ghost tensor。
   - 将 ghost tensor 地址设置为零，由传输层跳过。
   - 根据每一列的真实 tensor 计算统一的 block stride。

3. **Layerwise 布局校验**

   - 检查同一列所有真实 tensor 的 block stride 是否一致。
   - 不直接判断 `enable_sparse_sfa_c8` 或 `enable_sparse_li_c8`。
   - 如果同列大小不一致，则初始化失败，并提示检查 `ucm_config.yaml` 中的 `use_layerwise` 配置：

   ```text
   Set `use_layerwise: false` or make the tensor layout consistent across layers.
   ```

4. **Buffer 注册**

   - GPU KV buffer 注册时过滤 padding 产生的零地址和零大小 buffer。
   - 避免将 ghost tensor 注册为真实设备内存。

5. **数据传输**

   - C++ copy stream 和 Ascend SDMA Direct 跳过空指针或大小为零的 tensor。
   - 保持真实 tensor 在 host buffer 中的正确偏移关系。

6. **测试**

   - 覆盖非 Layerwise 不等长 tensor 行拍平。
   - 覆盖 GLM-5.2 四种 SFA C8/LI C8 tensor 布局。
   - 覆盖 Layerwise 同列 stride 一致的正常场景。
   - 覆盖 LI C8 部分生效导致同列 stride 不一致的报错场景。