### PR TITLE
[Feat]Add layeriwse support for glm5.2

### DIFF
--- a/test/suites/Unit/test_kv_cache_layout.py
+++ b/test/suites/Unit/test_kv_cache_layout.py
@@ -2,9 +2,10 @@ import ast
 import math
 import re
 import unittest
+from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import numpy as np
 
@@ -13,9 +14,16 @@ CONNECTOR_PATH = REPO_ROOT / "ucm" / "integration" / "vllm" / "ucm_connector.py"
 
 
 class FakeTensor:
-    def __init__(self, ptr: int, block_stride: int, num_blocks: int = 2):
+    def __init__(
+        self,
+        ptr: int,
+        block_stride: int,
+        num_blocks: int = 2,
+        element_size: int = 1,
+    ):
         self._ptr = ptr
-        self.shape = (num_blocks, 1, 1, block_stride)
+        self._element_size = element_size
+        self.shape = (num_blocks, 1, 1, block_stride // element_size)
 
     def __getitem__(self, _index):
         return self
@@ -27,7 +35,7 @@ class FakeTensor:
         return len(self.shape)
 
     def element_size(self):
-        return 1
+        return self._element_size
 
 
 class FakeTorch:
@@ -48,65 +56,94 @@ def _extract_layer_index(name: str) -> int:
     return int(match.group(1))
 
 
-def _load_kv_cache_layout_class():
+def _load_layout_symbols():
     source = CONNECTOR_PATH.read_text(encoding="utf-8-sig")
     tree = ast.parse(source)
-    class_node = next(
-        node
-        for node in tree.body
-        if isinstance(node, ast.ClassDef) and node.name == "KVCacheLayout"
-    )
-    module = ast.Module(body=[class_node], type_ignores=[])
+    selected_names = {
+        "_has_shared_indexer_layers",
+        "_supports_ascend_shared_indexer_layout",
+        "KVCacheSegment",
+        "KVCacheTensorInfo",
+        "SharedIndexerLayerInfo",
+        "KVCacheLayout",
+        "SharedIndexerKVCacheLayout",
+    }
+    selected_nodes = [
+        node for node in tree.body if getattr(node, "name", None) in selected_names
+    ]
+    module = ast.Module(body=selected_nodes, type_ignores=[])
     ast.fix_missing_locations(module)
     namespace = {
         "List": List,
+        "Optional": Optional,
         "Tuple": Tuple,
+        "dataclass": dataclass,
         "extract_layer_index": _extract_layer_index,
         "logger": FakeLogger(),
         "math": math,
         "np": np,
         "torch": FakeTorch,
+        "current_platform": SimpleNamespace(device_type="npu"),
     }
     exec(compile(module, str(CONNECTOR_PATH), "exec"), namespace)
-    return namespace["KVCacheLayout"]
+    return namespace
 
 
-KVCacheLayout = _load_kv_cache_layout_class()
+LAYOUT_SYMBOLS = _load_layout_symbols()
+KVCacheLayout = LAYOUT_SYMBOLS["KVCacheLayout"]
+SharedIndexerKVCacheLayout = LAYOUT_SYMBOLS["SharedIndexerKVCacheLayout"]
 
 
-def _build_layout(row_strides: list[list[int]], use_layerwise: bool):
-    next_ptr = 0x1000
+def _build_layout(
+    row_strides: list[list[int]],
+    *,
+    use_layerwise: bool,
+    shared_indexer: bool = False,
+    enable_sparse_sfa_c8: bool = False,
+    enable_sparse_li_c8: bool = False,
+):
+    next_ptr = 0x100000
     kvcaches = {}
     for layer_id, strides in enumerate(row_strides):
         tensors = []
         for stride in strides:
             tensors.append(FakeTensor(next_ptr, stride))
-            next_ptr += 0x1000
+            next_ptr += 0x100000
         kvcaches[f"model.layers.{layer_id}.self_attn"] = tuple(tensors)
 
+    hf_text_config = SimpleNamespace(num_hidden_layers=len(row_strides))
+    if shared_indexer:
+        hf_text_config.indexer_types = ["full", "shared"]
     vllm_config = SimpleNamespace(
+        additional_config={
+            "enable_sparse_sfa_c8": enable_sparse_sfa_c8,
+            "enable_sparse_li_c8": enable_sparse_li_c8,
+        },
         parallel_config=SimpleNamespace(pipeline_parallel_size=1),
-        model_config=SimpleNamespace(
-            hf_text_config=SimpleNamespace(num_hidden_layers=len(row_strides))
-        ),
+        model_config=SimpleNamespace(hf_text_config=hf_text_config),
     )
     kv_cache_config = SimpleNamespace(num_blocks=2)
-    return KVCacheLayout(
-        kvcaches,
-        {"use_layerwise": use_layerwise},
-        vllm_config,
-        kv_cache_config,
+    ucm_config = {"use_layerwise": use_layerwise}
+    layout_cls = (
+        SharedIndexerKVCacheLayout
+        if SharedIndexerKVCacheLayout.supports(vllm_config, ucm_config)
+        else KVCacheLayout
     )
+    return layout_cls(kvcaches, ucm_config, vllm_config, kv_cache_config)
 
 
 class KVCacheLayoutTest(unittest.TestCase):
-    def test_direct_layout_flattens_only_real_tensors_without_padding(self):
-        layout = _build_layout([[8, 4, 2], [8]], use_layerwise=False)
+    def test_direct_layout_flattens_only_real_tensors(self):
+        layout = _build_layout(
+            [[8, 4, 2], [8]],
+            use_layerwise=False,
+            shared_indexer=True,
+        )
 
+        self.assertIs(type(layout), KVCacheLayout)
         self.assertEqual(layout.base_ptrs.shape, (4,))
         self.assertEqual(layout.tensor_size_list, [8, 4, 2, 8])
         self.assertEqual(layout.buffer_sizes.tolist(), [16, 8, 4, 16])
-        self.assertTrue(layout.valid_mask.all())
         self.assertEqual(layout.shard_size, 22)
         self.assertEqual(layout.block_size, 22)
 
@@ -115,67 +152,149 @@ class KVCacheLayoutTest(unittest.TestCase):
         np.testing.assert_array_equal(
             addrs[1], layout.base_ptrs + layout.block_stride_lists
         )
-        with self.assertRaisesRegex(ValueError, "layer_first=True"):
-            layout.extract_block_addrs([0], layer_first=True)
 
-    def test_layerwise_layout_accepts_consistent_columns(self):
-        cases = [
-            (
-                [[131072, 16384, 32768], [131072, 16384]],
-                [131072, 16384, 32768],
-            ),
-            (
-                [[131072, 16384, 16384, 256], [131072, 16384]],
-                [131072, 16384, 16384, 256],
-            ),
-            ([[83968, 32768], [83968]], [83968, 32768]),
-            ([[83968, 16384, 256], [83968]], [83968, 16384, 256]),
-        ]
+    def test_generic_layerwise_layout_accepts_regular_matrix(self):
+        layout = _build_layout(
+            [[131072, 16384, 32768], [131072, 16384, 32768]],
+            use_layerwise=True,
+        )
 
-        for row_strides, expected_sizes in cases:
-            with self.subTest(row_strides=row_strides):
-                layout = _build_layout(row_strides, use_layerwise=True)
+        self.assertIs(type(layout), KVCacheLayout)
+        self.assertEqual(layout.tensor_size_list, [131072, 16384, 32768])
+        self.assertEqual(layout.base_ptrs.shape, (2, 3))
 
-                self.assertEqual(layout.base_ptrs.shape, (2, len(expected_sizes)))
-                self.assertEqual(layout.tensor_size_list, expected_sizes)
-                self.assertEqual(
-                    layout.tensor_size_lists.tolist(),
-                    [expected_sizes, expected_sizes],
-                )
-
-                addrs = layout.extract_block_addrs([0, 1], layer_first=True)
-                self.assertEqual(addrs.shape, (2, 2, len(expected_sizes)))
-                self.assertTrue(np.all(addrs[1, :, len(row_strides[1]) :] == 0))
-
-    def test_layerwise_layout_rejects_inconsistent_real_strides_in_a_column(self):
+    def test_generic_layerwise_layout_rejects_ragged_rows(self):
         with self.assertRaisesRegex(
             ValueError,
-            r"`use_layerwise: true` in ucm_config.yaml:.*"
-            r"column 1 must have an identical block stride, but got "
-            r"\[16384, 32768\]; stride_to_layer_ids="
-            r"\{16384: \[0\], 32768: \[1\]\}.*`use_layerwise: false`",
+            r"Invalid generic KV cache layout.*every layer must have the same "
+            r"tensor count.*SharedIndexerKVCacheLayout",
         ):
             _build_layout(
-                [[83968, 16384, 256], [83968, 32768], [83968]],
+                [[131072, 16384, 32768], [131072, 16384]],
                 use_layerwise=True,
             )
 
-    def test_layerwise_layout_logs_padding_details(self):
-        logger = FakeLogger()
-        previous_logger = KVCacheLayout.__init__.__globals__["logger"]
-        KVCacheLayout.__init__.__globals__["logger"] = logger
-        try:
-            _build_layout([[8, 4, 2], [8]], use_layerwise=True)
-        finally:
-            KVCacheLayout.__init__.__globals__["logger"] = previous_logger
-
-        padding_log = next(
-            message for message in logger.messages if "uses padding" in message
+    def test_shared_indexer_config_selects_dedicated_layout(self):
+        glm51_layout = _build_layout(
+            [[8, 4], [8, 4]],
+            use_layerwise=True,
+            shared_indexer=False,
         )
-        self.assertIn("max_tensors_per_layer=3", padding_log)
-        self.assertIn("padded_layers=1", padding_log)
-        self.assertIn("ghost_slots=2", padding_log)
-        self.assertIn("tensor_counts_per_layer=[3, 1]", padding_log)
+        glm52_layout = _build_layout(
+            [[8, 4, 2], [8, 4]],
+            use_layerwise=True,
+            shared_indexer=True,
+        )
+
+        self.assertIs(type(glm51_layout), KVCacheLayout)
+        self.assertIs(type(glm52_layout), SharedIndexerKVCacheLayout)
+
+    def test_shared_indexer_layout_is_restricted_to_ascend(self):
+        supports_globals = SharedIndexerKVCacheLayout.supports.__func__.__globals__
+        original_platform = supports_globals["current_platform"]
+        supports_globals["current_platform"] = SimpleNamespace(device_type="cuda")
+        try:
+            layout = _build_layout(
+                [[8, 4, 2], [8, 4, 2]],
+                use_layerwise=True,
+                shared_indexer=True,
+            )
+        finally:
+            supports_globals["current_platform"] = original_platform
+
+        self.assertIs(type(layout), KVCacheLayout)
+
+    def test_shared_indexer_li_c8_disabled_uses_padding_without_mask(self):
+        layout = _build_layout(
+            [[131072, 16384, 32768], [131072, 16384]],
+            use_layerwise=True,
+            shared_indexer=True,
+        )
+
+        self.assertEqual(layout.tensor_size_list, [131072, 16384, 32768])
+        self.assertEqual(layout.base_ptrs.shape, (2, 3))
+        self.assertEqual(layout.base_ptrs[1, 2], 0)
+        self.assertEqual(layout.block_stride_lists[1, 2], 0)
+        self.assertEqual(layout.buffer_sizes[1, 2], 0)
+        self.assertEqual(layout.extract_block_addrs([1], layer_first=True)[1, 0, 2], 0)
+
+    def test_shared_indexer_sfa_c8_li_c8_disabled_uses_padding(self):
+        layout = _build_layout(
+            [[83968, 32768], [83968]],
+            use_layerwise=True,
+            shared_indexer=True,
+            enable_sparse_sfa_c8=True,
+        )
+
+        self.assertEqual(layout.tensor_size_list, [83968, 32768])
+        self.assertEqual(layout.base_ptrs[1, 1], 0)
+        self.assertEqual(layout.block_stride_lists[1, 1], 0)
+
+    def test_shared_indexer_li_c8_splits_bf16_indexer(self):
+        layout = _build_layout(
+            [
+                [131072, 16384, 16384, 256],
+                [131072, 16384, 32768],
+                [131072, 16384],
+            ],
+            use_layerwise=True,
+            shared_indexer=True,
+            enable_sparse_li_c8=True,
+        )
+
+        expected_sizes = [131072, 16384, 16384, 16384, 256]
+        self.assertEqual(layout.tensor_size_list, expected_sizes)
+        self.assertEqual(
+            layout.tensor_size_lists.tolist(),
+            [expected_sizes, expected_sizes, expected_sizes],
+        )
+
+        bf16_ptr = int(layout.base_ptrs[1, 2])
+        self.assertEqual(int(layout.base_ptrs[1, 3]), bf16_ptr + 16384)
+        self.assertEqual(layout.block_stride_lists[1, 2:4].tolist(), [32768, 32768])
+        self.assertEqual(layout.buffer_sizes[1, 3], 0)
+
+        self.assertEqual(layout.base_ptrs[0, 3], 0)
+        self.assertEqual(layout.block_stride_lists[0, 3], 0)
+        self.assertEqual(layout.base_ptrs[1, 4], 0)
+        self.assertTrue(np.all(layout.base_ptrs[2, 2:] == 0))
+        self.assertTrue(np.all(layout.block_stride_lists[2, 2:] == 0))
+
+        block_one_addrs = layout.extract_block_addrs([1], layer_first=True)
+        self.assertEqual(block_one_addrs[1, 0, 2], bf16_ptr + 32768)
+        self.assertEqual(block_one_addrs[1, 0, 3], bf16_ptr + 16384 + 32768)
+        self.assertTrue(np.all(block_one_addrs[2, 0, 2:] == 0))
+
+    def test_shared_indexer_sfa_c8_supports_a5_fp32_scale(self):
+        layout = _build_layout(
+            [
+                [83968, 16384, 512],
+                [83968, 32768],
+                [83968],
+            ],
+            use_layerwise=True,
+            shared_indexer=True,
+            enable_sparse_sfa_c8=True,
+            enable_sparse_li_c8=True,
+        )
+
+        self.assertEqual(layout.tensor_size_list, [83968, 16384, 16384, 512])
+        self.assertEqual(layout.block_stride_lists[1, 1:3].tolist(), [32768, 32768])
+        self.assertEqual(layout.block_stride_lists[0, 3], 512)
+        self.assertTrue(np.all(layout.base_ptrs[2, 1:] == 0))
+
+    def test_shared_indexer_rejects_non_two_to_one_bf16_indexer(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            r"Cannot split BF16 Indexer tensor.*bf16_size=24576, c8_size=16384",
+        ):
+            _build_layout(
+                [[83968, 16384, 256], [83968, 24576], [83968]],
+                use_layerwise=True,
+                shared_indexer=True,
+                enable_sparse_sfa_c8=True,
+                enable_sparse_li_c8=True,
+            )
 
 
 if __name__ == "__main__":

--- a/test/suites/Unit/test_kv_cache_layout.py
+++ b/test/suites/Unit/test_kv_cache_layout.py
@@ -230,6 +230,37 @@ class KVCacheLayoutTest(unittest.TestCase):
         self.assertEqual(layout.base_ptrs[1, 1], 0)
         self.assertEqual(layout.block_stride_lists[1, 1], 0)
 
+    def test_shared_indexer_all_li_c8_uses_compact_w8a8_layout(self):
+        layout = _build_layout(
+            [
+                [83968, 16384, 256],
+                [83968],
+                [83968, 16384, 256],
+            ],
+            use_layerwise=True,
+            shared_indexer=True,
+            enable_sparse_sfa_c8=True,
+            enable_sparse_li_c8=True,
+        )
+
+        expected_sizes = [83968, 16384, 256]
+        self.assertEqual(layout.tensor_size_list, expected_sizes)
+        self.assertEqual(layout.base_ptrs.shape, (3, 3))
+        self.assertEqual(
+            layout.tensor_size_lists.tolist(),
+            [expected_sizes, expected_sizes, expected_sizes],
+        )
+
+        self.assertTrue(np.all(layout.base_ptrs[1, 1:] == 0))
+        self.assertTrue(np.all(layout.block_stride_lists[1, 1:] == 0))
+        self.assertTrue(np.all(layout.buffer_sizes[1, 1:] == 0))
+
+        indexer_ptr = int(layout.base_ptrs[0, 1])
+        scale_ptr = int(layout.base_ptrs[0, 2])
+        block_one_addrs = layout.extract_block_addrs([1], layer_first=True)
+        self.assertEqual(block_one_addrs[0, 0, 1], indexer_ptr + 16384)
+        self.assertEqual(block_one_addrs[0, 0, 2], scale_ptr + 256)
+
     def test_shared_indexer_li_c8_splits_bf16_indexer(self):
         layout = _build_layout(
             [

--- a/ucm/integration/vllm/patch/apply_patch.py
+++ b/ucm/integration/vllm/patch/apply_patch.py
@@ -224,10 +224,11 @@ def apply_all_patches() -> None:
             case "0.23.0":
                 logger.info(
                     "UCM patching vllm-ascend 0.23.0 for hybrid cache "
-                    "recovery and CPU affinity..."
+                    "recovery, CPU affinity, and SFA KV transfer..."
                 )
                 import ucm.integration.vllm.patch.v0230.vllm_ascend.ascend_hybrid_cache_patch
                 import ucm.integration.vllm.patch.v0230.vllm_ascend.cpu_binding_patch
+                import ucm.integration.vllm.patch.v0230.vllm_ascend.sfa_kv_transfer_patch
             case _:
                 pass
 

--- a/ucm/integration/vllm/patch/v0230/vllm_ascend/sfa_kv_transfer_patch.py
+++ b/ucm/integration/vllm/patch/v0230/vllm_ascend/sfa_kv_transfer_patch.py
@@ -1,0 +1,427 @@
+"""Replace the vLLM-Ascend 0.23.0 SFA forward with its KV-save fix."""
+
+from __future__ import annotations
+
+from types import FunctionType
+
+from ucm.integration.vllm.patch.utils import patch_or_inject, when_imported
+from ucm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def forward(
+    self,
+    layer_name,
+    hidden_states: torch.Tensor,  # query in unified attn
+    kv_cache: tuple[torch.Tensor, ...],
+    attn_metadata: M,
+    need_gather_q_kv: bool = False,
+    output: torch.Tensor | None = None,
+) -> torch.Tensor:
+    assert output is not None, "Output tensor must be provided."
+    if attn_metadata is None:
+        # Profiling run.
+        if self.enable_dsa_cp_with_layer_shard and not _EXTRA_CTX.in_profile_run:
+            for layer in self.layer_sharding_kwargs or []:
+                if is_hidden_layer(layer):
+                    reach_layer_for_shard_weight_series(layer)
+        return output.fill_(0)
+
+    cos = attn_metadata.cos
+    sin = attn_metadata.sin
+    slot_mapping = attn_metadata.slot_mapping
+    slot_mapping_cp = None
+    if self.enable_dsa_cp:
+        assert attn_metadata.dsa_cp_context is not None
+        slot_mapping_cp = attn_metadata.dsa_cp_context.slot_mapping_cp
+        actual_seq_lengths_query = attn_metadata.dsa_cp_context.actual_seq_lengths_query
+        actual_seq_lengths_key = attn_metadata.dsa_cp_context.actual_seq_lengths_key
+    else:
+        actual_seq_lengths_query = attn_metadata.cum_query_lens
+        actual_seq_lengths_key = attn_metadata.seq_lens
+    # DCP replicated indexer stores LI cache with the full/no-CP metadata, while
+    # SFA KV remains stored with the DCP-sharded slot mapping.
+    slot_mapping_sfa = (
+        attn_metadata.dcp_context.slot_mapping
+        if attn_metadata.dcp_context is not None
+        else attn_metadata.slot_mapping
+    )
+
+    # Inputs and outputs may be padded for CUDA graphs
+    num_input_tokens = attn_metadata.num_input_tokens
+    output_padded = output
+
+    # all-gather o_proj weight for prefill stage of PD mix node
+    o_proj_full_handle = None
+    o_proj_full_param_handles = None
+    # Prefill/mixed DSA-CP computes o_proj with a temporary full weight.
+    # Decode keeps the original TP path and only exchanges activations.
+    full_gather_o_proj_enabled = self.enable_dsa_cp_with_o_proj_tp and attn_metadata.attn_state not in {
+        AscendAttentionState.DecodeOnly,
+        AscendAttentionState.SpecDecoding,
+    }
+
+    if self.enable_sfa_prolog_v3 and attn_metadata.attn_state in (
+        AscendAttentionState.DecodeOnly,
+        AscendAttentionState.SpecDecoding,
+    ):
+        if self.enable_sp:
+            hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+                hidden_states.contiguous(), need_gather_q_kv
+            )
+        assert slot_mapping.numel() == hidden_states.shape[0], (
+            "SFA Prolog V3 requires one cache index per input token, "
+            f"got token_x={hidden_states.shape[0]} and cache_index={slot_mapping.numel()}."
+        )
+        if self.has_indexer:
+            k_li, k_li_scale = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
+        else:
+            k_li, k_li_scale = None, None
+
+        # Prolog updates the paged KV cache in place. Wait for the prompt
+        # blocks before writing the first Decode token into their tail block.
+        wait_for_kv_layer_from_connector(layer_name)
+        hidden_states, ql_nope, q_pe, q_c, _, _ = self._sfa_preprocess_with_prolog_v3(
+            hidden_states=hidden_states,
+            kv_cache=kv_cache,
+            cos=cos,
+            sin=sin,
+            slot_mapping=slot_mapping,
+            cache_mode="PA_BSND",
+        )
+    # run mlapo ops when dsa-cp is disabled, and ensure that num_tokens satisfies the count limitation
+    elif self.enable_mlapo and (
+        get_ascend_device_type() == AscendDeviceType.A5 or num_input_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
+    ):
+        hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+            hidden_states.contiguous(), need_gather_q_kv
+        )
+        hidden_states, ql_nope, q_pe, q_c = self._sfa_preprocess_with_mlapo(
+            hidden_states=hidden_states,
+            kv_cache=kv_cache,
+            cos=cos,
+            sin=sin,
+            slot_mapping=slot_mapping,
+            num_input_tokens=num_input_tokens,
+        )
+        if self.has_indexer:
+            k_li, k_li_scale = self.indexer_select_pre_process(
+                x=hidden_states,
+                cos=cos,
+                sin=sin,
+            )
+        else:
+            k_li, k_li_scale = None, None
+        wait_for_kv_layer_from_connector(layer_name)
+    # native
+    else:
+        assert self.fused_qkv_a_proj is not None, "q lora is required for DSA."
+        weight_prefetch_method = get_weight_prefetch_method()
+        weight_prefetch_method.maybe_prefetch_mla_or_sla_weight_in_current_stream(
+            inputs=self.fused_qkv_a_proj.weight, dependency=hidden_states
+        )
+        if self.enable_sp and not self.enable_dsa_cp:
+            hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
+                hidden_states.contiguous(), need_gather_q_kv
+            )
+        qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
+        q_c, kv_no_split = qkv_lora.split(
+            [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
+            dim=-1,
+        )
+        assert self.q_a_layernorm is not None, "q_a_layernorm must be initialized"
+        q_c = self.q_a_layernorm(q_c)
+
+        if self.has_indexer:
+            k_li, k_li_scale = self.indexer_select_pre_process(
+                x=hidden_states,
+                cos=cos,
+                sin=sin,
+            )
+        else:
+            k_li, k_li_scale = None, None
+
+        wait_for_kv_layer_from_connector(layer_name)
+
+        if self.enable_dsa_cp:
+            assert slot_mapping_cp is not None
+            kv_slots = slot_mapping_cp
+        else:
+            kv_slots = slot_mapping_sfa
+        kv_outputs = self.exec_kv(kv_no_split, cos, sin, kv_cache, kv_slots, attn_metadata)
+        k_pe, k_nope = kv_outputs[:2]
+        knope_scale = kv_outputs[2] if len(kv_outputs) == 3 else None
+
+        if (
+            self.enable_sparse_sfa_c8
+            and not self.enable_dsa_cp
+            and (get_ascend_device_type() != AscendDeviceType.A5 or not self.has_indexer)
+        ):
+            assert k_pe is not None
+            assert k_nope is not None
+            assert knope_scale is not None
+            packed_kv = torch.cat([k_nope, k_pe, knope_scale], dim=-1)
+            packed_head_dim = self.sfa_qsfa_packed_kv_head_dim
+            assert packed_kv.shape[-1] == packed_head_dim
+            torch_npu.npu_scatter_nd_update_(
+                kv_cache[0].view(-1, packed_head_dim),
+                slot_mapping_sfa.view(-1, 1),
+                packed_kv.view(-1, packed_head_dim),
+            )
+
+        if self.enable_dsa_cp:
+            assert k_pe is not None
+            assert k_nope is not None
+            async_op = self.enable_dsa_cp_with_layer_shard or full_gather_o_proj_enabled
+            kv_ag_handles = []
+            # support all_gather kv async for communication calculation overlap
+            if self.enable_sparse_sfa_c8:
+                assert knope_scale is not None
+                fused_kv_parts = [
+                    k_nope.view(-1, k_nope.shape[-1]),
+                    k_pe.view(-1, k_pe.shape[-1]),
+                    knope_scale.view(-1, knope_scale.shape[-1]),
+                ]
+            else:
+                fused_kv_parts = [
+                    k_pe.view(-1, k_pe.shape[-1]),
+                    k_nope.view(-1, k_nope.shape[-1]),
+                ]
+                if self.has_indexer and not self.enable_sparse_li_c8:
+                    assert k_li is not None
+                    fused_kv_parts.append(k_li.view(-1, k_li.shape[-1]))
+
+            fused_kv_input = torch.cat(fused_kv_parts, dim=1)
+            fused_kv_no_split, kv_ag_handle = all_gather_async(
+                fused_kv_input,
+                get_tp_group(),
+                async_op=async_op,
+            )
+            if kv_ag_handle is not None:
+                kv_ag_handles.append(kv_ag_handle)
+
+            if self.has_indexer and (self.enable_sparse_sfa_c8 or self.enable_sparse_li_c8):
+                assert k_li is not None
+                k_li, kv_ag_handle = all_gather_async(
+                    k_li,
+                    get_tp_group(),
+                    async_op=async_op,
+                )
+                if kv_ag_handle is not None:
+                    kv_ag_handles.append(kv_ag_handle)
+            if self.has_indexer and self.enable_sparse_li_c8:
+                assert k_li_scale is not None
+                k_li_scale, kv_ag_handle = all_gather_async(
+                    k_li_scale,
+                    get_tp_group(),
+                    async_op=async_op,
+                )
+                if kv_ag_handle is not None:
+                    kv_ag_handles.append(kv_ag_handle)
+
+        ql_nope, q_pe = self._q_proj_and_k_up_proj(q_c)
+        q_pe = self.rope_single(q_pe, cos, sin)
+        self._record_dcp_query_gather_context(ql_nope, q_pe, attn_metadata)
+
+        if self.enable_dsa_cp:
+            for kv_ag_handle in kv_ag_handles:
+                kv_ag_handle.wait()
+
+            if self.enable_dsa_cp_with_layer_shard:
+                for layer in self.layer_sharding_kwargs or []:
+                    if is_hidden_layer(layer):
+                        reach_layer_for_shard_weight_series(layer)
+            elif full_gather_o_proj_enabled:
+                _, o_proj_full_handle = all_gather_async(
+                    self.o_proj_tp_weight_gather_input,
+                    get_tp_group(),
+                    output=self.o_proj_full_gather_pool,
+                )
+                o_proj_full_param_handles = []
+                for param_name, param in self.o_proj_tp_input_sharded_quant_params.items():
+                    _, param_handle = all_gather_async(
+                        param,
+                        get_tp_group(),
+                        output=self.o_proj_full_input_sharded_quant_params[param_name],
+                    )
+                    o_proj_full_param_handles.append(param_handle)
+
+            if kv_cache is not None:
+                assert fused_kv_no_split is not None
+                if self.enable_sparse_sfa_c8:
+                    torch_npu.npu_scatter_nd_update_(
+                        kv_cache[0].view(-1, fused_kv_no_split.shape[-1]),
+                        slot_mapping_sfa[: attn_metadata.num_actual_tokens].view(-1, 1),
+                        fused_kv_no_split[: attn_metadata.num_actual_tokens],
+                    )
+                    k_pe = None
+                    k_nope = None
+                elif not self.has_indexer:
+                    k_pe, k_nope = fused_kv_no_split.split(
+                        [self.qk_rope_head_dim, self.kv_lora_rank],
+                        dim=-1,
+                    )
+                elif not self.enable_sparse_li_c8:
+                    k_pe, k_nope, k_li = fused_kv_no_split.split(
+                        [self.qk_rope_head_dim, self.kv_lora_rank, self.head_dim],
+                        dim=-1,
+                    )
+                else:
+                    k_pe, k_nope = fused_kv_no_split.split(
+                        [self.qk_rope_head_dim, self.kv_lora_rank],
+                        dim=-1,
+                    )
+                if not self.enable_sparse_sfa_c8:
+                    assert k_pe is not None
+                    assert k_nope is not None
+                    k_nope = k_nope.view(k_nope.shape[0], 1, -1)
+                    k_pe = k_pe.view(k_pe.shape[0], 1, -1)
+                    DeviceOperator.reshape_and_cache(
+                        key=k_nope[: attn_metadata.num_actual_tokens],
+                        value=k_pe[: attn_metadata.num_actual_tokens],
+                        key_cache=kv_cache[0],
+                        value_cache=kv_cache[1],
+                        slot_mapping=slot_mapping_sfa[: attn_metadata.num_actual_tokens],
+                    )
+
+        # DCP's prefill path may all-gather only the blocks referenced by
+        # this batch. It must start after the current layer's SFA KV write,
+        # but before the indexer/top-k work so communication can overlap it.
+        if kv_cache is not None:
+            self._record_dcp_kv_gather_context(kv_cache, attn_metadata)
+
+        if self.has_indexer:
+            assert k_li is not None
+            k_li = self._get_full_kv(k_li, attn_metadata)
+
+    if kv_cache is not None and self.is_kv_producer:
+        attn_metadata.reshape_cache_event = torch.npu.Event()
+
+    if kv_cache is not None and self.has_indexer:
+        assert k_li is not None
+        if self.enable_sparse_sfa_c8:
+            dsa_k_cache_idx = 1
+            dsa_k_scale_cache_idx = 2
+        else:
+            dsa_k_cache_idx = 2
+            dsa_k_scale_cache_idx = 3
+
+        if get_ascend_config().c8_enable_reshape_optim:
+            torch.ops._C_ascend.store_kv_block(
+                k_li,
+                kv_cache[dsa_k_cache_idx],
+                attn_metadata.group_len,
+                attn_metadata.group_key_idx,
+                attn_metadata.group_key_cache_idx,
+                attn_metadata.block_size,
+            )
+        else:
+            torch_npu.npu_scatter_nd_update_(
+                kv_cache[dsa_k_cache_idx].view(-1, k_li.shape[-1]),
+                slot_mapping.view(-1, 1),
+                k_li.view(-1, k_li.shape[-1]),
+            )  # b, s, n, d
+        if self.enable_sparse_li_c8:
+            assert len(kv_cache) == (3 if self.enable_sparse_sfa_c8 else 4)
+            if k_li_scale is not None:
+                if get_ascend_config().c8_enable_reshape_optim:
+                    torch.ops._C_ascend.store_kv_block(
+                        k_li_scale,
+                        kv_cache[dsa_k_scale_cache_idx],
+                        attn_metadata.group_len,
+                        attn_metadata.group_key_idx,
+                        attn_metadata.group_key_cache_idx,
+                        attn_metadata.block_size,
+                    )
+                else:
+                    torch_npu.npu_scatter_nd_update_(
+                        kv_cache[dsa_k_scale_cache_idx].view(-1, k_li_scale.shape[-1]),
+                        slot_mapping.view(-1, 1),
+                        k_li_scale.view(-1, k_li_scale.shape[-1]),
+                    )
+
+    if kv_cache is not None and self.is_kv_producer:
+        attn_metadata.reshape_cache_event.record()
+        notify_kv_cache_written(self.layer_name or "")
+
+    if self.enable_dsa_cp and attn_metadata.dsa_cp_context is not None:
+        topk_num_tokens = attn_metadata.dsa_cp_context.local_end_with_pad - attn_metadata.dsa_cp_context.local_start
+    else:
+        topk_num_tokens = num_input_tokens or hidden_states.shape[0]
+    if self.skip_topk:
+        topk_indices = self._get_indexcache_topk_indices(topk_num_tokens)
+    else:
+        if not self.has_indexer:
+            raise RuntimeError(f"skip_topk is False but indexer is None. layer_name={self.layer_name}.")
+        assert q_c is not None
+        topk_indices = self.indexer_select_post_process(
+            x=hidden_states,
+            q_c=q_c,
+            kv_cache=kv_cache,
+            attn_metadata=attn_metadata,
+            cos=cos,
+            sin=sin,
+            actual_seq_lengths_query=actual_seq_lengths_query,
+            actual_seq_lengths_key=actual_seq_lengths_key,
+        )
+        if self.use_index_cache:
+            self._update_indexcache_topk_indices(topk_indices)
+
+    attn_output = self._execute_sparse_flash_attention_process(
+        ql_nope,
+        q_pe,
+        kv_cache,
+        topk_indices,
+        attn_metadata,
+        actual_seq_lengths_query,
+        actual_seq_lengths_key,
+    )
+
+    attn_output = self._v_up_proj(attn_output)
+    weight_prefetch_method = get_weight_prefetch_method()
+    weight_prefetch_method.maybe_prefetch_mla_or_sla_weight_in_current_stream(
+        inputs=self.o_proj.weight,
+        dependency=attn_output,
+        max_size=MAX_O_PROJ_PREFETCH_SIZE,
+        linear_layer=self.o_proj,
+    )
+
+    if self.enable_dsa_cp_with_o_proj_tp:
+        # SFA DSA-CP mixed mode keeps o_proj weight sharded in the TP domain:
+        # 1. prefill/mixed: gather TP shards into a temporary full weight.
+        # 2. decode-only: all-to-all hidden states, then run TP o_proj.
+        result, require_o_proj_forward = self._handle_o_proj_weight_switch_and_forward(
+            attn_output=attn_output,
+            output=output,
+            o_proj_full_handle=o_proj_full_handle,
+            o_proj_full_param_handles=o_proj_full_param_handles,
+            should_shard_weight=full_gather_o_proj_enabled,
+        )
+        if not require_o_proj_forward:
+            maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
+            return result
+        attn_output = result
+
+    output[...] = self.o_proj(attn_output)[0]
+
+    maybe_save_kv_layer_to_connector(layer_name, list(kv_cache))
+
+    return output_padded
+
+
+@when_imported("vllm_ascend.attention.sfa_v1")
+def patch_sfa_kv_transfer(mod):
+    # Run the copied implementation with the original sfa_v1 module globals.
+    patched_forward = FunctionType(
+        forward.__code__,
+        vars(mod),
+        name=forward.__name__,
+        argdefs=forward.__defaults__,
+        closure=forward.__closure__,
+    )
+    patched_forward.__annotations__ = forward.__annotations__
+    patched_forward.__kwdefaults__ = forward.__kwdefaults__
+
+    patch_or_inject(mod.AscendSFAImpl, "forward", patched_forward)
+    logger.info("UCM Ascend SFA KV-transfer forward patch applied")

--- a/ucm/integration/vllm/patch/v0230/vllm_ascend/sfa_kv_transfer_patch.py
+++ b/ucm/integration/vllm/patch/v0230/vllm_ascend/sfa_kv_transfer_patch.py
@@ -57,10 +57,14 @@ def forward(
     o_proj_full_param_handles = None
     # Prefill/mixed DSA-CP computes o_proj with a temporary full weight.
     # Decode keeps the original TP path and only exchanges activations.
-    full_gather_o_proj_enabled = self.enable_dsa_cp_with_o_proj_tp and attn_metadata.attn_state not in {
-        AscendAttentionState.DecodeOnly,
-        AscendAttentionState.SpecDecoding,
-    }
+    full_gather_o_proj_enabled = (
+        self.enable_dsa_cp_with_o_proj_tp
+        and attn_metadata.attn_state
+        not in {
+            AscendAttentionState.DecodeOnly,
+            AscendAttentionState.SpecDecoding,
+        }
+    )
 
     if self.enable_sfa_prolog_v3 and attn_metadata.attn_state in (
         AscendAttentionState.DecodeOnly,
@@ -75,7 +79,9 @@ def forward(
             f"got token_x={hidden_states.shape[0]} and cache_index={slot_mapping.numel()}."
         )
         if self.has_indexer:
-            k_li, k_li_scale = self.indexer_select_pre_process(x=hidden_states, cos=cos, sin=sin)
+            k_li, k_li_scale = self.indexer_select_pre_process(
+                x=hidden_states, cos=cos, sin=sin
+            )
         else:
             k_li, k_li_scale = None, None
 
@@ -92,7 +98,8 @@ def forward(
         )
     # run mlapo ops when dsa-cp is disabled, and ensure that num_tokens satisfies the count limitation
     elif self.enable_mlapo and (
-        get_ascend_device_type() == AscendDeviceType.A5 or num_input_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
+        get_ascend_device_type() == AscendDeviceType.A5
+        or num_input_tokens <= MLAPO_MAX_SUPPORTED_TOKENS
     ):
         hidden_states = torch.ops.vllm.maybe_all_gather_and_maybe_unpad(
             hidden_states.contiguous(), need_gather_q_kv
@@ -149,14 +156,18 @@ def forward(
             kv_slots = slot_mapping_cp
         else:
             kv_slots = slot_mapping_sfa
-        kv_outputs = self.exec_kv(kv_no_split, cos, sin, kv_cache, kv_slots, attn_metadata)
+        kv_outputs = self.exec_kv(
+            kv_no_split, cos, sin, kv_cache, kv_slots, attn_metadata
+        )
         k_pe, k_nope = kv_outputs[:2]
         knope_scale = kv_outputs[2] if len(kv_outputs) == 3 else None
 
         if (
             self.enable_sparse_sfa_c8
             and not self.enable_dsa_cp
-            and (get_ascend_device_type() != AscendDeviceType.A5 or not self.has_indexer)
+            and (
+                get_ascend_device_type() != AscendDeviceType.A5 or not self.has_indexer
+            )
         ):
             assert k_pe is not None
             assert k_nope is not None
@@ -201,7 +212,9 @@ def forward(
             if kv_ag_handle is not None:
                 kv_ag_handles.append(kv_ag_handle)
 
-            if self.has_indexer and (self.enable_sparse_sfa_c8 or self.enable_sparse_li_c8):
+            if self.has_indexer and (
+                self.enable_sparse_sfa_c8 or self.enable_sparse_li_c8
+            ):
                 assert k_li is not None
                 k_li, kv_ag_handle = all_gather_async(
                     k_li,
@@ -239,7 +252,10 @@ def forward(
                     output=self.o_proj_full_gather_pool,
                 )
                 o_proj_full_param_handles = []
-                for param_name, param in self.o_proj_tp_input_sharded_quant_params.items():
+                for (
+                    param_name,
+                    param,
+                ) in self.o_proj_tp_input_sharded_quant_params.items():
                     _, param_handle = all_gather_async(
                         param,
                         get_tp_group(),
@@ -282,7 +298,9 @@ def forward(
                         value=k_pe[: attn_metadata.num_actual_tokens],
                         key_cache=kv_cache[0],
                         value_cache=kv_cache[1],
-                        slot_mapping=slot_mapping_sfa[: attn_metadata.num_actual_tokens],
+                        slot_mapping=slot_mapping_sfa[
+                            : attn_metadata.num_actual_tokens
+                        ],
                     )
 
         # DCP's prefill path may all-gather only the blocks referenced by
@@ -346,14 +364,19 @@ def forward(
         notify_kv_cache_written(self.layer_name or "")
 
     if self.enable_dsa_cp and attn_metadata.dsa_cp_context is not None:
-        topk_num_tokens = attn_metadata.dsa_cp_context.local_end_with_pad - attn_metadata.dsa_cp_context.local_start
+        topk_num_tokens = (
+            attn_metadata.dsa_cp_context.local_end_with_pad
+            - attn_metadata.dsa_cp_context.local_start
+        )
     else:
         topk_num_tokens = num_input_tokens or hidden_states.shape[0]
     if self.skip_topk:
         topk_indices = self._get_indexcache_topk_indices(topk_num_tokens)
     else:
         if not self.has_indexer:
-            raise RuntimeError(f"skip_topk is False but indexer is None. layer_name={self.layer_name}.")
+            raise RuntimeError(
+                f"skip_topk is False but indexer is None. layer_name={self.layer_name}."
+            )
         assert q_c is not None
         topk_indices = self.indexer_select_post_process(
             x=hidden_states,

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -496,9 +496,24 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
             )
 
         c8_layers = [layer for layer in layers if layer.scale is not None]
-        needs_split = bool(c8_layers)
+        bf16_layers = [
+            layer
+            for layer in layers
+            if layer.indexer is not None and layer.scale is None
+        ]
 
-        if needs_split:
+        if c8_layers and bf16_layers:
+            layout_mode = "mixed"
+        elif c8_layers:
+            layout_mode = "li_c8"
+        elif bf16_layers:
+            layout_mode = "bf16"
+        else:
+            raise ValueError(
+                "Shared Indexer KV cache layout did not find any full " "Indexer layer."
+            )
+
+        if c8_layers:
             index_chunk_size = self._validate_uniform_sizes(
                 [layer.indexer.bytes_per_block for layer in c8_layers],
                 "C8 Indexer block size",
@@ -509,20 +524,17 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
                 "LI C8 scale block size",
                 row_layer_ids,
             )
+        if layout_mode == "mixed":
             slot_sizes = base_sizes + [
                 index_chunk_size,
                 index_chunk_size,
                 scale_size,
             ]
+        elif layout_mode == "li_c8":
+            slot_sizes = base_sizes + [index_chunk_size, scale_size]
         else:
-            indexer_layers = [layer for layer in layers if layer.indexer is not None]
-            if not indexer_layers:
-                raise ValueError(
-                    "Shared Indexer KV cache layout did not find any full "
-                    "Indexer layer."
-                )
             indexer_size = self._validate_uniform_sizes(
-                [layer.indexer.bytes_per_block for layer in indexer_layers],
+                [layer.indexer.bytes_per_block for layer in bf16_layers],
                 "BF16 Indexer block size",
                 row_layer_ids,
             )
@@ -534,11 +546,26 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
                 self._whole_tensor_segment(tensor) for tensor in layer.sfa_tensors
             ]
 
-            if not needs_split:
+            if layout_mode == "bf16":
                 if layer.indexer is not None:
                     segments.append(self._whole_tensor_segment(layer.indexer))
                 else:
                     segments.append(self._ghost_segment(indexer_size))
+            elif layout_mode == "li_c8":
+                if layer.scale is not None:
+                    segments.extend(
+                        [
+                            self._whole_tensor_segment(layer.indexer),
+                            self._whole_tensor_segment(layer.scale),
+                        ]
+                    )
+                else:
+                    segments.extend(
+                        [
+                            self._ghost_segment(index_chunk_size),
+                            self._ghost_segment(scale_size),
+                        ]
+                    )
             elif layer.scale is not None:
                 segments.extend(
                     [
@@ -606,6 +633,7 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
         logger.info(
             "Shared Indexer layerwise KV cache layout: "
             f"sfa_c8={sfa_c8}, li_c8={li_c8}, "
+            f"layout_mode={layout_mode}, "
             f"slot_sizes={slot_sizes}, "
             f"layer_types={[self._layer_type(layer) for layer in layers]}"
         )

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -73,32 +73,21 @@ from ucm.sparse.state import has_ucm_sparse
 logger = init_logger(__name__)
 
 
-def _validate_layerwise_sparse_c8_config(
-    vllm_config: "VllmConfig", launch_config: dict
-) -> None:
-    use_layerwise = bool((launch_config or {}).get("use_layerwise", False))
-    if not use_layerwise:
-        return
-
-    additional_config = getattr(vllm_config, "additional_config", None) or {}
-    enable_sparse_sfa_c8 = bool(additional_config.get("enable_sparse_sfa_c8", False))
-    enable_sparse_li_c8 = bool(additional_config.get("enable_sparse_li_c8", False))
-    if enable_sparse_sfa_c8 == enable_sparse_li_c8:
-        return
-
-    raise ValueError(
-        "Invalid UCM layerwise KV cache configuration: `use_layerwise: true` "
-        "is set in ucm_config.yaml, but the C8 options from "
-        "`--additional-config` are inconsistent. Layerwise mode currently "
-        "requires `enable_sparse_sfa_c8` and `enable_sparse_li_c8` to have "
-        "the same value. Supported combinations are (false, false) and "
-        "(true, true); received "
-        f"(enable_sparse_sfa_c8={enable_sparse_sfa_c8}, "
-        f"enable_sparse_li_c8={enable_sparse_li_c8}). Either set "
-        "`use_layerwise: false` in ucm_config.yaml, or configure both C8 "
-        "options to the same boolean value. Non-layerwise mode supports all "
-        "four C8 combinations."
+def _has_shared_indexer_layers(vllm_config: "VllmConfig") -> bool:
+    model_config = getattr(vllm_config, "model_config", None)
+    hf_text_config = getattr(model_config, "hf_text_config", None)
+    indexer_types = getattr(hf_text_config, "indexer_types", None)
+    if not isinstance(indexer_types, (list, tuple)):
+        return False
+    return any(
+        isinstance(indexer_type, str) and indexer_type.lower() == "shared"
+        for indexer_type in indexer_types
     )
+
+
+def _supports_ascend_shared_indexer_layout(vllm_config: "VllmConfig") -> bool:
+    is_ascend = getattr(current_platform, "device_type", None) == "npu"
+    return is_ascend and _has_shared_indexer_layers(vllm_config)
 
 
 def _normalize_tensor_size_list(tensor_size_list: Any) -> list[int]:
@@ -169,6 +158,29 @@ class RequestDispatchMeta:
     dump_block_ids: tuple[list[bytes], list[int]]
 
 
+@dataclass(frozen=True)
+class KVCacheTensorInfo:
+    ptr: int
+    bytes_per_block: int
+    buffer_size: int
+
+
+@dataclass(frozen=True)
+class SharedIndexerLayerInfo:
+    layer_id: int
+    sfa_tensors: tuple[KVCacheTensorInfo, ...]
+    indexer: Optional[KVCacheTensorInfo]
+    scale: Optional[KVCacheTensorInfo]
+
+
+@dataclass(frozen=True)
+class KVCacheSegment:
+    ptr: int
+    copy_size: int
+    block_stride: int
+    buffer_size: int
+
+
 class KVCacheLayout:
     def __init__(
         self,
@@ -177,14 +189,14 @@ class KVCacheLayout:
         vllm_config: "VllmConfig",
         kv_cache_config: "KVCacheConfig",
     ) -> None:
-        # Direct mode stores only real tensors in flat arrays. Layerwise mode
-        # stores a padded [layer, tensor_slot] matrix because the store uses one
-        # tensor-size list for every layer.
+        # Direct mode stores only real tensors in flat arrays. Generic
+        # layerwise mode intentionally supports regular tensor matrices only;
+        # model families with checkpoint-level shared indexers use the
+        # dedicated SharedIndexerKVCacheLayout below.
         self.base_ptrs: np.ndarray
         self.buffer_sizes: np.ndarray
         self.tensor_size_lists: np.ndarray
         self.block_stride_lists: np.ndarray
-        self.valid_mask: np.ndarray
         self.use_layerwise = ucm_config.get("use_layerwise", False)
         self.kv_cache_config = kv_cache_config
         self.vllm_config = vllm_config
@@ -201,26 +213,25 @@ class KVCacheLayout:
         self.num_blocks = self.kv_cache_config.num_blocks
         self._build_layout(kvcaches)
 
-    def _build_layout(self, kvcaches):
-
+    def _collect_tensor_rows(self, kvcaches):
         num_rows = len(set(self.layer_name_to_id.values()))
-        raw_ptr_rows = [[] for _ in range(num_rows)]
-        stride_rows = [[] for _ in range(num_rows)]
-        buffer_size_rows = [[] for _ in range(num_rows)]
+        tensor_rows = [[] for _ in range(num_rows)]
         row_layer_ids = [None for _ in range(num_rows)]
 
         for layer_name, kv_layer in kvcaches.items():
-            ptrs = []
-            strides = []
-            buffer_sizes = []
 
             def handle_tensor(t: torch.Tensor, size_dims):
-                ptrs.append(t[0].data_ptr())
-
                 stride = math.prod([t.shape[i] for i in size_dims]) * t.element_size()
-                strides.append(stride)
-                buffer_sizes.append(int(t.shape[0]) * stride)
+                tensor_rows[local_layer_id].append(
+                    KVCacheTensorInfo(
+                        ptr=int(t[0].data_ptr()),
+                        bytes_per_block=int(stride),
+                        buffer_size=int(t.shape[0]) * int(stride),
+                    )
+                )
 
+            local_layer_id = self.layer_name_to_id[layer_name] - self.first_layer_id
+            row_layer_ids[local_layer_id] = self.layer_name_to_id[layer_name]
             if isinstance(kv_layer, torch.Tensor):
                 if kv_layer.dim() == 5:
                     # [2, num_blocks, block_size, num_head, head_dim]
@@ -240,11 +251,24 @@ class KVCacheLayout:
             else:
                 raise TypeError(f"Unsupported kv cache type: {type(kv_layer)}")
 
-            local_layer_id = self.layer_name_to_id[layer_name] - self.first_layer_id
-            row_layer_ids[local_layer_id] = self.layer_name_to_id[layer_name]
-            raw_ptr_rows[local_layer_id].extend(ptrs)
-            stride_rows[local_layer_id].extend(strides)
-            buffer_size_rows[local_layer_id].extend(buffer_sizes)
+        return tensor_rows, row_layer_ids
+
+    @staticmethod
+    def _unpack_tensor_rows(tensor_rows):
+        ptr_rows = [[tensor.ptr for tensor in row] for row in tensor_rows]
+        stride_rows = [
+            [tensor.bytes_per_block for tensor in row] for row in tensor_rows
+        ]
+        buffer_size_rows = [
+            [tensor.buffer_size for tensor in row] for row in tensor_rows
+        ]
+        return ptr_rows, stride_rows, buffer_size_rows
+
+    def _build_layout(self, kvcaches):
+        tensor_rows, row_layer_ids = self._collect_tensor_rows(kvcaches)
+        raw_ptr_rows, stride_rows, buffer_size_rows = self._unpack_tensor_rows(
+            tensor_rows
+        )
 
         if not self.use_layerwise:
             # A direct transfer copies one whole KV-cache block. Keep only real
@@ -260,67 +284,35 @@ class KVCacheLayout:
                 [size for row in buffer_size_rows for size in row], dtype=np.uint64
             )
             self.block_stride_lists = self.tensor_size_lists
-            self.valid_mask = np.ones(self.base_ptrs.shape, dtype=bool)
             logger.info(
                 f"base_ptrs: {self.base_ptrs.shape}, "
                 f"tensor_size_lists: {self.tensor_size_lists.shape}"
             )
             return
 
-        # A layerwise transfer uses one fixed tensor-size list for all layers.
-        # Pad shorter rows to the widest row, then verify that every real tensor
-        # in a column has the same block stride. This derives compatibility from
-        # the actual tensor layout without exposing model-specific C8 flags.
-        max_ptrs = max((len(r) for r in raw_ptr_rows), default=0)
-        if max_ptrs == 0:
+        if not tensor_rows or not tensor_rows[0]:
             raise ValueError("KV cache layout must contain at least one tensor")
-        tensor_counts_per_layer = [len(row) for row in raw_ptr_rows]
-        ghost_slots = sum(max_ptrs - count for count in tensor_counts_per_layer)
-        if ghost_slots > 0:
-            padded_layers = sum(count < max_ptrs for count in tensor_counts_per_layer)
-            logger.info(
-                "Layerwise KV cache layout uses padding: "
-                f"num_layers={num_rows}, max_tensors_per_layer={max_ptrs}, "
-                f"padded_layers={padded_layers}, ghost_slots={ghost_slots}, "
-                f"tensor_counts_per_layer={tensor_counts_per_layer}"
+
+        expected_strides = stride_rows[0]
+        incompatible_rows = {
+            row_layer_ids[row_id]: row
+            for row_id, row in enumerate(stride_rows)
+            if row != expected_strides
+        }
+        if incompatible_rows:
+            raise ValueError(
+                "Invalid generic KV cache layout for `use_layerwise: true` in "
+                "ucm_config.yaml: every layer must have the same tensor count "
+                "and per-block tensor sizes. "
+                f"expected={expected_strides} from layer {row_layer_ids[0]}, "
+                f"incompatible_layers={incompatible_rows}. Models with "
+                "checkpoint-level shared indexers require "
+                "SharedIndexerKVCacheLayout; otherwise set `use_layerwise: false`."
             )
-        for rows in (raw_ptr_rows, stride_rows, buffer_size_rows):
-            for r in rows:
-                r.extend([0] * (max_ptrs - len(r)))
 
         self.base_ptrs = np.asarray(raw_ptr_rows, dtype=np.uint64)
         self.tensor_size_lists = np.asarray(stride_rows, dtype=np.uint64)
         self.buffer_sizes = np.asarray(buffer_size_rows, dtype=np.uint64)
-        self.valid_mask = self.base_ptrs != 0
-
-        column_strides = np.zeros(max_ptrs, dtype=np.uint64)
-        for column_id in range(max_ptrs):
-            real_strides = self.tensor_size_lists[
-                self.valid_mask[:, column_id], column_id
-            ]
-            unique_strides = np.unique(real_strides)
-            if unique_strides.size != 1:
-                stride_to_layer_ids = {}
-                for row_id in np.flatnonzero(self.valid_mask[:, column_id]):
-                    stride = int(self.tensor_size_lists[row_id, column_id])
-                    stride_to_layer_ids.setdefault(stride, []).append(
-                        row_layer_ids[row_id]
-                    )
-                raise ValueError(
-                    "Invalid KV cache layout for `use_layerwise: true` in "
-                    "ucm_config.yaml: all real tensors in column "
-                    f"{column_id} must have an identical block stride, but got "
-                    f"{unique_strides.tolist()}; stride_to_layer_ids="
-                    f"{dict(stride_to_layer_ids)}. Set `use_layerwise: false` or "
-                    "make the tensor layout consistent across layers."
-                )
-            column_strides[column_id] = unique_strides[0]
-
-        # Ghost slots use the canonical column stride in store metadata, while
-        # their computed addresses remain zero and are skipped by copy streams.
-        self.tensor_size_lists = np.broadcast_to(
-            column_strides, self.base_ptrs.shape
-        ).copy()
         self.block_stride_lists = self.tensor_size_lists
 
         logger.info(
@@ -343,22 +335,14 @@ class KVCacheLayout:
 
         if layer_first:
             # (n_layers, num_blocks, n_ptrs)
-            addrs = (
+            return (
                 self.block_stride_lists[:, None, :] * vllm_block_ids_np[None, :, None]
                 + self.base_ptrs[:, None, :]
             )
-            if not self.valid_mask.all():
-                # zero out ghost (padded) slots so the C++ copy stream skips
-                # them via addr==nullptr (size is non-zero after col-broadcast).
-                addrs = addrs * self.valid_mask[:, None, :].astype(np.uint64)
-            return addrs
-        addrs = (
+        return (
             vllm_block_ids_np[:, None, None] * self.block_stride_lists[None, :, :]
             + self.base_ptrs[None, :, :]
         )  # (num_blocks, n_layers, n_ptrs)
-        if not self.valid_mask.all():
-            addrs = addrs * self.valid_mask[None, :, :].astype(np.uint64)
-        return addrs
 
     def extract_block_addrs_for_row(
         self, vllm_block_ids: List[int], row_id: int
@@ -368,13 +352,10 @@ class KVCacheLayout:
                 "Row address extraction requires a layerwise KV cache layout"
             )
         vllm_block_ids_np = np.asarray(vllm_block_ids, dtype=np.uint64)
-        addrs = (
+        return (
             vllm_block_ids_np[:, None] * self.block_stride_lists[row_id][None, :]
             + self.base_ptrs[row_id][None, :]
         )
-        if not self.valid_mask[row_id].all():
-            addrs = addrs * self.valid_mask[row_id][None, :].astype(np.uint64)
-        return addrs
 
     @property
     def tensor_size_list(self) -> list[int]:
@@ -397,6 +378,237 @@ class KVCacheLayout:
         if self.pp_size > 1:
             return int(self.tensor_size_lists[0].sum() * self.num_hidden_layers)
         return int(self.tensor_size_lists.sum())
+
+
+class SharedIndexerKVCacheLayout(KVCacheLayout):
+    """Layerwise layout for checkpoint-level shared Indexer models.
+
+    Missing semantic slots use ``base_ptr=0`` and ``block_stride=0``. This keeps
+    their computed device address at nullptr for every block without adding
+    mask behavior to the generic KV cache layout.
+    """
+
+    @classmethod
+    def supports(cls, vllm_config: "VllmConfig", ucm_config: dict) -> bool:
+        return bool(ucm_config.get("use_layerwise", False)) and (
+            _supports_ascend_shared_indexer_layout(vllm_config)
+        )
+
+    @staticmethod
+    def _ghost_segment(slot_size: int) -> KVCacheSegment:
+        return KVCacheSegment(
+            ptr=0,
+            copy_size=int(slot_size),
+            block_stride=0,
+            buffer_size=0,
+        )
+
+    @staticmethod
+    def _real_segment(
+        ptr: int,
+        copy_size: int,
+        block_stride: int,
+        buffer_size: int,
+    ) -> KVCacheSegment:
+        return KVCacheSegment(
+            ptr=int(ptr),
+            copy_size=int(copy_size),
+            block_stride=int(block_stride),
+            buffer_size=int(buffer_size),
+        )
+
+    @staticmethod
+    def _whole_tensor_segment(tensor: KVCacheTensorInfo) -> KVCacheSegment:
+        return KVCacheSegment(
+            ptr=tensor.ptr,
+            copy_size=tensor.bytes_per_block,
+            block_stride=tensor.bytes_per_block,
+            buffer_size=tensor.buffer_size,
+        )
+
+    @staticmethod
+    def _validate_uniform_sizes(
+        values: list[int], description: str, row_layer_ids: list[int]
+    ) -> int:
+        unique_values = sorted(set(values))
+        if len(unique_values) != 1:
+            raise ValueError(
+                f"Shared Indexer KV cache layout requires one {description}, "
+                f"but got {unique_values}; layers={row_layer_ids}."
+            )
+        return unique_values[0]
+
+    @staticmethod
+    def _layer_type(layer: SharedIndexerLayerInfo) -> str:
+        if layer.scale is not None:
+            return "li_c8"
+        if layer.indexer is not None:
+            return "bf16"
+        return "shared"
+
+    def _build_layout(self, kvcaches):
+        if not self.use_layerwise:
+            super()._build_layout(kvcaches)
+            return
+
+        tensor_rows, row_layer_ids = self._collect_tensor_rows(kvcaches)
+        if not tensor_rows or not tensor_rows[0]:
+            raise ValueError("KV cache layout must contain at least one tensor")
+
+        additional_config = getattr(self.vllm_config, "additional_config", None) or {}
+        sfa_c8 = bool(additional_config.get("enable_sparse_sfa_c8", False))
+        li_c8 = bool(additional_config.get("enable_sparse_li_c8", False))
+        base_tensor_count = 1 if sfa_c8 else 2
+
+        base_sizes = [
+            tensor.bytes_per_block for tensor in tensor_rows[0][:base_tensor_count]
+        ]
+        if len(base_sizes) != base_tensor_count:
+            raise ValueError("The first Shared Indexer layer has no SFA base tensor.")
+
+        for layer_id, row in zip(row_layer_ids, tensor_rows):
+            current_sizes = [
+                tensor.bytes_per_block for tensor in row[:base_tensor_count]
+            ]
+            if current_sizes != base_sizes:
+                raise ValueError(
+                    "Shared Indexer layers must have identical SFA base tensors: "
+                    f"expected={base_sizes}, layer={layer_id}, "
+                    f"actual={current_sizes}."
+                )
+
+        max_extra_count = 2 if li_c8 else 1
+        layers = []
+        for layer_id, row in zip(row_layer_ids, tensor_rows):
+            extras = row[base_tensor_count:]
+            if len(extras) > max_extra_count:
+                raise ValueError(
+                    "Unsupported Shared Indexer tensors after the SFA cache: "
+                    f"layer={layer_id}, count={len(extras)}."
+                )
+            layers.append(
+                SharedIndexerLayerInfo(
+                    layer_id=layer_id,
+                    sfa_tensors=tuple(row[:base_tensor_count]),
+                    indexer=extras[0] if extras else None,
+                    scale=extras[1] if len(extras) == 2 else None,
+                )
+            )
+
+        c8_layers = [layer for layer in layers if layer.scale is not None]
+        needs_split = bool(c8_layers)
+
+        if needs_split:
+            index_chunk_size = self._validate_uniform_sizes(
+                [layer.indexer.bytes_per_block for layer in c8_layers],
+                "C8 Indexer block size",
+                row_layer_ids,
+            )
+            scale_size = self._validate_uniform_sizes(
+                [layer.scale.bytes_per_block for layer in c8_layers],
+                "LI C8 scale block size",
+                row_layer_ids,
+            )
+            slot_sizes = base_sizes + [
+                index_chunk_size,
+                index_chunk_size,
+                scale_size,
+            ]
+        else:
+            indexer_layers = [layer for layer in layers if layer.indexer is not None]
+            if not indexer_layers:
+                raise ValueError(
+                    "Shared Indexer KV cache layout did not find any full "
+                    "Indexer layer."
+                )
+            indexer_size = self._validate_uniform_sizes(
+                [layer.indexer.bytes_per_block for layer in indexer_layers],
+                "BF16 Indexer block size",
+                row_layer_ids,
+            )
+            slot_sizes = base_sizes + [indexer_size]
+
+        segment_rows = []
+        for layer in layers:
+            segments = [
+                self._whole_tensor_segment(tensor) for tensor in layer.sfa_tensors
+            ]
+
+            if not needs_split:
+                if layer.indexer is not None:
+                    segments.append(self._whole_tensor_segment(layer.indexer))
+                else:
+                    segments.append(self._ghost_segment(indexer_size))
+            elif layer.scale is not None:
+                segments.extend(
+                    [
+                        self._real_segment(
+                            ptr=layer.indexer.ptr,
+                            copy_size=index_chunk_size,
+                            block_stride=layer.indexer.bytes_per_block,
+                            buffer_size=layer.indexer.buffer_size,
+                        ),
+                        self._ghost_segment(index_chunk_size),
+                        self._whole_tensor_segment(layer.scale),
+                    ]
+                )
+            elif layer.indexer is not None:
+                if layer.indexer.bytes_per_block != 2 * index_chunk_size:
+                    raise ValueError(
+                        "Cannot split BF16 Indexer tensor into two C8-sized "
+                        f"segments: bf16_size={layer.indexer.bytes_per_block}, "
+                        f"c8_size={index_chunk_size}."
+                    )
+                segments.extend(
+                    [
+                        self._real_segment(
+                            ptr=layer.indexer.ptr,
+                            copy_size=index_chunk_size,
+                            block_stride=layer.indexer.bytes_per_block,
+                            buffer_size=layer.indexer.buffer_size,
+                        ),
+                        self._real_segment(
+                            ptr=layer.indexer.ptr + index_chunk_size,
+                            copy_size=index_chunk_size,
+                            block_stride=layer.indexer.bytes_per_block,
+                            buffer_size=0,
+                        ),
+                        self._ghost_segment(scale_size),
+                    ]
+                )
+            else:
+                segments.extend(
+                    [
+                        self._ghost_segment(index_chunk_size),
+                        self._ghost_segment(index_chunk_size),
+                        self._ghost_segment(scale_size),
+                    ]
+                )
+            segment_rows.append(segments)
+
+        self.base_ptrs = np.asarray(
+            [[segment.ptr for segment in row] for row in segment_rows],
+            dtype=np.uint64,
+        )
+        self.tensor_size_lists = np.asarray(
+            [[segment.copy_size for segment in row] for row in segment_rows],
+            dtype=np.uint64,
+        )
+        self.block_stride_lists = np.asarray(
+            [[segment.block_stride for segment in row] for row in segment_rows],
+            dtype=np.uint64,
+        )
+        self.buffer_sizes = np.asarray(
+            [[segment.buffer_size for segment in row] for row in segment_rows],
+            dtype=np.uint64,
+        )
+
+        logger.info(
+            "Shared Indexer layerwise KV cache layout: "
+            f"sfa_c8={sfa_c8}, li_c8={li_c8}, "
+            f"slot_sizes={slot_sizes}, "
+            f"layer_types={[self._layer_type(layer) for layer in layers]}"
+        )
 
 
 @dataclass
@@ -554,7 +766,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
             "", vllm_config.kv_transfer_config.engine_id
         )
         self.launch_config = ucm_config.get_config()
-        _validate_layerwise_sparse_c8_config(vllm_config, self.launch_config)
         self.connector_configs = self.launch_config.get("ucm_connectors", [])
         self.enable_event_sync = self.launch_config.get("enable_event_sync", True)
         self.enable_record_traces = self.launch_config.get(
@@ -752,7 +963,14 @@ class UCMDirectConnector(KVConnectorBase_V1):
             # vllm_ascend >= 0.10.0 uses Tuple for kvcaches
             for i, tensor in enumerate(sample_kv_layer):
                 logger.info(f"kv cache shape {i}: {tensor.shape}")
-        self.kv_cache_layout = KVCacheLayout(
+        layout_cls = (
+            SharedIndexerKVCacheLayout
+            if SharedIndexerKVCacheLayout.supports(
+                self._vllm_config, self.launch_config
+            )
+            else KVCacheLayout
+        )
+        self.kv_cache_layout = layout_cls(
             self.kv_caches,
             self.launch_config,
             self._vllm_config,
@@ -2211,7 +2429,6 @@ class UCMConnector(KVConnectorBase_V1, SupportsHMA):
         self._setup_ucm_metrics(vllm_config, role)
         logger.info(f"self.launch_config: {self.launch_config}")
 
-        _validate_layerwise_sparse_c8_config(vllm_config, self.launch_config)
         use_layerwise = (
             self.launch_config.get("use_layerwise", False)
             if self.launch_config is not None


### PR DESCRIPTION
## Purpose
- 适配 Ascend 平台上 GLM-5.2 Shared Indexer 模型的 KV Cache 布局。在启用 layerwise 传输时，正确处理 SFA C8、LI C8 不同组
- 合产生的不规则 Tensor 布局，同时避免影响 CUDA 及其他普通模型的通用 KV Cache 路径。
## Modifications
- 新增 Ascend 专用 SharedIndexerKVCacheLayout。
- 通过 current_platform.device_type == "npu" 且 indexer_types 包含 shared 识别适用模型。
- LI C8 未启用时，通过 padding 补齐不同层缺失的 Indexer 列。
- LI C8 启用时，将 BF16 Indexer 拆分为两个 C8 大小的 segment，并为缺失位置补充 ghost segment。
- 支持不同代际 Ascend 设备的 scale Tensor，包括 A5 的 FP32、512B scale。
- 保留非 layerwise 模式下的真实 Tensor 拍平逻辑。
- 通用 KV Cache Layout 不再承担模型特定的 mask、padding 和 split 逻辑。
- 移除 SFA C8 与 LI C8 必须取值相同的全局前置校验，改由实际选择的 Layout 根据 Tensor 结构进行校验。
- 补充专用布局选择、四种 SFA/LI C8 组合、BF16 Indexer 拆分、ghost segment、A5 scale 以及非 Ascend 平台隔离等单元测试。
