### PR TITLE
[Fix] Fix accuracy problem on cuda for translating wrong params

### DIFF
--- a/ucm/integration/vllm/hla_connector.py
+++ b/ucm/integration/vllm/hla_connector.py
@@ -796,7 +796,7 @@ class UCMHybridLinearAttentionConnector(UCMDirectConnector, SupportsHMA):
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         self.kv_caches = kv_caches
         self.kv_cache_layout = self._create_kv_cache_layout(self.kv_caches)
-        self.store = self._create_store(self.kv_cache_layout)
+        self.store = self._create_store(kv_cache_layout=self.kv_cache_layout)
         self.block_data_size = self.kv_cache_layout.block_size
         self.device = create_device()
 
@@ -1349,7 +1349,7 @@ class UCMHybridLinearAttentionLayerWiseConnector(UCMHybridLinearAttentionConnect
         self.device = create_device()
 
         self.store = self._create_store(
-            self.kv_cache_layout,
+            kv_cache_layout=self.kv_cache_layout,
             tensor_size_list_override=row_tensor_size_list,
             shard_size_override=row_shard_size,
             block_size_override=row_shard_size * (max(self.row_ids) + 1),

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -617,10 +617,10 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                 self.fa_group_ids,
             )
         return self._create_store(
-            "FA",
-            "fa",
-            tensor_size_list,
-            cpu_affinity_cores,
+            label="FA",
+            store_suffix="fa",
+            tensor_size_list=tensor_size_list,
+            cpu_affinity_cores=cpu_affinity_cores,
         )
 
     def _create_wa_store(
@@ -639,10 +639,10 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                 self.window_group_ids,
             )
         return self._create_store(
-            "WA",
-            "wa",
-            tensor_size_list,
-            cpu_affinity_cores,
+            label="WA",
+            store_suffix="wa",
+            tensor_size_list=tensor_size_list,
+            cpu_affinity_cores=cpu_affinity_cores,
         )
 
     def _base_store_config(

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -900,6 +900,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
     def _create_store(
         self,
         kv_cache_layout: Optional[KVCacheLayout],
+        cpu_affinity_cores: Optional[list[int]] = None,
         tensor_size_list_override: Optional[list[int]] = None,
         shard_size_override: Optional[int] = None,
         block_size_override: Optional[int] = None,
@@ -960,6 +961,8 @@ class UCMDirectConnector(KVConnectorBase_V1):
                 gpu_kv_buffer_sizes.append(key[1])
             config["gpu_kv_buffer_addrs"] = gpu_kv_buffer_addrs
             config["gpu_kv_buffer_sizes"] = gpu_kv_buffer_sizes
+            if cpu_affinity_cores:
+                config["cpu_affinity_cores"] = list(cpu_affinity_cores)
         else:
             config_base = self.block_size * self.element_size * self.head_size
             config["block_size"] = (
@@ -1018,7 +1021,10 @@ class UCMDirectConnector(KVConnectorBase_V1):
             else (None, None)
         )
 
-        self.store = self._create_store(self.kv_cache_layout, store_cores)
+        self.store = self._create_store(
+            kv_cache_layout=self.kv_cache_layout,
+            cpu_affinity_cores=store_cores,
+        )
 
         if worker_cores:
             try:


### PR DESCRIPTION
## Purpose
Fix accuracy problem on Platform cuda when using GLM 5.2 as server's model

## Modifications 
- ucm_connector: add back param _cpu_affinity_cores_
- Use explicit arguments when calling _create_store
## Test
Tested with model GLM 5.2 on cuda