### PR TITLE
[bugfix]Add patch for v0.23.0rc1

### DIFF
--- a/ucm/integration/vllm/patch/apply_patch.py
+++ b/ucm/integration/vllm/patch/apply_patch.py
@@ -222,7 +222,11 @@ def apply_all_patches() -> None:
                 import ucm.integration.vllm.patch.v0221.vllm_ascend.ascend_hybrid_cache_patch
                 import ucm.integration.vllm.patch.v0221.vllm_ascend.cpu_binding_patch
             case "0.23.0":
-                logger.info("UCM patching vllm-ascend 0.23.0 for CPU affinity...")
+                logger.info(
+                    "UCM patching vllm-ascend 0.23.0 for hybrid cache "
+                    "recovery and CPU affinity..."
+                )
+                import ucm.integration.vllm.patch.v0230.vllm_ascend.ascend_hybrid_cache_patch
                 import ucm.integration.vllm.patch.v0230.vllm_ascend.cpu_binding_patch
             case _:
                 pass

--- a/ucm/integration/vllm/patch/v0230/vllm_ascend/ascend_hybrid_cache_patch.py
+++ b/ucm/integration/vllm/patch/v0230/vllm_ascend/ascend_hybrid_cache_patch.py
@@ -1,0 +1,77 @@
+"""Fix hybrid prefix-cache accounting in vLLM-Ascend 0.23.0rc1."""
+
+from ucm.integration.vllm.patch.utils import patch_or_inject, when_imported
+from ucm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+@when_imported("vllm_ascend.core.single_type_kv_cache_manager")
+def patch_ascend_single_type_kv_cache_manager(mod):
+    logger.debug(f"Patched {mod} called")
+
+    from ucm.integration.vllm.patch.v0230.vllm_ascend.core import (
+        single_type_kv_cache_manager,
+    )
+
+    if not hasattr(mod, "CompressAttentionManager"):
+        logger.warning(
+            "Skip Ascend compressed-attention KV allocation patch: "
+            "CompressAttentionManager is missing"
+        )
+        return
+
+    patched_manager_cls = single_type_kv_cache_manager.CompressAttentionManager
+    patch_or_inject(
+        mod.CompressAttentionManager,
+        "allocate_new_computed_blocks",
+        patched_manager_cls.allocate_new_computed_blocks,
+    )
+    logger.info(
+        "UCM Ascend compressed-attention KV allocation patch applied: "
+        "CompressAttentionManager.allocate_new_computed_blocks"
+    )
+
+
+@when_imported("vllm_ascend.patch.platform.patch_kv_cache_coordinator")
+def patch_ascend_kv_cache_coordinator(mod):
+    logger.debug(f"Patched {mod} called")
+
+    from ucm.integration.vllm.patch.v0230.vllm_ascend.patch.platform import (
+        patch_kv_cache_coordinator,
+    )
+
+    if not hasattr(mod, "AscendHybridKVCacheCoordinator"):
+        logger.warning(
+            "Skip Ascend hybrid KV cache coordinator patch: "
+            "AscendHybridKVCacheCoordinator is missing"
+        )
+        return
+
+    coordinator_cls = mod.AscendHybridKVCacheCoordinator
+    patched_methods = []
+    for method_name in (
+        "find_longest_cache_hit",
+        "find_longest_cache_hit_per_group",
+    ):
+        if not hasattr(coordinator_cls, method_name):
+            logger.warning(
+                "Skip Ascend hybrid KV cache coordinator patch: %s is missing",
+                method_name,
+            )
+            continue
+
+        original_method = getattr(coordinator_cls, method_name)
+        replacement_method = (
+            patch_kv_cache_coordinator.wrap_full_attention_cache_hit_lookup(
+                original_method
+            )
+        )
+        patch_or_inject(coordinator_cls, method_name, replacement_method)
+        patched_methods.append(method_name)
+
+    if patched_methods:
+        logger.info(
+            "UCM Ascend hybrid KV cache coordinator patch applied: %s",
+            ", ".join(patched_methods),
+        )

--- a/ucm/integration/vllm/patch/v0230/vllm_ascend/core/__init__.py
+++ b/ucm/integration/vllm/patch/v0230/vllm_ascend/core/__init__.py
@@ -1,0 +1,1 @@
+"""Compressed-attention manager replacements for vLLM-Ascend 0.23.0rc1."""

--- a/ucm/integration/vllm/patch/v0230/vllm_ascend/core/single_type_kv_cache_manager.py
+++ b/ucm/integration/vllm/patch/v0230/vllm_ascend/core/single_type_kv_cache_manager.py
@@ -1,0 +1,77 @@
+"""Defensive compressed-attention allocation for vLLM-Ascend 0.23.0rc1."""
+
+from vllm.utils.math_utils import cdiv
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+from ucm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class CompressAttentionManager:
+    def allocate_new_computed_blocks(
+        self,
+        request_id: str,
+        new_computed_blocks,
+        num_local_computed_tokens: int,
+        num_external_computed_tokens: int,
+    ) -> None:
+        """Prevent inconsistent compressed hits from corrupting the free queue."""
+        if request_id in self.num_cached_block:
+            assert len(new_computed_blocks) == 0
+            return
+
+        req_blocks = self.req_to_blocks[request_id]
+        assert len(req_blocks) == 0
+
+        num_total_computed_tokens = (
+            num_local_computed_tokens + num_external_computed_tokens
+        ) // self.compress_ratio
+        num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
+        num_skipped_blocks = num_skipped_tokens // self.block_size
+        if num_skipped_blocks > 0:
+            new_computed_blocks = new_computed_blocks[num_skipped_blocks:]
+            num_external_computed_tokens = min(
+                num_total_computed_tokens - num_skipped_tokens,
+                num_external_computed_tokens,
+            )
+
+        if self.enable_caching:
+            self.block_pool.touch(new_computed_blocks)
+        else:
+            assert not any(
+                new_computed_blocks
+            ), "Computed blocks should be empty when prefix caching is disabled"
+
+        req_blocks.extend([self._null_block] * num_skipped_blocks)
+        req_blocks.extend(new_computed_blocks)
+        self.num_cached_block[request_id] = len(req_blocks)
+
+        if num_external_computed_tokens > 0:
+            target_blocks = cdiv(num_total_computed_tokens, self.block_size)
+            num_new_blocks = target_blocks - len(req_blocks)
+            if num_new_blocks <= 0:
+                if num_new_blocks < 0:
+                    logger.warning(
+                        "Skip negative Ascend compressed-attention KV allocation: "
+                        "request_id=%s, num_new_blocks=%d, target_blocks=%d, "
+                        "req_blocks=%d, compress_ratio=%d, block_size=%d, "
+                        "compressed_total_tokens=%d, num_skipped_blocks=%d, "
+                        "kv_cache_group_id=%s, spec=%s",
+                        request_id,
+                        num_new_blocks,
+                        target_blocks,
+                        len(req_blocks),
+                        self.compress_ratio,
+                        self.block_size,
+                        num_total_computed_tokens,
+                        num_skipped_blocks,
+                        getattr(self, "kv_cache_group_id", None),
+                        type(self.kv_cache_spec).__name__,
+                    )
+                return
+
+            allocated_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+            req_blocks.extend(allocated_blocks)
+            if type(self.kv_cache_spec) is FullAttentionSpec:
+                self.new_block_ids.extend(b.block_id for b in allocated_blocks)

--- a/ucm/integration/vllm/patch/v0230/vllm_ascend/patch/__init__.py
+++ b/ucm/integration/vllm/patch/v0230/vllm_ascend/patch/__init__.py
@@ -1,0 +1,1 @@
+"""vLLM-Ascend monkey-patch replacements for version 0.23.0rc1."""

--- a/ucm/integration/vllm/patch/v0230/vllm_ascend/patch/platform/__init__.py
+++ b/ucm/integration/vllm/patch/v0230/vllm_ascend/patch/platform/__init__.py
@@ -1,0 +1,1 @@
+"""Platform patch replacements for vLLM-Ascend 0.23.0rc1."""

--- a/ucm/integration/vllm/patch/v0230/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/ucm/integration/vllm/patch/v0230/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -25,9 +25,7 @@ def wrap_full_attention_cache_hit_lookup(original_method):
 
     @wraps(original_method)
     def wrapped(coordinator, *args, **kwargs):
-        hit_blocks_by_group, hit_length = original_method(
-            coordinator, *args, **kwargs
-        )
+        hit_blocks_by_group, hit_length = original_method(coordinator, *args, **kwargs)
         _truncate_full_attention_groups(
             coordinator,
             hit_blocks_by_group,

--- a/ucm/integration/vllm/patch/v0230/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
+++ b/ucm/integration/vllm/patch/v0230/vllm_ascend/patch/platform/patch_kv_cache_coordinator.py
@@ -1,0 +1,38 @@
+"""Hybrid prefix-cache result correction for vLLM-Ascend 0.23.0rc1."""
+
+from functools import wraps
+
+from vllm.v1.kv_cache_interface import FullAttentionSpec
+
+
+def _truncate_full_attention_groups(
+    coordinator,
+    hit_blocks_by_group,
+    hit_length: int,
+) -> None:
+    """Align every full-attention group with the final shared hit length."""
+    for spec, group_ids, _ in coordinator.attention_groups:
+        if not isinstance(spec, FullAttentionSpec):
+            continue
+
+        num_blocks = hit_length // coordinator._get_effective_block_size(spec)
+        for group_id in group_ids:
+            del hit_blocks_by_group[group_id][num_blocks:]
+
+
+def wrap_full_attention_cache_hit_lookup(original_method):
+    """Preserve the rc1 lookup algorithm and correct all returned full groups."""
+
+    @wraps(original_method)
+    def wrapped(coordinator, *args, **kwargs):
+        hit_blocks_by_group, hit_length = original_method(
+            coordinator, *args, **kwargs
+        )
+        _truncate_full_attention_groups(
+            coordinator,
+            hit_blocks_by_group,
+            hit_length,
+        )
+        return hit_blocks_by_group, hit_length
+
+    return wrapped


### PR DESCRIPTION
## Purpose

Fix the DeepSeek-V4 hybrid prefix-cache inconsistency in vLLM-Ascend 0.23.0rc1.

When multiple compressed full-attention groups, such as c4 and c128, participate in cache lookup, only the first group is truncated to the final shared cache-hit length. Other groups may retain stale cached blocks, causing inconsistent block accounting and potentially negative block allocation that corrupts the free-block queue.

## Modifications

- Added a version-specific hybrid-cache patch for vLLM-Ascend 0.23.0rc1.
- Updated both `find_longest_cache_hit()` and `find_longest_cache_hit_per_group()` to truncate every full-attention group according to its effective block size.
- Preserved the original v0.23.0rc1 cache-lookup implementation by wrapping its returned results.
- Added defensive handling in `CompressAttentionManager.allocate_new_computed_blocks()` to prevent non-positive block counts from reaching `BlockPool.get_new_blocks()`.
- Added regression tests covering multiple compressed full-attention groups, zero and non-zero final cache-hit lengths, negative compressed-block allocation, and patch registration.