### PR TITLE
[Feat] AsuClient modifies the process of registration

### DIFF
--- a/examples/ucm_config_asu.yaml
+++ b/examples/ucm_config_asu.yaml
@@ -15,6 +15,10 @@ ucm_connectors:
       # Non-FAWA models use one ASU namespace. For DeepSeek V4 / FAWA,
       # replace this with: kv_ns_ids: [100, 101]  # [FA, WA]
       kv_ns_ids: [100]
+      # Ports map to asu_ids/asu_ips by index.
+      asu_ips: ["127.0.0.1", "127.0.0.1"]
+      asu_port: [19001, 19002]
+      device_id: 0
 
       # ASU client routing. Keep the default close to kv-test's fake_backend config.
       asu_router_type: "RING_HASH"

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -193,7 +193,7 @@ UC::ASU::TransportConfig BuildTransportConfig(const Config& config, std::size_t 
     if (!config.asuIps.empty()) {
         UC::ASU::AsuEndpoint endpoint;
         endpoint.ip = config.asuIps[index];
-        endpoint.port = config.asuPort;
+        endpoint.port = config.asuPorts[index];
         endpoint.deviceId = config.deviceId;
         transportConfig.endpoints.emplace_back(std::move(endpoint));
     }
@@ -471,9 +471,16 @@ private:
         inConfig.Get("asu_local_ip", config.asuLocalIp);
         inConfig.Get("asu_name_prefix", config.asuNamePrefix);
         inConfig.GetNumbers("kv_ns_ids", config.kvNsIds);
-        ssize_t asuPort = 0;
-        inConfig.GetNumber("asu_port", asuPort);
-        config.asuPort = static_cast<std::uint16_t>(std::max<ssize_t>(0, asuPort));
+        std::vector<ssize_t> asuPorts;
+        try {
+            inConfig.GetNumbers("asu_port", asuPorts);
+        } catch (const std::bad_any_cast&) {
+            asuPorts.clear();
+        }
+        config.asuPorts.reserve(asuPorts.size());
+        for (const auto port : asuPorts) {
+            config.asuPorts.emplace_back(static_cast<std::uint16_t>(std::max<ssize_t>(0, port)));
+        }
         inConfig.GetNumber("asu_default_wait_timeout_ms", config.defaultWaitTimeoutMs);
         inConfig.GetNumber("asu_query_timeout_ms", config.queryTimeoutMs);
         inConfig.GetNumber("asu_load_timeout_ms", config.loadTimeoutMs);
@@ -554,6 +561,9 @@ private:
         }
         if (!config.asuIps.empty() && config.asuIps.size() != config.asuIds.size()) {
             return Status::InvalidParam("asu_ips size must match asu_ids size");
+        }
+        if (config.configPath.empty() && config.asuPorts.size() != config.asuIds.size()) {
+            return Status::InvalidParam("asu_port size must match asu_ids size");
         }
         if (config.uniqueId.find("_fawa_") != std::string::npos && config.kvNsIds.size() != 2) {
             return Status::InvalidParam("FAWA requires exactly two kv_ns_ids");

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -21,7 +21,7 @@ struct Config {
     std::string asuLocalIp;
     std::string asuNamePrefix{"asu"};
     std::vector<std::uint32_t> kvNsIds;
-    std::uint16_t asuPort{0};
+    std::vector<std::uint16_t> asuPorts;
     std::uint64_t defaultWaitTimeoutMs{100};
     std::uint64_t queryTimeoutMs{5};
     std::uint64_t loadTimeoutMs{100};

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -209,7 +209,7 @@ UC::Detail::Dictionary MakeBaseConfig()
     UC::Detail::Dictionary config;
     config.Set("asu_client_id", std::string{"asu-store-test"});
     config.Set("asu_name_prefix", std::string{"asu-store-test"});
-    config.SetNumber("asu_port", 12345);
+    config.Set("asu_port", std::vector<ssize_t>{12345});
     config.SetNumber("device_id", -1);
     config.SetNumber("tensor_size", std::size_t{64});
     config.SetNumber("shard_size", std::size_t{64});
@@ -355,11 +355,53 @@ TEST(UCAsuStoreTest, ClientModeSmoke)
     auto config = MakeBaseConfig();
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1", "127.0.0.2"});
     config.Set("asu_ids", std::vector<ssize_t>{1001, 1002});
+    config.Set("asu_port", std::vector<ssize_t>{12345, 12346});
     ASSERT_TRUE(store.Setup(config).Success());
 
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("b1b2c3d4e5f6789012345678901234ab");
     ExpectLookupMiss(store, block);
     ExpectLoadDumpSmoke(store, block);
+}
+
+TEST(UCAsuStoreTest, MapsPortsToAsuEndpointsByIndex)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeBackend(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_ips", std::vector<std::string>{"127.0.0.1", "127.0.0.2"});
+    config.Set("asu_ids", std::vector<ssize_t>{1001, 1002});
+    config.Set("asu_port", std::vector<ssize_t>{19001, 19002});
+
+    ASSERT_TRUE(store.Setup(config).Success());
+    ASSERT_EQ(state->initConfigs.size(), std::size_t{1});
+
+    const auto first = UC::AsuStore::BuildTransportConfig(state->initConfigs[0], 0);
+    const auto second = UC::AsuStore::BuildTransportConfig(state->initConfigs[0], 1);
+    ASSERT_EQ(first.endpoints.size(), std::size_t{1});
+    ASSERT_EQ(second.endpoints.size(), std::size_t{1});
+    EXPECT_EQ(first.endpoints[0].port, std::uint16_t{19001});
+    EXPECT_EQ(second.endpoints[0].port, std::uint16_t{19002});
+}
+
+TEST(UCAsuStoreTest, RejectsMismatchedAsuPortCount)
+{
+    UC::AsuStore::AsuStore store;
+    auto config = MakeBaseConfig();
+    config.Set("asu_ips", std::vector<std::string>{"127.0.0.1", "127.0.0.2"});
+    config.Set("asu_ids", std::vector<ssize_t>{1001, 1002});
+
+    EXPECT_TRUE(store.Setup(config).Failure());
+}
+
+TEST(UCAsuStoreTest, RejectsScalarAsuPort)
+{
+    UC::AsuStore::AsuStore store;
+    auto config = MakeBaseConfig();
+    config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.SetNumber("asu_port", 12345);
+
+    EXPECT_TRUE(store.Setup(config).Failure());
 }
 
 TEST(UCAsuStoreTest, AllowsQueryOnlyConfigWithoutTensorSizes)
@@ -510,6 +552,7 @@ TEST(UCAsuStoreTest, LookupOnPrefixUsesPrefixQueryMode)
     auto config = MakeBaseConfig();
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1", "127.0.0.2"});
     config.Set("asu_ids", std::vector<ssize_t>{1001, 1002});
+    config.Set("asu_port", std::vector<ssize_t>{12345, 12346});
     ASSERT_TRUE(store.Setup(config).Success());
     std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
     RegisterPersistentRanges(store, {

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -355,6 +355,7 @@ Status AsuClientImpl::RegisterRegionsOnce(const std::vector<MemoryRegion>& regio
     }
 
     Status finalStatus = Status::OK();
+    std::vector<std::pair<AsuId, std::shared_ptr<AsuTransport>>> boundTransports;
     for (std::size_t asuIndex = 1; asuIndex < snapshot->asuIds.size(); ++asuIndex) {
         auto iter = snapshot->transports.find(snapshot->asuIds[asuIndex]);
         if (iter == snapshot->transports.end()) {
@@ -375,24 +376,44 @@ Status AsuClientImpl::RegisterRegionsOnce(const std::vector<MemoryRegion>& regio
                             "asuIndex=" + std::to_string(asuIndex) +
                                 " asuId=" + std::to_string(snapshot->asuIds[asuIndex]) +
                                 " region_count=" + std::to_string(registeredRegions.size()));
-        } else if (status.ok() && childResults.size() != registeredRegions.size() &&
-                   finalStatus.ok()) {
-            finalStatus =
-                WithContext(PartialFailed("one or more asu region bindings failed"),
-                            "asuIndex=" + std::to_string(asuIndex) +
-                                " asuId=" + std::to_string(snapshot->asuIds[asuIndex]) +
-                                " region_count=" + std::to_string(registeredRegions.size()) +
-                                " result_count=" + std::to_string(childResults.size()));
+        } else if (status.ok()) {
+            boundTransports.emplace_back(snapshot->asuIds[asuIndex], iter->second);
+            if (childResults.size() != registeredRegions.size() && finalStatus.ok()) {
+                finalStatus =
+                    WithContext(PartialFailed("one or more asu region bindings failed"),
+                                "asuIndex=" + std::to_string(asuIndex) +
+                                    " asuId=" + std::to_string(snapshot->asuIds[asuIndex]) +
+                                    " region_count=" + std::to_string(registeredRegions.size()) +
+                                    " result_count=" + std::to_string(childResults.size()));
+            }
         }
     }
 
-    if (finalStatus.ok()) {
-        std::lock_guard<std::mutex> lock{mutex_};
-        for (std::size_t index = 0; index < regions.size(); ++index) {
-            registeredResources_.emplace_back(RegisteredResource{regions[index], results[index]});
+    if (!finalStatus.ok()) {
+        std::vector<MRHandle> handles;
+        handles.reserve(results.size());
+        for (const auto& result : results) { handles.emplace_back(result.handle); }
+
+        for (auto iter = boundTransports.rbegin(); iter != boundTransports.rend(); ++iter) {
+            auto rollbackStatus = iter->second->UnbindRegisteredRegions(handles);
+            if (!rollbackStatus.ok()) {
+                UC_ERROR("Rollback bound ASU regions failed, asuId={}: {}", iter->first,
+                         rollbackStatus.message);
+            }
         }
+        auto rollbackStatus = firstIter->second->UnregisterRegions(handles);
+        if (!rollbackStatus.ok()) {
+            UC_ERROR("Rollback owner ASU regions failed, asuId={}: {}", snapshot->asuIds.front(),
+                     rollbackStatus.message);
+        }
+        return finalStatus;
     }
-    return finalStatus;
+
+    std::lock_guard<std::mutex> lock{mutex_};
+    for (std::size_t index = 0; index < regions.size(); ++index) {
+        registeredResources_.emplace_back(RegisteredResource{regions[index], results[index]});
+    }
+    return Status::OK();
 }
 
 Status AsuClientImpl::SubmitAsync(ClientOpType opType, const std::vector<KVBuffer>& entries,
@@ -796,13 +817,41 @@ Status AsuClientImpl::UnregisterRegionsOnce(const std::vector<MRHandle>& handles
     if (!snapshot) { return NotInitialized(); }
 
     Status finalStatus = Status::OK();
-    for (const auto& item : snapshot->transports) {
-        auto status = item.second->UnregisterRegions(handles);
+    for (std::size_t asuIndex = snapshot->asuIds.size(); asuIndex > 1; --asuIndex) {
+        const auto id = snapshot->asuIds[asuIndex - 1];
+        const auto iter = snapshot->transports.find(id);
+        if (iter == snapshot->transports.end()) {
+            if (finalStatus.ok()) {
+                finalStatus = WithContext(
+                    Status::Error(StatusCode::NOT_FOUND, "bound asu transport not found"),
+                    "asuId=" + std::to_string(id));
+            }
+            continue;
+        }
+        auto status = iter->second->UnbindRegisteredRegions(handles);
         if (!status.ok() && finalStatus.ok()) {
             MarkRefreshIfNeeded(status, needRefresh);
-            finalStatus =
-                WithContext(status, "asuId=" + std::to_string(item.first) +
-                                        " handle_count=" + std::to_string(handles.size()));
+            finalStatus = WithContext(status, "asuId=" + std::to_string(id) + " handle_count=" +
+                                                  std::to_string(handles.size()));
+        }
+    }
+
+    if (!snapshot->asuIds.empty()) {
+        const auto id = snapshot->asuIds.front();
+        const auto iter = snapshot->transports.find(id);
+        if (iter == snapshot->transports.end()) {
+            if (finalStatus.ok()) {
+                finalStatus = WithContext(
+                    Status::Error(StatusCode::NOT_FOUND, "first asu transport not found"),
+                    "asuId=" + std::to_string(id));
+            }
+        } else {
+            auto status = iter->second->UnregisterRegions(handles);
+            if (!status.ok() && finalStatus.ok()) {
+                MarkRefreshIfNeeded(status, needRefresh);
+                finalStatus = WithContext(status, "asuId=" + std::to_string(id) + " handle_count=" +
+                                                      std::to_string(handles.size()));
+            }
         }
     }
     if (finalStatus.ok()) {
@@ -1007,8 +1056,11 @@ Status AsuClientImpl::ShutdownSnapshotTransports(const std::shared_ptr<ViewSnaps
 {
     if (!snapshot) { return Status::OK(); }
     Status finalStatus = Status::OK();
-    for (auto& item : snapshot->transports) {
-        auto status = item.second->Shutdown();
+    for (std::size_t asuIndex = snapshot->asuIds.size(); asuIndex > 0; --asuIndex) {
+        const auto id = snapshot->asuIds[asuIndex - 1];
+        const auto iter = snapshot->transports.find(id);
+        if (iter == snapshot->transports.end()) { continue; }
+        auto status = iter->second->Shutdown();
         if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
     }
     return finalStatus;

--- a/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
@@ -58,6 +58,7 @@ struct TestState {
     std::unordered_map<AsuId, QueryResult> prefixQueryResults;
     std::vector<AsuId> registerCalls;
     std::vector<AsuId> bindCalls;
+    std::vector<AsuId> unbindCalls;
     std::unordered_map<AsuId, std::vector<RegisteredMemory>> boundRegions;
     std::vector<AsuId> unregisterCalls;
     std::vector<AsuId> queryCalls;
@@ -241,6 +242,12 @@ public:
     Status UnregisterRegions(const std::vector<MRHandle>&) override
     {
         state_->unregisterCalls.emplace_back(config_.asuId);
+        return Status::OK();
+    }
+
+    Status UnbindRegisteredRegions(const std::vector<MRHandle>&) override
+    {
+        state_->unbindCalls.emplace_back(config_.asuId);
         return Status::OK();
     }
 
@@ -1163,6 +1170,45 @@ TEST(AsuClientImplTest, MemoryRegister_BindFailureIncludesAsuContext)
     EXPECT_NE(status.message.find("region_count=1"), std::string::npos);
 }
 
+TEST(AsuClientImplTest, MemoryRegister_BindFailureRollsBackFollowersThenOwner)
+{
+    class FailingBindTransport final : public FakeTransport {
+    public:
+        explicit FailingBindTransport(std::shared_ptr<TestState> state)
+            : FakeTransport(state), state_(std::move(state))
+        {
+        }
+
+        Status BindRegisteredRegions(const std::vector<RegisteredMemory>&,
+                                     std::vector<RegisterResult>&) override
+        {
+            state_->bindCalls.emplace_back(30);
+            return Status::Error(StatusCode::CONNECTION_ERROR, "fake bind failure");
+        }
+
+    private:
+        std::shared_ptr<TestState> state_;
+    };
+
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient([state] {
+        ++state->createdTransports;
+        if (state->createdTransports == 3) {
+            return std::unique_ptr<AsuTransport>(new FailingBindTransport(state));
+        }
+        return std::unique_ptr<AsuTransport>(new FakeTransport(state));
+    });
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20, 30})).ok());
+
+    std::vector<RegisterResult> results;
+    auto status = client->RegisterRegions({MemoryRegion{}}, results);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_EQ(state->bindCalls, std::vector<AsuId>({20, 30}));
+    EXPECT_EQ(state->unbindCalls, std::vector<AsuId>({20}));
+    EXPECT_EQ(state->unregisterCalls, std::vector<AsuId>({10}));
+}
+
 TEST(AsuClientImplTest, MemoryRegister_SuccessfulBindWithMismatchedResultCountFails)
 {
     class MismatchedBindTransport final : public FakeTransport {
@@ -1311,6 +1357,24 @@ TEST(AsuClientImplTest, MemoryRegister_UnregisterRemovesCachedResourceBeforeFutu
     ASSERT_TRUE(client->Shutdown().ok());
     EXPECT_EQ(state->createdTransports, std::uint32_t{2});
     EXPECT_TRUE(state->bindCalls.empty());
+}
+
+TEST(AsuClientImplTest, MemoryRegister_UnregisterUnbindsFollowersThenUnregistersFirstTransport)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({30, 10, 20})).ok());
+
+    std::vector<RegisterResult> results;
+    auto status = client->RegisterRegions({MemoryRegion{}}, results);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(results.size(), std::size_t{1});
+
+    status = client->UnregisterRegions({results[0].handle});
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(state->unbindCalls, std::vector<AsuId>({30, 20}));
+    EXPECT_EQ(state->unregisterCalls, std::vector<AsuId>({10}));
 }
 
 TEST(AsuClientImplTest, Task_CheckRemovesTaskAfterCompletion)

--- a/ucm/transport/kv/asu/test/case/asu_client_e2e_metrics_test.cc
+++ b/ucm/transport/kv/asu/test/case/asu_client_e2e_metrics_test.cc
@@ -509,6 +509,8 @@ public:
         return Status::OK();
     }
 
+    Status UnbindRegisteredRegions(const std::vector<MRHandle>&) override { return Status::OK(); }
+
     Status UnregisterRegions(const std::vector<MRHandle>&) override { return Status::OK(); }
 
 private:

--- a/ucm/transport/kv/asu/test/case/asu_smoke_test.cc
+++ b/ucm/transport/kv/asu/test/case/asu_smoke_test.cc
@@ -133,6 +133,8 @@ public:
         return Status::OK();
     }
 
+    Status UnbindRegisteredRegions(const std::vector<MRHandle>&) override { return Status::OK(); }
+
     Status UnregisterRegions(const std::vector<MRHandle>&) override { return Status::OK(); }
 
 private:

--- a/ucm/transport/kv/asu/test/case/buffer_manager_test.cc
+++ b/ucm/transport/kv/asu/test/case/buffer_manager_test.cc
@@ -431,6 +431,18 @@ public:
         handles.push_back(reinterpret_cast<MRHandle>(static_cast<uintptr_t>(registerCount)));
         return Status::OK();
     }
+    Status BindMemory(const std::vector<RegisteredMemory>& regions,
+                      std::vector<MRHandle>& handles) override
+    {
+        handles.clear();
+        for (const auto& region : regions) { handles.push_back(region.handle); }
+        return Status::OK();
+    }
+
+    std::vector<Status> UnbindMemory(const std::vector<UnbindMemoryDesc>& handles) override
+    {
+        return std::vector<Status>(handles.size(), Status::OK());
+    }
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& descs) override
     {
         unregisterCount += static_cast<uint32_t>(descs.size());

--- a/ucm/transport/kv/asu/test/case/connection_manager_test.cc
+++ b/ucm/transport/kv/asu/test/case/connection_manager_test.cc
@@ -75,6 +75,18 @@ public:
         }
         return Status::OK();
     }
+    Status BindMemory(const std::vector<RegisteredMemory>& regions,
+                      std::vector<MRHandle>& handles) override
+    {
+        handles.clear();
+        for (const auto& region : regions) { handles.push_back(region.handle); }
+        return Status::OK();
+    }
+
+    std::vector<Status> UnbindMemory(const std::vector<UnbindMemoryDesc>& handles) override
+    {
+        return std::vector<Status>(handles.size(), Status::OK());
+    }
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>&) override
     {
         return {};

--- a/ucm/transport/kv/asu/trans/include/aiv_transport/aiv_transport.h
+++ b/ucm/transport/kv/asu/trans/include/aiv_transport/aiv_transport.h
@@ -66,6 +66,15 @@ public:
     virtual Status RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
                                   std::vector<MRHandle>& mrHandles) = 0;
 
+    virtual Status BindMemory(const std::vector<RegisteredMemory>& regions,
+                              std::vector<MRHandle>& mrHandles) = 0;
+
+    struct UnbindMemoryDesc {
+        MRHandle mrHandle;
+    };
+
+    virtual std::vector<Status> UnbindMemory(const std::vector<UnbindMemoryDesc>& memoryDescs) = 0;
+
     struct UnregisterMemoryDesc {
         MRHandle mrHandle;
     };

--- a/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
@@ -118,6 +118,8 @@ public:
     virtual Status BindRegisteredRegions(const std::vector<RegisteredMemory>& regions,
                                          std::vector<RegisterResult>& results) = 0;
 
+    virtual Status UnbindRegisteredRegions(const std::vector<MRHandle>& handles) = 0;
+
     virtual Status UnregisterRegions(const std::vector<MRHandle>& handles) = 0;
 };
 

--- a/ucm/transport/kv/asu/trans/src/aicpu_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/aicpu_trans_provider.h
@@ -27,6 +27,22 @@ public:
         return Status::OK();
     }
 
+    // placeholder
+    Status BindMemory(const std::vector<RegisteredMemory>& regions,
+                      std::vector<MRHandle>& mrHandles) override
+    {
+        mrHandles.clear();
+        mrHandles.reserve(regions.size());
+        for (const auto& region : regions) { mrHandles.push_back(region.handle); }
+        return Status::OK();
+    }
+
+    // placeholder
+    std::vector<Status> UnbindMemory(const std::vector<UnbindMemoryDesc>& handles) override
+    {
+        return std::vector<Status>(handles.size(), Status::OK());
+    }
+
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& handles) override
     {
         return std::vector<Status>(handles.size(), Status::OK());

--- a/ucm/transport/kv/asu/trans/src/aiv_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/aiv_trans_provider.h
@@ -71,6 +71,22 @@ public:
         return FromImpl(impl_->RegisterMemory(descs, mrHandles));
     }
 
+    // placeholder
+    Status BindMemory(const std::vector<RegisteredMemory>& regions,
+                      std::vector<MRHandle>& mrHandles) override
+    {
+        return FromImpl(impl_->BindMemory(regions, mrHandles));
+    }
+
+    // placeholder
+    std::vector<Status> UnbindMemory(const std::vector<UnbindMemoryDesc>& memoryDescs) override
+    {
+        std::vector<AIVTransport::UnbindMemoryDesc> descs;
+        descs.reserve(memoryDescs.size());
+        for (const auto& desc : memoryDescs) { descs.push_back({desc.mrHandle}); }
+        return FromImpl(impl_->UnbindMemory(descs));
+    }
+
     std::vector<Status> UnregisterMemory(
         const std::vector<UnregisterMemoryDesc>& memoryDescs) override
     {

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -207,6 +207,19 @@ Status AsuTransportImpl::Shutdown()
     }
     {
         std::lock_guard<std::mutex> lock(registeredRegionsMu_);
+        std::vector<MRHandle> boundHandles;
+        boundHandles.reserve(registeredRegions_.size());
+        for (const auto& item : registeredRegions_) {
+            if (ownedRegisteredRegionHandles_.find(item.first) ==
+                ownedRegisteredRegionHandles_.end()) {
+                boundHandles.push_back(item.first);
+            }
+        }
+        if (!boundHandles.empty() && transProvider_) {
+            const auto status = UnbindRegionHandles(boundHandles);
+            if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+        }
+
         std::vector<MRHandle> handles;
         handles.reserve(ownedRegisteredRegionHandles_.size());
         for (auto handle : ownedRegisteredRegionHandles_) { handles.push_back(handle); }
@@ -419,11 +432,98 @@ Status AsuTransportImpl::BindRegisteredRegions(const std::vector<RegisteredMemor
     results.reserve(regions.size());
 
     std::lock_guard<std::mutex> lock(registeredRegionsMu_);
-    for (const auto& region : regions) {
-        registeredRegions_[region.handle] = region;
-        results.emplace_back(RegisterResult{Status::OK(), region.handle, region.tokenId});
+    const auto rollbackBoundMemory = [this](const std::vector<MRHandle>& handles) {
+        if (handles.empty()) { return; }
+
+        std::vector<TransProvider::UnbindMemoryDesc> unbindDescs;
+        unbindDescs.reserve(handles.size());
+        for (auto handle : handles) { unbindDescs.push_back({handle}); }
+
+        const auto statuses = transProvider_->UnbindMemory(unbindDescs);
+        if (statuses.size() != handles.size()) {
+            UC_ERROR("Rollback bound memory result count mismatch, handle_count={} result_count={}",
+                     handles.size(), statuses.size());
+        }
+        for (std::size_t index = 0; index < std::min(handles.size(), statuses.size()); ++index) {
+            if (!statuses[index].ok()) {
+                UC_ERROR("Rollback bound memory failed, handle={} code={} message={}",
+                         handles[index], static_cast<int>(statuses[index].code),
+                         statuses[index].message);
+            }
+        }
+    };
+
+    std::vector<MRHandle> localHandles;
+    auto status = transProvider_->BindMemory(regions, localHandles);
+    if (!status.ok()) {
+        rollbackBoundMemory(localHandles);
+        return status;
+    }
+    if (localHandles.size() != regions.size()) {
+        rollbackBoundMemory(localHandles);
+        return Status::Error(StatusCode::INTERNAL_ERROR,
+                             "bind result count does not match region count");
+    }
+
+    std::vector<std::uint32_t> tokenIds(regions.size());
+    for (std::size_t index = 0; index < localHandles.size(); ++index) {
+        status = transProvider_->GetMemTokenId(localHandles[index], tokenIds[index]);
+        if (status.ok()) { continue; }
+
+        rollbackBoundMemory(localHandles);
+        return status;
+    }
+
+    for (std::size_t index = 0; index < regions.size(); ++index) {
+        auto localRegion = regions[index];
+        localRegion.handle = localHandles[index];
+        localRegion.tokenId = tokenIds[index];
+        registeredRegions_[regions[index].handle] = localRegion;
+        results.emplace_back(
+            RegisterResult{Status::OK(), regions[index].handle, regions[index].tokenId});
     }
     return Status::OK();
+}
+
+Status AsuTransportImpl::UnbindRegisteredRegions(const std::vector<MRHandle>& handles)
+{
+    std::lock_guard<std::mutex> lock(registeredRegionsMu_);
+    return UnbindRegionHandles(handles);
+}
+
+Status AsuTransportImpl::UnbindRegionHandles(const std::vector<MRHandle>& handles)
+{
+    std::vector<MRHandle> canonicalHandles;
+    std::vector<TransProvider::UnbindMemoryDesc> unbindDescs;
+    canonicalHandles.reserve(handles.size());
+    unbindDescs.reserve(handles.size());
+    for (auto handle : handles) {
+        const auto iter = registeredRegions_.find(handle);
+        if (iter == registeredRegions_.end() ||
+            ownedRegisteredRegionHandles_.find(handle) != ownedRegisteredRegionHandles_.end()) {
+            continue;
+        }
+        canonicalHandles.push_back(handle);
+        unbindDescs.push_back({iter->second.handle});
+    }
+    if (unbindDescs.empty()) { return Status::OK(); }
+
+    const auto statuses = transProvider_->UnbindMemory(unbindDescs);
+    Status failure = statuses.size() == canonicalHandles.size()
+                         ? Status::OK()
+                         : Status::Error(StatusCode::INTERNAL_ERROR,
+                                         "unbind result count does not match handle count");
+    for (std::size_t index = 0; index < canonicalHandles.size(); ++index) {
+        if (index < statuses.size() && statuses[index].ok()) {
+            registeredRegions_.erase(canonicalHandles[index]);
+        } else if (failure.ok()) {
+            failure = index < statuses.size()
+                          ? statuses[index]
+                          : Status::Error(StatusCode::INTERNAL_ERROR,
+                                          "unbind result count does not match handle count");
+        }
+    }
+    return failure;
 }
 
 Status AsuTransportImpl::UnregisterRegions(const std::vector<MRHandle>& handles)

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
@@ -88,6 +88,8 @@ public:
     Status BindRegisteredRegions(const std::vector<RegisteredMemory>& regions,
                                  std::vector<RegisterResult>& results) override;
 
+    Status UnbindRegisteredRegions(const std::vector<MRHandle>& handles) override;
+
     Status UnregisterRegions(const std::vector<MRHandle>& handles) override;
 
 private:
@@ -121,6 +123,7 @@ private:
     void BuildResult(const TransportTaskContext& ctx, TaskResult& result);
 
     void SetTransProvider(std::unique_ptr<TransProvider> provider);
+    Status UnbindRegionHandles(const std::vector<MRHandle>& handles);
     Status UnregisterOwnedRegionHandles(const std::vector<MRHandle>& handles);
 
     TransportConfig config_;

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
@@ -521,6 +521,30 @@ Status FakeTransProvider::RegisterMemory(const std::vector<RegisterMemoryDesc>& 
     return Status::OK();
 }
 
+Status FakeTransProvider::BindMemory(const std::vector<::UC::ASU::RegisteredMemory>& regions,
+                                     std::vector<MRHandle>& mrHandles)
+{
+    mrHandles.clear();
+    mrHandles.reserve(regions.size());
+    std::lock_guard<std::mutex> lock(registeredMemoryMu_);
+    for (const auto& region : regions) {
+        auto handle = nextMrHandle_.fetch_add(1, std::memory_order_relaxed);
+        if (handle == 0) { handle = nextMrHandle_.fetch_add(1, std::memory_order_relaxed); }
+        auto mrHandle = reinterpret_cast<MRHandle>(handle);
+        registeredMemories_[mrHandle] =
+            RegisteredMemory{region.region.addr, region.region.addr, region.region.size};
+        mrHandles.push_back(mrHandle);
+    }
+    return Status::OK();
+}
+
+std::vector<Status> FakeTransProvider::UnbindMemory(const std::vector<UnbindMemoryDesc>& handles)
+{
+    std::lock_guard<std::mutex> lock(registeredMemoryMu_);
+    for (const auto& desc : handles) { registeredMemories_.erase(desc.mrHandle); }
+    return std::vector<Status>(handles.size(), Status::OK());
+}
+
 std::vector<Status> FakeTransProvider::UnregisterMemory(
     const std::vector<UnregisterMemoryDesc>& handles)
 {

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
@@ -53,6 +53,11 @@ public:
     Status RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
                           std::vector<MRHandle>& mrHandles) override;
 
+    Status BindMemory(const std::vector<::UC::ASU::RegisteredMemory>& regions,
+                      std::vector<MRHandle>& mrHandles) override;
+
+    std::vector<Status> UnbindMemory(const std::vector<UnbindMemoryDesc>& handles) override;
+
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& handles) override;
 
     Status AllocThread(uint32_t, const std::vector<uint32_t>&, std::vector<ThreadHandle>&) override;

--- a/ucm/transport/kv/asu/trans/src/trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/trans_provider.h
@@ -44,6 +44,16 @@ public:
     virtual Status RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
                                   std::vector<MRHandle>& mrHandles) = 0;
 
+    // To be discussed
+    virtual Status BindMemory(const std::vector<RegisteredMemory>& regions,
+                              std::vector<MRHandle>& mrHandles) = 0;
+
+    struct UnbindMemoryDesc {
+        MRHandle mrHandle;
+    };
+
+    virtual std::vector<Status> UnbindMemory(const std::vector<UnbindMemoryDesc>& memoryDescs) = 0;
+
     struct UnregisterMemoryDesc {
         MRHandle mrHandle;
     };

--- a/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
@@ -45,12 +45,16 @@ class StubTransProvider : public TransProvider {
 public:
     std::uint32_t registerCount{0};
     std::uint32_t registerCallCount{0};
+    std::uint32_t bindCount{0};
+    std::uint32_t unbindCount{0};
     std::uint32_t unregisterCount{0};
     std::uint32_t failRegisterAt{0};
     std::uint32_t tokenLookupCount{0};
     std::uint32_t failTokenLookupAt{0};
     std::uint32_t failUnregisterAt{0};
     bool failUnregister{false};
+    std::vector<MRHandle> unboundHandles;
+    std::vector<MRHandle> unregisteredHandles;
 
     Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t qpNum,
                             uint32_t, std::vector<ConnectionHandle>& handles) override
@@ -90,12 +94,35 @@ public:
         return Status::OK();
     }
 
+    Status BindMemory(const std::vector<RegisteredMemory>& regions,
+                      std::vector<MRHandle>& handles) override
+    {
+        handles.clear();
+        handles.reserve(regions.size());
+        for (std::size_t index = 0; index < regions.size(); ++index) {
+            ++bindCount;
+            handles.push_back(
+                reinterpret_cast<MRHandle>(static_cast<std::uintptr_t>(1000 + bindCount)));
+        }
+        return Status::OK();
+    }
+
+    std::vector<Status> UnbindMemory(const std::vector<UnbindMemoryDesc>& descs) override
+    {
+        for (const auto& desc : descs) {
+            ++unbindCount;
+            unboundHandles.push_back(desc.mrHandle);
+        }
+        return std::vector<Status>(descs.size(), Status::OK());
+    }
+
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& descs) override
     {
         std::vector<Status> statuses;
         statuses.reserve(descs.size());
         for (std::size_t index = 0; index < descs.size(); ++index) {
             ++unregisterCount;
+            unregisteredHandles.push_back(descs[index].mrHandle);
             if (failUnregister || (failUnregisterAt != 0 && unregisterCount == failUnregisterAt)) {
                 statuses.emplace_back(
                     Status::Error(StatusCode::INTERNAL_ERROR, "stub unregister failed"));
@@ -230,6 +257,44 @@ TEST(AsuTransportRegisterTest, RegisterDeviceRegionDoesNotRequireConnection)
     ASSERT_EQ(results.size(), std::size_t{1});
     EXPECT_TRUE(results[0].status.ok()) << results[0].status.message;
     EXPECT_EQ(providerPtr->registerCount, std::uint32_t{1});
+}
+
+TEST(AsuTransportRegisterTest, BoundRegionsUnbindLocalMemoryWithoutUnregisteringOwnerMemory)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    RegisteredMemory region;
+    region.region.memoryType = MemoryType::ASCEND_DEVICE;
+    region.region.addr = 0x1000;
+    region.region.size = 4096;
+    region.handle = reinterpret_cast<MRHandle>(std::uintptr_t{7});
+    region.tokenId = 23;
+
+    std::vector<RegisterResult> results;
+    auto status = transport.BindRegisteredRegions({region}, results);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(results.size(), std::size_t{1});
+    EXPECT_EQ(results[0].handle, region.handle);
+    EXPECT_EQ(results[0].tokenId, region.tokenId);
+    EXPECT_EQ(providerPtr->bindCount, std::uint32_t{1});
+    ASSERT_EQ(transport.registeredRegions_.size(), std::size_t{1});
+    const auto localHandle = transport.registeredRegions_.at(region.handle).handle;
+    EXPECT_NE(localHandle, region.handle);
+
+    status = transport.UnbindRegisteredRegions({region.handle});
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(providerPtr->unbindCount, std::uint32_t{1});
+    EXPECT_EQ(providerPtr->unboundHandles, std::vector<MRHandle>({localHandle}));
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{0});
+    EXPECT_TRUE(providerPtr->unregisteredHandles.empty());
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
 }
 
 TEST(AsuTransportRegisterTest, RegisterRegionsReturnsAllResultsAfterBatchFailure)

--- a/ucm/transport/kv/asu/trans/test/fake_trans_provider_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/fake_trans_provider_test.cpp
@@ -25,5 +25,26 @@ TEST(FakeTransProviderTest, RegisterMemoryReturnsUniqueHandlesAcrossCalls)
     EXPECT_EQ(uniqueHandles.count(kInvalidMRHandle), 0);
 }
 
+TEST(FakeTransProviderTest, BindMemoryAcceptsRegisteredRegions)
+{
+    FakeTransProvider provider(FakeTransProviderConfig{});
+    std::vector<RegisteredMemory> regions(2);
+    regions[0].handle = reinterpret_cast<MRHandle>(std::uintptr_t{101});
+    regions[1].handle = reinterpret_cast<MRHandle>(std::uintptr_t{102});
+
+    std::vector<MRHandle> handles;
+    ASSERT_TRUE(provider.BindMemory(regions, handles).ok());
+    ASSERT_EQ(handles.size(), regions.size());
+    EXPECT_NE(handles[0], regions[0].handle);
+    EXPECT_NE(handles[1], regions[1].handle);
+
+    std::vector<TransProvider::UnbindMemoryDesc> descs;
+    for (auto handle : handles) { descs.push_back({handle}); }
+    const auto statuses = provider.UnbindMemory(descs);
+    ASSERT_EQ(statuses.size(), regions.size());
+    EXPECT_TRUE(statuses[0].ok());
+    EXPECT_TRUE(statuses[1].ok());
+}
+
 }  // namespace
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
@@ -73,6 +73,18 @@ public:
         handles.push_back(reinterpret_cast<MRHandle>(static_cast<uintptr_t>(1)));
         return Status::OK();
     }
+    Status BindMemory(const std::vector<RegisteredMemory>& regions,
+                      std::vector<MRHandle>& handles) override
+    {
+        handles.clear();
+        for (const auto& region : regions) { handles.push_back(region.handle); }
+        return Status::OK();
+    }
+
+    std::vector<Status> UnbindMemory(const std::vector<UnbindMemoryDesc>& handles) override
+    {
+        return std::vector<Status>(handles.size(), Status::OK());
+    }
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>&) override
     {
         return {};

--- a/ucm/transport/kv/asu/trans/test/transport_task_completion_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/transport_task_completion_test.cpp
@@ -65,6 +65,18 @@ public:
         handles.push_back(reinterpret_cast<MRHandle>(static_cast<uintptr_t>(1)));
         return Status::OK();
     }
+    Status BindMemory(const std::vector<RegisteredMemory>& regions,
+                      std::vector<MRHandle>& handles) override
+    {
+        handles.clear();
+        for (const auto& region : regions) { handles.push_back(region.handle); }
+        return Status::OK();
+    }
+
+    std::vector<Status> UnbindMemory(const std::vector<UnbindMemoryDesc>& handles) override
+    {
+        return std::vector<Status>(handles.size(), Status::OK());
+    }
     std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>&) override
     {
         return {};


### PR DESCRIPTION
## Purpose
Adapt AsuClient to senarios where there are multiple ASUs.
For temprary implementation, the very first transport (ASU) does the actual registering and unregistering; the followers does binding and unbinding to avoid redundant operations.
In the future, we plan to remove the *owner* transport and let Client chooses which transport does the action of reg and unreg. This needs several modifications or refactors in AIV / AICPU TransProvider.

## Modifications 
1. In commit 28b3fc4, asu_port is modified from an integer to a vector.
2. In commit e90178e, we add Bind and Unbind interface in Client, Transport, and TransProvider which is currently placeholder to be discussed.

## Test
Only for discussion in this stage.