### PR TITLE
[Opt] Free slot buffer in metadata Deletion

### DIFF
--- a/ucm/store/dram/cc/drampool/entry.h
+++ b/ucm/store/dram/cc/drampool/entry.h
@@ -75,6 +75,15 @@ struct Entry {
         return status == EntryStatus::INITIALIZED && refCnt == 0;
     }
 
+    bool TryMarkDeleting()
+    {
+        SpinLockGuard guard(lock);
+        if (status == EntryStatus::DELETING) { return false; }
+        if (refCnt != 0) { return false; }
+        status = EntryStatus::DELETING;
+        return true;
+    }
+
     bool TryMarkEvicting(std::chrono::system_clock::time_point now)
     {
         SpinLockGuard guard(lock);

--- a/ucm/store/dram/cc/drampool/metadata.cc
+++ b/ucm/store/dram/cc/drampool/metadata.cc
@@ -132,6 +132,17 @@ Status ShardMetadata::Delete(const BlockId& key)
     return Status::OK();
 }
 
+Status ShardMetadata::TryDelete(const BlockId& key, EntryPtr& entry)
+{
+    ReadOnlyGuard lock(mtx_);
+    auto it = metadata_.find(key);
+    if (it == metadata_.end()) { return Status::NotFound(); }
+    auto& existingEntry = it->second;
+    if (!existingEntry->TryMarkDeleting()) { return Status::Error(); }
+    entry = existingEntry;
+    return Status::OK();
+}
+
 std::size_t ShardMetadata::GetKeyCnt() const noexcept
 {
     ReadOnlyGuard lock(mtx_);
@@ -148,6 +159,18 @@ std::vector<EntryPtr> ShardMetadata::EvictDeep(double evict_ratio)
 {
     ReadOnlyGuard lock(mtx_);
     return deepEvictor_->GetEvictionResults(evict_ratio);
+}
+
+Status MetadataManager::Delete(const BlockId& key)
+{
+    EntryPtr entry;
+    auto st = ShardOf(key).TryDelete(key, entry);
+    if (!st.Success()) { return st; }
+    auto freeSt = bufferManager_.Free(entry->size, entry->buffer.slot);
+    if (!freeSt.Success()) {
+        UC_ERROR("Delete: Free slot {} failed, status {}.", entry->buffer.slot, freeSt.ToString());
+    }
+    return ShardOf(key).Delete(key);
 }
 
 Status MetadataManager::StoreBegin(const BlockId& key, EntryPtr entry)

--- a/ucm/store/dram/cc/drampool/metadata.h
+++ b/ucm/store/dram/cc/drampool/metadata.h
@@ -114,6 +114,16 @@ public:
     Status Delete(const BlockId& key);
 
     /**
+     * @brief Attempt to mark the entry for deletion under a read lock.
+     * @param key BlockId to look up.
+     * @param entry [out] Receives the entry on success.
+     * @return Status::OK() on success; Status::NotFound() if the key is
+     *         missing; Status::Error() if the entry cannot transition to
+     *         DELETING (already DELETING or refCnt != 0).
+     */
+    Status TryDelete(const BlockId& key, EntryPtr& entry);
+
+    /**
      * @brief Return the number of keys tracked by this shard. Read-locks.
      */
     std::size_t GetKeyCnt() const noexcept;
@@ -161,7 +171,7 @@ public:
     Status LoadEnd(const BlockId& key) { return ShardOf(key).LoadEnd(key); }
     bool Exist(const BlockId& key) { return ShardOf(key).Exist(key); }
     bool Query(const BlockId& key) const { return ShardOf(key).Query(key); }
-    Status Delete(const BlockId& key) { return ShardOf(key).Delete(key); }
+    Status Delete(const BlockId& key);
 
     std::size_t GetKeyCnt() const noexcept
     {

--- a/ucm/store/test/case/dram/drampool/dram_metadata_test.cc
+++ b/ucm/store/test/case/dram/drampool/dram_metadata_test.cc
@@ -281,6 +281,57 @@ TEST_F(UCShardMetadataTest, FullLifecycleStoreStoreEndLoadExist)
     EXPECT_EQ(entry->refCnt, 0U);
 }
 
+TEST_F(UCShardMetadataTest, TryDeleteReturnsOkAndMarksDeleting)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
+    md.StoreBegin(k, entry);
+    EntryPtr out;
+    EXPECT_TRUE(md.TryDelete(k, out).Success());
+    EXPECT_EQ(out.get(), entry.get());
+    EXPECT_EQ(entry->status, EntryStatus::DELETING);
+    EXPECT_EQ(md.GetKeyCnt(), 1UL);
+}
+
+TEST_F(UCShardMetadataTest, TryDeleteReturnsNotFoundWhenMissing)
+{
+    ShardMetadata md(MakeConfig());
+    EntryPtr out;
+    EXPECT_EQ(md.TryDelete(KeyFromHex("a1"), out), Status::NotFound());
+    EXPECT_EQ(out, nullptr);
+}
+
+TEST_F(UCShardMetadataTest, TryDeleteFailsWhenAlreadyDeleting)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
+    md.StoreBegin(k, entry);
+    EntryPtr first;
+    ASSERT_TRUE(md.TryDelete(k, first).Success());
+    EntryPtr second;
+    EXPECT_EQ(md.TryDelete(k, second), Status::Error());
+    EXPECT_EQ(second, nullptr);
+    EXPECT_EQ(first->status, EntryStatus::DELETING);
+}
+
+TEST_F(UCShardMetadataTest, TryDeleteFailsWhenRefCntNonZero)
+{
+    ShardMetadata md(MakeConfig());
+    auto k = KeyFromHex("a1");
+    auto entry = MakeEntry(k, 0, past_, EntryStatus::INITIALIZED);
+    md.StoreBegin(k, entry);
+    md.StoreEnd(k);
+    EntryPtr loaded;
+    ASSERT_TRUE(md.LoadBegin(k, loaded).Success());
+    ASSERT_EQ(entry->refCnt, 1U);
+    EntryPtr out;
+    EXPECT_EQ(md.TryDelete(k, out), Status::Error());
+    EXPECT_EQ(out, nullptr);
+    EXPECT_EQ(entry->status, EntryStatus::READY);
+}
+
 class UCMetadataManagerTest : public testing::Test {
 protected:
     static void SetUpTestSuite()


### PR DESCRIPTION
## Purpose
Add slot buffer free in metadata's deletion. When transfer of an entry failed, the server will try to delete the key directly, we need to free the slot buffer for this kind of scenario.

## Modifications 
1. `entry.h`: Add `TryMarkDeleting` to check and set the status of entry to DELETING.
2. `metadata.cc/.h`: In `MetadataManager::Delete` function, call `ShardMetadata::TryDelete` first to check and set the status of related entry, then free the slot buffer and delete the metadata.
3. `dram_metadata_test.cc`: Add relavant unit tests.

## Test
```
[==========] Running 30 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 26 tests from UCShardMetadataTest
[----------] 26 tests from UCShardMetadataTest (6 ms total)
[----------] 4 tests from UCMetadataManagerTest
[----------] 4 tests from UCMetadataManagerTest (7 ms total)
[==========] 30 tests from 2 test suites ran. (5517 ms total)
[  PASSED  ] 30 tests.
```