### PR TITLE
[Feat] Add DramPool task worker

### DIFF
--- a/examples/drampool.yaml
+++ b/examples/drampool.yaml
@@ -23,6 +23,12 @@ request_receiver:
 poller:
   pending_depth: 64
 
+# Local staging memory used for response/flag RDMA writes. This capacity is
+# independent from the KVCache pool configured by --pool-size-gb.
+flag_buffer:
+  capacity_mb: 64
+  slot_size_bytes: 64
+
 gc:
   enabled: true
   interval_ms: 1000

--- a/ucm/store/dram/cc/drampool/drampool_config.h
+++ b/ucm/store/dram/cc/drampool/drampool_config.h
@@ -23,6 +23,7 @@
  * */
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <unordered_map>
@@ -35,6 +36,8 @@ namespace UC::DramPool {
 
 inline constexpr std::uint32_t kDefaultPollerPendingDepth = 64;
 inline constexpr std::uint64_t kBytesPerGiB = 1024ULL * 1024ULL * 1024ULL;
+inline constexpr std::uint64_t kBytesPerMiB = 1024ULL * 1024ULL;
+inline constexpr std::size_t kFlagBufferSlotAlignment = 64;
 inline constexpr std::uint64_t kMillisecondsPerMinute = 60'000;
 inline constexpr std::uint64_t kDefaultTtlMinutes = 120;
 inline constexpr std::uint64_t kDefaultDumpTtlMs = kDefaultTtlMinutes * kMillisecondsPerMinute;
@@ -65,6 +68,12 @@ struct DramPoolConfig {
     std::uint32_t requestReceiverIdleWaitUs{100};
 
     std::uint32_t pollerPendingDepth{kDefaultPollerPendingDepth};
+
+    // Local staging pool used only for response/flag RDMA writes.
+    std::uint64_t flagBufferCapacityMb{64};
+    std::uint64_t flagBufferSlotSizeBytes{64};
+    // Resolved by ParseYamlConfig from capacity and slot layout.
+    std::uint32_t flagBufferSlotCount{0};
 
     bool gcEnabled{true};
     std::uint32_t gcIntervalMs{1000};

--- a/ucm/store/dram/cc/drampool/drampool_types.h
+++ b/ucm/store/dram/cc/drampool/drampool_types.h
@@ -1,0 +1,134 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ */
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+#include "core/transport.h"
+#include "kv_protocol.h"
+#include "pool/buffer_pool.h"
+#include "status/status.h"
+#include "template/spsc_ring_queue.h"
+
+namespace transport {
+class TransportManager;
+}
+
+namespace UC::DramPool {
+class MetadataManager;
+
+inline constexpr auto kThreadIdleSleepDuration = std::chrono::microseconds(100);
+
+inline std::uint64_t SteadyNowMs()
+{
+    const auto now = std::chrono::steady_clock::now().time_since_epoch();
+    return static_cast<std::uint64_t>(
+        std::chrono::duration_cast<std::chrono::milliseconds>(now).count());
+}
+
+using RequestPtr = std::unique_ptr<KvRequest>;
+
+// Receiver keeps transport identity beside the parsed KV request.
+struct RequestTask {
+    RequestPtr request;
+    transport::ManagerID peer_one_sided_id;
+};
+
+using RequestTaskPtr = std::unique_ptr<RequestTask>;
+using RequestQueue = UC::SpscRingQueue<RequestTaskPtr>;
+
+using TransportHandle = transport::TransferHandle;
+
+inline Status ToUcStatus(transport::Status status, const char* operation)
+{
+    if (status == transport::Status::Ok) { return Status::OK(); }
+    if (status == transport::Status::InvalidArgument) {
+        return Status::InvalidParam("{}: invalid transport argument", operation);
+    }
+    return Status::Error(std::string{operation} + ": transport operation failed");
+}
+
+struct TransferItem {
+    // State needed to settle one item after the batch reaches terminal.
+    std::uint16_t index_in_request{0};
+    BlockId key{};
+};
+
+enum class DumpLoadResult : std::uint8_t {
+    Ok = 0,
+    Failed = 1,
+};
+
+enum class LookupResult : std::uint8_t {
+    NotFound = 0,
+    Exists = 1,
+};
+
+static_assert(static_cast<std::uint8_t>(DumpLoadResult::Failed) <= 0x0FU,
+              "Dump/Load result codes must fit in 4 bits");
+
+enum class InflightPhase : std::uint8_t {
+    Polling = 0,
+    // The transfer must still reach terminal, but its request result is forced to failure.
+    DrainingAsFailed = 1,
+};
+
+enum class CompletionStage : std::uint8_t {
+    PollDataTransfer = 0,
+    SubmitResponse = 1,
+    PollResponseTransfer = 2,
+};
+
+struct CompletionRecord {
+    CompletionStage stage{CompletionStage::PollDataTransfer};
+
+    // State used while the request's data transfer is in flight.
+    TransportHandle data_handle{transport::kInvalidTransferHandle};
+    std::vector<TransferItem> transfer_items;
+    std::uint64_t submit_ms{0};
+    InflightPhase phase{InflightPhase::Polling};
+
+    // State needed to construct the request's sole response.
+    KvOpcode opcode{KvOpcode::None};
+    std::uint64_t response_addr{0};
+    transport::ManagerID peer_one_sided_id;
+    std::vector<std::uint8_t> results;
+
+    // Ownership held from response submission until its handle reaches terminal.
+    TransportHandle response_handle{transport::kInvalidTransferHandle};
+    UC::BufferPool::Slot resp_buffer;
+};
+
+using CompletionQueue = UC::SpscRingQueue<CompletionRecord>;
+
+// Non-owning runtime view. DramPoolServer owns every referenced component.
+struct DramPoolRuntime {
+    DramPoolRuntime(UC::DramPool::MetadataManager& metadataRef, UC::BufferPool& flagBufferPoolRef,
+                    transport::TransportManager& transportRef, ProtocolManager& protocolRef,
+                    RequestQueue& requestQueueRef, CompletionQueue& completionQueueRef)
+        : metadata(metadataRef),
+          flagBufferPool(flagBufferPoolRef),
+          transport(transportRef),
+          protocol(protocolRef),
+          requestQueue(requestQueueRef),
+          completionQueue(completionQueueRef)
+    {
+    }
+
+    UC::DramPool::MetadataManager& metadata;
+    UC::BufferPool& flagBufferPool;
+    transport::TransportManager& transport;
+    ProtocolManager& protocol;
+    RequestQueue& requestQueue;
+    CompletionQueue& completionQueue;
+};
+
+}  // namespace UC::DramPool

--- a/ucm/store/dram/cc/drampool/drampool_yaml_config.cpp
+++ b/ucm/store/dram/cc/drampool/drampool_yaml_config.cpp
@@ -58,6 +58,8 @@ constexpr const char* kRequiredRuntimeConfigKeys[] = {
     "queue.completion_depth",
     "request_receiver.idle_wait_us",
     "poller.pending_depth",
+    "flag_buffer.capacity_mb",
+    "flag_buffer.slot_size_bytes",
     "gc.enabled",
     "gc.interval_ms",
     "metadata.periodic_eviction_policy",
@@ -274,6 +276,12 @@ Status ApplyRuntimeConfigValue(DramPoolConfig& config, const std::string& key,
     if (key == "poller.pending_depth") {
         return ParseUint32Value(key, value, config.pollerPendingDepth);
     }
+    if (key == "flag_buffer.capacity_mb") {
+        return ParseUint64Value(key, value, config.flagBufferCapacityMb);
+    }
+    if (key == "flag_buffer.slot_size_bytes") {
+        return ParseUint64Value(key, value, config.flagBufferSlotSizeBytes);
+    }
     if (key == "gc.enabled") { return ParseBoolValue(key, value, config.gcEnabled); }
     if (key == "gc.interval_ms") { return ParseUint32Value(key, value, config.gcIntervalMs); }
     if (key == "metadata.periodic_eviction_policy") {
@@ -305,7 +313,7 @@ Status ApplyRuntimeConfigValue(DramPoolConfig& config, const std::string& key,
     return Status::InvalidParam("unknown DramPool runtime YAML key: {}", key);
 }
 
-Status ValidateRuntimeConfig(const DramPoolConfig& config)
+Status ValidateRuntimeConfig(DramPoolConfig& config)
 {
     if (config.twoSidedToOneSided.empty()) {
         return Status::InvalidParam("transport.endpoints must not be empty");
@@ -334,6 +342,31 @@ Status ValidateRuntimeConfig(const DramPoolConfig& config)
     if (config.pollerPendingDepth == 0) {
         return Status::InvalidParam("poller.pending_depth must be greater than zero");
     }
+    if (config.flagBufferCapacityMb == 0 || config.flagBufferSlotSizeBytes == 0) {
+        return Status::InvalidParam(
+            "flag_buffer.capacity_mb and flag_buffer.slot_size_bytes must be greater than zero");
+    }
+    if (config.flagBufferCapacityMb > std::numeric_limits<std::uint64_t>::max() / kBytesPerMiB) {
+        return Status::InvalidParam("flag_buffer.capacity_mb is too large");
+    }
+    const auto capacityBytes = config.flagBufferCapacityMb * kBytesPerMiB;
+    if (capacityBytes > static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max()) ||
+        config.flagBufferSlotSizeBytes >
+            static_cast<std::uint64_t>(std::numeric_limits<std::size_t>::max()) ||
+        config.flagBufferSlotSizeBytes >
+            std::numeric_limits<std::uint64_t>::max() - (kFlagBufferSlotAlignment - 1)) {
+        return Status::InvalidParam("flag_buffer layout exceeds addressable process memory");
+    }
+    const auto slotStride = (config.flagBufferSlotSizeBytes + kFlagBufferSlotAlignment - 1) /
+                            kFlagBufferSlotAlignment * kFlagBufferSlotAlignment;
+    const auto slotCount = capacityBytes / slotStride;
+    if (slotCount < config.pollerPendingDepth ||
+        slotCount >= std::numeric_limits<std::uint32_t>::max()) {
+        return Status::InvalidParam(
+            "flag_buffer capacity must provide at least poller.pending_depth slots and fit "
+            "the BufferPool index range");
+    }
+    config.flagBufferSlotCount = static_cast<std::uint32_t>(slotCount);
     if (config.gcEnabled && config.gcIntervalMs == 0) {
         return Status::InvalidParam("gc.interval_ms must be greater than zero when GC is enabled");
     }

--- a/ucm/store/dram/cc/drampool/task_worker.cpp
+++ b/ucm/store/dram/cc/drampool/task_worker.cpp
@@ -1,0 +1,307 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ * */
+#include "task_worker.h"
+#include <algorithm>
+#include <chrono>
+#include <thread>
+#include <utility>
+#include "core/transport_manager.h"
+#include "drampool_config.h"
+#include "logger/logger.h"
+#include "metadata.h"
+
+namespace UC::DramPool {
+namespace {
+
+std::chrono::system_clock::time_point LifeTimeout(std::uint64_t ttlMs)
+{
+    return ttlMs == 0 ? std::chrono::system_clock::time_point{}
+                      : std::chrono::system_clock::now() + std::chrono::milliseconds(ttlMs);
+}
+
+}  // namespace
+
+TaskWorker::TaskWorker(DramPoolRuntime& runtime) : runtime_(runtime) {}
+
+void TaskWorker::Run(const std::atomic_bool& stop)
+{
+    while (true) {
+        RequestTaskPtr task;
+        if (runtime_.requestQueue.TryPop(task)) {
+            const auto processStatus = ProcessOneRequest(std::move(task));
+            if (processStatus.Failure()) {
+                UC_ERROR("TaskWorker ProcessOneRequest failed: {}", processStatus);
+            }
+            continue;
+        }
+
+        // Stop is requested only after RequestReceiveLoop has exited, so an empty queue is drained.
+        if (stop.load(std::memory_order_acquire)) { break; }
+        std::this_thread::sleep_for(kThreadIdleSleepDuration);
+    }
+}
+
+Status TaskWorker::ProcessOneRequest(RequestTaskPtr task)
+{
+    if (!task || !task->request || task->peer_one_sided_id.empty()) {
+        return Status::InvalidParam("TaskWorker got an invalid request task");
+    }
+    const auto peerStatus = EnsurePeerReady(task->peer_one_sided_id);
+    if (peerStatus.Failure()) { return peerStatus; }
+    const auto& peerOneSidedId = task->peer_one_sided_id;
+    const auto& request = task->request;
+    switch (request->opcode) {
+        case KvOpcode::Dump: {
+            const auto* dump = dynamic_cast<const KvDumpRequest*>(request.get());
+            return dump == nullptr ? Status::InvalidParam("DUMP request type does not match opcode")
+                                   : ProcessDump(*dump, peerOneSidedId);
+        }
+        case KvOpcode::Load: {
+            const auto* load = dynamic_cast<const KvLoadRequest*>(request.get());
+            return load == nullptr ? Status::InvalidParam("LOAD request type does not match opcode")
+                                   : ProcessLoad(*load, peerOneSidedId);
+        }
+        case KvOpcode::Lookup: {
+            const auto* lookup = dynamic_cast<const KvLookupRequest*>(request.get());
+            return lookup == nullptr
+                       ? Status::InvalidParam("LOOKUP request type does not match opcode")
+                       : ProcessLookup(*lookup, peerOneSidedId);
+        }
+        case KvOpcode::None: break;
+    }
+    return Status::InvalidParam("TaskWorker got invalid opcode");
+}
+
+Status TaskWorker::EnsurePeerReady(const transport::ManagerID& targetOneSidedId)
+{
+    return ToUcStatus(
+        runtime_.transport.Connect(transport::TransportProtocol::Hixl, targetOneSidedId),
+        "TransportManager::Connect");
+}
+
+Status TaskWorker::ProcessDump(const KvDumpRequest& request,
+                               const transport::ManagerID& peerOneSidedId)
+{
+    if (runtime_.protocol.GetPackedResponseSize(KvOpcode::Dump, request.batch_size) >
+        g_config.flagBufferSlotSizeBytes) {
+        return Status::InvalidParam("DUMP response exceeds configured flag buffer slot size");
+    }
+    const std::uint64_t ttl_ms =
+        request.ttl != 0 ? static_cast<std::uint64_t>(request.ttl) : g_config.defaultDumpTtlMs;
+    const auto lifeTimeout = LifeTimeout(ttl_ms);
+    std::vector<std::uint8_t> results(request.batch_size,
+                                      static_cast<std::uint8_t>(DumpLoadResult::Ok));
+    const auto mark_remaining_failed = [&results](std::size_t first) {
+        std::fill(results.begin() + first, results.end(),
+                  static_cast<std::uint8_t>(DumpLoadResult::Failed));
+    };
+    std::vector<TransferItem> transfer_items;
+    transfer_items.reserve(request.entries.size());
+    transport::Operation operation;
+    operation.opcode = transport::Opcode::Read;
+    operation.direct = transport::OperationDirect::RemoteDeviceHost;
+    operation.target_manager = peerOneSidedId;
+    operation.ops.reserve(request.entries.size());
+
+    for (std::uint16_t index = 0; index < request.batch_size; ++index) {
+        const auto& entry = request.entries[index];
+
+        auto metadataEntry = std::make_shared<UC::DramPool::Entry>();
+        metadataEntry->key = entry.key;
+        metadataEntry->size = entry.len;
+        metadataEntry->lifeTimeout = lifeTimeout;
+        metadataEntry->position = entry.idx;
+
+        const auto storeStatus = runtime_.metadata.StoreBegin(entry.key, metadataEntry);
+        if (storeStatus == Status::DuplicateKey()) {
+            results[index] = static_cast<std::uint8_t>(DumpLoadResult::Ok);
+            continue;
+        }
+        if (storeStatus.Failure()) {
+            UC_ERROR("Dump[{}] StoreBegin failed: {}", index, storeStatus);
+            // StoreBegin failures are typically resource-related after eviction retries.
+            // Stop here to avoid costly allocation attempts for the remaining items.
+            mark_remaining_failed(index);
+            break;
+        }
+
+        // INITIALIZED entries are not eviction candidates while the DUMP is in flight.
+        transfer_items.emplace_back(TransferItem{index, entry.key});
+        operation.ops.emplace_back(
+            transport::Segment{metadataEntry->buffer.addr, entry.addr, entry.len});
+    }
+
+    if (transfer_items.empty()) {
+        return QueueResponse(KvOpcode::Dump, request.resp_addr, peerOneSidedId, std::move(results));
+    }
+
+    TransportHandle handle = transport::kInvalidTransferHandle;
+    const auto submit_status = runtime_.transport.ExecuteAsync(operation, handle);
+    if (submit_status != transport::Status::Ok || handle == transport::kInvalidTransferHandle) {
+        UC_ERROR("Dump SubmitAsync failed, items={}", transfer_items.size());
+        DeleteItemsMetadata(transfer_items);
+        for (const auto& item : transfer_items) {
+            results[item.index_in_request] = static_cast<std::uint8_t>(DumpLoadResult::Failed);
+        }
+        return QueueResponse(KvOpcode::Dump, request.resp_addr, peerOneSidedId, std::move(results));
+    }
+
+    CompletionRecord record;
+    record.stage = CompletionStage::PollDataTransfer;
+    record.opcode = KvOpcode::Dump;
+    record.data_handle = handle;
+    record.response_addr = request.resp_addr;
+    record.peer_one_sided_id = peerOneSidedId;
+    record.results = std::move(results);
+    record.transfer_items = std::move(transfer_items);
+    record.submit_ms = SteadyNowMs();
+    return SubmitCompletion(std::move(record));
+}
+
+Status TaskWorker::ProcessLoad(const KvLoadRequest& request,
+                               const transport::ManagerID& peerOneSidedId)
+{
+    if (runtime_.protocol.GetPackedResponseSize(KvOpcode::Load, request.batch_size) >
+        g_config.flagBufferSlotSizeBytes) {
+        return Status::InvalidParam("LOAD response exceeds configured flag buffer slot size");
+    }
+    std::vector<std::uint8_t> results(request.batch_size,
+                                      static_cast<std::uint8_t>(DumpLoadResult::Ok));
+    std::vector<TransferItem> transfer_items;
+    transfer_items.reserve(request.entries.size());
+    transport::Operation operation;
+    operation.opcode = transport::Opcode::Write;
+    operation.direct = transport::OperationDirect::RemoteDeviceHost;
+    operation.target_manager = peerOneSidedId;
+    operation.ops.reserve(request.entries.size());
+
+    for (std::uint16_t index = 0; index < request.batch_size; ++index) {
+        const auto& entry = request.entries[index];
+        UC::DramPool::EntryPtr metadataEntry;
+        const auto loadStatus = runtime_.metadata.LoadBegin(entry.key, metadataEntry);
+        if (loadStatus.Failure() || !metadataEntry) {
+            results[index] = static_cast<std::uint8_t>(DumpLoadResult::Failed);
+            UC_ERROR("Load[{}] LoadBegin failed: {}", index, loadStatus);
+            continue;
+        }
+        if (entry.len > metadataEntry->size) {
+            const auto releaseStatus = runtime_.metadata.LoadEnd(entry.key);
+            if (releaseStatus.Failure()) {
+                UC_ERROR("Load[{}] LoadEnd after len mismatch failed: {}", index, releaseStatus);
+            }
+            UC_ERROR("Load[{}] invalid len, requested={}, stored={}", index, entry.len,
+                     metadataEntry->size);
+            results[index] = static_cast<std::uint8_t>(DumpLoadResult::Failed);
+            continue;
+        }
+
+        // The LOAD pin keeps metadata and buffer alive through async transport.
+        transfer_items.emplace_back(TransferItem{index, entry.key});
+        operation.ops.emplace_back(
+            transport::Segment{metadataEntry->buffer.addr, entry.addr, entry.len});
+    }
+
+    if (transfer_items.empty()) {
+        return QueueResponse(KvOpcode::Load, request.resp_addr, peerOneSidedId, std::move(results));
+    }
+
+    TransportHandle handle = transport::kInvalidTransferHandle;
+    const auto submit_status = runtime_.transport.ExecuteAsync(operation, handle);
+    if (submit_status != transport::Status::Ok || handle == transport::kInvalidTransferHandle) {
+        UC_ERROR("Load SubmitAsync failed, items={}", transfer_items.size());
+        LoadEndItems(transfer_items);
+        for (const auto& item : transfer_items) {
+            results[item.index_in_request] = static_cast<std::uint8_t>(DumpLoadResult::Failed);
+        }
+        return QueueResponse(KvOpcode::Load, request.resp_addr, peerOneSidedId, std::move(results));
+    }
+
+    CompletionRecord record;
+    record.stage = CompletionStage::PollDataTransfer;
+    record.opcode = KvOpcode::Load;
+    record.data_handle = handle;
+    record.response_addr = request.resp_addr;
+    record.peer_one_sided_id = peerOneSidedId;
+    record.results = std::move(results);
+    record.transfer_items = std::move(transfer_items);
+    record.submit_ms = SteadyNowMs();
+    return SubmitCompletion(std::move(record));
+}
+
+Status TaskWorker::ProcessLookup(const KvLookupRequest& request,
+                                 const transport::ManagerID& peerOneSidedId)
+{
+    if (runtime_.protocol.GetPackedResponseSize(KvOpcode::Lookup, request.batch_size) >
+        g_config.flagBufferSlotSizeBytes) {
+        return Status::InvalidParam("LOOKUP response exceeds configured flag buffer slot size");
+    }
+    std::vector<std::uint8_t> results(request.batch_size,
+                                      static_cast<std::uint8_t>(LookupResult::NotFound));
+    for (std::uint16_t index = 0; index < request.batch_size; ++index) {
+        if (runtime_.metadata.Exist(request.entries[index].key)) {
+            results[index] = static_cast<std::uint8_t>(LookupResult::Exists);
+        }
+    }
+
+    return QueueResponse(KvOpcode::Lookup, request.resp_addr, peerOneSidedId, std::move(results));
+}
+
+void TaskWorker::DeleteItemsMetadata(const std::vector<TransferItem>& items)
+{
+    for (const auto& item : items) {
+        // Remove metadata first so no index can retain a freed buffer address.
+        const auto abortStatus = runtime_.metadata.Delete(item.key);
+        if (abortStatus.Failure()) {
+            UC_ERROR("DeleteItemsMetadata Delete reserved DUMP failed: {}", abortStatus);
+        }
+    }
+}
+
+void TaskWorker::LoadEndItems(const std::vector<TransferItem>& items)
+{
+    for (const auto& item : items) {
+        const auto status = runtime_.metadata.LoadEnd(item.key);
+        if (status.Failure()) { UC_ERROR("LoadEndItems LoadEnd failed: {}", status); }
+    }
+}
+
+Status TaskWorker::QueueResponse(KvOpcode opcode, std::uint64_t responseAddr,
+                                 const transport::ManagerID& peerOneSidedId,
+                                 std::vector<std::uint8_t>&& results)
+{
+    CompletionRecord record;
+    record.stage = CompletionStage::SubmitResponse;
+    record.opcode = opcode;
+    record.response_addr = responseAddr;
+    record.peer_one_sided_id = peerOneSidedId;
+    record.results = std::move(results);
+    return SubmitCompletion(std::move(record));
+}
+
+Status TaskWorker::SubmitCompletion(CompletionRecord&& record)
+{
+    // TaskWorker is the sole producer; CompletionPoller is the sole consumer.
+    runtime_.completionQueue.Push(std::move(record));
+    return Status::OK();
+}
+
+}  // namespace UC::DramPool

--- a/ucm/store/dram/cc/drampool/task_worker.h
+++ b/ucm/store/dram/cc/drampool/task_worker.h
@@ -1,0 +1,57 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ * */
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <vector>
+#include "drampool_types.h"
+#include "kv_protocol.h"
+#include "status/status.h"
+
+namespace UC::DramPool {
+
+class TaskWorker final {
+public:
+    explicit TaskWorker(DramPoolRuntime& runtime);
+
+    void Run(const std::atomic_bool& stop);
+
+private:
+    Status ProcessOneRequest(RequestTaskPtr task);
+    Status EnsurePeerReady(const transport::ManagerID& targetOneSidedId);
+    Status ProcessDump(const KvDumpRequest& request, const transport::ManagerID& peerOneSidedId);
+    Status ProcessLoad(const KvLoadRequest& request, const transport::ManagerID& peerOneSidedId);
+    Status ProcessLookup(const KvLookupRequest& request,
+                         const transport::ManagerID& peerOneSidedId);
+
+    void DeleteItemsMetadata(const std::vector<TransferItem>& items);
+    void LoadEndItems(const std::vector<TransferItem>& items);
+    Status QueueResponse(KvOpcode opcode, std::uint64_t responseAddr,
+                         const transport::ManagerID& peerOneSidedId,
+                         std::vector<std::uint8_t>&& results);
+    Status SubmitCompletion(CompletionRecord&& record);
+
+    DramPoolRuntime& runtime_;
+};
+
+}  // namespace UC::DramPool

--- a/ucm/store/test/case/dram/drampool/drampool_yaml_config_test.cpp
+++ b/ucm/store/test/case/dram/drampool/drampool_yaml_config_test.cpp
@@ -49,6 +49,9 @@ request_receiver:
   idle_wait_us: 100
 poller:
   pending_depth: 64
+flag_buffer:
+  capacity_mb: 64
+  slot_size_bytes: 64
 gc:
   enabled: true
   interval_ms: 1000
@@ -116,6 +119,9 @@ TEST(DramPoolRuntimeYamlTest, LoadsEveryRuntimeFieldAndPreservesLaunchFields)
     EXPECT_EQ(config.completionQueueDepth, 65536U);
     EXPECT_EQ(config.requestReceiverIdleWaitUs, 100U);
     EXPECT_EQ(config.pollerPendingDepth, 64U);
+    EXPECT_EQ(config.flagBufferCapacityMb, 64U);
+    EXPECT_EQ(config.flagBufferSlotSizeBytes, 64U);
+    EXPECT_EQ(config.flagBufferSlotCount, 1'048'576U);
     EXPECT_TRUE(config.gcEnabled);
     EXPECT_EQ(config.gcIntervalMs, 1000U);
     EXPECT_EQ(config.metadataPeriodicEvictionPolicy, EvictionPolicyType::TTL);
@@ -203,6 +209,10 @@ INSTANTIATE_TEST_SUITE_P(
                         "at least 2"},
         InvalidYamlCase{"ZeroPollerPendingDepth", "pending_depth: 64", "pending_depth: 0",
                         "greater than zero"},
+        InvalidYamlCase{"ZeroFlagBufferCapacity", "capacity_mb: 64", "capacity_mb: 0",
+                        "must be greater than zero"},
+        InvalidYamlCase{"ZeroFlagBufferSlotSize", "slot_size_bytes: 64", "slot_size_bytes: 0",
+                        "must be greater than zero"},
         InvalidYamlCase{"EnabledGcHasZeroInterval", "interval_ms: 1000", "interval_ms: 0",
                         "when GC is enabled"},
         InvalidYamlCase{"UnsupportedPeriodicEvictionPolicy", "periodic_eviction_policy: TTL",

--- a/ucm/store/test/case/dram/drampool/task_worker_test.cpp
+++ b/ucm/store/test/case/dram/drampool/task_worker_test.cpp
@@ -1,0 +1,324 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ */
+#include <acl/acl.h>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <utility>
+#include <vector>
+#include "buffer_manager.h"
+#include "core/transport_manager.h"
+#include "dram/dram_test_common.h"
+#include "drampool_config.h"
+#include "drampool_types.h"
+#include "kv_protocol.h"
+#include "metadata.h"
+#include "status/status.h"
+
+// Keep white-box access entirely in the test translation unit. Production code uses the real
+// TransportManager directly and exposes no test-only interface.
+#define private public
+#include "task_worker.h"
+#undef private
+
+namespace UC::DramPool {
+namespace {
+
+constexpr std::size_t kQueueCapacity = 16;
+constexpr std::uint32_t kValueLength = 16;
+constexpr std::uint64_t kResponseAddress = 0x9000;
+constexpr char kTargetManager[] = "127.0.0.1:29000";
+
+using UC::Test::Dram::Clock;
+using UC::Test::Dram::KeyFromHex;
+using UC::Test::Dram::MakeBufferManager;
+using UC::Test::Dram::MakeEntry;
+
+std::uint8_t DumpLoadCode(DumpLoadResult result) { return static_cast<std::uint8_t>(result); }
+
+std::uint8_t LookupCode(LookupResult result) { return static_cast<std::uint8_t>(result); }
+
+class TaskWorkerTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        ASSERT_EQ(aclInit(nullptr), ACL_SUCCESS);
+        ASSERT_EQ(aclrtSetDevice(0), ACL_SUCCESS);
+    }
+
+    static void TearDownTestSuite()
+    {
+        EXPECT_EQ(aclrtResetDevice(0), ACL_SUCCESS);
+        EXPECT_EQ(aclFinalize(), ACL_SUCCESS);
+    }
+
+    void SetUp() override
+    {
+        savedConfig_ = g_config;
+        g_config.flagBufferSlotSizeBytes = 64;
+        g_config.defaultDumpTtlMs = 60'000;
+
+        requestQueue_.Setup(kQueueCapacity);
+        completionQueue_.Setup(kQueueCapacity);
+        bufferManager_ = MakeBufferManager({
+            {kValueLength, kQueueCapacity}
+        });
+        const MetadataConfig metadataConfig{EvictionPolicyType::TTL, EvictionPolicyType::POSITION,
+                                            std::chrono::milliseconds(100), 0.0};
+        metadata_ = std::make_unique<MetadataManager>(metadataConfig, *bufferManager_);
+        runtime_ = std::make_unique<DramPoolRuntime>(*metadata_, flagBufferPool_, manager_,
+                                                     protocols_, requestQueue_, completionQueue_);
+    }
+
+    void TearDown() override
+    {
+        runtime_.reset();
+        metadata_.reset();
+        bufferManager_.reset();
+        g_config = std::move(savedConfig_);
+    }
+
+    EntryPtr PublishEntry(const BlockId& key)
+    {
+        auto entry = MakeEntry(key, 0, Clock::now() + std::chrono::hours(1),
+                               EntryStatus::INITIALIZED, 0, {}, kValueLength);
+        EXPECT_TRUE(metadata_->StoreBegin(key, entry).Success());
+        EXPECT_TRUE(metadata_->StoreEnd(key).Success());
+        return entry;
+    }
+
+    Status ProcessDump(KvDumpRequest& request)
+    {
+        TaskWorker worker(*runtime_);
+        return worker.ProcessDump(request, kTargetManager);
+    }
+
+    Status ProcessLoad(KvLoadRequest& request)
+    {
+        TaskWorker worker(*runtime_);
+        return worker.ProcessLoad(request, kTargetManager);
+    }
+
+    Status ProcessLookup(KvLookupRequest& request)
+    {
+        TaskWorker worker(*runtime_);
+        return worker.ProcessLookup(request, kTargetManager);
+    }
+
+    CompletionRecord PopCompletion()
+    {
+        CompletionRecord record;
+        EXPECT_TRUE(completionQueue_.TryPop(record));
+        return record;
+    }
+
+    void ExpectNoCompletion()
+    {
+        CompletionRecord record;
+        EXPECT_FALSE(completionQueue_.TryPop(record));
+    }
+
+    RequestQueue requestQueue_;
+    CompletionQueue completionQueue_;
+    std::unique_ptr<BufferManager> bufferManager_;
+    std::unique_ptr<MetadataManager> metadata_;
+    BufferPool flagBufferPool_;
+    ProtocolManager protocols_;
+    transport::TransportManager manager_{"127.0.0.1:28000"};
+    std::unique_ptr<DramPoolRuntime> runtime_;
+    DramPoolConfig savedConfig_;
+};
+
+TEST_F(TaskWorkerTest, RejectsMalformedTasksBeforeTransport)
+{
+    TaskWorker worker(*runtime_);
+    EXPECT_TRUE(worker.ProcessOneRequest(nullptr).Failure());
+
+    auto missingRequest = std::make_unique<RequestTask>();
+    missingRequest->peer_one_sided_id = kTargetManager;
+    EXPECT_TRUE(worker.ProcessOneRequest(std::move(missingRequest)).Failure());
+
+    auto missingPeer = std::make_unique<RequestTask>();
+    missingPeer->request = std::make_unique<KvLookupRequest>();
+    EXPECT_TRUE(worker.ProcessOneRequest(std::move(missingPeer)).Failure());
+    ExpectNoCompletion();
+}
+
+TEST_F(TaskWorkerTest, RealTransportManagerRejectsUnavailablePeer)
+{
+    TaskWorker worker(*runtime_);
+    EXPECT_TRUE(worker.EnsurePeerReady(kTargetManager).Failure());
+    ExpectNoCompletion();
+}
+
+TEST_F(TaskWorkerTest, LookupReturnsHitAndMiss)
+{
+    const auto hitKey = KeyFromHex("a1");
+    PublishEntry(hitKey);
+
+    KvLookupRequest request;
+    request.opcode = KvOpcode::Lookup;
+    request.resp_addr = kResponseAddress;
+    request.entries = {{hitKey}, {KeyFromHex("a2")}};
+    request.batch_size = static_cast<std::uint16_t>(request.entries.size());
+    ASSERT_TRUE(ProcessLookup(request).Success());
+
+    const auto record = PopCompletion();
+    EXPECT_EQ(record.stage, CompletionStage::SubmitResponse);
+    EXPECT_EQ(record.opcode, KvOpcode::Lookup);
+    EXPECT_EQ(record.results, (std::vector<std::uint8_t>{LookupCode(LookupResult::Exists),
+                                                         LookupCode(LookupResult::NotFound)}));
+}
+
+TEST_F(TaskWorkerTest, DuplicateDumpIsIdempotent)
+{
+    const auto key = KeyFromHex("a1");
+    PublishEntry(key);
+
+    KvDumpRequest request;
+    request.opcode = KvOpcode::Dump;
+    request.resp_addr = kResponseAddress;
+    request.entries = {
+        {key, 0x1000, kValueLength, 0}
+    };
+    request.batch_size = static_cast<std::uint16_t>(request.entries.size());
+    ASSERT_TRUE(ProcessDump(request).Success());
+
+    const auto record = PopCompletion();
+    EXPECT_EQ(record.stage, CompletionStage::SubmitResponse);
+    EXPECT_EQ(record.results, (std::vector<std::uint8_t>{DumpLoadCode(DumpLoadResult::Ok)}));
+    EXPECT_TRUE(metadata_->Exist(key));
+}
+
+TEST_F(TaskWorkerTest, DumpStopsAfterFirstStoreBeginFailure)
+{
+    const auto duplicateKey = KeyFromHex("a1");
+    const auto failedKey = KeyFromHex("a2");
+    const auto skippedKey = KeyFromHex("a3");
+    PublishEntry(duplicateKey);
+
+    KvDumpRequest request;
+    request.opcode = KvOpcode::Dump;
+    request.resp_addr = kResponseAddress;
+    request.entries = {
+        {duplicateKey, 0x1000, kValueLength,     0},
+        {failedKey,    0x2000, kValueLength * 2, 1},
+        {skippedKey,   0x3000, kValueLength,     2},
+    };
+    request.batch_size = static_cast<std::uint16_t>(request.entries.size());
+    ASSERT_TRUE(ProcessDump(request).Success());
+
+    const auto record = PopCompletion();
+    EXPECT_EQ(record.stage, CompletionStage::SubmitResponse);
+    EXPECT_EQ(record.results, (std::vector<std::uint8_t>{DumpLoadCode(DumpLoadResult::Ok),
+                                                         DumpLoadCode(DumpLoadResult::Failed),
+                                                         DumpLoadCode(DumpLoadResult::Failed)}));
+    EXPECT_TRUE(metadata_->Exist(duplicateKey));
+    EXPECT_FALSE(metadata_->Query(failedKey));
+    EXPECT_FALSE(metadata_->Query(skippedKey));
+}
+
+TEST_F(TaskWorkerTest, DumpSubmitFailureDeletesReservedMetadata)
+{
+    const auto key = KeyFromHex("a1");
+
+    KvDumpRequest request;
+    request.opcode = KvOpcode::Dump;
+    request.resp_addr = kResponseAddress;
+    request.entries = {
+        {key, 0x1000, kValueLength, 0}
+    };
+    request.batch_size = static_cast<std::uint16_t>(request.entries.size());
+    ASSERT_TRUE(ProcessDump(request).Success());
+
+    const auto record = PopCompletion();
+    EXPECT_EQ(record.stage, CompletionStage::SubmitResponse);
+    EXPECT_EQ(record.results, (std::vector<std::uint8_t>{DumpLoadCode(DumpLoadResult::Failed)}));
+    EXPECT_FALSE(metadata_->Query(key));
+}
+
+TEST_F(TaskWorkerTest, LoadReportsMissingAndOversizedItems)
+{
+    const auto missingKey = KeyFromHex("a1");
+    const auto oversizedKey = KeyFromHex("a2");
+    const auto oversizedEntry = PublishEntry(oversizedKey);
+
+    KvLoadRequest request;
+    request.opcode = KvOpcode::Load;
+    request.resp_addr = kResponseAddress;
+    request.entries = {
+        {missingKey,   0x1000, kValueLength,     0},
+        {oversizedKey, 0x2000, kValueLength + 1, 1},
+    };
+    request.batch_size = static_cast<std::uint16_t>(request.entries.size());
+    ASSERT_TRUE(ProcessLoad(request).Success());
+
+    const auto record = PopCompletion();
+    EXPECT_EQ(record.stage, CompletionStage::SubmitResponse);
+    EXPECT_EQ(record.results, (std::vector<std::uint8_t>{DumpLoadCode(DumpLoadResult::Failed),
+                                                         DumpLoadCode(DumpLoadResult::Failed)}));
+    EXPECT_EQ(oversizedEntry->refCnt, 0U);
+}
+
+TEST_F(TaskWorkerTest, LoadSubmitFailureEndsAllPinnedItems)
+{
+    const auto firstKey = KeyFromHex("a1");
+    const auto secondKey = KeyFromHex("a2");
+    const auto firstEntry = PublishEntry(firstKey);
+    const auto secondEntry = PublishEntry(secondKey);
+
+    KvLoadRequest request;
+    request.opcode = KvOpcode::Load;
+    request.resp_addr = kResponseAddress;
+    request.entries = {
+        {firstKey,  0x1000, kValueLength, 0},
+        {secondKey, 0x2000, kValueLength, 1},
+    };
+    request.batch_size = static_cast<std::uint16_t>(request.entries.size());
+    ASSERT_TRUE(ProcessLoad(request).Success());
+
+    const auto record = PopCompletion();
+    EXPECT_EQ(record.stage, CompletionStage::SubmitResponse);
+    EXPECT_EQ(record.results, (std::vector<std::uint8_t>{DumpLoadCode(DumpLoadResult::Failed),
+                                                         DumpLoadCode(DumpLoadResult::Failed)}));
+    EXPECT_EQ(firstEntry->refCnt, 0U);
+    EXPECT_EQ(secondEntry->refCnt, 0U);
+    EXPECT_TRUE(metadata_->Exist(firstKey));
+    EXPECT_TRUE(metadata_->Exist(secondKey));
+}
+
+TEST_F(TaskWorkerTest, RejectsResponsesLargerThanFlagBufferSlot)
+{
+    g_config.flagBufferSlotSizeBytes = 0;
+
+    KvDumpRequest dump;
+    dump.opcode = KvOpcode::Dump;
+    dump.batch_size = 1;
+    dump.entries = {
+        {KeyFromHex("a1"), 0x1000, kValueLength, 0}
+    };
+    EXPECT_TRUE(ProcessDump(dump).Failure());
+
+    KvLoadRequest load;
+    load.opcode = KvOpcode::Load;
+    load.batch_size = 1;
+    load.entries = {
+        {KeyFromHex("a2"), 0x2000, kValueLength, 0}
+    };
+    EXPECT_TRUE(ProcessLoad(load).Failure());
+
+    KvLookupRequest lookup;
+    lookup.opcode = KvOpcode::Lookup;
+    lookup.batch_size = 1;
+    lookup.entries = {{KeyFromHex("a3")}};
+    EXPECT_TRUE(ProcessLookup(lookup).Failure());
+    ExpectNoCompletion();
+}
+
+}  // namespace
+}  // namespace UC::DramPool


### PR DESCRIPTION
## Purpose

* Process DramPool Dump, Load, and Lookup requests asynchronously without blocking request reception

## Modifications

* Add TaskWorker request dispatch and asynchronous data-transfer submission
* Add per-item Dump, Load, and Lookup result handling with metadata lifecycle cleanup
* Use the DramPool runtime TransportManager directly for peer connection and transfer submission

## Test
```
  [==========] Running 9 tests from 1 test suite.
  [----------] 9 tests from TaskWorkerTest (16 ms total)
  [==========] 9 tests from 1 test suite ran. (1332 ms total)
  [  PASSED  ] 9 tests.
```