### PR TITLE
[Feat] AsuStore adds configurations of device_ip

### DIFF
--- a/docs/source/developer-guide/kv-test.md
+++ b/docs/source/developer-guide/kv-test.md
@@ -189,9 +189,10 @@ ring_hash.virtual_node_count=128
 
 transport.asu_ids=1,2,3
 transport.provider_type=FAKE
-asu_info.1=protocol=TCP,local.comm_id=127.0.0.1,port=19001,local.logical_device_id=0
-asu_info.2=protocol=TCP,local.comm_id=127.0.0.1,port=19002,local.logical_device_id=0
-asu_info.3=protocol=TCP,local.comm_id=127.0.0.1,port=19003,local.logical_device_id=0
+transport.device_id=0
+asu_info.1=protocol=TCP,local.comm_id=127.0.0.1,port=19001
+asu_info.2=protocol=TCP,local.comm_id=127.0.0.1,port=19002
+asu_info.3=protocol=TCP,local.comm_id=127.0.0.1,port=19003
 
 kv.key_prefix=kv-test-key-
 kv.seed=20260530
@@ -224,6 +225,7 @@ These fields are parsed by the ASU client config parser:
 | `default_wait_timeout_ms` | Default wait timeout in milliseconds. |
 | `transport.asu_ids` | ASU ids. |
 | `transport.provider_type` | Transport provider used by `AsuTransportImpl`. Supported values are `AICPU`, `FAKE`, and `AIV`. The selected provider must also be enabled in CMake. The aliases `transport.provider_backend`, `transport.trans_provider_type`, and `transport.trans_provider_backend` are also accepted. |
+| `transport.device_id` | Local logical device id used to initialize the transport provider. |
 | `asu_info.<id>` | Endpoint config for one ASU. |
 | `hash_table.type` | Router hash table type. |
 | `ring_hash.virtual_node_count` | Ring hash virtual node count. |

--- a/examples/ucm_config_asu.yaml
+++ b/examples/ucm_config_asu.yaml
@@ -1,4 +1,4 @@
-# UCM ASU fake backend example for vLLM / vLLM-Ascend software integration tests.
+# UCM ASU AIV backend example for vLLM / vLLM-Ascend integration.
 #
 # Use with:
 # kv_connector_extra_config={"UCM_CONFIG_FILE": "/workspace/unified-cache-management/examples/ucm_config_asu.yaml"}
@@ -8,22 +8,28 @@ ucm_connectors:
     ucm_connector_config:
       store_pipeline: "ASU"
       asu_mode: "client"
-      asu_client_id: "ucm-vllm-asu-fake"
-      asu_ids: [1, 2]
-      asu_trans_provider_backend: "fake"
+      asu_client_id: "ucm-vllm-asu-aiv"
+      asu_ids: [1]
+      asu_trans_provider_backend: "aiv"
 
       # Non-FAWA models use one ASU namespace. For DeepSeek V4 / FAWA,
       # replace this with: kv_ns_ids: [100, 101]  # [FA, WA]
       kv_ns_ids: [100]
 
-      # ASU client routing. Keep the default close to kv-test's fake_backend config.
+      # cpu ip where mock server runs
+      asu_ips: ["223.223.8.11"]
+      asu_port: 19001
+      # Used by the scheduler. Worker processes overwrite it with local_rank.
+      device_id: 0
+
+      # ASU client routing.
       asu_router_type: "RING_HASH"
       asu_ring_hash_virtual_node_count: 128
 
       # Local software backend. This uses normal AsuClient + AsuTransportImpl submit/CQE paths
       # and replaces the missing device Send/backend execution with local files.
-      asu_fake_backend_path: "./asu-fake-backend-store"
-      asu_fake_backend_latency_ms: 1
+      # asu_fake_backend_path: "./asu-fake-backend-store"
+      # asu_fake_backend_latency_ms: 1
 
       # ASU wait and operation timeouts.
       asu_default_wait_timeout_ms: 5000

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,12 @@ BUILD_UCM_ASU_PROVIDER_AIV = os.getenv("BUILD_UCM_ASU_PROVIDER_AIV", "0") not in
     "false",
     "False",
 )
+BUILD_UCM_ASU_PROVIDER_AICPU = os.getenv("BUILD_UCM_ASU_PROVIDER_AICPU", "0") not in (
+    "",
+    "0",
+    "false",
+    "False",
+)
 
 
 def get_abi_flag_from_env() -> str:
@@ -71,14 +77,14 @@ def print_platform_warning():
         RESET = "\033[0m"
 
         warning_msg = f"""
-{RED}{'=' * 80}
+{RED}{"=" * 80}
 {BOLD}⚠️  WARNING: PLATFORM environment variable is not set! ⚠️{RESET}
-{RED}{'=' * 80}{RESET}
+{RED}{"=" * 80}{RESET}
 {YELLOW}Please set PLATFORM to one of: cuda, ascend, ascend-a3, musa, maca{RESET}
 Example:
   {BOLD}export PLATFORM=cuda{RESET}    # For CUDA platform
 {YELLOW}In CI scenarios only, you don't need to specify PLATFORM. If it's not a CI scenario, please uninstall and then reinstall with PLATFORM specified.{RESET}
-{RED}{'=' * 80}{RESET}
+{RED}{"=" * 80}{RESET}
 """
         # Use write and flush to ensure output even without -v flag
         sys.stderr.write(warning_msg)
@@ -175,6 +181,10 @@ class CMakeBuild(build_ext):
             cmake_args += ["-DBUILD_UCM_SPARSE=ON"]
         if BUILD_UCM_ASU:
             cmake_args += ["-DBUILD_UCM_ASU=ON"]
+        if BUILD_UCM_ASU_PROVIDER_AIV:
+            cmake_args += ["-DBUILD_UCM_ASU_PROVIDER_AIV=ON"]
+        if BUILD_UCM_ASU_PROVIDER_AICPU:
+            cmake_args += ["-DBUILD_UCM_ASU_PROVIDER_AICPU=ON"]
 
         match PLATFORM:
             case "cuda":

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -29,6 +29,7 @@
 #include <cstddef>
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <numeric>
@@ -473,7 +474,10 @@ private:
         inConfig.GetNumbers("kv_ns_ids", config.kvNsIds);
         ssize_t asuPort = 0;
         inConfig.GetNumber("asu_port", asuPort);
-        config.asuPort = static_cast<std::uint16_t>(std::max<ssize_t>(0, asuPort));
+        if (asuPort > 0 &&
+            static_cast<std::uint64_t>(asuPort) <= std::numeric_limits<std::uint16_t>::max()) {
+            config.asuPort = static_cast<std::uint16_t>(asuPort);
+        }
         inConfig.GetNumber("asu_default_wait_timeout_ms", config.defaultWaitTimeoutMs);
         inConfig.GetNumber("asu_query_timeout_ms", config.queryTimeoutMs);
         inConfig.GetNumber("asu_load_timeout_ms", config.loadTimeoutMs);
@@ -544,6 +548,15 @@ private:
         if (config.configPath.empty() && config.asuIds.empty()) {
             return Status::InvalidParam("invalid asu_ids");
         }
+        if (std::any_of(config.asuIds.begin(), config.asuIds.end(),
+                        [](ssize_t asuId) { return asuId < 0; })) {
+            return Status::InvalidParam("asu_ids must not contain negative values");
+        }
+        auto sortedAsuIds = config.asuIds;
+        std::sort(sortedAsuIds.begin(), sortedAsuIds.end());
+        if (std::adjacent_find(sortedAsuIds.begin(), sortedAsuIds.end()) != sortedAsuIds.end()) {
+            return Status::InvalidParam("asu_ids must not contain duplicate values");
+        }
         if (config.mode == "transport") {
             if (config.configPath.empty() && config.asuIds.size() != 1) {
                 return Status::InvalidParam("transport mode requires exactly one asu_id");
@@ -555,11 +568,25 @@ private:
         if (!config.asuIps.empty() && config.asuIps.size() != config.asuIds.size()) {
             return Status::InvalidParam("asu_ips size must match asu_ids size");
         }
-        if (config.uniqueId.find("_fawa_") != std::string::npos && config.kvNsIds.size() != 2) {
-            return Status::InvalidParam("FAWA requires exactly two kv_ns_ids");
+        if (!config.asuIps.empty() && config.asuPort == 0) {
+            return Status::InvalidParam("asu_port must be in range [1, 65535] when asu_ips is set");
+        }
+        if (config.configPath.empty()) {
+            const auto expectedKvNsCount = config.uniqueId.find("_fawa_") == std::string::npos
+                                               ? std::size_t{1}
+                                               : std::size_t{2};
+            if (config.kvNsIds.size() != expectedKvNsCount) {
+                return Status::InvalidParam("kv_ns_ids must contain exactly {} value(s)",
+                                            expectedKvNsCount);
+            }
         }
         if (config.transProviderType == UC::ASU::TransProviderType::UNSUPPORTED) {
             return Status::Unsupported();
+        }
+        if (config.configPath.empty() &&
+            config.transProviderType == UC::ASU::TransProviderType::AIV && config.deviceId < 0) {
+            return Status::InvalidParam(
+                "device_id is required when asu_trans_provider_backend is aiv");
         }
         if (config.transProviderType == UC::ASU::TransProviderType::FAKE &&
             !config.configPath.empty()) {
@@ -573,6 +600,13 @@ private:
         if (!config.role.empty() && config.role != "scheduler" && config.role != "worker") {
             return Status::InvalidParam("invalid role({})", config.role);
         }
+        if (config.maxInflightTasks > std::numeric_limits<std::uint32_t>::max()) {
+            return Status::InvalidParam("asu_max_inflight_tasks exceeds uint32 range");
+        }
+        if (!config.memoryType.empty() && config.memoryType != "host" &&
+            config.memoryType != "host_pinned" && config.memoryType != "ascend_device") {
+            return Status::InvalidParam("invalid asu_memory_type({})", config.memoryType);
+        }
 
         // Scheduler config check done
         if (config.role == "scheduler") { return Status::OK(); }
@@ -584,6 +618,9 @@ private:
         }
         if (config.shardSize == 0) { return Status::InvalidParam("invalid shard size"); }
         if (config.blockSize == 0) { return Status::InvalidParam("invalid block size"); }
+        if (config.blockSize > std::numeric_limits<std::uint32_t>::max()) {
+            return Status::InvalidParam("block size exceeds uint32 offset range");
+        }
         const auto tensorSum =
             std::accumulate(config.tensorSizes.begin(), config.tensorSizes.end(), std::size_t{0});
         if (tensorSum == 0 || tensorSum > config.shardSize) {

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -171,6 +171,7 @@ UC::ASU::TransportConfig BuildTransportConfig(const Config& config, std::size_t 
     UC::ASU::TransportConfig transportConfig;
     transportConfig.asuId = static_cast<UC::ASU::AsuId>(config.asuIds[index]);
     transportConfig.asuName = config.asuNamePrefix + "-" + std::to_string(config.asuIds[index]);
+    transportConfig.deviceId = config.deviceId;
     transportConfig.queryTimeoutMs = config.queryTimeoutMs;
     transportConfig.loadTimeoutMs = config.loadTimeoutMs;
     transportConfig.storeTimeoutMs = config.storeTimeoutMs;
@@ -181,17 +182,17 @@ UC::ASU::TransportConfig BuildTransportConfig(const Config& config, std::size_t 
     // Set for all backends including fake
     const auto kvNsIndex = config.uniqueId.find("_fawa_wa") == std::string::npos ? 0 : 1;
     transportConfig.attrs["kv_ns_id"] = std::to_string(config.kvNsIds[kvNsIndex]);
-    if (!config.asuLocalIp.empty()) { transportConfig.attrs["localIp"] = config.asuLocalIp; }
+    if (!config.localIp.empty()) { transportConfig.attrs["localIp"] = config.localIp; }
 
     if (!config.asuIps.empty()) {
         UC::ASU::AsuEndpoint endpoint;
         endpoint.ip = config.asuIps[index];
         endpoint.port = config.asuPort;
-        endpoint.deviceId = config.deviceId;
         transportConfig.endpoints.emplace_back(std::move(endpoint));
     }
     if (config.transProviderType == UC::ASU::TransProviderType::FAKE) {
         const auto fakeDeviceId = config.deviceId >= 0 ? config.deviceId : 0;
+        transportConfig.deviceId = fakeDeviceId;
         transportConfig.attrs.try_emplace("kernel_count", "1");
         transportConfig.attrs.try_emplace("quiet_count", "1");
         transportConfig.attrs.try_emplace("dtype", "0");
@@ -207,7 +208,6 @@ UC::ASU::TransportConfig BuildTransportConfig(const Config& config, std::size_t 
             endpoint.ip = "fake_backend";
             endpoint.port = 19001;
             endpoint.protocol = UC::ASU::Protocol::TCP;
-            endpoint.deviceId = fakeDeviceId;
             transportConfig.endpoints.emplace_back(std::move(endpoint));
         }
     }
@@ -460,7 +460,7 @@ private:
         inConfig.Get("asu_view_service_addrs", config.viewServiceAddrs);
         inConfig.GetNumbers("asu_ids", config.asuIds);
         inConfig.Get("asu_ips", config.asuIps);
-        inConfig.Get("asu_local_ip", config.asuLocalIp);
+        inConfig.Get("asu_local_ip", config.localIp);
         inConfig.Get("asu_name_prefix", config.asuNamePrefix);
         inConfig.GetNumbers("kv_ns_ids", config.kvNsIds);
         ssize_t asuPort = 0;

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -131,14 +131,6 @@ UC::ASU::TransProviderType ParseTransProviderBackend(std::string backend)
     return UC::ASU::TransProviderType::UNSUPPORTED;
 }
 
-UC::ASU::MemoryType ParseMemoryType(const std::string& memoryType)
-{
-    if (memoryType == "host") { return UC::ASU::MemoryType::HOST; }
-    if (memoryType == "host_pinned") { return UC::ASU::MemoryType::HOST_PINNED; }
-    if (memoryType == "ascend_device") { return UC::ASU::MemoryType::ASCEND_DEVICE; }
-    return UC::ASU::MemoryType::ASCEND_DEVICE;
-}
-
 bool TryGetStringLike(const Detail::Dictionary& inConfig, const std::string& key,
                       std::string& value)
 {
@@ -377,13 +369,12 @@ public:
     {
         if (!backend_) { return Status::Error("ASU backend is not initialized"); }
 
-        const auto memoryType = ConfiguredMemoryType();
         std::vector<UC::ASU::MemoryRegion> regions;
         regions.reserve(count);
         for (std::size_t index = 0; index < count; ++index) {
             if (registrations[index].addr == 0 || registrations[index].size == 0) { continue; }
             UC::ASU::MemoryRegion region;
-            region.memoryType = memoryType;
+            region.memoryType = UC::ASU::MemoryType::ASCEND_DEVICE;
             region.addr = static_cast<std::uint64_t>(registrations[index].addr);
             region.size = static_cast<std::uint64_t>(registrations[index].size);
             region.deviceId = config_.deviceId;
@@ -487,7 +478,6 @@ private:
         inConfig.GetNumber("shard_size", config.shardSize);
         inConfig.GetNumber("block_size", config.blockSize);
         inConfig.GetNumber("device_id", config.deviceId);
-        inConfig.Get("asu_memory_type", config.memoryType);
         inConfig.Get("tensor_layout", config.tensorLayout);
         std::string providerBackend;
         if (TryGetStringLike(inConfig, "asu_trans_provider_backend", providerBackend)) {
@@ -603,11 +593,6 @@ private:
         if (config.maxInflightTasks > std::numeric_limits<std::uint32_t>::max()) {
             return Status::InvalidParam("asu_max_inflight_tasks exceeds uint32 range");
         }
-        if (!config.memoryType.empty() && config.memoryType != "host" &&
-            config.memoryType != "host_pinned" && config.memoryType != "ascend_device") {
-            return Status::InvalidParam("invalid asu_memory_type({})", config.memoryType);
-        }
-
         // Scheduler config check done
         if (config.role == "scheduler") { return Status::OK(); }
 
@@ -760,7 +745,6 @@ private:
     {
         std::vector<UC::ASU::KVBuffer> entries;
         entries.reserve(task.size() * config_.tensorSizes.size());
-        const auto memoryType = ConfiguredMemoryType();
 
         for (const auto& shard : task) {
             if (shard.index >= ShardsPerBlock()) {
@@ -773,7 +757,7 @@ private:
             for (std::size_t tensorIndex = 0; tensorIndex < shard.addrs.size(); ++tensorIndex) {
                 UC::ASU::KVBuffer entry;
                 entry.key = MakeAsuKey(shard.owner);
-                entry.buffer.region.memoryType = memoryType;
+                entry.buffer.region.memoryType = UC::ASU::MemoryType::ASCEND_DEVICE;
                 entry.buffer.region.addr =
                     reinterpret_cast<std::uint64_t>(shard.addrs[tensorIndex]);
                 entry.buffer.region.size = config_.tensorSizes[tensorIndex];
@@ -807,14 +791,6 @@ private:
         UC_INFO("Set AsuStore::TransProviderBackend to {}.",
                 TransProviderBackendName(config.transProviderType));
         UC_INFO("Set AsuStore::FakeBackendPath to {}.", config.fakeBackendPath);
-    }
-
-    UC::ASU::MemoryType ConfiguredMemoryType() const
-    {
-        return config_.memoryType.empty()
-                   ? (config_.deviceId >= 0 ? UC::ASU::MemoryType::ASCEND_DEVICE
-                                            : UC::ASU::MemoryType::HOST)
-                   : ParseMemoryType(config_.memoryType);
     }
 
     UC::ASU::MRHandle FindPersistentHandle(const UC::ASU::MemoryRegion& region) const

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -32,7 +32,6 @@ struct Config {
     std::size_t shardSize{0};
     std::size_t blockSize{0};
     std::int32_t deviceId{-1};
-    std::string memoryType;
     std::string tensorLayout;
     UC::ASU::TransProviderType transProviderType{UC::ASU::TransProviderType::AICPU};
     std::string fakeBackendPath;

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -18,7 +18,7 @@ struct Config {
     std::vector<std::string> viewServiceAddrs;
     std::vector<ssize_t> asuIds;
     std::vector<std::string> asuIps;
-    std::string asuLocalIp;
+    std::string localIp;
     std::string asuNamePrefix{"asu"};
     std::vector<std::uint32_t> kvNsIds;
     std::uint16_t asuPort{0};

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -28,6 +28,7 @@
 #include <cstdio>
 #include <fstream>
 #include <gtest/gtest.h>
+#include <limits>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -315,6 +316,104 @@ TEST(UCAsuStoreTest, ParsesKvNamespaces)
         EXPECT_EQ(state->initConfigs.back().kvNsIds, (std::vector<std::uint32_t>{100U, 101U}));
         auto transportConfig = UC::AsuStore::BuildTransportConfig(state->initConfigs.back(), 0);
         EXPECT_EQ(transportConfig.attrs.at("kv_ns_id"), std::to_string(expected));
+    }
+}
+
+TEST(UCAsuStoreTest, RejectsMissingKvNamespaces)
+{
+    UC::AsuStore::AsuStore store;
+    auto config = MakeBaseConfig();
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("kv_ns_ids", std::vector<ssize_t>{});
+
+    EXPECT_TRUE(store.Setup(config).Failure());
+}
+
+TEST(UCAsuStoreTest, RejectsUnexpectedKvNamespaceCount)
+{
+    UC::AsuStore::AsuStore store;
+    auto config = MakeBaseConfig();
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("kv_ns_ids", std::vector<ssize_t>{100, 101});
+
+    EXPECT_TRUE(store.Setup(config).Failure());
+}
+
+TEST(UCAsuStoreTest, RejectsInvalidAsuIds)
+{
+    for (const auto& asuIds : std::vector<std::vector<ssize_t>>{
+             {-1},
+             {1001, 1001}
+    }) {
+        UC::AsuStore::AsuStore store;
+        auto config = MakeBaseConfig();
+        config.Set("asu_ids", asuIds);
+
+        EXPECT_TRUE(store.Setup(config).Failure());
+    }
+}
+
+TEST(UCAsuStoreTest, RejectsInvalidAsuPort)
+{
+    UC::AsuStore::AsuStore store;
+    auto config = MakeBaseConfig();
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
+    config.SetNumber("asu_port", 65536);
+
+    EXPECT_TRUE(store.Setup(config).Failure());
+}
+
+TEST(UCAsuStoreTest, RejectsTransportIntegerOverflow)
+{
+    {
+        UC::AsuStore::AsuStore store;
+        auto config = MakeBaseConfig();
+        config.Set("asu_ids", std::vector<ssize_t>{1001});
+        config.SetNumber("asu_max_inflight_tasks",
+                         std::uint64_t{std::numeric_limits<std::uint32_t>::max()} + 1);
+
+        EXPECT_TRUE(store.Setup(config).Failure());
+    }
+    {
+        UC::AsuStore::AsuStore store;
+        auto config = MakeBaseConfig();
+        config.Set("asu_ids", std::vector<ssize_t>{1001});
+        config.SetNumber("block_size",
+                         std::uint64_t{std::numeric_limits<std::uint32_t>::max()} + 1);
+
+        EXPECT_TRUE(store.Setup(config).Failure());
+    }
+}
+
+TEST(UCAsuStoreTest, RejectsInvalidMemoryType)
+{
+    UC::AsuStore::AsuStore store;
+    auto config = MakeBaseConfig();
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("asu_memory_type", std::string{"device"});
+
+    EXPECT_TRUE(store.Setup(config).Failure());
+}
+
+TEST(UCAsuStoreTest, AivRequiresDeviceIdAndDeviceIp)
+{
+    {
+        UC::AsuStore::AsuStore store;
+        auto config = MakeBaseConfig();
+        config.Set("asu_ids", std::vector<ssize_t>{1001});
+        config.Set("asu_trans_provider_backend", std::string{"aiv"});
+
+        EXPECT_TRUE(store.Setup(config).Failure());
+    }
+    {
+        UC::AsuStore::AsuStore store;
+        auto config = MakeBaseConfig();
+        config.Set("asu_ids", std::vector<ssize_t>{1001});
+        config.Set("asu_trans_provider_backend", std::string{"aiv"});
+        config.SetNumber("device_id", 0);
+
+        EXPECT_TRUE(store.Setup(config).Failure());
     }
 }
 

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -386,16 +386,6 @@ TEST(UCAsuStoreTest, RejectsTransportIntegerOverflow)
     }
 }
 
-TEST(UCAsuStoreTest, RejectsInvalidMemoryType)
-{
-    UC::AsuStore::AsuStore store;
-    auto config = MakeBaseConfig();
-    config.Set("asu_ids", std::vector<ssize_t>{1001});
-    config.Set("asu_memory_type", std::string{"device"});
-
-    EXPECT_TRUE(store.Setup(config).Failure());
-}
-
 TEST(UCAsuStoreTest, AivRequiresDeviceIdAndDeviceIp)
 {
     {

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -386,7 +386,7 @@ TEST(UCAsuStoreTest, RejectsTransportIntegerOverflow)
     }
 }
 
-TEST(UCAsuStoreTest, AivRequiresDeviceIdAndDeviceIp)
+TEST(UCAsuStoreTest, AivRequiresDeviceId)
 {
     {
         UC::AsuStore::AsuStore store;
@@ -398,12 +398,13 @@ TEST(UCAsuStoreTest, AivRequiresDeviceIdAndDeviceIp)
     }
     {
         UC::AsuStore::AsuStore store;
+        UseFakeBackend(store);
         auto config = MakeBaseConfig();
         config.Set("asu_ids", std::vector<ssize_t>{1001});
         config.Set("asu_trans_provider_backend", std::string{"aiv"});
         config.SetNumber("device_id", 0);
 
-        EXPECT_TRUE(store.Setup(config).Failure());
+        EXPECT_TRUE(store.Setup(config).Success());
     }
 }
 
@@ -412,14 +413,46 @@ TEST(UCAsuStoreTest, PropagatesKvNamespaceToEveryTransport)
     UC::AsuStore::Config config;
     config.asuIds = {1001, 1002};
     config.kvNsIds = {100};
+    config.deviceId = 3;
+    config.localIp = "192.168.0.3";
     config.transProviderType = UC::ASU::TransProviderType::FAKE;
 
     for (std::size_t index = 0; index < config.asuIds.size(); ++index) {
         auto transportConfig = UC::AsuStore::BuildTransportConfig(config, index);
+        EXPECT_EQ(transportConfig.deviceId, 3);
+        EXPECT_EQ(transportConfig.attrs.at("localIp"), "192.168.0.3");
         auto iter = transportConfig.attrs.find("kv_ns_id");
         ASSERT_NE(iter, transportConfig.attrs.end());
         EXPECT_EQ(iter->second, "100");
     }
+}
+
+TEST(UCAsuStoreTest, SchedulerUsesConfiguredDeviceId)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeBackend(store);
+    auto config = MakeBaseConfig();
+    config.Set("role", std::string{"scheduler"});
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.SetNumber("device_id", 5);
+
+    ASSERT_TRUE(store.Setup(config).Success());
+    ASSERT_FALSE(state->initConfigs.empty());
+    EXPECT_EQ(state->initConfigs.back().deviceId, 5);
+}
+
+TEST(UCAsuStoreTest, WorkerUsesLocalRankDeviceId)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeBackend(store);
+    auto config = MakeBaseConfig();
+    config.Set("role", std::string{"worker"});
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.SetNumber("device_id", 2);
+
+    ASSERT_TRUE(store.Setup(config).Success());
+    ASSERT_FALSE(state->initConfigs.empty());
+    EXPECT_EQ(state->initConfigs.back().deviceId, 2);
 }
 
 TEST(UCAsuStoreTest, TransportModeSmoke)

--- a/ucm/transport/kv/asu/client/src/client_config_parser.cpp
+++ b/ucm/transport/kv/asu/client/src/client_config_parser.cpp
@@ -140,6 +140,9 @@ Status LoadAsuClientConfig(const std::string& configPath, AsuClientConfig& confi
             if (ApplyTransportProviderConfigField(transportConfig, field.first, field.second)) {
                 continue;
             }
+            if (ApplyTransportDeviceConfigField(transportConfig, field.first, field.second)) {
+                continue;
+            }
             transportConfig.attrs.emplace(field);
         }
 

--- a/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
@@ -507,8 +507,9 @@ TEST(AsuClientImplTest, Lifecycle_PublicInitLoadsClientConfigFile)
         configFile << "transport.batch_store_io_num=12\n";
         configFile << "transport.delete_io_num=13\n";
         configFile << "transport.query_io_num=14\n";
+        configFile << "transport.device_id=6\n";
         configFile << "asuInfo.20=protocol=roce,placement=device,port=6000,"
-                   << "local.comm_id=192.168.1.20,local.logical_device_id=6\n";
+                   << "local.comm_id=192.168.1.20\n";
     }
 
     auto state = std::make_shared<TestState>();
@@ -521,7 +522,7 @@ TEST(AsuClientImplTest, Lifecycle_PublicInitLoadsClientConfigFile)
     ASSERT_EQ(state->initConfigs[20].endpoints.size(), std::size_t{1});
     EXPECT_EQ(state->initConfigs[20].endpoints[0].ip, "192.168.1.20");
     EXPECT_EQ(state->initConfigs[20].endpoints[0].protocol, Protocol::ROCE);
-    EXPECT_EQ(state->initConfigs[20].endpoints[0].deviceId, std::int32_t{6});
+    EXPECT_EQ(state->initConfigs[20].deviceId, std::int32_t{6});
     for (auto asuId : {AsuId{10}, AsuId{20}}) {
         EXPECT_EQ(state->initConfigs[asuId].sendBufferSlotSize, std::size_t{8192});
         EXPECT_EQ(state->initConfigs[asuId].sendBufferSlotNum, std::size_t{2});

--- a/ucm/transport/kv/asu/client/test/view_server_test.cpp
+++ b/ucm/transport/kv/asu/client/test/view_server_test.cpp
@@ -17,8 +17,8 @@ TEST(ViewServerTest, ConfigFileViewServerLoadsView)
         configFile << "viewId=3\n";
         configFile << "asuIds=10,20\n";
         configFile << "asuInfo.20=protocol=uboe,placement=device,port=6000,"
-                   << "local.comm_id=192.168.1.20,local.logical_device_id=6,"
-                   << "send_size=4096,remote_send_addr=0x100000000\n";
+                   << "local.comm_id=192.168.1.20,send_size=4096,"
+                   << "remote_send_addr=0x100000000\n";
     }
 
     AsuClientConfig config;
@@ -37,7 +37,6 @@ TEST(ViewServerTest, ConfigFileViewServerLoadsView)
     EXPECT_EQ(view.asuMap[20].endpoints[0].ip, "192.168.1.20");
     EXPECT_EQ(view.asuMap[20].endpoints[0].port, std::uint16_t{6000});
     EXPECT_EQ(view.asuMap[20].endpoints[0].protocol, Protocol::UB);
-    EXPECT_EQ(view.asuMap[20].endpoints[0].deviceId, std::int32_t{6});
     EXPECT_EQ(view.asuMap[20].endpoints[0].attrs["protocol"], "uboe");
     EXPECT_EQ(view.asuMap[20].endpoints[0].attrs["placement"], "device");
     EXPECT_EQ(view.asuMap[20].endpoints[0].attrs["send_size"], "4096");

--- a/ucm/transport/kv/asu/common/config_parser_common.cpp
+++ b/ucm/transport/kv/asu/common/config_parser_common.cpp
@@ -46,9 +46,6 @@ void ApplyTransportEndpointField(AsuEndpoint& endpoint, const std::string& key,
         endpoint.protocol = ParseConfigProtocol(value);
     } else if (key == "numa_node" || key == "numaNode") {
         endpoint.numaNode = static_cast<std::int32_t>(ParseConfigUint64(value));
-    } else if (key == "device_id" || key == "deviceId" || key == "local.logical_device_id" ||
-               key == "localLogicalDeviceId") {
-        endpoint.deviceId = static_cast<std::int32_t>(ParseConfigUint64(value));
     } else if (key == "hca_name" || key == "hcaName") {
         endpoint.hcaName = value;
     } else if (key == "hca_port" || key == "hcaPort") {
@@ -70,8 +67,6 @@ void ApplyClientViewEndpointField(AsuEndpoint& endpoint, const std::string& key,
         endpoint.port = static_cast<std::uint16_t>(ParseConfigUint64(value));
     } else if (key == "local.comm_id" || key == "localCommId") {
         endpoint.ip = value;
-    } else if (key == "local.logical_device_id" || key == "localLogicalDeviceId") {
-        endpoint.deviceId = static_cast<std::int32_t>(ParseConfigUint64(value));
     } else if (key == "tc") {
         SetEndpointAttr(endpoint, "tc", value);
     } else if (key == "sl") {
@@ -180,6 +175,16 @@ bool ApplyTransportProviderConfigField(TransportConfig& config, const std::strin
         return false;
     }
     return true;
+}
+
+bool ApplyTransportDeviceConfigField(TransportConfig& config, const std::string& key,
+                                     const std::string& value)
+{
+    if (key == "deviceId" || key == "device_id") {
+        config.deviceId = static_cast<std::int32_t>(ParseConfigUint64(value));
+        return true;
+    }
+    return false;
 }
 
 bool TryParseAsuInfoKey(const std::string& key, AsuId& asuId)

--- a/ucm/transport/kv/asu/common/config_parser_common.h
+++ b/ucm/transport/kv/asu/common/config_parser_common.h
@@ -42,6 +42,8 @@ bool ApplyTransportIoNumConfigField(TransportConfig& config, const std::string& 
                                     const std::string& value);
 bool ApplyTransportProviderConfigField(TransportConfig& config, const std::string& key,
                                        const std::string& value);
+bool ApplyTransportDeviceConfigField(TransportConfig& config, const std::string& key,
+                                     const std::string& value);
 bool TryParseAsuInfoKey(const std::string& key, AsuId& asuId);
 bool TryGetTransportAttrKey(const std::string& key, std::string& attrKey);
 

--- a/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
@@ -38,7 +38,6 @@ struct AsuEndpoint {
     std::uint16_t port{0};
     Protocol protocol{Protocol::ROCE};
     std::int32_t numaNode{-1};
-    std::int32_t deviceId{-1};
     std::string hcaName;
     std::uint8_t hcaPort{1};
     std::unordered_map<std::string, std::string> attrs;
@@ -48,6 +47,8 @@ struct TransportConfig {
     // TODO: 拆分Config，按逻辑模块细化
     std::string asuName;
     AsuId asuId{0};
+    // Local logical device ID used by the transport provider.
+    std::int32_t deviceId{-1};
     std::vector<AsuEndpoint> endpoints;
 
     TransProviderType providerType{TransProviderType::AICPU};

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -112,8 +112,7 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
 #endif
             case TransProviderType::AIV:
 #ifdef UCM_ASU_ENABLE_AIV_PROVIDER
-                transProvider_ = std::make_unique<AIVTransProviderAdapter>(
-                    config_.endpoints.empty() ? -1 : config_.endpoints.front().deviceId);
+                transProvider_ = std::make_unique<AIVTransProviderAdapter>(config_.deviceId);
                 break;
 #else
                 return Status::Error(

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
@@ -378,7 +378,7 @@ Status CompleteFakeBackendRequest(const FakeTransProviderConfig& config, const v
 FakeTransProviderConfig MakeFakeTransProviderConfig(const TransportConfig& config)
 {
     FakeTransProviderConfig fakeConfig;
-    fakeConfig.deviceId = config.endpoints.empty() ? 0 : config.endpoints.front().deviceId;
+    fakeConfig.deviceId = config.deviceId < 0 ? 0 : config.deviceId;
     auto pathIter = config.attrs.find("fake_backend.path");
     if (pathIter != config.attrs.end() && !pathIter->second.empty()) {
         fakeConfig.storePath = pathIter->second;

--- a/ucm/transport/kv/asu/trans/src/transport_config_parser.cpp
+++ b/ucm/transport/kv/asu/trans/src/transport_config_parser.cpp
@@ -165,6 +165,8 @@ Status LoadTransportConfig(const std::string& configPath, TransportConfig& confi
             continue;
         } else if (ApplyTransportProviderConfigField(config, key, value)) {
             continue;
+        } else if (ApplyTransportDeviceConfigField(config, key, value)) {
+            continue;
         } else {
             config.attrs[key] = value;
         }

--- a/ucm/transport/kv/kv-test/asu_kv_test.conf
+++ b/ucm/transport/kv/kv-test/asu_kv_test.conf
@@ -27,18 +27,20 @@ transport.asu_ids=1
 # matching BUILD_UCM_ASU_PROVIDER_* CMake option when testing them directly.
 # Use FAKE for the local mock Send/CQE backend.
 transport.provider_type=AIV
+transport.device_id=0
 transport.localIp=127.0.0.1
 
 # ASU endpoint list. Endpoint format:
-# protocol=<UB|ROCE|TCP>,local.comm_id=<ip-or-comm-id>,port=<port>,local.logical_device_id=<device>
+# protocol=<UB|ROCE|TCP>,local.comm_id=<ip-or-comm-id>,port=<port>
 #
 # With the FAKE provider, protocol=TCP is a convenient placeholder for parser
 # and validation compatibility; it does not imply real TCP IO. For real
 # ASU/Hcomm testing, replace protocol/local.comm_id/port/device with the target
-# setup and select AIV or AICPU.
+# setup and select AIV or AICPU. Configure the local provider device through
+# transport.device_id.
 fake_backend.path=./kv-test-fake-backend-store
 fake_backend.latency_ms=1
-asu_info.1=protocol=TCP,local.comm_id=127.0.0.1,port=19001,local.logical_device_id=0
+asu_info.1=protocol=TCP,local.comm_id=127.0.0.1,port=19001
 
 # kv-test data generation defaults.
 kv.key_prefix=k

--- a/ucm/transport/kv/kv-test/asu_view.conf
+++ b/ucm/transport/kv/kv-test/asu_view.conf
@@ -4,4 +4,4 @@
 viewEpoch=1
 viewId=1
 asuIds=1
-asu_info.1=protocol=TCP,local.comm_id=127.0.0.1,port=19001,local.logical_device_id=0
+asu_info.1=protocol=TCP,local.comm_id=127.0.0.1,port=19001

--- a/ucm/transport/kv/kv-test/scripts/fake_backend_common.sh
+++ b/ucm/transport/kv/kv-test/scripts/fake_backend_common.sh
@@ -73,7 +73,7 @@ write_fake_backend_config() {
         local id
         IFS=',' read -ra ids <<< "${asu_ids}"
         for id in "${ids[@]}"; do
-            echo "asu_info.${id}=protocol=TCP,local.comm_id=127.0.0.1,port=$((19000 + id)),local.logical_device_id=0"
+            echo "asu_info.${id}=protocol=TCP,local.comm_id=127.0.0.1,port=$((19000 + id))"
         done
     } > "${view_path}"
 
@@ -91,7 +91,7 @@ write_fake_backend_config() {
         echo "transport.provider_type=FAKE"
         IFS=',' read -ra ids <<< "${asu_ids}"
         for id in "${ids[@]}"; do
-            echo "asu_info.${id}=protocol=TCP,local.comm_id=127.0.0.1,port=$((19000 + id)),local.logical_device_id=0"
+            echo "asu_info.${id}=protocol=TCP,local.comm_id=127.0.0.1,port=$((19000 + id))"
         done
         echo
         echo "kv.key_prefix=k"

--- a/ucm/transport/kv/kv-test/src/kv_test_config_helpers.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_config_helpers.cpp
@@ -21,7 +21,8 @@ void PatchFakeBackendTransportConfig(UC::ASU::TransportConfig& config,
                                      const KvTestFakeBackendConfig& fakeConfig)
 {
     const auto fakeBackendDeviceId =
-        config.endpoints.empty() ? kFakeBackendAclDeviceId : config.endpoints.front().deviceId;
+        config.deviceId < 0 ? kFakeBackendAclDeviceId : config.deviceId;
+    config.deviceId = fakeBackendDeviceId;
     config.providerType = UC::ASU::TransProviderType::FAKE;
     config.attrs.try_emplace("kernel_count", "1");
     config.attrs.try_emplace("quiet_count", "1");
@@ -38,7 +39,6 @@ void PatchFakeBackendTransportConfig(UC::ASU::TransportConfig& config,
         endpoint.ip = "fake_backend";
         endpoint.port = 19001;
         endpoint.protocol = UC::ASU::Protocol::TCP;
-        endpoint.deviceId = fakeBackendDeviceId;
         config.endpoints.emplace_back(std::move(endpoint));
     }
 }

--- a/ucm/transport/kv/kv-test/src/payload_buffer_runtime.cpp
+++ b/ucm/transport/kv/kv-test/src/payload_buffer_runtime.cpp
@@ -28,7 +28,7 @@ std::int32_t ResolveFakeBackendPayloadDeviceId(const KvTestConfig& config)
     if (deviceIter != transportConfig.attrs.end() && !deviceIter->second.empty()) {
         return static_cast<std::int32_t>(std::stol(deviceIter->second));
     }
-    if (!transportConfig.endpoints.empty()) { return transportConfig.endpoints.front().deviceId; }
+    if (transportConfig.deviceId >= 0) { return transportConfig.deviceId; }
     return kDefaultPayloadAclDeviceId;
 }
 
@@ -46,9 +46,7 @@ std::int32_t ResolvePayloadDeviceId(const KvTestConfig& config)
     }
 
     for (const auto& transportConfig : config.asuClientConfig.transportConfigs) {
-        for (const auto& endpoint : transportConfig.endpoints) {
-            if (endpoint.deviceId >= 0) { return endpoint.deviceId; }
-        }
+        if (transportConfig.deviceId >= 0) { return transportConfig.deviceId; }
     }
     return kDefaultPayloadAclDeviceId;
 }


### PR DESCRIPTION
## Purpose
This PR modifies configuration for Device IPs in AsuClient.

## Modifications 
1. Commit a4af992 moves configurations of deviceId from EndpointConfig to TransportConfig.
2. Commit 418f662 removes useless memoryType in AsuStore.
3. Commit 50dba85 adds config checks in AsuStore.
4. Commit 7aa52e3 fixes a bug where TransProvider cannot be compiled correctly.

## Test
An offline inference runs succesfully with TP=2, OOB=rasocket, asu_trans_provider_backend="aiv", model="Qwen2.5-0.5B-Instruct", together with commit of https://gitcode.com/rainsnowice/nids_aiv_ub/commits/ucm_adaptor_v1 till a67efeefb.