### PR TITLE
[Feat] Add asynchronous buffer delegator executor

### DIFF
--- a/ucm/store/delegator/CMakeLists.txt
+++ b/ucm/store/delegator/CMakeLists.txt
@@ -6,7 +6,30 @@ add_library(delegator STATIC
 target_include_directories(delegator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(delegator
     PUBLIC
+        storeintf
         infra_status
         buffer_pool
         trans
+    PRIVATE
+        infra_logger
 )
+
+add_library(delegatorstore SHARED
+    cc/delegator_store.cc
+)
+target_link_libraries(delegatorstore
+    PUBLIC
+        storeintf
+        delegator
+    PRIVATE
+        infra_logger
+        asustore
+)
+set_target_properties(delegatorstore PROPERTIES
+    BUILD_WITH_INSTALL_RPATH TRUE
+    BUILD_RPATH "$ORIGIN;$ORIGIN/../asu;$ORIGIN/../../transport/kv/asu"
+    INSTALL_RPATH "$ORIGIN;$ORIGIN/../asu;$ORIGIN/../../transport/kv/asu"
+)
+
+file(RELATIVE_PATH INSTALL_REL_PATH ${UCM_ROOT_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+install(TARGETS delegatorstore LIBRARY DESTINATION ${INSTALL_REL_PATH} COMPONENT ucm)

--- a/ucm/store/delegator/CMakeLists.txt
+++ b/ucm/store/delegator/CMakeLists.txt
@@ -1,10 +1,12 @@
 add_library(delegator STATIC
     cc/delegator_copy_stream.cc
+    cc/delegator_executor.cc
 )
 
 target_include_directories(delegator PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..)
 target_link_libraries(delegator
     PUBLIC
         infra_status
+        buffer_pool
         trans
 )

--- a/ucm/store/delegator/CMakeLists.txt
+++ b/ucm/store/delegator/CMakeLists.txt
@@ -13,23 +13,3 @@ target_link_libraries(delegator
     PRIVATE
         infra_logger
 )
-
-add_library(delegatorstore SHARED
-    cc/delegator_store.cc
-)
-target_link_libraries(delegatorstore
-    PUBLIC
-        storeintf
-        delegator
-    PRIVATE
-        infra_logger
-        asustore
-)
-set_target_properties(delegatorstore PROPERTIES
-    BUILD_WITH_INSTALL_RPATH TRUE
-    BUILD_RPATH "$ORIGIN;$ORIGIN/../asu;$ORIGIN/../../transport/kv/asu"
-    INSTALL_RPATH "$ORIGIN;$ORIGIN/../asu;$ORIGIN/../../transport/kv/asu"
-)
-
-file(RELATIVE_PATH INSTALL_REL_PATH ${UCM_ROOT_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
-install(TARGETS delegatorstore LIBRARY DESTINATION ${INSTALL_REL_PATH} COMPONENT ucm)

--- a/ucm/store/delegator/cc/delegator_copy_stream.cc
+++ b/ucm/store/delegator/cc/delegator_copy_stream.cc
@@ -96,6 +96,17 @@ Status CopyStream::DeviceToDeviceAsync(aclrtStream stream, void* destination,
     return ret == ACL_SUCCESS ? Status::OK() : AclStatus("aclrtMemcpyAsync", ret);
 }
 
+Status CopyStream::WaitEvent(aclrtStream stream, aclrtEvent event)
+{
+    if (stream == nullptr || event == nullptr ||
+        std::find(streams_.begin(), streams_.end(), stream) == streams_.end()) {
+        return Status::InvalidParam("invalid delegator stream event");
+    }
+
+    const auto ret = aclrtStreamWaitEvent(stream, event);
+    return ret == ACL_SUCCESS ? Status::OK() : AclStatus("aclrtStreamWaitEvent", ret);
+}
+
 Status CopyStream::Synchronize(aclrtStream stream)
 {
     if (stream == nullptr ||

--- a/ucm/store/delegator/cc/delegator_copy_stream.h
+++ b/ucm/store/delegator/cc/delegator_copy_stream.h
@@ -46,6 +46,7 @@ public:
     Status DeviceToDeviceAsync(aclrtStream stream, void* destination,
                                std::size_t destinationCapacity, const void* source,
                                std::size_t size);
+    Status WaitEvent(aclrtStream stream, aclrtEvent event);
     Status Synchronize(aclrtStream stream);
     Status SynchronizeAll();
     std::size_t Size() const { return streams_.size(); }

--- a/ucm/store/delegator/cc/delegator_executor.cc
+++ b/ucm/store/delegator/cc/delegator_executor.cc
@@ -73,32 +73,32 @@ Status BindDevice(std::int32_t deviceId)
 }  // namespace
 
 Expected<std::unique_ptr<Executor>> Executor::Create(std::shared_ptr<StoreV1> backend,
-                                                     std::vector<std::size_t> tensor_sizes,
-                                                     std::int32_t device_id, std::size_t slot_num,
-                                                     std::size_t stream_number)
+                                                     std::vector<std::size_t> tensorSizes,
+                                                     std::int32_t deviceId, std::size_t slotNum,
+                                                     std::size_t streamNumber)
 {
-    if (backend == nullptr || device_id < 0 || slot_num == 0 || stream_number == 0 ||
-        tensor_sizes.empty()) {
+    if (backend == nullptr || deviceId < 0 || slotNum == 0 || streamNumber == 0 ||
+        tensorSizes.empty()) {
         return Status::InvalidParam("invalid delegator executor config");
     }
 
     std::size_t payloadSize = 0;
-    for (const auto size : tensor_sizes) {
+    for (const auto size : tensorSizes) {
         if (size == 0 || size > std::numeric_limits<std::size_t>::max() - payloadSize) {
             return Status::InvalidParam("invalid delegator tensor sizes");
         }
         payloadSize += size;
     }
 
-    auto status = ValidateCurrentDevice(device_id);
+    auto status = ValidateCurrentDevice(deviceId);
     if (status.Failure()) { return status; }
 
     auto executor = std::unique_ptr<Executor>{new (std::nothrow) Executor(
-        std::move(backend), std::move(tensor_sizes), device_id, slot_num, stream_number)};
+        std::move(backend), std::move(tensorSizes), deviceId, slotNum, streamNumber)};
     if (!executor) { return Status::OutOfMemory(); }
 
     try {
-        status = executor->Start(payloadSize, slot_num);
+        status = executor->Start(payloadSize, slotNum);
     } catch (const std::bad_alloc&) {
         return Status::OutOfMemory();
     } catch (const std::system_error& error) {
@@ -109,37 +109,37 @@ Expected<std::unique_ptr<Executor>> Executor::Create(std::shared_ptr<StoreV1> ba
     return executor;
 }
 
-Executor::Executor(std::shared_ptr<StoreV1> backend, std::vector<std::size_t> tensor_sizes,
-                   std::int32_t device_id, std::size_t slot_num, std::size_t stream_number)
+Executor::Executor(std::shared_ptr<StoreV1> backend, std::vector<std::size_t> tensorSizes,
+                   std::int32_t deviceId, std::size_t slotNum, std::size_t streamNumber)
     : backend_{std::move(backend)},
-      tensor_sizes_{std::move(tensor_sizes)},
-      device_id_{device_id},
-      stream_number_{std::min(stream_number, slot_num)}
+      tensorSizes_{std::move(tensorSizes)},
+      deviceId_{deviceId},
+      streamNumber_{std::min(streamNumber, slotNum)}
 {
 }
 
-Status Executor::Start(std::size_t payload_size, std::size_t slot_num)
+Status Executor::Start(std::size_t payloadSize, std::size_t slotNum)
 {
-    auto status = buffer_pool_.Init("delegator_buffer_pool", BufferPool::MemoryType::ASCEND_DEVICE,
-                                    payload_size, slot_num, false, kBufferAlignment);
+    auto status = bufferPool_.Init("delegator_buffer_pool", BufferPool::MemoryType::ASCEND_DEVICE,
+                                   payloadSize, slotNum, false, kBufferAlignment);
     if (status.Failure()) { return status; }
-    slot_num_ = slot_num;
+    slotNum_ = slotNum;
     if (backend_->NeedRegisterKVCaches()) {
         const KVCacheRegistration registration{
-            reinterpret_cast<std::uintptr_t>(buffer_pool_.GetDeviceAddr()),
-            buffer_pool_.GetTotalSize()};
+            reinterpret_cast<std::uintptr_t>(bufferPool_.GetDeviceAddr()),
+            bufferPool_.GetTotalSize()};
         status = backend_->RegisterKVCaches(&registration, 1);
         if (status.Failure()) { return status; }
     }
-    available_slots_ = slot_num;
+    availableSlots_ = slotNum;
 
     std::promise<Status> dumpStarted;
     std::promise<Status> loadStarted;
     auto dumpStartedFuture = dumpStarted.get_future();
     auto loadStartedFuture = loadStarted.get_future();
     try {
-        dump_thread_ = std::thread(&Executor::DumpLoop, this, std::ref(dumpStarted));
-        load_thread_ = std::thread(&Executor::LoadLoop, this, std::ref(loadStarted));
+        dumpThread_ = std::thread(&Executor::DumpLoop, this, std::ref(dumpStarted));
+        loadThread_ = std::thread(&Executor::LoadLoop, this, std::ref(loadStarted));
     } catch (...) {
         Shutdown();
         return Status::Error();
@@ -164,15 +164,15 @@ Expected<Detail::TaskDesc> Executor::MakeBackendTask(const TransferGroup& group)
     try {
         task.reserve(group.shards.size());
         for (const auto& shard : group.shards) {
-            const auto& source = group.task->desc[shard.shard_index];
+            const auto& source = group.task->desc[shard.shardIndex];
             Detail::Shard backendShard;
             backendShard.owner = source.owner;
             backendShard.index = source.index;
-            backendShard.addrs.reserve(tensor_sizes_.size());
+            backendShard.addrs.reserve(tensorSizes_.size());
 
             auto* address = static_cast<std::byte*>(shard.slot.device_addr);
             std::size_t offset = 0;
-            for (const auto size : tensor_sizes_) {
+            for (const auto size : tensorSizes_) {
                 backendShard.addrs.push_back(address + offset);
                 offset += size;
             }
@@ -189,13 +189,13 @@ Status Executor::ValidateTask(const Detail::TaskDesc& task, Operation operation)
     if (operation != Operation::LOAD && operation != Operation::DUMP) {
         return Status::InvalidParam("invalid delegator operation");
     }
-    if (task.empty() || tensor_sizes_.empty()) {
+    if (task.empty() || tensorSizes_.empty()) {
         return Status::InvalidParam("empty delegator task");
     }
     // Verify that the submitted task matches the tensor layout configured for this executor.
     for (std::size_t shardIndex = 0; shardIndex < task.size(); ++shardIndex) {
         const auto& addrs = task[shardIndex].addrs;
-        if (addrs.size() != tensor_sizes_.size()) {
+        if (addrs.size() != tensorSizes_.size()) {
             return Status::InvalidParam("invalid delegator shard({}) address count", shardIndex);
         }
         for (const auto* addr : addrs) {
@@ -210,7 +210,7 @@ Status Executor::ValidateTask(const Detail::TaskDesc& task, Operation operation)
 Status Executor::GatherAsync(const TransferGroup& group, CopyStream& streams)
 {
     for (const auto& shard : group.shards) {
-        const auto& desc = group.task->desc[shard.shard_index];
+        const auto& desc = group.task->desc[shard.shardIndex];
         const auto stream = streams.NextStream();
         if (group.task->desc.prerequisiteHandle != 0) {
             const auto status = streams.WaitEvent(
@@ -220,11 +220,11 @@ Status Executor::GatherAsync(const TransferGroup& group, CopyStream& streams)
         auto* destination = static_cast<std::byte*>(shard.slot.device_addr);
         std::size_t offset = 0;
         for (std::size_t index = 0; index < desc.addrs.size(); ++index) {
-            const auto status = streams.DeviceToDeviceAsync(
-                stream, destination + offset, shard.slot.length - offset, desc.addrs[index],
-                tensor_sizes_[index]);
+            const auto status = streams.DeviceToDeviceAsync(stream, destination + offset,
+                                                            shard.slot.length - offset,
+                                                            desc.addrs[index], tensorSizes_[index]);
             if (status.Failure()) { return status; }
-            offset += tensor_sizes_[index];
+            offset += tensorSizes_[index];
         }
     }
     return Status::OK();
@@ -233,16 +233,16 @@ Status Executor::GatherAsync(const TransferGroup& group, CopyStream& streams)
 Status Executor::ScatterAsync(const TransferGroup& group, CopyStream& streams)
 {
     for (const auto& shard : group.shards) {
-        const auto& desc = group.task->desc[shard.shard_index];
+        const auto& desc = group.task->desc[shard.shardIndex];
         const auto stream = streams.NextStream();
         const auto* source = static_cast<const std::byte*>(shard.slot.device_addr);
         std::size_t offset = 0;
         for (std::size_t index = 0; index < desc.addrs.size(); ++index) {
             const auto status =
-                streams.DeviceToDeviceAsync(stream, desc.addrs[index], tensor_sizes_[index],
-                                            source + offset, tensor_sizes_[index]);
+                streams.DeviceToDeviceAsync(stream, desc.addrs[index], tensorSizes_[index],
+                                            source + offset, tensorSizes_[index]);
             if (status.Failure()) { return status; }
-            offset += tensor_sizes_[index];
+            offset += tensorSizes_[index];
         }
     }
     return Status::OK();
@@ -252,7 +252,7 @@ std::string Executor::DescribeShards(const TransferGroup& group) const
 {
     std::string result;
     for (const auto& shard : group.shards) {
-        const auto& desc = group.task->desc[shard.shard_index];
+        const auto& desc = group.task->desc[shard.shardIndex];
         if (!result.empty()) { result += ", "; }
         result += fmt::format("{{owner={:02x},index={},slot={}}}", fmt::join(desc.owner, ""),
                               desc.index, shard.slot.slot_index);
@@ -274,11 +274,11 @@ void Executor::LogTaskCompletion(const TaskContext& task) const
 
 void Executor::AssertSchedulerInvariantsLocked() const
 {
-    assert(available_slots_ + in_flight_load_shards_ + in_flight_dump_shards_ == slot_num_);
-    assert(outstanding_shards_ == queued_load_shards_ + queued_dump_shards_ +
-                                      in_flight_load_shards_ + in_flight_dump_shards_);
-    assert(load_queue_.size() == queued_load_shards_);
-    assert(dump_queue_.size() == queued_dump_shards_);
+    assert(availableSlots_ + inFlightLoadShards_ + inFlightDumpShards_ == slotNum_);
+    assert(outstandingShards_ ==
+           queuedLoadShards_ + queuedDumpShards_ + inFlightLoadShards_ + inFlightDumpShards_);
+    assert(loadQueue_.size() == queuedLoadShards_);
+    assert(dumpQueue_.size() == queuedDumpShards_);
 }
 
 Expected<Detail::TaskHandle> Executor::Submit(Detail::TaskDesc task, Operation operation)
@@ -299,15 +299,15 @@ Expected<Detail::TaskHandle> Executor::Submit(Detail::TaskDesc task, Operation o
     const auto handle = taskContext->id;
     {
         // Keep the whole publish atomic against Shutdown.
-        std::lock_guard<std::mutex> schedLock(sched_mutex_);
-        if (shutdown_started_) { return Status::Error(); }
+        std::lock_guard<std::mutex> schedLock(schedMutex_);
+        if (shutdownStarted_) { return Status::Error(); }
         AssertSchedulerInvariantsLocked();
         const auto count = taskContext->desc.size();
-        if (count > std::numeric_limits<std::size_t>::max() - outstanding_shards_) {
+        if (count > std::numeric_limits<std::size_t>::max() - outstandingShards_) {
             return Status::OutOfMemory();
         }
 
-        auto& queue = operation == Operation::LOAD ? load_queue_ : dump_queue_;
+        auto& queue = operation == Operation::LOAD ? loadQueue_ : dumpQueue_;
         if (count > queue.max_size() - queue.size()) { return Status::OutOfMemory(); }
 
         const auto previousQueueSize = queue.size();
@@ -330,14 +330,14 @@ Expected<Detail::TaskHandle> Executor::Submit(Detail::TaskDesc task, Operation o
             return Status::OutOfMemory();
         }
 
-        outstanding_shards_ += count;
-        auto& queued = operation == Operation::LOAD ? queued_load_shards_ : queued_dump_shards_;
+        outstandingShards_ += count;
+        auto& queued = operation == Operation::LOAD ? queuedLoadShards_ : queuedDumpShards_;
         queued += count;
         AssertSchedulerInvariantsLocked();
     }
     UC_INFO_UNLIMITED("Delegator {} task({},{}) submitted, shards={}.", OperationName(operation),
                       handle, taskContext->desc.brief, taskContext->desc.size());
-    slots_ready_.notify_all();
+    slotsReady_.notify_all();
     return Detail::TaskHandle{handle};
 }
 
@@ -376,10 +376,10 @@ Status Executor::Wait(Detail::TaskHandle task)
 Expected<Executor::TransferBatch> Executor::AcquireBatch(Operation operation)
 {
     assert(operation == Operation::LOAD || operation == Operation::DUMP);
-    auto& queue = operation == Operation::LOAD ? load_queue_ : dump_queue_;
+    auto& queue = operation == Operation::LOAD ? loadQueue_ : dumpQueue_;
     TransferBatch batch;
     std::vector<QueuedShardContext> reservedShards;
-    const auto batchCapacity = slot_num_;
+    const auto batchCapacity = slotNum_;
     try {
         batch.groups.reserve(batchCapacity);
         reservedShards.reserve(batchCapacity);
@@ -388,11 +388,11 @@ Expected<Executor::TransferBatch> Executor::AcquireBatch(Operation operation)
     }
 
     const auto canReserve = [this, operation]() {
-        if (available_slots_ == 0) { return false; }
+        if (availableSlots_ == 0) { return false; }
         // LOAD is admitted whenever a queued shard and a slot are available.
-        if (operation == Operation::LOAD) { return queued_load_shards_ != 0; }
+        if (operation == Operation::LOAD) { return queuedLoadShards_ != 0; }
         // DUMP is admitted only when no LOAD shard is queued or in flight.
-        return queued_dump_shards_ != 0 && queued_load_shards_ == 0 && in_flight_load_shards_ == 0;
+        return queuedDumpShards_ != 0 && queuedLoadShards_ == 0 && inFlightLoadShards_ == 0;
     };
 
     // Keep trying until a non-empty batch can be returned or shutdown begins.
@@ -402,22 +402,21 @@ Expected<Executor::TransferBatch> Executor::AcquireBatch(Operation operation)
         while (reservedShards.size() < batchCapacity) {
             std::optional<QueuedShardContext> cancelledShard;
             {
-                std::unique_lock<std::mutex> lock(sched_mutex_);
+                std::unique_lock<std::mutex> lock(schedMutex_);
 
                 // Wait only for the first shard; do not wait to fill a partial batch.
                 if (reservedShards.empty()) {
-                    slots_ready_.wait(
-                        lock, [this, &canReserve]() { return shutdown_started_ || canReserve(); });
+                    slotsReady_.wait(
+                        lock, [this, &canReserve]() { return shutdownStarted_ || canReserve(); });
                 }
-                if (shutdown_started_) {
+                if (shutdownStarted_) {
                     if (reservedShards.empty()) { return Status::Error(); }
                     break;
                 }
 
-                auto& queued =
-                    operation == Operation::LOAD ? queued_load_shards_ : queued_dump_shards_;
+                auto& queued = operation == Operation::LOAD ? queuedLoadShards_ : queuedDumpShards_;
                 auto& inFlight =
-                    operation == Operation::LOAD ? in_flight_load_shards_ : in_flight_dump_shards_;
+                    operation == Operation::LOAD ? inFlightLoadShards_ : inFlightDumpShards_;
                 while (reservedShards.size() < batchCapacity && canReserve()) {
                     assert(!queue.empty());
                     if (queue.empty()) { std::terminate(); }
@@ -430,14 +429,14 @@ Expected<Executor::TransferBatch> Executor::AcquireBatch(Operation operation)
                     --queued;
 
                     if (shard.task->failed.load(std::memory_order_acquire)) {
-                        assert(outstanding_shards_ != 0);
-                        --outstanding_shards_;
+                        assert(outstandingShards_ != 0);
+                        --outstandingShards_;
                         cancelledShard = std::move(shard);
                         break;
                     }
 
                     ++inFlight;
-                    --available_slots_;
+                    --availableSlots_;
                     reservedShards.push_back(std::move(shard));
                 }
                 AssertSchedulerInvariantsLocked();
@@ -445,7 +444,7 @@ Expected<Executor::TransferBatch> Executor::AcquireBatch(Operation operation)
 
             if (cancelledShard) {
                 CompleteTaskShards(cancelledShard->task, 1, Status::OK());
-                slots_ready_.notify_all();
+                slotsReady_.notify_all();
                 continue;
             }
             break;
@@ -489,14 +488,14 @@ Expected<Executor::TransferBatch> Executor::AcquireBatch(Operation operation)
                 }
 
                 BufferPool::Slot slot;
-                const auto status = buffer_pool_.Allocate(slot);
+                const auto status = bufferPool_.Allocate(slot);
                 if (status.Failure()) {
                     DiscardShard(reservedShard, status, ShardStage::IN_FLIGHT);
                     continue;
                 }
 
                 InFlightShardContext inFlightShard;
-                inFlightShard.shard_index = reservedShard.shard_index;
+                inFlightShard.shardIndex = reservedShard.shardIndex;
                 inFlightShard.slot = std::move(slot);
                 group.shards.push_back(std::move(inFlightShard));
             }
@@ -530,7 +529,7 @@ void Executor::ReleaseBatch(TransferBatch& batch)
         if (!validGroup) { std::terminate(); }
 
         for (const auto& shard : group.shards) {
-            const auto freeStatus = buffer_pool_.Free(shard.slot.slot_index);
+            const auto freeStatus = bufferPool_.Free(shard.slot.slot_index);
             if (!group.error && freeStatus.Failure()) { group.error = freeStatus; }
         }
         count += group.shards.size();
@@ -545,17 +544,16 @@ void Executor::ReleaseBatch(TransferBatch& batch)
 
     // Phase 2: publish the released slots only after task completion state is visible.
     {
-        std::lock_guard<std::mutex> lock(sched_mutex_);
-        auto& inFlight =
-            operation == Operation::LOAD ? in_flight_load_shards_ : in_flight_dump_shards_;
+        std::lock_guard<std::mutex> lock(schedMutex_);
+        auto& inFlight = operation == Operation::LOAD ? inFlightLoadShards_ : inFlightDumpShards_;
         assert(inFlight >= count);
-        assert(outstanding_shards_ >= count);
+        assert(outstandingShards_ >= count);
         inFlight -= count;
-        available_slots_ += count;
-        outstanding_shards_ -= count;
+        availableSlots_ += count;
+        outstandingShards_ -= count;
         AssertSchedulerInvariantsLocked();
     }
-    slots_ready_.notify_all();
+    slotsReady_.notify_all();
 }
 
 void Executor::CompleteTaskShards(const std::shared_ptr<TaskContext>& task, std::size_t count,
@@ -580,25 +578,25 @@ void Executor::DiscardShard(const QueuedShardContext& shard, const Status& statu
 {
     CompleteTaskShards(shard.task, 1, status);
     {
-        std::lock_guard<std::mutex> lock(sched_mutex_);
+        std::lock_guard<std::mutex> lock(schedMutex_);
         auto& queued =
-            shard.task->operation == Operation::LOAD ? queued_load_shards_ : queued_dump_shards_;
-        auto& inFlight = shard.task->operation == Operation::LOAD ? in_flight_load_shards_
-                                                                  : in_flight_dump_shards_;
-        assert(outstanding_shards_ != 0);
+            shard.task->operation == Operation::LOAD ? queuedLoadShards_ : queuedDumpShards_;
+        auto& inFlight =
+            shard.task->operation == Operation::LOAD ? inFlightLoadShards_ : inFlightDumpShards_;
+        assert(outstandingShards_ != 0);
         if (stage == ShardStage::QUEUED) {
             assert(queued != 0);
             --queued;
         } else {
             assert(inFlight != 0);
             --inFlight;
-            ++available_slots_;
+            ++availableSlots_;
         }
-        --outstanding_shards_;
+        --outstandingShards_;
         AssertSchedulerInvariantsLocked();
     }
 
-    slots_ready_.notify_all();
+    slotsReady_.notify_all();
 }
 
 void Executor::DrainQueue(std::deque<QueuedShardContext>& queue)
@@ -615,8 +613,8 @@ void Executor::DumpLoop(std::promise<Status>& started)
 {
     // Init
     CopyStream streams;
-    auto status = BindDevice(device_id_);
-    if (status.Success()) { status = streams.Setup(device_id_, stream_number_); }
+    auto status = BindDevice(deviceId_);
+    if (status.Success()) { status = streams.Setup(deviceId_, streamNumber_); }
     started.set_value(status);
     if (status.Failure()) { return; }
 
@@ -671,12 +669,12 @@ void Executor::DumpLoop(std::promise<Status>& started)
             }
             auto submitted = backend_->Dump(std::move(backendTask).Value());
             if (submitted) {
-                group.transfer_task = std::move(submitted).Value();
-                group.transfer_pending = true;
+                group.transferTask = std::move(submitted).Value();
+                group.transferPending = true;
                 UC_DEBUG_UNLIMITED(
                     "Delegator DUMP task({},{}) stage=backend_submitted, backend_task={}, "
                     "shards={}.",
-                    group.task->id, group.task->desc.brief, group.transfer_task,
+                    group.task->id, group.task->desc.brief, group.transferTask,
                     group.shards.size());
             } else {
                 group.error = submitted.Error();
@@ -687,22 +685,22 @@ void Executor::DumpLoop(std::promise<Status>& started)
         }
 
         for (auto& group : batch.groups) {
-            if (!group.transfer_pending) { continue; }
-            const auto waitStatus = backend_->Wait(group.transfer_task);
+            if (!group.transferPending) { continue; }
+            const auto waitStatus = backend_->Wait(group.transferTask);
             if (waitStatus.Failure()) {
                 group.error = waitStatus;
                 UC_ERROR_UNLIMITED(
                     "Delegator DUMP task({},{}) stage=backend_wait failed, backend_task={}, "
                     "status={}.",
-                    group.task->id, group.task->desc.brief, group.transfer_task, waitStatus);
+                    group.task->id, group.task->desc.brief, group.transferTask, waitStatus);
             } else {
                 UC_DEBUG_UNLIMITED(
                     "Delegator DUMP task({},{}) stage=backend_complete, backend_task={}, "
                     "shards={}.",
-                    group.task->id, group.task->desc.brief, group.transfer_task,
+                    group.task->id, group.task->desc.brief, group.transferTask,
                     group.shards.size());
             }
-            group.transfer_pending = false;
+            group.transferPending = false;
         }
 
         ReleaseBatch(batch);
@@ -713,8 +711,8 @@ void Executor::LoadLoop(std::promise<Status>& started)
 {
     // Init
     CopyStream streams;
-    auto status = BindDevice(device_id_);
-    if (status.Success()) { status = streams.Setup(device_id_, stream_number_); }
+    auto status = BindDevice(deviceId_);
+    if (status.Success()) { status = streams.Setup(deviceId_, streamNumber_); }
     started.set_value(status);
     if (status.Failure()) { return; }
 
@@ -739,13 +737,13 @@ void Executor::LoadLoop(std::promise<Status>& started)
             }
             auto submitted = backend_->Load(std::move(backendTask).Value());
             if (submitted) {
-                group.transfer_task = std::move(submitted).Value();
-                group.transfer_pending = true;
+                group.transferTask = std::move(submitted).Value();
+                group.transferPending = true;
                 ++pendingGroupCount;
                 UC_DEBUG_UNLIMITED(
                     "Delegator LOAD task({},{}) stage=backend_submitted, backend_task={}, "
                     "shards={}.",
-                    group.task->id, group.task->desc.brief, group.transfer_task,
+                    group.task->id, group.task->desc.brief, group.transferTask,
                     group.shards.size());
             } else {
                 group.error = submitted.Error();
@@ -757,31 +755,30 @@ void Executor::LoadLoop(std::promise<Status>& started)
 
         while (pendingGroupCount != 0) {
             for (auto& group : batch.groups) {
-                if (!group.transfer_pending) { continue; }
+                if (!group.transferPending) { continue; }
 
-                auto completed = backend_->Check(group.transfer_task);
+                auto completed = backend_->Check(group.transferTask);
                 if (!completed) {
                     group.error = completed.Error();
                     UC_ERROR_UNLIMITED(
                         "Delegator LOAD task({},{}) stage=backend_check failed, "
                         "backend_task={}, status={}.",
-                        group.task->id, group.task->desc.brief, group.transfer_task, *group.error);
+                        group.task->id, group.task->desc.brief, group.transferTask, *group.error);
                 } else if (!completed.Value()) {
                     continue;
                 } else {
-                    const auto waitStatus = backend_->Wait(group.transfer_task);
+                    const auto waitStatus = backend_->Wait(group.transferTask);
                     if (waitStatus.Failure()) {
                         group.error = waitStatus;
                         UC_ERROR_UNLIMITED(
                             "Delegator LOAD task({},{}) stage=backend_wait failed, "
                             "backend_task={}, status={}.",
-                            group.task->id, group.task->desc.brief, group.transfer_task,
-                            waitStatus);
+                            group.task->id, group.task->desc.brief, group.transferTask, waitStatus);
                     } else {
                         UC_DEBUG_UNLIMITED(
                             "Delegator LOAD task({},{}) stage=backend_complete, "
                             "backend_task={}, shards={}.",
-                            group.task->id, group.task->desc.brief, group.transfer_task,
+                            group.task->id, group.task->desc.brief, group.transferTask,
                             group.shards.size());
                         const auto scatterStatus = ScatterAsync(group, streams);
                         if (scatterStatus.Failure()) {
@@ -792,7 +789,7 @@ void Executor::LoadLoop(std::promise<Status>& started)
                         }
                     }
                 }
-                group.transfer_pending = false;
+                group.transferPending = false;
                 --pendingGroupCount;
             }
         }
@@ -822,31 +819,31 @@ void Executor::LoadLoop(std::promise<Status>& started)
 void Executor::Shutdown()
 {
     {
-        std::unique_lock<std::mutex> lock(sched_mutex_);
-        if (shutdown_started_) {
-            shutdown_completed_.wait(lock, [this]() { return shutdown_complete_; });
+        std::unique_lock<std::mutex> lock(schedMutex_);
+        if (shutdownStarted_) {
+            shutdownCompleted_.wait(lock, [this]() { return shutdownComplete_; });
             return;
         }
-        shutdown_started_ = true;
-        slots_ready_.notify_all();
+        shutdownStarted_ = true;
+        slotsReady_.notify_all();
     }
 
-    if (dump_thread_.joinable()) { dump_thread_.join(); }
-    if (load_thread_.joinable()) { load_thread_.join(); }
+    if (dumpThread_.joinable()) { dumpThread_.join(); }
+    if (loadThread_.joinable()) { loadThread_.join(); }
 
     // Workers are gone; we are now the sole consumer of both queues.
-    DrainQueue(dump_queue_);
-    DrainQueue(load_queue_);
-    if (buffer_pool_.IsInitialized()) {
+    DrainQueue(dumpQueue_);
+    DrainQueue(loadQueue_);
+    if (bufferPool_.IsInitialized()) {
         // Assumption: Executor is created, used, and destroyed under the same ACL device context.
-        buffer_pool_.Reset();
+        bufferPool_.Reset();
     }
 
     {
-        std::lock_guard<std::mutex> lock(sched_mutex_);
-        shutdown_complete_ = true;
+        std::lock_guard<std::mutex> lock(schedMutex_);
+        shutdownComplete_ = true;
     }
-    shutdown_completed_.notify_all();
+    shutdownCompleted_.notify_all();
 }
 
 }  // namespace UC::Delegator

--- a/ucm/store/delegator/cc/delegator_executor.cc
+++ b/ucm/store/delegator/cc/delegator_executor.cc
@@ -264,8 +264,8 @@ void Executor::LogTaskCompletion(const TaskContext& task) const
 {
     const auto* operation = OperationName(task.operation);
     if (task.error) {
-        UC_ERROR("Delegator {} task({},{}) failed, shards={}, status={}.", operation,
-                           task.id, task.desc.brief, task.desc.size(), *task.error);
+        UC_ERROR("Delegator {} task({},{}) failed, shards={}, status={}.", operation, task.id,
+                 task.desc.brief, task.desc.size(), *task.error);
         return;
     }
     UC_INFO_UNLIMITED("Delegator {} task({},{}) completed, shards={}.", operation, task.id,
@@ -516,7 +516,7 @@ void Executor::ReleaseBatch(TransferBatch& batch)
 {
     assert(!batch.groups.empty());
     assert(batch.groups.front().task);
-    
+
     const auto operation = batch.groups.front().task->operation;
     assert(operation == Operation::LOAD || operation == Operation::DUMP);
 
@@ -631,7 +631,7 @@ void Executor::DumpLoop(std::promise<Status>& started)
             if (gatherStatus.Failure()) {
                 group.error = gatherStatus;
                 UC_ERROR("Delegator DUMP task({},{}) stage=gather failed, status={}.",
-                                   group.task->id, group.task->desc.brief, gatherStatus);
+                         group.task->id, group.task->desc.brief, gatherStatus);
             }
         }
 
@@ -640,9 +640,8 @@ void Executor::DumpLoop(std::promise<Status>& started)
             for (auto& group : batch.groups) {
                 if (!group.error) {
                     group.error = syncStatus;
-                    UC_ERROR(
-                        "Delegator DUMP task({},{}) stage=gather_sync failed, status={}.",
-                        group.task->id, group.task->desc.brief, syncStatus);
+                    UC_ERROR("Delegator DUMP task({},{}) stage=gather_sync failed, status={}.",
+                             group.task->id, group.task->desc.brief, syncStatus);
                 }
             }
         } else {
@@ -661,9 +660,8 @@ void Executor::DumpLoop(std::promise<Status>& started)
             auto backendTask = MakeBackendTask(group);
             if (!backendTask) {
                 group.error = backendTask.Error();
-                UC_ERROR(
-                    "Delegator DUMP task({},{}) stage=backend_task_build failed, status={}.",
-                    group.task->id, group.task->desc.brief, *group.error);
+                UC_ERROR("Delegator DUMP task({},{}) stage=backend_task_build failed, status={}.",
+                         group.task->id, group.task->desc.brief, *group.error);
                 continue;
             }
             auto submitted = backend_->Dump(std::move(backendTask).Value());
@@ -677,9 +675,8 @@ void Executor::DumpLoop(std::promise<Status>& started)
                     group.shards.size());
             } else {
                 group.error = submitted.Error();
-                UC_ERROR(
-                    "Delegator DUMP task({},{}) stage=backend_submit failed, status={}.",
-                    group.task->id, group.task->desc.brief, *group.error);
+                UC_ERROR("Delegator DUMP task({},{}) stage=backend_submit failed, status={}.",
+                         group.task->id, group.task->desc.brief, *group.error);
             }
         }
 
@@ -729,9 +726,8 @@ void Executor::LoadLoop(std::promise<Status>& started)
             auto backendTask = MakeBackendTask(group);
             if (!backendTask) {
                 group.error = backendTask.Error();
-                UC_ERROR(
-                    "Delegator LOAD task({},{}) stage=backend_task_build failed, status={}.",
-                    group.task->id, group.task->desc.brief, *group.error);
+                UC_ERROR("Delegator LOAD task({},{}) stage=backend_task_build failed, status={}.",
+                         group.task->id, group.task->desc.brief, *group.error);
                 continue;
             }
             auto submitted = backend_->Load(std::move(backendTask).Value());
@@ -746,9 +742,8 @@ void Executor::LoadLoop(std::promise<Status>& started)
                     group.shards.size());
             } else {
                 group.error = submitted.Error();
-                UC_ERROR(
-                    "Delegator LOAD task({},{}) stage=backend_submit failed, status={}.",
-                    group.task->id, group.task->desc.brief, *group.error);
+                UC_ERROR("Delegator LOAD task({},{}) stage=backend_submit failed, status={}.",
+                         group.task->id, group.task->desc.brief, *group.error);
             }
         }
 
@@ -782,9 +777,8 @@ void Executor::LoadLoop(std::promise<Status>& started)
                         const auto scatterStatus = ScatterAsync(group, streams);
                         if (scatterStatus.Failure()) {
                             group.error = scatterStatus;
-                            UC_ERROR(
-                                "Delegator LOAD task({},{}) stage=scatter failed, status={}.",
-                                group.task->id, group.task->desc.brief, scatterStatus);
+                            UC_ERROR("Delegator LOAD task({},{}) stage=scatter failed, status={}.",
+                                     group.task->id, group.task->desc.brief, scatterStatus);
                         }
                     }
                 }
@@ -797,9 +791,8 @@ void Executor::LoadLoop(std::promise<Status>& started)
             for (auto& group : batch.groups) {
                 if (!group.error) {
                     group.error = syncStatus;
-                    UC_ERROR(
-                        "Delegator LOAD task({},{}) stage=scatter_sync failed, status={}.",
-                        group.task->id, group.task->desc.brief, syncStatus);
+                    UC_ERROR("Delegator LOAD task({},{}) stage=scatter_sync failed, status={}.",
+                             group.task->id, group.task->desc.brief, syncStatus);
                 }
             }
         } else {

--- a/ucm/store/delegator/cc/delegator_executor.cc
+++ b/ucm/store/delegator/cc/delegator_executor.cc
@@ -268,7 +268,7 @@ void Executor::LogTaskCompletion(const TaskContext& task) const
                  task.desc.brief, task.desc.size(), *task.error);
         return;
     }
-    UC_INFO_UNLIMITED("Delegator {} task({},{}) completed, shards={}.", operation, task.id,
+    UC_INFO("Delegator {} task({},{}) completed, shards={}.", operation, task.id,
                       task.desc.brief, task.desc.size());
 }
 
@@ -343,7 +343,7 @@ Expected<Detail::TaskHandle> Executor::Submit(Detail::TaskDesc task, Operation o
         queuedNum += count;
         CheckSchedulerInvariantsLocked();
     }
-    UC_INFO_UNLIMITED("Delegator {} task({},{}) submitted, shards={}.", OperationName(operation),
+    UC_INFO("Delegator {} task({},{}) submitted, shards={}.", OperationName(operation),
                       handle, taskContext->desc.brief, taskContext->desc.size());
     slotsReady_.notify_all();
     return Detail::TaskHandle{handle};
@@ -622,7 +622,7 @@ void Executor::DumpLoop(std::promise<Status>& started)
 
         for (auto& group : batch.groups) {
             if (Logger::isEnabledFor(Logger::Level::DEBUG)) {
-                UC_DEBUG_UNLIMITED("Delegator DUMP task({},{}) processing KVCache shards=[{}].",
+                UC_DEBUG("Delegator DUMP task({},{}) processing KVCache shards=[{}].",
                                    group.task->id, group.task->desc.brief, DescribeShards(group));
             }
             const auto gatherStatus = GatherAsync(group, streams);
@@ -645,7 +645,7 @@ void Executor::DumpLoop(std::promise<Status>& started)
         } else {
             for (const auto& group : batch.groups) {
                 if (!group.error) {
-                    UC_DEBUG_UNLIMITED(
+                    UC_DEBUG(
                         "Delegator DUMP task({},{}) stage=gather_complete, shards={}.",
                         group.task->id, group.task->desc.brief, group.shards.size());
                 }
@@ -666,7 +666,7 @@ void Executor::DumpLoop(std::promise<Status>& started)
             if (submitted) {
                 group.transferTask = std::move(submitted).Value();
                 group.transferPending = true;
-                UC_DEBUG_UNLIMITED(
+                UC_DEBUG(
                     "Delegator DUMP task({},{}) stage=backend_submitted, backend_task={}, "
                     "shards={}.",
                     group.task->id, group.task->desc.brief, group.transferTask,
@@ -688,7 +688,7 @@ void Executor::DumpLoop(std::promise<Status>& started)
                     "status={}.",
                     group.task->id, group.task->desc.brief, group.transferTask, waitStatus);
             } else {
-                UC_DEBUG_UNLIMITED(
+                UC_DEBUG(
                     "Delegator DUMP task({},{}) stage=backend_complete, backend_task={}, "
                     "shards={}.",
                     group.task->id, group.task->desc.brief, group.transferTask,
@@ -718,7 +718,7 @@ void Executor::LoadLoop(std::promise<Status>& started)
         std::size_t pendingGroupCount = 0;
         for (auto& group : batch.groups) {
             if (Logger::isEnabledFor(Logger::Level::DEBUG)) {
-                UC_DEBUG_UNLIMITED("Delegator LOAD task({},{}) processing KVCache shards=[{}].",
+                UC_DEBUG("Delegator LOAD task({},{}) processing KVCache shards=[{}].",
                                    group.task->id, group.task->desc.brief, DescribeShards(group));
             }
             auto backendTask = MakeBackendTask(group);
@@ -733,7 +733,7 @@ void Executor::LoadLoop(std::promise<Status>& started)
                 group.transferTask = std::move(submitted).Value();
                 group.transferPending = true;
                 ++pendingGroupCount;
-                UC_DEBUG_UNLIMITED(
+                UC_DEBUG(
                     "Delegator LOAD task({},{}) stage=backend_submitted, backend_task={}, "
                     "shards={}.",
                     group.task->id, group.task->desc.brief, group.transferTask,
@@ -767,7 +767,7 @@ void Executor::LoadLoop(std::promise<Status>& started)
                             "backend_task={}, status={}.",
                             group.task->id, group.task->desc.brief, group.transferTask, waitStatus);
                     } else {
-                        UC_DEBUG_UNLIMITED(
+                        UC_DEBUG(
                             "Delegator LOAD task({},{}) stage=backend_complete, "
                             "backend_task={}, shards={}.",
                             group.task->id, group.task->desc.brief, group.transferTask,
@@ -796,7 +796,7 @@ void Executor::LoadLoop(std::promise<Status>& started)
         } else {
             for (const auto& group : batch.groups) {
                 if (!group.error) {
-                    UC_DEBUG_UNLIMITED(
+                    UC_DEBUG(
                         "Delegator LOAD task({},{}) stage=scatter_complete, shards={}.",
                         group.task->id, group.task->desc.brief, group.shards.size());
                 }

--- a/ucm/store/delegator/cc/delegator_executor.cc
+++ b/ucm/store/delegator/cc/delegator_executor.cc
@@ -1,0 +1,701 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "delegator_executor.h"
+#include <acl/acl.h>
+#include <algorithm>
+#include <atomic>
+#include <cassert>
+#include <exception>
+#include <functional>
+#include <limits>
+#include <new>
+#include <system_error>
+
+namespace UC::Delegator {
+namespace {
+
+constexpr std::size_t kBufferAlignment = 16 * 1024;
+
+Status ValidateCurrentDevice(std::int32_t expectedDeviceId)
+{
+    aclrtContext context = nullptr;
+    auto ret = aclrtGetCurrentContext(&context);
+    if (ret != ACL_SUCCESS || context == nullptr) {
+        return Status::Error("delegator executor requires a current ACL context");
+    }
+
+    std::int32_t currentDeviceId = -1;
+    ret = aclrtGetDevice(&currentDeviceId);
+    if (ret != ACL_SUCCESS) { return Status::Error("aclrtGetDevice failed"); }
+    if (currentDeviceId != expectedDeviceId) {
+        return Status::InvalidParam("current ACL context device does not match device_id");
+    }
+    return Status::OK();
+}
+
+Status BindDevice(std::int32_t deviceId)
+{
+    const auto ret = aclrtSetDevice(deviceId);
+    return ret == ACL_SUCCESS ? Status::OK() : Status::Error("aclrtSetDevice failed");
+}
+
+}  // namespace
+
+Expected<std::unique_ptr<Executor>> Executor::Create(
+    std::unique_ptr<TransferEndpoint> endpoint, std::vector<std::size_t> tensor_sizes,
+    std::int32_t device_id, std::size_t slot_num, std::size_t stream_number)
+{
+    if (endpoint == nullptr || device_id < 0 || slot_num == 0 || stream_number == 0 ||
+        tensor_sizes.empty()) {
+        return Status::InvalidParam("invalid delegator executor config");
+    }
+
+    std::size_t payloadSize = 0;
+    for (const auto size : tensor_sizes) {
+        if (size == 0 || size > std::numeric_limits<std::size_t>::max() - payloadSize) {
+            return Status::InvalidParam("invalid delegator tensor sizes");
+        }
+        payloadSize += size;
+    }
+
+    auto status = ValidateCurrentDevice(device_id);
+    if (status.Failure()) { return status; }
+
+    auto executor = std::unique_ptr<Executor>{new (std::nothrow) Executor(
+        std::move(endpoint), std::move(tensor_sizes), device_id, slot_num, stream_number)};
+    if (!executor) { return Status::OutOfMemory(); }
+
+    try {
+        status = executor->Start(payloadSize, slot_num);
+    } catch (const std::bad_alloc&) {
+        return Status::OutOfMemory();
+    } catch (const std::system_error& error) {
+        return Status::OsApiError(error.what());
+    }
+    if (status.Failure()) { return status; }
+
+    return executor;
+}
+
+Executor::Executor(std::unique_ptr<TransferEndpoint> endpoint,
+                   std::vector<std::size_t> tensor_sizes, std::int32_t device_id,
+                   std::size_t slot_num, std::size_t stream_number)
+    : endpoint_{std::move(endpoint)},
+      tensor_sizes_{std::move(tensor_sizes)},
+      device_id_{device_id},
+      stream_number_{std::min(stream_number, slot_num)}
+{
+}
+
+Status Executor::Start(std::size_t payload_size, std::size_t slot_num)
+{
+    auto status = buffer_pool_.Init("delegator_buffer_pool", BufferPool::MemoryType::ASCEND_DEVICE,
+                                    payload_size, slot_num, false, kBufferAlignment);
+    if (status.Failure()) { return status; }
+    slot_num_ = slot_num;
+    status = endpoint_->SetupTransferRegion(
+        TransferRegion{buffer_pool_.GetLocalAddr(), buffer_pool_.GetDeviceAddr(),
+                       buffer_pool_.GetTotalSize(), buffer_pool_.GetMemoryType(), device_id_});
+    if (status.Failure()) { return status; }
+    transfer_region_ready_ = true;
+    available_slots_ = slot_num;
+
+    std::promise<Status> dumpStarted;
+    std::promise<Status> loadStarted;
+    auto dumpStartedFuture = dumpStarted.get_future();
+    auto loadStartedFuture = loadStarted.get_future();
+    try {
+        dump_thread_ = std::thread(&Executor::DumpLoop, this, std::ref(dumpStarted));
+        load_thread_ = std::thread(&Executor::LoadLoop, this, std::ref(loadStarted));
+    } catch (...) {
+        Shutdown();
+        return Status::Error();
+    }
+
+    const auto dumpStatus = dumpStartedFuture.get();
+    const auto loadStatus = loadStartedFuture.get();
+    if (dumpStatus.Failure() || loadStatus.Failure()) {
+        const auto status = dumpStatus.Failure() ? dumpStatus : loadStatus;
+        Shutdown();
+        return status;
+    }
+    return Status::OK();
+}
+
+Executor::~Executor() { Shutdown(); }
+
+Status Executor::ValidateTask(const Detail::TaskDesc& task, Operation operation) const
+{
+    if (operation != Operation::LOAD && operation != Operation::DUMP) {
+        return Status::InvalidParam("invalid delegator operation");
+    }
+    if (task.empty() || tensor_sizes_.empty()) {
+        return Status::InvalidParam("empty delegator task");
+    }
+    // Verify that the submitted task matches the tensor layout configured for this executor.
+    for (std::size_t shardIndex = 0; shardIndex < task.size(); ++shardIndex) {
+        const auto& addrs = task[shardIndex].addrs;
+        if (addrs.size() != tensor_sizes_.size()) {
+            return Status::InvalidParam("invalid delegator shard({}) address count", shardIndex);
+        }
+        for (const auto* addr : addrs) {
+            if (addr == nullptr) {
+                return Status::InvalidParam("null address in delegator shard({})", shardIndex);
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status Executor::GatherAsync(const TransferGroup& group, CopyStream& streams)
+{
+    for (const auto& shard : group.shards) {
+        const auto& desc = group.task->desc[shard.shard_index];
+        const auto stream = streams.NextStream();
+        auto* destination = static_cast<std::byte*>(shard.slot.device_addr);
+        std::size_t offset = 0;
+        for (std::size_t index = 0; index < desc.addrs.size(); ++index) {
+            const auto status =
+                streams.DeviceToDeviceAsync(stream, destination + offset,
+                                            shard.slot.length - offset, desc.addrs[index],
+                                            tensor_sizes_[index]);
+            if (status.Failure()) { return status; }
+            offset += tensor_sizes_[index];
+        }
+    }
+    return Status::OK();
+}
+
+Status Executor::ScatterAsync(const TransferGroup& group, CopyStream& streams)
+{
+    for (const auto& shard : group.shards) {
+        const auto& desc = group.task->desc[shard.shard_index];
+        const auto stream = streams.NextStream();
+        const auto* source = static_cast<const std::byte*>(shard.slot.device_addr);
+        std::size_t offset = 0;
+        for (std::size_t index = 0; index < desc.addrs.size(); ++index) {
+            const auto status =
+                streams.DeviceToDeviceAsync(stream, desc.addrs[index], tensor_sizes_[index],
+                                            source + offset, tensor_sizes_[index]);
+            if (status.Failure()) { return status; }
+            offset += tensor_sizes_[index];
+        }
+    }
+    return Status::OK();
+}
+
+void Executor::AssertSchedulerInvariantsLocked() const
+{
+    assert(available_slots_ + in_flight_load_shards_ + in_flight_dump_shards_ == slot_num_);
+    assert(outstanding_shards_ == queued_load_shards_ + queued_dump_shards_ +
+                                      in_flight_load_shards_ + in_flight_dump_shards_);
+    assert(load_queue_.size() == queued_load_shards_);
+    assert(dump_queue_.size() == queued_dump_shards_);
+}
+
+Expected<Detail::TaskHandle> Executor::Submit(Detail::TaskDesc task, Operation operation)
+{
+    auto status = ValidateTask(task, operation);
+    if (status.Failure()) { return status; }
+
+    std::shared_ptr<TaskContext> taskContext;
+    try {
+        taskContext = std::make_shared<TaskContext>();
+    } catch (const std::bad_alloc&) {
+        return Status::OutOfMemory();
+    }
+    taskContext->desc = std::move(task);
+    taskContext->operation = operation;
+    taskContext->remaining = taskContext->desc.size();
+
+    const auto handle = taskContext->id;
+    {
+        // Keep the whole publish atomic against Shutdown.
+        std::lock_guard<std::mutex> schedLock(sched_mutex_);
+        if (shutdown_started_) { return Status::Error(); }
+        AssertSchedulerInvariantsLocked();
+        const auto count = taskContext->desc.size();
+        if (count > std::numeric_limits<std::size_t>::max() - outstanding_shards_) {
+            return Status::OutOfMemory();
+        }
+
+        auto& queue = operation == Operation::LOAD ? load_queue_ : dump_queue_;
+        if (count > queue.max_size() - queue.size()) { return Status::OutOfMemory(); }
+
+        const auto previousQueueSize = queue.size();
+        const auto rollbackPublishedShards = [&queue, previousQueueSize]() noexcept {
+            while (queue.size() != previousQueueSize) { queue.pop_back(); }
+        };
+        try {
+            for (std::size_t shardIndex = 0; shardIndex < count; ++shardIndex) {
+                queue.push_back(QueuedShardContext{taskContext, shardIndex});
+            }
+            {
+                std::lock_guard<std::mutex> tasksLock(tasks_mutex_);
+                if (!tasks_.emplace(handle, taskContext).second) {
+                    rollbackPublishedShards();
+                    return Status::DuplicateKey();
+                }
+            }
+        } catch (const std::bad_alloc&) {
+            rollbackPublishedShards();
+            return Status::OutOfMemory();
+        }
+
+        outstanding_shards_ += count;
+        auto& queued =
+            operation == Operation::LOAD ? queued_load_shards_ : queued_dump_shards_;
+        queued += count;
+        AssertSchedulerInvariantsLocked();
+    }
+    slots_ready_.notify_all();
+    return Detail::TaskHandle{handle};
+}
+
+Expected<bool> Executor::Check(Detail::TaskHandle task)
+{
+    std::lock_guard<std::mutex> lock(tasks_mutex_);
+    const auto iter = tasks_.find(task);
+    if (iter == tasks_.end()) { return Status::NotFound(); }
+    return bool{iter->second->remaining == 0};
+}
+
+Status Executor::Wait(Detail::TaskHandle task)
+{
+    std::unique_lock<std::mutex> lock(tasks_mutex_);
+    const auto iter = tasks_.find(task);
+    if (iter == tasks_.end()) { return Status::NotFound(); }
+
+    const auto taskContext = iter->second;
+    taskContext->completed.wait(lock, [&taskContext]() { return taskContext->remaining == 0; });
+    const auto status = taskContext->error.value_or(Status::OK());
+    tasks_.erase(task);
+    return status;
+}
+
+Expected<Executor::TransferBatch> Executor::AcquireBatch(Operation operation)
+{
+    assert(operation == Operation::LOAD || operation == Operation::DUMP);
+    auto& queue = operation == Operation::LOAD ? load_queue_ : dump_queue_;
+    TransferBatch batch;
+    std::vector<QueuedShardContext> reservedShards;
+    const auto batchCapacity = slot_num_;
+    try {
+        batch.groups.reserve(batchCapacity);
+        reservedShards.reserve(batchCapacity);
+    } catch (const std::bad_alloc&) {
+        return Status::OutOfMemory();
+    }
+
+    const auto canReserve = [this, operation]() {
+        if (available_slots_ == 0) { return false; }
+        // LOAD is admitted whenever a queued shard and a slot are available.
+        if (operation == Operation::LOAD) { return queued_load_shards_ != 0; }
+        // DUMP is admitted only when no LOAD shard is queued or in flight.
+        return queued_dump_shards_ != 0 && queued_load_shards_ == 0 &&
+               in_flight_load_shards_ == 0;
+    };
+
+    // Keep trying until a non-empty batch can be returned or shutdown begins.
+    for (;;) {
+        // Phase 1: reserve shards under the scheduler lock and complete cancellations outside it.
+        reservedShards.clear();
+        while (reservedShards.size() < batchCapacity) {
+            std::optional<QueuedShardContext> cancelledShard;
+            {
+                std::unique_lock<std::mutex> lock(sched_mutex_);
+
+                // Wait only for the first shard; do not wait to fill a partial batch.
+                if (reservedShards.empty()) {
+                    slots_ready_.wait(lock, [this, &canReserve]() {
+                        return shutdown_started_ || canReserve();
+                    });
+                }
+                if (shutdown_started_) {
+                    if (reservedShards.empty()) { return Status::Error(); }
+                    break;
+                }
+                if (!canReserve()) { break; }
+
+                auto& queued =
+                    operation == Operation::LOAD ? queued_load_shards_ : queued_dump_shards_;
+                auto& inFlight = operation == Operation::LOAD ? in_flight_load_shards_
+                                                              : in_flight_dump_shards_;
+                while (reservedShards.size() < batchCapacity && canReserve()) {
+                    assert(!queue.empty());
+                    if (queue.empty()) { std::terminate(); }
+
+                    auto shard = std::move(queue.front());
+                    queue.pop_front();
+                    assert(shard.task);
+                    if (!shard.task) { std::terminate(); }
+                    assert(queued != 0);
+                    --queued;
+
+                    if (shard.task->failed.load(std::memory_order_acquire)) {
+                        assert(outstanding_shards_ != 0);
+                        --outstanding_shards_;
+                        cancelledShard = std::move(shard);
+                        break;
+                    }
+
+                    ++inFlight;
+                    --available_slots_;
+                    reservedShards.push_back(std::move(shard));
+                }
+                AssertSchedulerInvariantsLocked();
+            }
+
+            if (cancelledShard) {
+                RecordShardCompletion(*cancelledShard, Status::OK());
+                slots_ready_.notify_all();
+                continue;
+            }
+            break;
+        }
+
+        // Phase 2: create groups and preallocate their shard lists, rolling back on OOM.
+        batch.groups.clear();
+        try {
+            std::size_t groupBegin = 0;
+            while (groupBegin < reservedShards.size()) {
+                std::size_t groupEnd = groupBegin + 1;
+                while (groupEnd < reservedShards.size() &&
+                       reservedShards[groupEnd].task.get() ==
+                           reservedShards[groupBegin].task.get()) {
+                    ++groupEnd;
+                }
+
+                TransferGroup group;
+                group.task = reservedShards[groupBegin].task;
+                group.shards.reserve(groupEnd - groupBegin);
+                batch.groups.push_back(std::move(group));
+                groupBegin = groupEnd;
+            }
+        } catch (const std::bad_alloc&) {
+            batch.groups.clear();
+            for (const auto& reservedShard : reservedShards) {
+                DiscardShard(reservedShard, Status::OutOfMemory(), ShardStage::IN_FLIGHT);
+            }
+            continue;
+        }
+
+        // Phase 3: allocate BufferPool slots and materialize the reserved shards into groups.
+        std::size_t reservedIndex = 0;
+        for (auto& group : batch.groups) {
+            while (reservedIndex < reservedShards.size() &&
+                   reservedShards[reservedIndex].task.get() == group.task.get()) {
+                auto& reservedShard = reservedShards[reservedIndex++];
+                if (reservedShard.task->failed.load(std::memory_order_acquire)) {
+                    DiscardShard(reservedShard, Status::OK(), ShardStage::IN_FLIGHT);
+                    continue;
+                }
+
+                BufferPool::Slot slot;
+                const auto status = buffer_pool_.Allocate(slot);
+                if (status.Failure()) {
+                    DiscardShard(reservedShard, status, ShardStage::IN_FLIGHT);
+                    continue;
+                }
+
+                InFlightShardContext inFlightShard;
+                inFlightShard.shard_index = reservedShard.shard_index;
+                inFlightShard.slot = std::move(slot);
+                group.shards.push_back(std::move(inFlightShard));
+            }
+        }
+        assert(reservedIndex == reservedShards.size());
+
+        batch.groups.erase(
+            std::remove_if(batch.groups.begin(), batch.groups.end(),
+                           [](const TransferGroup& group) { return group.shards.empty(); }),
+            batch.groups.end());
+        if (!batch.groups.empty()) { return batch; }
+    }
+}
+
+void Executor::ReleaseBatch(TransferBatch& batch)
+{
+    assert(!batch.groups.empty());
+    if (batch.groups.empty()) { std::terminate(); }
+
+    assert(batch.groups.front().task);
+    if (!batch.groups.front().task) { std::terminate(); }
+    const auto operation = batch.groups.front().task->operation;
+    assert(operation == Operation::LOAD || operation == Operation::DUMP);
+    if (operation != Operation::LOAD && operation != Operation::DUMP) { std::terminate(); }
+
+    std::size_t count = 0;
+    for (auto& group : batch.groups) {
+        const bool validGroup =
+            group.task && !group.shards.empty() && group.task->operation == operation;
+        assert(validGroup);
+        if (!validGroup) { std::terminate(); }
+
+        for (const auto& shard : group.shards) {
+            const auto freeStatus = buffer_pool_.Free(shard.slot.slot_index);
+            if (!group.error && freeStatus.Failure()) { group.error = freeStatus; }
+        }
+        count += group.shards.size();
+    }
+
+    // Publish task state before making the released slots available. A worker woken by the slot
+    // update must observe task->failed before acquiring later shards of the same task.
+    // Phase 1: publish each transfer group's result and completion independently.
+    {
+        std::lock_guard<std::mutex> lock(tasks_mutex_);
+        for (const auto& group : batch.groups) {
+            assert(group.task->remaining >= group.shards.size());
+            group.task->remaining -= group.shards.size();
+            if (!group.task->error && group.error) {
+                group.task->error = *group.error;
+                group.task->failed.store(true, std::memory_order_release);
+            }
+            if (group.task->remaining == 0) { group.task->completed.notify_all(); }
+        }
+    }
+
+    // Phase 2: publish the released slots only after task completion state is visible.
+    {
+        std::lock_guard<std::mutex> lock(sched_mutex_);
+        auto& inFlight = operation == Operation::LOAD ? in_flight_load_shards_
+                                                     : in_flight_dump_shards_;
+        assert(inFlight >= count);
+        assert(outstanding_shards_ >= count);
+        inFlight -= count;
+        available_slots_ += count;
+        outstanding_shards_ -= count;
+        AssertSchedulerInvariantsLocked();
+    }
+    slots_ready_.notify_all();
+}
+
+void Executor::RecordShardCompletion(const QueuedShardContext& shard, const Status& status)
+{
+    bool completed = false;
+    {
+        std::lock_guard<std::mutex> lock(tasks_mutex_);
+        if (!shard.task->error && status.Failure()) {
+            shard.task->error = status;
+            shard.task->failed.store(true, std::memory_order_release);
+        }
+        if (shard.task->remaining > 0) { --shard.task->remaining; }
+        completed = shard.task->remaining == 0;
+    }
+    if (completed) { shard.task->completed.notify_all(); }
+}
+
+void Executor::DiscardShard(const QueuedShardContext& shard, const Status& status,
+                            ShardStage stage)
+{
+    RecordShardCompletion(shard, status);
+    {
+        std::lock_guard<std::mutex> lock(sched_mutex_);
+        auto& queued = shard.task->operation == Operation::LOAD ? queued_load_shards_
+                                                               : queued_dump_shards_;
+        auto& inFlight = shard.task->operation == Operation::LOAD ? in_flight_load_shards_
+                                                                 : in_flight_dump_shards_;
+        assert(outstanding_shards_ != 0);
+        if (stage == ShardStage::QUEUED) {
+            assert(queued != 0);
+            --queued;
+        } else {
+            assert(inFlight != 0);
+            --inFlight;
+            ++available_slots_;
+        }
+        --outstanding_shards_;
+        AssertSchedulerInvariantsLocked();
+    }
+
+    slots_ready_.notify_all();
+}
+
+void Executor::DrainQueue(std::deque<QueuedShardContext>& queue)
+{
+    const auto status = Status::Error();
+    while (!queue.empty()) {
+        auto shard = std::move(queue.front());
+        queue.pop_front();
+        DiscardShard(shard, status, ShardStage::QUEUED);
+    }
+}
+
+void Executor::DumpLoop(std::promise<Status>& started)
+{
+    // Init
+    CopyStream streams;
+    auto status = BindDevice(device_id_);
+    if (status.Success()) { status = streams.Setup(device_id_, stream_number_); }
+    started.set_value(status);
+    if (status.Failure()) { return; }
+
+    for (;;) {
+        auto batchResult = AcquireBatch(Operation::DUMP);
+        if (!batchResult) { break; }
+        auto batch = std::move(batchResult).Value();
+
+        std::vector<TransferBuffer> buffers;
+        for (auto& group : batch.groups) {
+            const auto gatherStatus = GatherAsync(group, streams);
+            if (gatherStatus.Failure()) { group.error = gatherStatus; }
+        }
+
+        const auto syncStatus = streams.SynchronizeAll();
+        if (syncStatus.Failure()) {
+            for (auto& group : batch.groups) {
+                if (!group.error) { group.error = syncStatus; }
+            }
+        }
+
+        for (auto& group : batch.groups) {
+            if (group.error) { continue; }
+
+            try {
+                buffers.clear();
+                for (const auto& shard : group.shards) {
+                    const auto& desc = group.task->desc[shard.shard_index];
+                    buffers.push_back(TransferBuffer{desc.owner, desc.index, shard.slot});
+                }
+                auto submitted = endpoint_->SubmitDump(buffers);
+                if (submitted) {
+                    group.transfer_task = std::move(submitted).Value();
+                    group.transfer_pending = true;
+                } else {
+                    group.error = submitted.Error();
+                }
+            } catch (const std::bad_alloc&) {
+                group.error = Status::OutOfMemory();
+            }
+        }
+
+        for (auto& group : batch.groups) {
+            if (!group.transfer_pending) { continue; }
+            const auto waitStatus = endpoint_->Wait(group.transfer_task);
+            if (waitStatus.Failure()) { group.error = waitStatus; }
+            group.transfer_pending = false;
+        }
+
+        ReleaseBatch(batch);
+    }
+}
+
+void Executor::LoadLoop(std::promise<Status>& started)
+{
+    // Init
+    CopyStream streams;
+    auto status = BindDevice(device_id_);
+    if (status.Success()) { status = streams.Setup(device_id_, stream_number_); }
+    started.set_value(status);
+    if (status.Failure()) { return; }
+
+    for (;;) {
+        auto batchResult = AcquireBatch(Operation::LOAD);
+        if (!batchResult) { break; }
+        auto batch = std::move(batchResult).Value();
+
+        std::vector<TransferBuffer> buffers;
+        std::size_t pendingGroupCount = 0;
+        for (auto& group : batch.groups) {
+            try {
+                buffers.clear();
+                for (const auto& shard : group.shards) {
+                    const auto& desc = group.task->desc[shard.shard_index];
+                    buffers.push_back(TransferBuffer{desc.owner, desc.index, shard.slot});
+                }
+                auto submitted = endpoint_->SubmitLoad(buffers);
+                if (submitted) {
+                    group.transfer_task = std::move(submitted).Value();
+                    group.transfer_pending = true;
+                    ++pendingGroupCount;
+                } else {
+                    group.error = submitted.Error();
+                }
+            } catch (const std::bad_alloc&) {
+                group.error = Status::OutOfMemory();
+            }
+        }
+
+        while (pendingGroupCount != 0) {
+            for (auto& group : batch.groups) {
+                if (!group.transfer_pending) { continue; }
+
+                auto completed = endpoint_->Check(group.transfer_task);
+                if (!completed) {
+                    group.error = completed.Error();
+                } else if (!completed.Value()) {
+                    continue;
+                } else {
+                    const auto scatterStatus = ScatterAsync(group, streams);
+                    if (scatterStatus.Failure()) { group.error = scatterStatus; }
+                }
+                group.transfer_pending = false;
+                --pendingGroupCount;
+            }
+        }
+        const auto syncStatus = streams.SynchronizeAll();
+        if (syncStatus.Failure()) {
+            for (auto& group : batch.groups) {
+                if (!group.error) { group.error = syncStatus; }
+            }
+        }
+        ReleaseBatch(batch);
+    }
+}
+
+void Executor::Shutdown()
+{
+    {
+        std::unique_lock<std::mutex> lock(sched_mutex_);
+        if (shutdown_started_) {
+            shutdown_completed_.wait(lock, [this]() { return shutdown_complete_; });
+            return;
+        }
+        shutdown_started_ = true;
+        slots_ready_.notify_all();
+    }
+
+    if (dump_thread_.joinable()) { dump_thread_.join(); }
+    if (load_thread_.joinable()) { load_thread_.join(); }
+
+    // Workers are gone; we are now the sole consumer of both queues.
+    DrainQueue(dump_queue_);
+    DrainQueue(load_queue_);
+    if (transfer_region_ready_) {
+        endpoint_->ResetTransferRegion();
+        transfer_region_ready_ = false;
+    }
+    if (buffer_pool_.IsInitialized()) {
+        // Assumption: Executor is created, used, and destroyed under the same ACL device context.
+        buffer_pool_.Reset();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(sched_mutex_);
+        shutdown_complete_ = true;
+    }
+    shutdown_completed_.notify_all();
+}
+
+}  // namespace UC::Delegator

--- a/ucm/store/delegator/cc/delegator_executor.cc
+++ b/ucm/store/delegator/cc/delegator_executor.cc
@@ -41,12 +41,9 @@ constexpr std::size_t kBufferAlignment = 16 * 1024;
 const char* OperationName(Operation operation) noexcept
 {
     switch (operation) {
-        case Operation::LOAD:
-            return "LOAD";
-        case Operation::DUMP:
-            return "DUMP";
-        default:
-            return "UNKNOWN";
+        case Operation::LOAD: return "LOAD";
+        case Operation::DUMP: return "DUMP";
+        default: return "UNKNOWN";
     }
 }
 
@@ -112,9 +109,8 @@ Expected<std::unique_ptr<Executor>> Executor::Create(std::shared_ptr<StoreV1> ba
     return executor;
 }
 
-Executor::Executor(std::shared_ptr<StoreV1> backend,
-                   std::vector<std::size_t> tensor_sizes, std::int32_t device_id,
-                   std::size_t slot_num, std::size_t stream_number)
+Executor::Executor(std::shared_ptr<StoreV1> backend, std::vector<std::size_t> tensor_sizes,
+                   std::int32_t device_id, std::size_t slot_num, std::size_t stream_number)
     : backend_{std::move(backend)},
       tensor_sizes_{std::move(tensor_sizes)},
       device_id_{device_id},
@@ -131,8 +127,7 @@ Status Executor::Start(std::size_t payload_size, std::size_t slot_num)
     if (backend_->NeedRegisterKVCaches()) {
         const KVCacheRegistration registration{
             reinterpret_cast<std::uintptr_t>(buffer_pool_.GetDeviceAddr()),
-            buffer_pool_.GetTotalSize()
-        };
+            buffer_pool_.GetTotalSize()};
         status = backend_->RegisterKVCaches(&registration, 1);
         if (status.Failure()) { return status; }
     }
@@ -259,8 +254,8 @@ std::string Executor::DescribeShards(const TransferGroup& group) const
     for (const auto& shard : group.shards) {
         const auto& desc = group.task->desc[shard.shard_index];
         if (!result.empty()) { result += ", "; }
-        result += fmt::format("{{owner={:02x},index={},slot={}}}",
-                              fmt::join(desc.owner, ""), desc.index, shard.slot.slot_index);
+        result += fmt::format("{{owner={:02x},index={},slot={}}}", fmt::join(desc.owner, ""),
+                              desc.index, shard.slot.slot_index);
     }
     return result;
 }
@@ -269,9 +264,8 @@ void Executor::LogTaskCompletion(const TaskContext& task) const
 {
     const auto* operation = OperationName(task.operation);
     if (task.error) {
-        UC_ERROR_UNLIMITED(
-            "Delegator {} task({},{}) failed, shards={}, status={}.", operation, task.id,
-            task.desc.brief, task.desc.size(), *task.error);
+        UC_ERROR_UNLIMITED("Delegator {} task({},{}) failed, shards={}, status={}.", operation,
+                           task.id, task.desc.brief, task.desc.size(), *task.error);
         return;
     }
     UC_INFO_UNLIMITED("Delegator {} task({},{}) completed, shards={}.", operation, task.id,
@@ -341,9 +335,8 @@ Expected<Detail::TaskHandle> Executor::Submit(Detail::TaskDesc task, Operation o
         queued += count;
         AssertSchedulerInvariantsLocked();
     }
-    UC_INFO_UNLIMITED("Delegator {} task({},{}) submitted, shards={}.",
-                      OperationName(operation), handle, taskContext->desc.brief,
-                      taskContext->desc.size());
+    UC_INFO_UNLIMITED("Delegator {} task({},{}) submitted, shards={}.", OperationName(operation),
+                      handle, taskContext->desc.brief, taskContext->desc.size());
     slots_ready_.notify_all();
     return Detail::TaskHandle{handle};
 }
@@ -634,16 +627,14 @@ void Executor::DumpLoop(std::promise<Status>& started)
 
         for (auto& group : batch.groups) {
             if (Logger::isEnabledFor(Logger::Level::DEBUG)) {
-                UC_DEBUG_UNLIMITED(
-                    "Delegator DUMP task({},{}) processing KVCache shards=[{}].",
-                    group.task->id, group.task->desc.brief, DescribeShards(group));
+                UC_DEBUG_UNLIMITED("Delegator DUMP task({},{}) processing KVCache shards=[{}].",
+                                   group.task->id, group.task->desc.brief, DescribeShards(group));
             }
             const auto gatherStatus = GatherAsync(group, streams);
             if (gatherStatus.Failure()) {
                 group.error = gatherStatus;
-                UC_ERROR_UNLIMITED(
-                    "Delegator DUMP task({},{}) stage=gather failed, status={}.",
-                    group.task->id, group.task->desc.brief, gatherStatus);
+                UC_ERROR_UNLIMITED("Delegator DUMP task({},{}) stage=gather failed, status={}.",
+                                   group.task->id, group.task->desc.brief, gatherStatus);
             }
         }
 
@@ -735,9 +726,8 @@ void Executor::LoadLoop(std::promise<Status>& started)
         std::size_t pendingGroupCount = 0;
         for (auto& group : batch.groups) {
             if (Logger::isEnabledFor(Logger::Level::DEBUG)) {
-                UC_DEBUG_UNLIMITED(
-                    "Delegator LOAD task({},{}) processing KVCache shards=[{}].",
-                    group.task->id, group.task->desc.brief, DescribeShards(group));
+                UC_DEBUG_UNLIMITED("Delegator LOAD task({},{}) processing KVCache shards=[{}].",
+                                   group.task->id, group.task->desc.brief, DescribeShards(group));
             }
             auto backendTask = MakeBackendTask(group);
             if (!backendTask) {
@@ -775,8 +765,7 @@ void Executor::LoadLoop(std::promise<Status>& started)
                     UC_ERROR_UNLIMITED(
                         "Delegator LOAD task({},{}) stage=backend_check failed, "
                         "backend_task={}, status={}.",
-                        group.task->id, group.task->desc.brief, group.transfer_task,
-                        *group.error);
+                        group.task->id, group.task->desc.brief, group.transfer_task, *group.error);
                 } else if (!completed.Value()) {
                     continue;
                 } else {

--- a/ucm/store/delegator/cc/delegator_executor.cc
+++ b/ucm/store/delegator/cc/delegator_executor.cc
@@ -31,11 +31,24 @@
 #include <limits>
 #include <new>
 #include <system_error>
+#include "logger/logger.h"
 
 namespace UC::Delegator {
 namespace {
 
 constexpr std::size_t kBufferAlignment = 16 * 1024;
+
+const char* OperationName(Operation operation) noexcept
+{
+    switch (operation) {
+        case Operation::LOAD:
+            return "LOAD";
+        case Operation::DUMP:
+            return "DUMP";
+        default:
+            return "UNKNOWN";
+    }
+}
 
 Status ValidateCurrentDevice(std::int32_t expectedDeviceId)
 {
@@ -62,11 +75,12 @@ Status BindDevice(std::int32_t deviceId)
 
 }  // namespace
 
-Expected<std::unique_ptr<Executor>> Executor::Create(
-    std::unique_ptr<TransferEndpoint> endpoint, std::vector<std::size_t> tensor_sizes,
-    std::int32_t device_id, std::size_t slot_num, std::size_t stream_number)
+Expected<std::unique_ptr<Executor>> Executor::Create(std::shared_ptr<StoreV1> backend,
+                                                     std::vector<std::size_t> tensor_sizes,
+                                                     std::int32_t device_id, std::size_t slot_num,
+                                                     std::size_t stream_number)
 {
-    if (endpoint == nullptr || device_id < 0 || slot_num == 0 || stream_number == 0 ||
+    if (backend == nullptr || device_id < 0 || slot_num == 0 || stream_number == 0 ||
         tensor_sizes.empty()) {
         return Status::InvalidParam("invalid delegator executor config");
     }
@@ -83,7 +97,7 @@ Expected<std::unique_ptr<Executor>> Executor::Create(
     if (status.Failure()) { return status; }
 
     auto executor = std::unique_ptr<Executor>{new (std::nothrow) Executor(
-        std::move(endpoint), std::move(tensor_sizes), device_id, slot_num, stream_number)};
+        std::move(backend), std::move(tensor_sizes), device_id, slot_num, stream_number)};
     if (!executor) { return Status::OutOfMemory(); }
 
     try {
@@ -98,10 +112,10 @@ Expected<std::unique_ptr<Executor>> Executor::Create(
     return executor;
 }
 
-Executor::Executor(std::unique_ptr<TransferEndpoint> endpoint,
+Executor::Executor(std::shared_ptr<StoreV1> backend,
                    std::vector<std::size_t> tensor_sizes, std::int32_t device_id,
                    std::size_t slot_num, std::size_t stream_number)
-    : endpoint_{std::move(endpoint)},
+    : backend_{std::move(backend)},
       tensor_sizes_{std::move(tensor_sizes)},
       device_id_{device_id},
       stream_number_{std::min(stream_number, slot_num)}
@@ -114,11 +128,14 @@ Status Executor::Start(std::size_t payload_size, std::size_t slot_num)
                                     payload_size, slot_num, false, kBufferAlignment);
     if (status.Failure()) { return status; }
     slot_num_ = slot_num;
-    status = endpoint_->SetupTransferRegion(
-        TransferRegion{buffer_pool_.GetLocalAddr(), buffer_pool_.GetDeviceAddr(),
-                       buffer_pool_.GetTotalSize(), buffer_pool_.GetMemoryType(), device_id_});
-    if (status.Failure()) { return status; }
-    transfer_region_ready_ = true;
+    if (backend_->NeedRegisterKVCaches()) {
+        const KVCacheRegistration registration{
+            reinterpret_cast<std::uintptr_t>(buffer_pool_.GetDeviceAddr()),
+            buffer_pool_.GetTotalSize()
+        };
+        status = backend_->RegisterKVCaches(&registration, 1);
+        if (status.Failure()) { return status; }
+    }
     available_slots_ = slot_num;
 
     std::promise<Status> dumpStarted;
@@ -144,6 +161,33 @@ Status Executor::Start(std::size_t payload_size, std::size_t slot_num)
 }
 
 Executor::~Executor() { Shutdown(); }
+
+Expected<Detail::TaskDesc> Executor::MakeBackendTask(const TransferGroup& group) const
+{
+    Detail::TaskDesc task;
+    task.brief = group.task->desc.brief;
+    try {
+        task.reserve(group.shards.size());
+        for (const auto& shard : group.shards) {
+            const auto& source = group.task->desc[shard.shard_index];
+            Detail::Shard backendShard;
+            backendShard.owner = source.owner;
+            backendShard.index = source.index;
+            backendShard.addrs.reserve(tensor_sizes_.size());
+
+            auto* address = static_cast<std::byte*>(shard.slot.device_addr);
+            std::size_t offset = 0;
+            for (const auto size : tensor_sizes_) {
+                backendShard.addrs.push_back(address + offset);
+                offset += size;
+            }
+            task.push_back(std::move(backendShard));
+        }
+    } catch (const std::bad_alloc&) {
+        return Status::OutOfMemory();
+    }
+    return task;
+}
 
 Status Executor::ValidateTask(const Detail::TaskDesc& task, Operation operation) const
 {
@@ -173,13 +217,17 @@ Status Executor::GatherAsync(const TransferGroup& group, CopyStream& streams)
     for (const auto& shard : group.shards) {
         const auto& desc = group.task->desc[shard.shard_index];
         const auto stream = streams.NextStream();
+        if (group.task->desc.prerequisiteHandle != 0) {
+            const auto status = streams.WaitEvent(
+                stream, reinterpret_cast<aclrtEvent>(group.task->desc.prerequisiteHandle));
+            if (status.Failure()) { return status; }
+        }
         auto* destination = static_cast<std::byte*>(shard.slot.device_addr);
         std::size_t offset = 0;
         for (std::size_t index = 0; index < desc.addrs.size(); ++index) {
-            const auto status =
-                streams.DeviceToDeviceAsync(stream, destination + offset,
-                                            shard.slot.length - offset, desc.addrs[index],
-                                            tensor_sizes_[index]);
+            const auto status = streams.DeviceToDeviceAsync(
+                stream, destination + offset, shard.slot.length - offset, desc.addrs[index],
+                tensor_sizes_[index]);
             if (status.Failure()) { return status; }
             offset += tensor_sizes_[index];
         }
@@ -203,6 +251,31 @@ Status Executor::ScatterAsync(const TransferGroup& group, CopyStream& streams)
         }
     }
     return Status::OK();
+}
+
+std::string Executor::DescribeShards(const TransferGroup& group) const
+{
+    std::string result;
+    for (const auto& shard : group.shards) {
+        const auto& desc = group.task->desc[shard.shard_index];
+        if (!result.empty()) { result += ", "; }
+        result += fmt::format("{{owner={:02x},index={},slot={}}}",
+                              fmt::join(desc.owner, ""), desc.index, shard.slot.slot_index);
+    }
+    return result;
+}
+
+void Executor::LogTaskCompletion(const TaskContext& task) const
+{
+    const auto* operation = OperationName(task.operation);
+    if (task.error) {
+        UC_ERROR_UNLIMITED(
+            "Delegator {} task({},{}) failed, shards={}, status={}.", operation, task.id,
+            task.desc.brief, task.desc.size(), *task.error);
+        return;
+    }
+    UC_INFO_UNLIMITED("Delegator {} task({},{}) completed, shards={}.", operation, task.id,
+                      task.desc.brief, task.desc.size());
 }
 
 void Executor::AssertSchedulerInvariantsLocked() const
@@ -252,7 +325,7 @@ Expected<Detail::TaskHandle> Executor::Submit(Detail::TaskDesc task, Operation o
                 queue.push_back(QueuedShardContext{taskContext, shardIndex});
             }
             {
-                std::lock_guard<std::mutex> tasksLock(tasks_mutex_);
+                std::lock_guard<std::shared_mutex> tasksLock(taskMapMutex_);
                 if (!tasks_.emplace(handle, taskContext).second) {
                     rollbackPublishedShards();
                     return Status::DuplicateKey();
@@ -264,34 +337,47 @@ Expected<Detail::TaskHandle> Executor::Submit(Detail::TaskDesc task, Operation o
         }
 
         outstanding_shards_ += count;
-        auto& queued =
-            operation == Operation::LOAD ? queued_load_shards_ : queued_dump_shards_;
+        auto& queued = operation == Operation::LOAD ? queued_load_shards_ : queued_dump_shards_;
         queued += count;
         AssertSchedulerInvariantsLocked();
     }
+    UC_INFO_UNLIMITED("Delegator {} task({},{}) submitted, shards={}.",
+                      OperationName(operation), handle, taskContext->desc.brief,
+                      taskContext->desc.size());
     slots_ready_.notify_all();
     return Detail::TaskHandle{handle};
 }
 
 Expected<bool> Executor::Check(Detail::TaskHandle task)
 {
-    std::lock_guard<std::mutex> lock(tasks_mutex_);
-    const auto iter = tasks_.find(task);
-    if (iter == tasks_.end()) { return Status::NotFound(); }
-    return bool{iter->second->remaining == 0};
+    std::shared_ptr<TaskContext> taskContext;
+    {
+        std::shared_lock<std::shared_mutex> lock(taskMapMutex_);
+        const auto iter = tasks_.find(task);
+        if (iter == tasks_.end()) { return Status::NotFound(); }
+        taskContext = iter->second;
+    }
+
+    std::lock_guard<std::mutex> lock(taskContext->stateMutex);
+    return bool{taskContext->remaining == 0};
 }
 
 Status Executor::Wait(Detail::TaskHandle task)
 {
-    std::unique_lock<std::mutex> lock(tasks_mutex_);
-    const auto iter = tasks_.find(task);
-    if (iter == tasks_.end()) { return Status::NotFound(); }
+    std::shared_ptr<TaskContext> taskContext;
+    {
+        std::lock_guard<std::shared_mutex> lock(taskMapMutex_);
+        const auto iter = tasks_.find(task);
+        if (iter == tasks_.end()) { return Status::NotFound(); }
 
-    const auto taskContext = iter->second;
+        // Wait claims the handle before blocking; task handles have single-consumer semantics.
+        taskContext = iter->second;
+        tasks_.erase(iter);
+    }
+
+    std::unique_lock<std::mutex> lock(taskContext->stateMutex);
     taskContext->completed.wait(lock, [&taskContext]() { return taskContext->remaining == 0; });
-    const auto status = taskContext->error.value_or(Status::OK());
-    tasks_.erase(task);
-    return status;
+    return taskContext->error.value_or(Status::OK());
 }
 
 Expected<Executor::TransferBatch> Executor::AcquireBatch(Operation operation)
@@ -313,8 +399,7 @@ Expected<Executor::TransferBatch> Executor::AcquireBatch(Operation operation)
         // LOAD is admitted whenever a queued shard and a slot are available.
         if (operation == Operation::LOAD) { return queued_load_shards_ != 0; }
         // DUMP is admitted only when no LOAD shard is queued or in flight.
-        return queued_dump_shards_ != 0 && queued_load_shards_ == 0 &&
-               in_flight_load_shards_ == 0;
+        return queued_dump_shards_ != 0 && queued_load_shards_ == 0 && in_flight_load_shards_ == 0;
     };
 
     // Keep trying until a non-empty batch can be returned or shutdown begins.
@@ -328,20 +413,18 @@ Expected<Executor::TransferBatch> Executor::AcquireBatch(Operation operation)
 
                 // Wait only for the first shard; do not wait to fill a partial batch.
                 if (reservedShards.empty()) {
-                    slots_ready_.wait(lock, [this, &canReserve]() {
-                        return shutdown_started_ || canReserve();
-                    });
+                    slots_ready_.wait(
+                        lock, [this, &canReserve]() { return shutdown_started_ || canReserve(); });
                 }
                 if (shutdown_started_) {
                     if (reservedShards.empty()) { return Status::Error(); }
                     break;
                 }
-                if (!canReserve()) { break; }
 
                 auto& queued =
                     operation == Operation::LOAD ? queued_load_shards_ : queued_dump_shards_;
-                auto& inFlight = operation == Operation::LOAD ? in_flight_load_shards_
-                                                              : in_flight_dump_shards_;
+                auto& inFlight =
+                    operation == Operation::LOAD ? in_flight_load_shards_ : in_flight_dump_shards_;
                 while (reservedShards.size() < batchCapacity && canReserve()) {
                     assert(!queue.empty());
                     if (queue.empty()) { std::terminate(); }
@@ -368,7 +451,7 @@ Expected<Executor::TransferBatch> Executor::AcquireBatch(Operation operation)
             }
 
             if (cancelledShard) {
-                RecordShardCompletion(*cancelledShard, Status::OK());
+                CompleteTaskShards(cancelledShard->task, 1, Status::OK());
                 slots_ready_.notify_all();
                 continue;
             }
@@ -463,24 +546,15 @@ void Executor::ReleaseBatch(TransferBatch& batch)
     // Publish task state before making the released slots available. A worker woken by the slot
     // update must observe task->failed before acquiring later shards of the same task.
     // Phase 1: publish each transfer group's result and completion independently.
-    {
-        std::lock_guard<std::mutex> lock(tasks_mutex_);
-        for (const auto& group : batch.groups) {
-            assert(group.task->remaining >= group.shards.size());
-            group.task->remaining -= group.shards.size();
-            if (!group.task->error && group.error) {
-                group.task->error = *group.error;
-                group.task->failed.store(true, std::memory_order_release);
-            }
-            if (group.task->remaining == 0) { group.task->completed.notify_all(); }
-        }
+    for (const auto& group : batch.groups) {
+        CompleteTaskShards(group.task, group.shards.size(), group.error.value_or(Status::OK()));
     }
 
     // Phase 2: publish the released slots only after task completion state is visible.
     {
         std::lock_guard<std::mutex> lock(sched_mutex_);
-        auto& inFlight = operation == Operation::LOAD ? in_flight_load_shards_
-                                                     : in_flight_dump_shards_;
+        auto& inFlight =
+            operation == Operation::LOAD ? in_flight_load_shards_ : in_flight_dump_shards_;
         assert(inFlight >= count);
         assert(outstanding_shards_ >= count);
         inFlight -= count;
@@ -491,31 +565,33 @@ void Executor::ReleaseBatch(TransferBatch& batch)
     slots_ready_.notify_all();
 }
 
-void Executor::RecordShardCompletion(const QueuedShardContext& shard, const Status& status)
+void Executor::CompleteTaskShards(const std::shared_ptr<TaskContext>& task, std::size_t count,
+                                  const Status& status)
 {
     bool completed = false;
     {
-        std::lock_guard<std::mutex> lock(tasks_mutex_);
-        if (!shard.task->error && status.Failure()) {
-            shard.task->error = status;
-            shard.task->failed.store(true, std::memory_order_release);
+        std::lock_guard<std::mutex> lock(task->stateMutex);
+        assert(task->remaining >= count);
+        task->remaining -= count;
+        if (!task->error && status.Failure()) {
+            task->error = status;
+            task->failed.store(true, std::memory_order_release);
         }
-        if (shard.task->remaining > 0) { --shard.task->remaining; }
-        completed = shard.task->remaining == 0;
+        completed = task->remaining == 0;
+        if (completed) { LogTaskCompletion(*task); }
     }
-    if (completed) { shard.task->completed.notify_all(); }
+    if (completed) { task->completed.notify_all(); }
 }
 
-void Executor::DiscardShard(const QueuedShardContext& shard, const Status& status,
-                            ShardStage stage)
+void Executor::DiscardShard(const QueuedShardContext& shard, const Status& status, ShardStage stage)
 {
-    RecordShardCompletion(shard, status);
+    CompleteTaskShards(shard.task, 1, status);
     {
         std::lock_guard<std::mutex> lock(sched_mutex_);
-        auto& queued = shard.task->operation == Operation::LOAD ? queued_load_shards_
-                                                               : queued_dump_shards_;
+        auto& queued =
+            shard.task->operation == Operation::LOAD ? queued_load_shards_ : queued_dump_shards_;
         auto& inFlight = shard.task->operation == Operation::LOAD ? in_flight_load_shards_
-                                                                 : in_flight_dump_shards_;
+                                                                  : in_flight_dump_shards_;
         assert(outstanding_shards_ != 0);
         if (stage == ShardStage::QUEUED) {
             assert(queued != 0);
@@ -556,44 +632,85 @@ void Executor::DumpLoop(std::promise<Status>& started)
         if (!batchResult) { break; }
         auto batch = std::move(batchResult).Value();
 
-        std::vector<TransferBuffer> buffers;
         for (auto& group : batch.groups) {
+            if (Logger::isEnabledFor(Logger::Level::DEBUG)) {
+                UC_DEBUG_UNLIMITED(
+                    "Delegator DUMP task({},{}) processing KVCache shards=[{}].",
+                    group.task->id, group.task->desc.brief, DescribeShards(group));
+            }
             const auto gatherStatus = GatherAsync(group, streams);
-            if (gatherStatus.Failure()) { group.error = gatherStatus; }
+            if (gatherStatus.Failure()) {
+                group.error = gatherStatus;
+                UC_ERROR_UNLIMITED(
+                    "Delegator DUMP task({},{}) stage=gather failed, status={}.",
+                    group.task->id, group.task->desc.brief, gatherStatus);
+            }
         }
 
         const auto syncStatus = streams.SynchronizeAll();
         if (syncStatus.Failure()) {
             for (auto& group : batch.groups) {
-                if (!group.error) { group.error = syncStatus; }
+                if (!group.error) {
+                    group.error = syncStatus;
+                    UC_ERROR_UNLIMITED(
+                        "Delegator DUMP task({},{}) stage=gather_sync failed, status={}.",
+                        group.task->id, group.task->desc.brief, syncStatus);
+                }
+            }
+        } else {
+            for (const auto& group : batch.groups) {
+                if (!group.error) {
+                    UC_DEBUG_UNLIMITED(
+                        "Delegator DUMP task({},{}) stage=gather_complete, shards={}.",
+                        group.task->id, group.task->desc.brief, group.shards.size());
+                }
             }
         }
 
         for (auto& group : batch.groups) {
             if (group.error) { continue; }
 
-            try {
-                buffers.clear();
-                for (const auto& shard : group.shards) {
-                    const auto& desc = group.task->desc[shard.shard_index];
-                    buffers.push_back(TransferBuffer{desc.owner, desc.index, shard.slot});
-                }
-                auto submitted = endpoint_->SubmitDump(buffers);
-                if (submitted) {
-                    group.transfer_task = std::move(submitted).Value();
-                    group.transfer_pending = true;
-                } else {
-                    group.error = submitted.Error();
-                }
-            } catch (const std::bad_alloc&) {
-                group.error = Status::OutOfMemory();
+            auto backendTask = MakeBackendTask(group);
+            if (!backendTask) {
+                group.error = backendTask.Error();
+                UC_ERROR_UNLIMITED(
+                    "Delegator DUMP task({},{}) stage=backend_task_build failed, status={}.",
+                    group.task->id, group.task->desc.brief, *group.error);
+                continue;
+            }
+            auto submitted = backend_->Dump(std::move(backendTask).Value());
+            if (submitted) {
+                group.transfer_task = std::move(submitted).Value();
+                group.transfer_pending = true;
+                UC_DEBUG_UNLIMITED(
+                    "Delegator DUMP task({},{}) stage=backend_submitted, backend_task={}, "
+                    "shards={}.",
+                    group.task->id, group.task->desc.brief, group.transfer_task,
+                    group.shards.size());
+            } else {
+                group.error = submitted.Error();
+                UC_ERROR_UNLIMITED(
+                    "Delegator DUMP task({},{}) stage=backend_submit failed, status={}.",
+                    group.task->id, group.task->desc.brief, *group.error);
             }
         }
 
         for (auto& group : batch.groups) {
             if (!group.transfer_pending) { continue; }
-            const auto waitStatus = endpoint_->Wait(group.transfer_task);
-            if (waitStatus.Failure()) { group.error = waitStatus; }
+            const auto waitStatus = backend_->Wait(group.transfer_task);
+            if (waitStatus.Failure()) {
+                group.error = waitStatus;
+                UC_ERROR_UNLIMITED(
+                    "Delegator DUMP task({},{}) stage=backend_wait failed, backend_task={}, "
+                    "status={}.",
+                    group.task->id, group.task->desc.brief, group.transfer_task, waitStatus);
+            } else {
+                UC_DEBUG_UNLIMITED(
+                    "Delegator DUMP task({},{}) stage=backend_complete, backend_task={}, "
+                    "shards={}.",
+                    group.task->id, group.task->desc.brief, group.transfer_task,
+                    group.shards.size());
+            }
             group.transfer_pending = false;
         }
 
@@ -615,25 +732,36 @@ void Executor::LoadLoop(std::promise<Status>& started)
         if (!batchResult) { break; }
         auto batch = std::move(batchResult).Value();
 
-        std::vector<TransferBuffer> buffers;
         std::size_t pendingGroupCount = 0;
         for (auto& group : batch.groups) {
-            try {
-                buffers.clear();
-                for (const auto& shard : group.shards) {
-                    const auto& desc = group.task->desc[shard.shard_index];
-                    buffers.push_back(TransferBuffer{desc.owner, desc.index, shard.slot});
-                }
-                auto submitted = endpoint_->SubmitLoad(buffers);
-                if (submitted) {
-                    group.transfer_task = std::move(submitted).Value();
-                    group.transfer_pending = true;
-                    ++pendingGroupCount;
-                } else {
-                    group.error = submitted.Error();
-                }
-            } catch (const std::bad_alloc&) {
-                group.error = Status::OutOfMemory();
+            if (Logger::isEnabledFor(Logger::Level::DEBUG)) {
+                UC_DEBUG_UNLIMITED(
+                    "Delegator LOAD task({},{}) processing KVCache shards=[{}].",
+                    group.task->id, group.task->desc.brief, DescribeShards(group));
+            }
+            auto backendTask = MakeBackendTask(group);
+            if (!backendTask) {
+                group.error = backendTask.Error();
+                UC_ERROR_UNLIMITED(
+                    "Delegator LOAD task({},{}) stage=backend_task_build failed, status={}.",
+                    group.task->id, group.task->desc.brief, *group.error);
+                continue;
+            }
+            auto submitted = backend_->Load(std::move(backendTask).Value());
+            if (submitted) {
+                group.transfer_task = std::move(submitted).Value();
+                group.transfer_pending = true;
+                ++pendingGroupCount;
+                UC_DEBUG_UNLIMITED(
+                    "Delegator LOAD task({},{}) stage=backend_submitted, backend_task={}, "
+                    "shards={}.",
+                    group.task->id, group.task->desc.brief, group.transfer_task,
+                    group.shards.size());
+            } else {
+                group.error = submitted.Error();
+                UC_ERROR_UNLIMITED(
+                    "Delegator LOAD task({},{}) stage=backend_submit failed, status={}.",
+                    group.task->id, group.task->desc.brief, *group.error);
             }
         }
 
@@ -641,14 +769,39 @@ void Executor::LoadLoop(std::promise<Status>& started)
             for (auto& group : batch.groups) {
                 if (!group.transfer_pending) { continue; }
 
-                auto completed = endpoint_->Check(group.transfer_task);
+                auto completed = backend_->Check(group.transfer_task);
                 if (!completed) {
                     group.error = completed.Error();
+                    UC_ERROR_UNLIMITED(
+                        "Delegator LOAD task({},{}) stage=backend_check failed, "
+                        "backend_task={}, status={}.",
+                        group.task->id, group.task->desc.brief, group.transfer_task,
+                        *group.error);
                 } else if (!completed.Value()) {
                     continue;
                 } else {
-                    const auto scatterStatus = ScatterAsync(group, streams);
-                    if (scatterStatus.Failure()) { group.error = scatterStatus; }
+                    const auto waitStatus = backend_->Wait(group.transfer_task);
+                    if (waitStatus.Failure()) {
+                        group.error = waitStatus;
+                        UC_ERROR_UNLIMITED(
+                            "Delegator LOAD task({},{}) stage=backend_wait failed, "
+                            "backend_task={}, status={}.",
+                            group.task->id, group.task->desc.brief, group.transfer_task,
+                            waitStatus);
+                    } else {
+                        UC_DEBUG_UNLIMITED(
+                            "Delegator LOAD task({},{}) stage=backend_complete, "
+                            "backend_task={}, shards={}.",
+                            group.task->id, group.task->desc.brief, group.transfer_task,
+                            group.shards.size());
+                        const auto scatterStatus = ScatterAsync(group, streams);
+                        if (scatterStatus.Failure()) {
+                            group.error = scatterStatus;
+                            UC_ERROR_UNLIMITED(
+                                "Delegator LOAD task({},{}) stage=scatter failed, status={}.",
+                                group.task->id, group.task->desc.brief, scatterStatus);
+                        }
+                    }
                 }
                 group.transfer_pending = false;
                 --pendingGroupCount;
@@ -657,7 +810,20 @@ void Executor::LoadLoop(std::promise<Status>& started)
         const auto syncStatus = streams.SynchronizeAll();
         if (syncStatus.Failure()) {
             for (auto& group : batch.groups) {
-                if (!group.error) { group.error = syncStatus; }
+                if (!group.error) {
+                    group.error = syncStatus;
+                    UC_ERROR_UNLIMITED(
+                        "Delegator LOAD task({},{}) stage=scatter_sync failed, status={}.",
+                        group.task->id, group.task->desc.brief, syncStatus);
+                }
+            }
+        } else {
+            for (const auto& group : batch.groups) {
+                if (!group.error) {
+                    UC_DEBUG_UNLIMITED(
+                        "Delegator LOAD task({},{}) stage=scatter_complete, shards={}.",
+                        group.task->id, group.task->desc.brief, group.shards.size());
+                }
             }
         }
         ReleaseBatch(batch);
@@ -682,10 +848,6 @@ void Executor::Shutdown()
     // Workers are gone; we are now the sole consumer of both queues.
     DrainQueue(dump_queue_);
     DrainQueue(load_queue_);
-    if (transfer_region_ready_) {
-        endpoint_->ResetTransferRegion();
-        transfer_region_ready_ = false;
-    }
     if (buffer_pool_.IsInitialized()) {
         // Assumption: Executor is created, used, and destroyed under the same ACL device context.
         buffer_pool_.Reset();

--- a/ucm/store/delegator/cc/delegator_executor.cc
+++ b/ucm/store/delegator/cc/delegator_executor.cc
@@ -268,8 +268,8 @@ void Executor::LogTaskCompletion(const TaskContext& task) const
                  task.desc.brief, task.desc.size(), *task.error);
         return;
     }
-    UC_INFO("Delegator {} task({},{}) completed, shards={}.", operation, task.id,
-                      task.desc.brief, task.desc.size());
+    UC_INFO("Delegator {} task({},{}) completed, shards={}.", operation, task.id, task.desc.brief,
+            task.desc.size());
 }
 
 void Executor::CheckSchedulerInvariantsLocked() const
@@ -343,8 +343,8 @@ Expected<Detail::TaskHandle> Executor::Submit(Detail::TaskDesc task, Operation o
         queuedNum += count;
         CheckSchedulerInvariantsLocked();
     }
-    UC_INFO("Delegator {} task({},{}) submitted, shards={}.", OperationName(operation),
-                      handle, taskContext->desc.brief, taskContext->desc.size());
+    UC_INFO("Delegator {} task({},{}) submitted, shards={}.", OperationName(operation), handle,
+            taskContext->desc.brief, taskContext->desc.size());
     slotsReady_.notify_all();
     return Detail::TaskHandle{handle};
 }
@@ -623,7 +623,7 @@ void Executor::DumpLoop(std::promise<Status>& started)
         for (auto& group : batch.groups) {
             if (Logger::isEnabledFor(Logger::Level::DEBUG)) {
                 UC_DEBUG("Delegator DUMP task({},{}) processing KVCache shards=[{}].",
-                                   group.task->id, group.task->desc.brief, DescribeShards(group));
+                         group.task->id, group.task->desc.brief, DescribeShards(group));
             }
             const auto gatherStatus = GatherAsync(group, streams);
             if (gatherStatus.Failure()) {
@@ -645,9 +645,8 @@ void Executor::DumpLoop(std::promise<Status>& started)
         } else {
             for (const auto& group : batch.groups) {
                 if (!group.error) {
-                    UC_DEBUG(
-                        "Delegator DUMP task({},{}) stage=gather_complete, shards={}.",
-                        group.task->id, group.task->desc.brief, group.shards.size());
+                    UC_DEBUG("Delegator DUMP task({},{}) stage=gather_complete, shards={}.",
+                             group.task->id, group.task->desc.brief, group.shards.size());
                 }
             }
         }
@@ -719,7 +718,7 @@ void Executor::LoadLoop(std::promise<Status>& started)
         for (auto& group : batch.groups) {
             if (Logger::isEnabledFor(Logger::Level::DEBUG)) {
                 UC_DEBUG("Delegator LOAD task({},{}) processing KVCache shards=[{}].",
-                                   group.task->id, group.task->desc.brief, DescribeShards(group));
+                         group.task->id, group.task->desc.brief, DescribeShards(group));
             }
             auto backendTask = MakeBackendTask(group);
             if (!backendTask) {
@@ -796,9 +795,8 @@ void Executor::LoadLoop(std::promise<Status>& started)
         } else {
             for (const auto& group : batch.groups) {
                 if (!group.error) {
-                    UC_DEBUG(
-                        "Delegator LOAD task({},{}) stage=scatter_complete, shards={}.",
-                        group.task->id, group.task->desc.brief, group.shards.size());
+                    UC_DEBUG("Delegator LOAD task({},{}) stage=scatter_complete, shards={}.",
+                             group.task->id, group.task->desc.brief, group.shards.size());
                 }
             }
         }

--- a/ucm/store/delegator/cc/delegator_executor.cc
+++ b/ucm/store/delegator/cc/delegator_executor.cc
@@ -522,9 +522,7 @@ void Executor::ReleaseBatch(TransferBatch& batch)
 
     std::size_t count = 0;
     for (auto& group : batch.groups) {
-        const bool validGroup =
-            group.task && !group.shards.empty() && group.task->operation == operation;
-        assert(validGroup);
+        assert(group.task && !group.shards.empty() && group.task->operation == operation;);
 
         for (const auto& shard : group.shards) {
             const auto freeStatus = bufferPool_.Free(shard.slot.slot_index);

--- a/ucm/store/delegator/cc/delegator_executor.cc
+++ b/ucm/store/delegator/cc/delegator_executor.cc
@@ -264,7 +264,7 @@ void Executor::LogTaskCompletion(const TaskContext& task) const
 {
     const auto* operation = OperationName(task.operation);
     if (task.error) {
-        UC_ERROR_UNLIMITED("Delegator {} task({},{}) failed, shards={}, status={}.", operation,
+        UC_ERROR("Delegator {} task({},{}) failed, shards={}, status={}.", operation,
                            task.id, task.desc.brief, task.desc.size(), *task.error);
         return;
     }
@@ -272,13 +272,21 @@ void Executor::LogTaskCompletion(const TaskContext& task) const
                       task.desc.brief, task.desc.size());
 }
 
-void Executor::AssertSchedulerInvariantsLocked() const
+void Executor::CheckSchedulerInvariantsLocked() const
 {
-    assert(availableSlots_ + inFlightLoadShards_ + inFlightDumpShards_ == slotNum_);
-    assert(outstandingShards_ ==
-           queuedLoadShards_ + queuedDumpShards_ + inFlightLoadShards_ + inFlightDumpShards_);
-    assert(loadQueue_.size() == queuedLoadShards_);
-    assert(dumpQueue_.size() == queuedDumpShards_);
+    const bool valid =
+        availableSlots_ + inFlightLoadShardNum_ + inFlightDumpShardNum_ == slotNum_ &&
+        outstandingShardNum_ == queuedLoadShardNum_ + queuedDumpShardNum_ + inFlightLoadShardNum_ +
+                                    inFlightDumpShardNum_ &&
+        loadQueue_.size() == queuedLoadShardNum_ && dumpQueue_.size() == queuedDumpShardNum_;
+    if (valid) { return; }
+
+    UC_ERROR(
+        "Delegator scheduler invariant violated: slots={}/{}, outstanding={}, queued(load/dump)="
+        "{}/{}, in_flight(load/dump)={}/{}, queue(load/dump)={}/{}.",
+        availableSlots_, slotNum_, outstandingShardNum_, queuedLoadShardNum_, queuedDumpShardNum_,
+        inFlightLoadShardNum_, inFlightDumpShardNum_, loadQueue_.size(), dumpQueue_.size());
+    assert(valid);
 }
 
 Expected<Detail::TaskHandle> Executor::Submit(Detail::TaskDesc task, Operation operation)
@@ -301,9 +309,9 @@ Expected<Detail::TaskHandle> Executor::Submit(Detail::TaskDesc task, Operation o
         // Keep the whole publish atomic against Shutdown.
         std::lock_guard<std::mutex> schedLock(schedMutex_);
         if (shutdownStarted_) { return Status::Error(); }
-        AssertSchedulerInvariantsLocked();
+        CheckSchedulerInvariantsLocked();
         const auto count = taskContext->desc.size();
-        if (count > std::numeric_limits<std::size_t>::max() - outstandingShards_) {
+        if (count > std::numeric_limits<std::size_t>::max() - outstandingShardNum_) {
             return Status::OutOfMemory();
         }
 
@@ -330,10 +338,10 @@ Expected<Detail::TaskHandle> Executor::Submit(Detail::TaskDesc task, Operation o
             return Status::OutOfMemory();
         }
 
-        outstandingShards_ += count;
-        auto& queued = operation == Operation::LOAD ? queuedLoadShards_ : queuedDumpShards_;
-        queued += count;
-        AssertSchedulerInvariantsLocked();
+        outstandingShardNum_ += count;
+        auto& queuedNum = operation == Operation::LOAD ? queuedLoadShardNum_ : queuedDumpShardNum_;
+        queuedNum += count;
+        CheckSchedulerInvariantsLocked();
     }
     UC_INFO_UNLIMITED("Delegator {} task({},{}) submitted, shards={}.", OperationName(operation),
                       handle, taskContext->desc.brief, taskContext->desc.size());
@@ -390,9 +398,9 @@ Expected<Executor::TransferBatch> Executor::AcquireBatch(Operation operation)
     const auto canReserve = [this, operation]() {
         if (availableSlots_ == 0) { return false; }
         // LOAD is admitted whenever a queued shard and a slot are available.
-        if (operation == Operation::LOAD) { return queuedLoadShards_ != 0; }
+        if (operation == Operation::LOAD) { return queuedLoadShardNum_ != 0; }
         // DUMP is admitted only when no LOAD shard is queued or in flight.
-        return queuedDumpShards_ != 0 && queuedLoadShards_ == 0 && inFlightLoadShards_ == 0;
+        return queuedDumpShardNum_ != 0 && queuedLoadShardNum_ == 0 && inFlightLoadShardNum_ == 0;
     };
 
     // Keep trying until a non-empty batch can be returned or shutdown begins.
@@ -414,32 +422,26 @@ Expected<Executor::TransferBatch> Executor::AcquireBatch(Operation operation)
                     break;
                 }
 
-                auto& queued = operation == Operation::LOAD ? queuedLoadShards_ : queuedDumpShards_;
-                auto& inFlight =
-                    operation == Operation::LOAD ? inFlightLoadShards_ : inFlightDumpShards_;
+                auto& queuedNum =
+                    operation == Operation::LOAD ? queuedLoadShardNum_ : queuedDumpShardNum_;
+                auto& inFlightNum =
+                    operation == Operation::LOAD ? inFlightLoadShardNum_ : inFlightDumpShardNum_;
                 while (reservedShards.size() < batchCapacity && canReserve()) {
-                    assert(!queue.empty());
-                    if (queue.empty()) { std::terminate(); }
-
                     auto shard = std::move(queue.front());
                     queue.pop_front();
-                    assert(shard.task);
-                    if (!shard.task) { std::terminate(); }
-                    assert(queued != 0);
-                    --queued;
+                    --queuedNum;
 
                     if (shard.task->failed.load(std::memory_order_acquire)) {
-                        assert(outstandingShards_ != 0);
-                        --outstandingShards_;
+                        --outstandingShardNum_;
                         cancelledShard = std::move(shard);
                         break;
                     }
 
-                    ++inFlight;
+                    ++inFlightNum;
                     --availableSlots_;
                     reservedShards.push_back(std::move(shard));
                 }
-                AssertSchedulerInvariantsLocked();
+                CheckSchedulerInvariantsLocked();
             }
 
             if (cancelledShard) {
@@ -513,20 +515,16 @@ Expected<Executor::TransferBatch> Executor::AcquireBatch(Operation operation)
 void Executor::ReleaseBatch(TransferBatch& batch)
 {
     assert(!batch.groups.empty());
-    if (batch.groups.empty()) { std::terminate(); }
-
     assert(batch.groups.front().task);
-    if (!batch.groups.front().task) { std::terminate(); }
+    
     const auto operation = batch.groups.front().task->operation;
     assert(operation == Operation::LOAD || operation == Operation::DUMP);
-    if (operation != Operation::LOAD && operation != Operation::DUMP) { std::terminate(); }
 
     std::size_t count = 0;
     for (auto& group : batch.groups) {
         const bool validGroup =
             group.task && !group.shards.empty() && group.task->operation == operation;
         assert(validGroup);
-        if (!validGroup) { std::terminate(); }
 
         for (const auto& shard : group.shards) {
             const auto freeStatus = bufferPool_.Free(shard.slot.slot_index);
@@ -545,13 +543,14 @@ void Executor::ReleaseBatch(TransferBatch& batch)
     // Phase 2: publish the released slots only after task completion state is visible.
     {
         std::lock_guard<std::mutex> lock(schedMutex_);
-        auto& inFlight = operation == Operation::LOAD ? inFlightLoadShards_ : inFlightDumpShards_;
-        assert(inFlight >= count);
-        assert(outstandingShards_ >= count);
-        inFlight -= count;
+        auto& inFlightNum =
+            operation == Operation::LOAD ? inFlightLoadShardNum_ : inFlightDumpShardNum_;
+        assert(inFlightNum >= count);
+        assert(outstandingShardNum_ >= count);
+        inFlightNum -= count;
         availableSlots_ += count;
-        outstandingShards_ -= count;
-        AssertSchedulerInvariantsLocked();
+        outstandingShardNum_ -= count;
+        CheckSchedulerInvariantsLocked();
     }
     slotsReady_.notify_all();
 }
@@ -579,21 +578,21 @@ void Executor::DiscardShard(const QueuedShardContext& shard, const Status& statu
     CompleteTaskShards(shard.task, 1, status);
     {
         std::lock_guard<std::mutex> lock(schedMutex_);
-        auto& queued =
-            shard.task->operation == Operation::LOAD ? queuedLoadShards_ : queuedDumpShards_;
-        auto& inFlight =
-            shard.task->operation == Operation::LOAD ? inFlightLoadShards_ : inFlightDumpShards_;
-        assert(outstandingShards_ != 0);
+        auto& queuedNum =
+            shard.task->operation == Operation::LOAD ? queuedLoadShardNum_ : queuedDumpShardNum_;
+        auto& inFlightNum = shard.task->operation == Operation::LOAD ? inFlightLoadShardNum_
+                                                                     : inFlightDumpShardNum_;
+        assert(outstandingShardNum_ != 0);
         if (stage == ShardStage::QUEUED) {
-            assert(queued != 0);
-            --queued;
+            assert(queuedNum != 0);
+            --queuedNum;
         } else {
-            assert(inFlight != 0);
-            --inFlight;
+            assert(inFlightNum != 0);
+            --inFlightNum;
             ++availableSlots_;
         }
-        --outstandingShards_;
-        AssertSchedulerInvariantsLocked();
+        --outstandingShardNum_;
+        CheckSchedulerInvariantsLocked();
     }
 
     slotsReady_.notify_all();
@@ -631,7 +630,7 @@ void Executor::DumpLoop(std::promise<Status>& started)
             const auto gatherStatus = GatherAsync(group, streams);
             if (gatherStatus.Failure()) {
                 group.error = gatherStatus;
-                UC_ERROR_UNLIMITED("Delegator DUMP task({},{}) stage=gather failed, status={}.",
+                UC_ERROR("Delegator DUMP task({},{}) stage=gather failed, status={}.",
                                    group.task->id, group.task->desc.brief, gatherStatus);
             }
         }
@@ -641,7 +640,7 @@ void Executor::DumpLoop(std::promise<Status>& started)
             for (auto& group : batch.groups) {
                 if (!group.error) {
                     group.error = syncStatus;
-                    UC_ERROR_UNLIMITED(
+                    UC_ERROR(
                         "Delegator DUMP task({},{}) stage=gather_sync failed, status={}.",
                         group.task->id, group.task->desc.brief, syncStatus);
                 }
@@ -662,7 +661,7 @@ void Executor::DumpLoop(std::promise<Status>& started)
             auto backendTask = MakeBackendTask(group);
             if (!backendTask) {
                 group.error = backendTask.Error();
-                UC_ERROR_UNLIMITED(
+                UC_ERROR(
                     "Delegator DUMP task({},{}) stage=backend_task_build failed, status={}.",
                     group.task->id, group.task->desc.brief, *group.error);
                 continue;
@@ -678,7 +677,7 @@ void Executor::DumpLoop(std::promise<Status>& started)
                     group.shards.size());
             } else {
                 group.error = submitted.Error();
-                UC_ERROR_UNLIMITED(
+                UC_ERROR(
                     "Delegator DUMP task({},{}) stage=backend_submit failed, status={}.",
                     group.task->id, group.task->desc.brief, *group.error);
             }
@@ -689,7 +688,7 @@ void Executor::DumpLoop(std::promise<Status>& started)
             const auto waitStatus = backend_->Wait(group.transferTask);
             if (waitStatus.Failure()) {
                 group.error = waitStatus;
-                UC_ERROR_UNLIMITED(
+                UC_ERROR(
                     "Delegator DUMP task({},{}) stage=backend_wait failed, backend_task={}, "
                     "status={}.",
                     group.task->id, group.task->desc.brief, group.transferTask, waitStatus);
@@ -730,7 +729,7 @@ void Executor::LoadLoop(std::promise<Status>& started)
             auto backendTask = MakeBackendTask(group);
             if (!backendTask) {
                 group.error = backendTask.Error();
-                UC_ERROR_UNLIMITED(
+                UC_ERROR(
                     "Delegator LOAD task({},{}) stage=backend_task_build failed, status={}.",
                     group.task->id, group.task->desc.brief, *group.error);
                 continue;
@@ -747,7 +746,7 @@ void Executor::LoadLoop(std::promise<Status>& started)
                     group.shards.size());
             } else {
                 group.error = submitted.Error();
-                UC_ERROR_UNLIMITED(
+                UC_ERROR(
                     "Delegator LOAD task({},{}) stage=backend_submit failed, status={}.",
                     group.task->id, group.task->desc.brief, *group.error);
             }
@@ -760,7 +759,7 @@ void Executor::LoadLoop(std::promise<Status>& started)
                 auto completed = backend_->Check(group.transferTask);
                 if (!completed) {
                     group.error = completed.Error();
-                    UC_ERROR_UNLIMITED(
+                    UC_ERROR(
                         "Delegator LOAD task({},{}) stage=backend_check failed, "
                         "backend_task={}, status={}.",
                         group.task->id, group.task->desc.brief, group.transferTask, *group.error);
@@ -770,7 +769,7 @@ void Executor::LoadLoop(std::promise<Status>& started)
                     const auto waitStatus = backend_->Wait(group.transferTask);
                     if (waitStatus.Failure()) {
                         group.error = waitStatus;
-                        UC_ERROR_UNLIMITED(
+                        UC_ERROR(
                             "Delegator LOAD task({},{}) stage=backend_wait failed, "
                             "backend_task={}, status={}.",
                             group.task->id, group.task->desc.brief, group.transferTask, waitStatus);
@@ -783,7 +782,7 @@ void Executor::LoadLoop(std::promise<Status>& started)
                         const auto scatterStatus = ScatterAsync(group, streams);
                         if (scatterStatus.Failure()) {
                             group.error = scatterStatus;
-                            UC_ERROR_UNLIMITED(
+                            UC_ERROR(
                                 "Delegator LOAD task({},{}) stage=scatter failed, status={}.",
                                 group.task->id, group.task->desc.brief, scatterStatus);
                         }
@@ -798,7 +797,7 @@ void Executor::LoadLoop(std::promise<Status>& started)
             for (auto& group : batch.groups) {
                 if (!group.error) {
                     group.error = syncStatus;
-                    UC_ERROR_UNLIMITED(
+                    UC_ERROR(
                         "Delegator LOAD task({},{}) stage=scatter_sync failed, status={}.",
                         group.task->id, group.task->desc.brief, syncStatus);
                 }

--- a/ucm/store/delegator/cc/delegator_executor.h
+++ b/ucm/store/delegator/cc/delegator_executor.h
@@ -1,0 +1,195 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "delegator_copy_stream.h"
+#include "detail/type/types.h"
+#include "pool/buffer_pool.h"
+
+namespace UC::Delegator {
+
+struct TransferBuffer {
+    Detail::BlockId owner;
+    std::size_t index{0};
+    BufferPool::Slot slot;
+};
+
+struct TransferRegion {
+    void* local_addr{nullptr};
+    void* device_addr{nullptr};
+    std::size_t size{0};
+    BufferPool::MemoryType memory_type{BufferPool::MemoryType::ASCEND_DEVICE};
+    std::int32_t device_id{-1};
+};
+
+class TransferEndpoint {
+public:
+    virtual ~TransferEndpoint() = default;
+
+    virtual Status SetupTransferRegion(const TransferRegion& region) = 0;
+    virtual void ResetTransferRegion() noexcept = 0;
+    virtual Expected<Detail::TaskHandle> SubmitLoad(
+        const std::vector<TransferBuffer>& buffers) = 0;
+    virtual Expected<Detail::TaskHandle> SubmitDump(
+        const std::vector<TransferBuffer>& buffers) = 0;
+    virtual Expected<bool> Check(Detail::TaskHandle task) = 0;
+    virtual Status Wait(Detail::TaskHandle task) = 0;
+};
+
+enum class Operation {
+    LOAD,
+    DUMP,
+};
+
+class Executor {
+public:
+    static constexpr std::size_t kDefaultStreamNumber = 4;
+
+    static Expected<std::unique_ptr<Executor>> Create(
+        std::unique_ptr<TransferEndpoint> endpoint, std::vector<std::size_t> tensor_sizes,
+        std::int32_t device_id, std::size_t slot_num,
+        std::size_t stream_number = kDefaultStreamNumber);
+    ~Executor();
+
+    Executor(const Executor&) = delete;
+    Executor& operator=(const Executor&) = delete;
+
+    Expected<Detail::TaskHandle> Submit(Detail::TaskDesc task, Operation operation);
+    Expected<bool> Check(Detail::TaskHandle task);
+    Status Wait(Detail::TaskHandle task);
+    void Shutdown();
+
+private:
+    Executor(std::unique_ptr<TransferEndpoint> endpoint,
+             std::vector<std::size_t> tensor_sizes,
+             std::int32_t device_id, std::size_t slot_num, std::size_t stream_number);
+
+    struct TaskContext {
+        Detail::TaskHandle id{NextId()};
+        Detail::TaskDesc desc;
+        Operation operation{Operation::LOAD};
+        std::size_t remaining{0};
+        std::optional<Status> error;
+        std::atomic<bool> failed{false};
+        std::condition_variable completed;
+
+        static Detail::TaskHandle NextId() noexcept
+        {
+            static std::atomic<Detail::TaskHandle> id{1};
+            auto next = id.fetch_add(1, std::memory_order_relaxed);
+            if (next == 0) { next = id.fetch_add(1, std::memory_order_relaxed); }
+            return next;
+        }
+    };
+
+    enum class ShardStage {
+        QUEUED,
+        IN_FLIGHT,
+    };
+
+    struct QueuedShardContext {
+        std::shared_ptr<TaskContext> task;
+        std::size_t shard_index{0};
+    };
+
+    // Always owned by a TransferGroup, which records the shard's parent task.
+    struct InFlightShardContext {
+        std::size_t shard_index{0};
+        BufferPool::Slot slot;
+    };
+
+    struct TransferGroup {
+        std::shared_ptr<TaskContext> task;
+        std::vector<InFlightShardContext> shards;
+        Detail::TaskHandle transfer_task{0};
+        bool transfer_pending{false};
+        std::optional<Status> error;
+    };
+
+    struct TransferBatch {
+        std::vector<TransferGroup> groups;
+    };
+
+    Status ValidateTask(const Detail::TaskDesc& task, Operation operation) const;
+    Status Start(std::size_t payload_size, std::size_t slot_num);
+
+    Status GatherAsync(const TransferGroup& group, CopyStream& streams);
+    Status ScatterAsync(const TransferGroup& group, CopyStream& streams);
+
+    Expected<TransferBatch> AcquireBatch(Operation operation);
+    void ReleaseBatch(TransferBatch& batch);
+
+    void RecordShardCompletion(const QueuedShardContext& shard, const Status& status);
+    void DiscardShard(const QueuedShardContext& shard, const Status& status, ShardStage stage);
+    void DrainQueue(std::deque<QueuedShardContext>& queue);
+    void AssertSchedulerInvariantsLocked() const;
+
+    void DumpLoop(std::promise<Status>& started);
+    void LoadLoop(std::promise<Status>& started);
+
+    BufferPool buffer_pool_;
+    std::unique_ptr<TransferEndpoint> endpoint_;
+    std::vector<std::size_t> tensor_sizes_;
+    std::int32_t device_id_{-1};
+    std::size_t stream_number_{0};
+
+    std::mutex tasks_mutex_;
+    std::mutex sched_mutex_;
+    std::condition_variable slots_ready_;
+    std::condition_variable shutdown_completed_;
+
+    std::deque<QueuedShardContext> dump_queue_;
+    std::deque<QueuedShardContext> load_queue_;
+    std::unordered_map<Detail::TaskHandle, std::shared_ptr<TaskContext>> tasks_;
+
+    std::size_t slot_num_{0};
+    std::size_t available_slots_{0};
+    std::size_t outstanding_shards_{0};
+    std::size_t queued_load_shards_{0};
+    std::size_t queued_dump_shards_{0};
+    std::size_t in_flight_load_shards_{0};
+    std::size_t in_flight_dump_shards_{0};
+
+    bool shutdown_started_{false};
+    bool shutdown_complete_{false};
+    bool transfer_region_ready_{false};
+
+    std::thread dump_thread_;
+    std::thread load_thread_;
+};
+
+}  // namespace UC::Delegator

--- a/ucm/store/delegator/cc/delegator_executor.h
+++ b/ucm/store/delegator/cc/delegator_executor.h
@@ -76,11 +76,11 @@ private:
         Detail::TaskHandle id{NextId()};
         Detail::TaskDesc desc;
         Operation operation{Operation::LOAD};
-        
+
         std::mutex stateMutex;  // Protects remaining and error.
         std::size_t remaining{0};
         std::optional<Status> error;
-        
+
         std::atomic<bool> failed{false};
         std::condition_variable completed;
 

--- a/ucm/store/delegator/cc/delegator_executor.h
+++ b/ucm/store/delegator/cc/delegator_executor.h
@@ -32,6 +32,8 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <shared_mutex>
+#include <string>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -39,36 +41,9 @@
 #include "delegator_copy_stream.h"
 #include "detail/type/types.h"
 #include "pool/buffer_pool.h"
+#include "ucmstore_v1.h"
 
 namespace UC::Delegator {
-
-struct TransferBuffer {
-    Detail::BlockId owner;
-    std::size_t index{0};
-    BufferPool::Slot slot;
-};
-
-struct TransferRegion {
-    void* local_addr{nullptr};
-    void* device_addr{nullptr};
-    std::size_t size{0};
-    BufferPool::MemoryType memory_type{BufferPool::MemoryType::ASCEND_DEVICE};
-    std::int32_t device_id{-1};
-};
-
-class TransferEndpoint {
-public:
-    virtual ~TransferEndpoint() = default;
-
-    virtual Status SetupTransferRegion(const TransferRegion& region) = 0;
-    virtual void ResetTransferRegion() noexcept = 0;
-    virtual Expected<Detail::TaskHandle> SubmitLoad(
-        const std::vector<TransferBuffer>& buffers) = 0;
-    virtual Expected<Detail::TaskHandle> SubmitDump(
-        const std::vector<TransferBuffer>& buffers) = 0;
-    virtual Expected<bool> Check(Detail::TaskHandle task) = 0;
-    virtual Status Wait(Detail::TaskHandle task) = 0;
-};
 
 enum class Operation {
     LOAD,
@@ -80,7 +55,7 @@ public:
     static constexpr std::size_t kDefaultStreamNumber = 4;
 
     static Expected<std::unique_ptr<Executor>> Create(
-        std::unique_ptr<TransferEndpoint> endpoint, std::vector<std::size_t> tensor_sizes,
+        std::shared_ptr<StoreV1> backend, std::vector<std::size_t> tensor_sizes,
         std::int32_t device_id, std::size_t slot_num,
         std::size_t stream_number = kDefaultStreamNumber);
     ~Executor();
@@ -94,16 +69,18 @@ public:
     void Shutdown();
 
 private:
-    Executor(std::unique_ptr<TransferEndpoint> endpoint,
-             std::vector<std::size_t> tensor_sizes,
+    Executor(std::shared_ptr<StoreV1> backend, std::vector<std::size_t> tensor_sizes,
              std::int32_t device_id, std::size_t slot_num, std::size_t stream_number);
 
     struct TaskContext {
         Detail::TaskHandle id{NextId()};
         Detail::TaskDesc desc;
         Operation operation{Operation::LOAD};
+        
+        std::mutex stateMutex;  // Protects remaining and error.
         std::size_t remaining{0};
         std::optional<Status> error;
+        
         std::atomic<bool> failed{false};
         std::condition_variable completed;
 
@@ -146,15 +123,20 @@ private:
 
     Status ValidateTask(const Detail::TaskDesc& task, Operation operation) const;
     Status Start(std::size_t payload_size, std::size_t slot_num);
+    Expected<Detail::TaskDesc> MakeBackendTask(const TransferGroup& group) const;
 
     Status GatherAsync(const TransferGroup& group, CopyStream& streams);
     Status ScatterAsync(const TransferGroup& group, CopyStream& streams);
+    std::string DescribeShards(const TransferGroup& group) const;
+    void LogTaskCompletion(const TaskContext& task) const;
 
     Expected<TransferBatch> AcquireBatch(Operation operation);
     void ReleaseBatch(TransferBatch& batch);
 
-    void RecordShardCompletion(const QueuedShardContext& shard, const Status& status);
+    void CompleteTaskShards(const std::shared_ptr<TaskContext>& task, std::size_t count,
+                            const Status& status);
     void DiscardShard(const QueuedShardContext& shard, const Status& status, ShardStage stage);
+    // Called only after all worker threads have stopped, when Shutdown is the sole queue consumer.
     void DrainQueue(std::deque<QueuedShardContext>& queue);
     void AssertSchedulerInvariantsLocked() const;
 
@@ -162,12 +144,12 @@ private:
     void LoadLoop(std::promise<Status>& started);
 
     BufferPool buffer_pool_;
-    std::unique_ptr<TransferEndpoint> endpoint_;
+    std::shared_ptr<StoreV1> backend_;
     std::vector<std::size_t> tensor_sizes_;
     std::int32_t device_id_{-1};
     std::size_t stream_number_{0};
 
-    std::mutex tasks_mutex_;
+    std::shared_mutex taskMapMutex_;  // Protects tasks_ only.
     std::mutex sched_mutex_;
     std::condition_variable slots_ready_;
     std::condition_variable shutdown_completed_;
@@ -186,8 +168,6 @@ private:
 
     bool shutdown_started_{false};
     bool shutdown_complete_{false};
-    bool transfer_region_ready_{false};
-
     std::thread dump_thread_;
     std::thread load_thread_;
 };

--- a/ucm/store/delegator/cc/delegator_executor.h
+++ b/ucm/store/delegator/cc/delegator_executor.h
@@ -138,7 +138,7 @@ private:
     void DiscardShard(const QueuedShardContext& shard, const Status& status, ShardStage stage);
     // Called only after all worker threads have stopped, when Shutdown is the sole queue consumer.
     void DrainQueue(std::deque<QueuedShardContext>& queue);
-    void AssertSchedulerInvariantsLocked() const;
+    void CheckSchedulerInvariantsLocked() const;
 
     void DumpLoop(std::promise<Status>& started);
     void LoadLoop(std::promise<Status>& started);
@@ -160,11 +160,11 @@ private:
 
     std::size_t slotNum_{0};
     std::size_t availableSlots_{0};
-    std::size_t outstandingShards_{0};
-    std::size_t queuedLoadShards_{0};
-    std::size_t queuedDumpShards_{0};
-    std::size_t inFlightLoadShards_{0};
-    std::size_t inFlightDumpShards_{0};
+    std::size_t outstandingShardNum_{0};
+    std::size_t queuedLoadShardNum_{0};
+    std::size_t queuedDumpShardNum_{0};
+    std::size_t inFlightLoadShardNum_{0};
+    std::size_t inFlightDumpShardNum_{0};
 
     bool shutdownStarted_{false};
     bool shutdownComplete_{false};

--- a/ucm/store/delegator/cc/delegator_executor.h
+++ b/ucm/store/delegator/cc/delegator_executor.h
@@ -55,9 +55,9 @@ public:
     static constexpr std::size_t kDefaultStreamNumber = 4;
 
     static Expected<std::unique_ptr<Executor>> Create(
-        std::shared_ptr<StoreV1> backend, std::vector<std::size_t> tensor_sizes,
-        std::int32_t device_id, std::size_t slot_num,
-        std::size_t stream_number = kDefaultStreamNumber);
+        std::shared_ptr<StoreV1> backend, std::vector<std::size_t> tensorSizes,
+        std::int32_t deviceId, std::size_t slotNum,
+        std::size_t streamNumber = kDefaultStreamNumber);
     ~Executor();
 
     Executor(const Executor&) = delete;
@@ -69,8 +69,8 @@ public:
     void Shutdown();
 
 private:
-    Executor(std::shared_ptr<StoreV1> backend, std::vector<std::size_t> tensor_sizes,
-             std::int32_t device_id, std::size_t slot_num, std::size_t stream_number);
+    Executor(std::shared_ptr<StoreV1> backend, std::vector<std::size_t> tensorSizes,
+             std::int32_t deviceId, std::size_t slotNum, std::size_t streamNumber);
 
     struct TaskContext {
         Detail::TaskHandle id{NextId()};
@@ -100,20 +100,20 @@ private:
 
     struct QueuedShardContext {
         std::shared_ptr<TaskContext> task;
-        std::size_t shard_index{0};
+        std::size_t shardIndex{0};
     };
 
     // Always owned by a TransferGroup, which records the shard's parent task.
     struct InFlightShardContext {
-        std::size_t shard_index{0};
+        std::size_t shardIndex{0};
         BufferPool::Slot slot;
     };
 
     struct TransferGroup {
         std::shared_ptr<TaskContext> task;
         std::vector<InFlightShardContext> shards;
-        Detail::TaskHandle transfer_task{0};
-        bool transfer_pending{false};
+        Detail::TaskHandle transferTask{0};
+        bool transferPending{false};
         std::optional<Status> error;
     };
 
@@ -122,7 +122,7 @@ private:
     };
 
     Status ValidateTask(const Detail::TaskDesc& task, Operation operation) const;
-    Status Start(std::size_t payload_size, std::size_t slot_num);
+    Status Start(std::size_t payloadSize, std::size_t slotNum);
     Expected<Detail::TaskDesc> MakeBackendTask(const TransferGroup& group) const;
 
     Status GatherAsync(const TransferGroup& group, CopyStream& streams);
@@ -143,33 +143,33 @@ private:
     void DumpLoop(std::promise<Status>& started);
     void LoadLoop(std::promise<Status>& started);
 
-    BufferPool buffer_pool_;
+    BufferPool bufferPool_;
     std::shared_ptr<StoreV1> backend_;
-    std::vector<std::size_t> tensor_sizes_;
-    std::int32_t device_id_{-1};
-    std::size_t stream_number_{0};
+    std::vector<std::size_t> tensorSizes_;
+    std::int32_t deviceId_{-1};
+    std::size_t streamNumber_{0};
 
     std::shared_mutex taskMapMutex_;  // Protects tasks_ only.
-    std::mutex sched_mutex_;
-    std::condition_variable slots_ready_;
-    std::condition_variable shutdown_completed_;
+    std::mutex schedMutex_;
+    std::condition_variable slotsReady_;
+    std::condition_variable shutdownCompleted_;
 
-    std::deque<QueuedShardContext> dump_queue_;
-    std::deque<QueuedShardContext> load_queue_;
+    std::deque<QueuedShardContext> dumpQueue_;
+    std::deque<QueuedShardContext> loadQueue_;
     std::unordered_map<Detail::TaskHandle, std::shared_ptr<TaskContext>> tasks_;
 
-    std::size_t slot_num_{0};
-    std::size_t available_slots_{0};
-    std::size_t outstanding_shards_{0};
-    std::size_t queued_load_shards_{0};
-    std::size_t queued_dump_shards_{0};
-    std::size_t in_flight_load_shards_{0};
-    std::size_t in_flight_dump_shards_{0};
+    std::size_t slotNum_{0};
+    std::size_t availableSlots_{0};
+    std::size_t outstandingShards_{0};
+    std::size_t queuedLoadShards_{0};
+    std::size_t queuedDumpShards_{0};
+    std::size_t inFlightLoadShards_{0};
+    std::size_t inFlightDumpShards_{0};
 
-    bool shutdown_started_{false};
-    bool shutdown_complete_{false};
-    std::thread dump_thread_;
-    std::thread load_thread_;
+    bool shutdownStarted_{false};
+    bool shutdownComplete_{false};
+    std::thread dumpThread_;
+    std::thread loadThread_;
 };
 
 }  // namespace UC::Delegator

--- a/ucm/store/test/case/delegator/delegator_copy_stream_test.cc
+++ b/ucm/store/test/case/delegator/delegator_copy_stream_test.cc
@@ -115,10 +115,14 @@ TEST_F(CopyStreamTest, RejectsInvalidConfigurationAndCopies)
     EXPECT_EQ(streams.Synchronize(nullptr), Status::InvalidParam());
 
     auto stream = reinterpret_cast<aclrtStream>(std::uintptr_t{1});
+    auto event = reinterpret_cast<aclrtEvent>(std::uintptr_t{1});
     auto* source = reinterpret_cast<void*>(std::uintptr_t{1});
     auto* destination = reinterpret_cast<void*>(std::uintptr_t{2});
 
     EXPECT_EQ(streams.Synchronize(stream), Status::InvalidParam());
+    EXPECT_EQ(streams.WaitEvent(nullptr, event), Status::InvalidParam());
+    EXPECT_EQ(streams.WaitEvent(stream, nullptr), Status::InvalidParam());
+    EXPECT_EQ(streams.WaitEvent(stream, event), Status::InvalidParam());
 
     EXPECT_EQ(streams.DeviceToDeviceAsync(nullptr, destination, 1, source, 1),
               Status::InvalidParam());

--- a/ucm/store/test/case/delegator/delegator_executor_test.cc
+++ b/ucm/store/test/case/delegator/delegator_executor_test.cc
@@ -1,0 +1,866 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "delegator/cc/delegator_executor.h"
+#include <acl/acl.h>
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace UC::Delegator {
+namespace {
+
+class ExecutorTest : public ::testing::Test {
+public:
+    static void SetUpTestSuite()
+    {
+        const auto ret = aclInit(nullptr);
+        if (ret != ACL_SUCCESS && ret != ACL_ERROR_REPEAT_INITIALIZE) {
+            FAIL() << "aclInit failed: " << ret;
+        }
+        ASSERT_EQ(aclrtSetDevice(0), ACL_SUCCESS);
+    }
+
+    static void TearDownTestSuite()
+    {
+        (void)aclrtResetDevice(0);
+        (void)aclFinalize();
+    }
+
+    static std::shared_ptr<void> MakeDeviceBuffer(std::size_t size)
+    {
+        void* address = nullptr;
+        if (aclrtMalloc(&address, size, ACL_MEM_TYPE_HIGH_BAND_WIDTH) != ACL_SUCCESS) {
+            return nullptr;
+        }
+        return std::shared_ptr<void>(address, [](void* ptr) { (void)aclrtFree(ptr); });
+    }
+};
+
+class FakeTransferEndpoint final : public TransferEndpoint {
+public:
+    struct Call {
+        Operation operation;
+        std::vector<std::size_t> shards;
+    };
+
+    explicit FakeTransferEndpoint(std::size_t payload_size) : payload_size_{payload_size} {}
+
+    Status SetupTransferRegion(const TransferRegion& region) override
+    {
+        if (region.device_addr == nullptr || region.size == 0) {
+            return Status::InvalidParam();
+        }
+        return Status::OK();
+    }
+
+    void ResetTransferRegion() noexcept override {}
+
+    Expected<Detail::TaskHandle> SubmitLoad(
+        const std::vector<TransferBuffer>& buffers) override
+    {
+        if (buffers.empty()) { return Status::InvalidParam(); }
+
+        std::vector<std::size_t> batch;
+        std::vector<std::vector<std::uint8_t>> data;
+        batch.reserve(buffers.size());
+        data.reserve(buffers.size());
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            for (const auto& buffer : buffers) {
+                batch.push_back(buffer.index);
+                load_submissions_.push_back(buffer.index);
+            }
+            calls_.push_back(Call{Operation::LOAD, batch});
+            if (std::find(batch.begin(), batch.end(), fail_load_index_) != batch.end()) {
+                return Status::Error("injected load submission failure");
+            }
+            for (const auto index : batch) { data.push_back(stored_[index]); }
+        }
+
+        for (std::size_t index = 0; index < buffers.size(); ++index) {
+            if (data[index].size() != payload_size_) {
+                return Status::InvalidParam("missing fake load data");
+            }
+            const auto ret = aclrtMemcpy(buffers[index].slot.device_addr, payload_size_,
+                                         data[index].data(),
+                                         data[index].size(), ACL_MEMCPY_HOST_TO_DEVICE);
+            if (ret != ACL_SUCCESS) { return Status::Error("fake load copy failed"); }
+        }
+        return NewTask(false, Status::OK(), buffers.front().index);
+    }
+
+    Expected<Detail::TaskHandle> SubmitDump(
+        const std::vector<TransferBuffer>& buffers) override
+    {
+        if (buffers.empty()) { return Status::InvalidParam(); }
+
+        std::vector<std::size_t> batch;
+        batch.reserve(buffers.size());
+        for (const auto& buffer : buffers) {
+            std::vector<std::uint8_t> data(payload_size_);
+            const auto ret = aclrtMemcpy(data.data(), data.size(), buffer.slot.device_addr,
+                                         data.size(), ACL_MEMCPY_DEVICE_TO_HOST);
+            if (ret != ACL_SUCCESS) { return Status::Error("fake store copy failed"); }
+            batch.push_back(buffer.index);
+
+            std::lock_guard<std::mutex> lock(mutex_);
+            stored_[buffer.index] = std::move(data);
+            dump_slots_.push_back(buffer.slot);
+        }
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            calls_.push_back(Call{Operation::DUMP, batch});
+            store_batches_.push_back(std::move(batch));
+        }
+        const auto groupIndex = buffers.front().index;
+        if (groupIndex == fail_dump_submit_index_) {
+            return Status::Error("injected dump submission failure");
+        }
+        const auto waitStatus =
+            fail_first_store_ || groupIndex == fail_dump_wait_index_
+                ? Status::Error("injected store failure")
+                : Status::OK();
+        return NewTask(true, waitStatus, groupIndex);
+    }
+
+    Status Wait(Detail::TaskHandle task) override
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        const auto iter = tasks_.find(task);
+        if (iter == tasks_.end()) { return Status::NotFound(); }
+        if (iter->second.is_store && block_first_store_ && !store_wait_seen_) {
+            store_wait_seen_ = true;
+            wait_entered_.notify_all();
+            wait_released_.wait(lock, [this]() { return release_store_; });
+        }
+        return iter->second.status;
+    }
+
+    Expected<bool> Check(Detail::TaskHandle task) override
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        const auto iter = tasks_.find(task);
+        if (iter == tasks_.end()) { return Status::NotFound(); }
+
+        const auto& entry = iter->second;
+        if (std::find(checked_load_groups_.begin(), checked_load_groups_.end(),
+                      entry.group_index) == checked_load_groups_.end()) {
+            checked_load_groups_.push_back(entry.group_index);
+            wait_entered_.notify_all();
+        }
+        if (entry.blocked && !release_load_) { return false; }
+        if (entry.group_index == fail_load_check_index_) {
+            return Status::Error("injected load check failure");
+        }
+        if (entry.status.Failure()) { return entry.status; }
+        return true;
+    }
+
+    void SetData(std::size_t index, std::vector<std::uint8_t> data)
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stored_[index] = std::move(data);
+    }
+
+    void BlockFirstStore()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        block_first_store_ = true;
+    }
+
+    void BlockFirstLoad()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        block_first_load_ = true;
+    }
+
+    bool WaitForStoreWait() { return WaitFor(store_wait_seen_); }
+
+    bool WaitForLoadGroupCheck(std::size_t group)
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        return wait_entered_.wait_for(lock, std::chrono::seconds(2), [this, group]() {
+            return std::find(checked_load_groups_.begin(), checked_load_groups_.end(), group) !=
+                   checked_load_groups_.end();
+        });
+    }
+
+    void ReleaseStore()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        release_store_ = true;
+        wait_released_.notify_all();
+    }
+
+    void ReleaseLoad()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        release_load_ = true;
+        wait_released_.notify_all();
+    }
+
+    std::vector<std::vector<std::size_t>> StoreBatches()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return store_batches_;
+    }
+
+    std::vector<std::size_t> LoadSubmissions()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return load_submissions_;
+    }
+
+    std::vector<std::size_t> CheckedLoadGroups()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return checked_load_groups_;
+    }
+
+    std::vector<Call> Calls()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return calls_;
+    }
+
+    std::vector<BufferPool::Slot> DumpSlots()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return dump_slots_;
+    }
+
+    std::size_t fail_load_index_{std::numeric_limits<std::size_t>::max()};
+    std::size_t fail_load_check_index_{std::numeric_limits<std::size_t>::max()};
+    std::size_t fail_dump_submit_index_{std::numeric_limits<std::size_t>::max()};
+    std::size_t fail_dump_wait_index_{std::numeric_limits<std::size_t>::max()};
+    bool fail_first_store_{false};
+
+private:
+    struct Task {
+        bool is_store;
+        Status status;
+        std::size_t group_index;
+        bool blocked;
+    };
+
+    Expected<Detail::TaskHandle> NewTask(
+        bool is_store, Status status,
+        std::size_t group_index = std::numeric_limits<std::size_t>::max())
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        const auto task = next_task_++;
+        const auto blocked = !is_store && block_first_load_ && !blocked_load_assigned_;
+        if (blocked) { blocked_load_assigned_ = true; }
+        tasks_.emplace(task, Task{is_store, std::move(status), group_index, blocked});
+        return Detail::TaskHandle{task};
+    }
+
+    bool WaitFor(bool& ready)
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        return wait_entered_.wait_for(lock, std::chrono::seconds(2), [&ready]() { return ready; });
+    }
+
+    std::size_t payload_size_;
+    std::mutex mutex_;
+    std::condition_variable wait_entered_;
+    std::condition_variable wait_released_;
+    Detail::TaskHandle next_task_{1};
+    std::unordered_map<Detail::TaskHandle, Task> tasks_;
+    std::unordered_map<std::size_t, std::vector<std::uint8_t>> stored_;
+    std::vector<std::vector<std::size_t>> store_batches_;
+    std::vector<std::size_t> load_submissions_;
+    std::vector<std::size_t> checked_load_groups_;
+    std::vector<Call> calls_;
+    std::vector<BufferPool::Slot> dump_slots_;
+    bool block_first_store_{false};
+    bool block_first_load_{false};
+    bool blocked_load_assigned_{false};
+    bool store_wait_seen_{false};
+    bool release_store_{false};
+    bool release_load_{false};
+};
+
+class TransferEndpointRef final : public TransferEndpoint {
+public:
+    explicit TransferEndpointRef(TransferEndpoint& endpoint) : endpoint_{endpoint} {}
+
+    Status SetupTransferRegion(const TransferRegion& region) override
+    {
+        return endpoint_.SetupTransferRegion(region);
+    }
+
+    void ResetTransferRegion() noexcept override { endpoint_.ResetTransferRegion(); }
+
+    Expected<Detail::TaskHandle> SubmitLoad(
+        const std::vector<TransferBuffer>& buffers) override
+    {
+        return endpoint_.SubmitLoad(buffers);
+    }
+
+    Expected<Detail::TaskHandle> SubmitDump(
+        const std::vector<TransferBuffer>& buffers) override
+    {
+        return endpoint_.SubmitDump(buffers);
+    }
+
+    Expected<bool> Check(Detail::TaskHandle task) override
+    {
+        return endpoint_.Check(task);
+    }
+
+    Status Wait(Detail::TaskHandle task) override { return endpoint_.Wait(task); }
+
+private:
+    TransferEndpoint& endpoint_;
+};
+
+Expected<std::unique_ptr<Executor>> CreateTestExecutor(
+    FakeTransferEndpoint& endpoint, std::vector<std::size_t> tensor_sizes,
+    std::int32_t device_id, std::size_t slot_num,
+    std::size_t stream_number = Executor::kDefaultStreamNumber)
+{
+    return Executor::Create(std::make_unique<TransferEndpointRef>(endpoint),
+                            std::move(tensor_sizes), device_id, slot_num,
+                            stream_number);
+}
+
+struct DeviceShard {
+    std::shared_ptr<void> first;
+    std::shared_ptr<void> second;
+    Detail::Shard desc;
+};
+
+DeviceShard MakeShard(std::size_t index, std::uint8_t first_value = 0)
+{
+    DeviceShard shard;
+    shard.first = ExecutorTest::MakeDeviceBuffer(3);
+    shard.second = ExecutorTest::MakeDeviceBuffer(5);
+    std::array<std::uint8_t, 3> first{first_value, static_cast<std::uint8_t>(first_value + 1),
+                                      static_cast<std::uint8_t>(first_value + 2)};
+    std::array<std::uint8_t, 5> second{
+        static_cast<std::uint8_t>(first_value + 3), static_cast<std::uint8_t>(first_value + 4),
+        static_cast<std::uint8_t>(first_value + 5), static_cast<std::uint8_t>(first_value + 6),
+        static_cast<std::uint8_t>(first_value + 7)};
+    (void)aclrtMemcpy(shard.first.get(), first.size(), first.data(), first.size(),
+                      ACL_MEMCPY_HOST_TO_DEVICE);
+    (void)aclrtMemcpy(shard.second.get(), second.size(), second.data(), second.size(),
+                      ACL_MEMCPY_HOST_TO_DEVICE);
+    shard.desc = Detail::Shard{
+        {                  },
+        index, { shard.first.get(), shard.second.get()}
+    };
+    return shard;
+}
+
+DeviceShard MakeEmptyShard(std::size_t index)
+{
+    auto shard = MakeShard(index);
+    (void)aclrtMemset(shard.first.get(), 3, 0, 3);
+    (void)aclrtMemset(shard.second.get(), 5, 0, 5);
+    return shard;
+}
+
+Detail::TaskDesc MakeTask(std::vector<DeviceShard>& shards)
+{
+    Detail::TaskDesc task;
+    for (auto& shard : shards) { task.push_back(shard.desc); }
+    return task;
+}
+
+std::array<std::uint8_t, 8> ReadShard(const DeviceShard& shard)
+{
+    std::array<std::uint8_t, 8> result{};
+    (void)aclrtMemcpy(result.data(), 3, shard.first.get(), 3, ACL_MEMCPY_DEVICE_TO_HOST);
+    (void)aclrtMemcpy(result.data() + 3, 5, shard.second.get(), 5, ACL_MEMCPY_DEVICE_TO_HOST);
+    return result;
+}
+
+bool WaitForShardData(const DeviceShard& shard, const std::array<std::uint8_t, 8>& expected)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (ReadShard(shard) == expected) { return true; }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+TEST_F(ExecutorTest, DumpBatchUsesAvailableSlotsAndOneStoreBatch)
+{
+    FakeTransferEndpoint store(8);
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 3, 2);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+    std::vector<DeviceShard> shards;
+    for (std::size_t index = 0; index < 5; ++index) {
+        shards.push_back(MakeShard(index, static_cast<std::uint8_t>(index * 10 + 1)));
+    }
+
+    auto task = executor->Submit(MakeTask(shards), Operation::DUMP);
+    ASSERT_TRUE(task);
+    ASSERT_TRUE(executor->Wait(task.Value()).Success());
+    EXPECT_EQ(store.StoreBatches(), (std::vector<std::vector<std::size_t>>{
+                                          {0, 1, 2},
+                                          {3, 4 }
+    }));
+
+    const auto slots = store.DumpSlots();
+    ASSERT_EQ(slots.size(), std::size_t{5});
+    std::vector<std::size_t> firstBatchOffsets;
+    for (std::size_t index = 0; index < 3; ++index) {
+        EXPECT_EQ(slots[index].length, std::size_t{8});
+        EXPECT_EQ(slots[index].offset % (16 * 1024), std::size_t{0});
+        firstBatchOffsets.push_back(slots[index].offset);
+    }
+    std::sort(firstBatchOffsets.begin(), firstBatchOffsets.end());
+    EXPECT_EQ(firstBatchOffsets, (std::vector<std::size_t>{0, 16 * 1024, 32 * 1024}));
+}
+
+TEST_F(ExecutorTest, LoadScattersCompletedGroupsWhileFirstIsPending)
+{
+    FakeTransferEndpoint store(8);
+    store.BlockFirstLoad();
+    store.BlockFirstStore();
+    store.SetData(0, {1, 2, 3, 4, 5, 6, 7, 8});
+    store.SetData(1, {11, 12, 13, 14, 15, 16, 17, 18});
+    store.SetData(2, {21, 22, 23, 24, 25, 26, 27, 28});
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 3, 2);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    std::vector<DeviceShard> blockerShards{MakeShard(100), MakeShard(101), MakeShard(102)};
+    auto blocker = executor->Submit(MakeTask(blockerShards), Operation::DUMP);
+    ASSERT_TRUE(blocker);
+    const auto storeWaitSeen = store.WaitForStoreWait();
+    if (!storeWaitSeen) { store.ReleaseStore(); }
+    ASSERT_TRUE(storeWaitSeen);
+
+    std::vector<DeviceShard> firstShard{MakeEmptyShard(0)};
+    std::vector<DeviceShard> secondShard{MakeEmptyShard(1)};
+    std::vector<DeviceShard> thirdShard{MakeEmptyShard(2)};
+    auto first = executor->Submit(MakeTask(firstShard), Operation::LOAD);
+    auto second = executor->Submit(MakeTask(secondShard), Operation::LOAD);
+    auto third = executor->Submit(MakeTask(thirdShard), Operation::LOAD);
+    store.ReleaseStore();
+    ASSERT_TRUE(first);
+    ASSERT_TRUE(second);
+    ASSERT_TRUE(third);
+
+    ASSERT_TRUE(executor->Wait(blocker.Value()).Success());
+    const auto firstChecked = store.WaitForLoadGroupCheck(0);
+    const auto thirdChecked = store.WaitForLoadGroupCheck(2);
+    if (!firstChecked || !thirdChecked) { store.ReleaseLoad(); }
+    ASSERT_TRUE(firstChecked);
+    ASSERT_TRUE(thirdChecked);
+    EXPECT_EQ(store.LoadSubmissions(), (std::vector<std::size_t>{0, 1, 2}));
+    const std::array<std::uint8_t, 8> thirdData{21, 22, 23, 24, 25, 26, 27, 28};
+    EXPECT_TRUE(WaitForShardData(thirdShard[0], thirdData));
+    EXPECT_EQ(ReadShard(firstShard[0]), (std::array<std::uint8_t, 8>{}));
+    store.ReleaseLoad();
+    ASSERT_TRUE(executor->Wait(first.Value()).Success());
+    ASSERT_TRUE(executor->Wait(second.Value()).Success());
+    ASSERT_TRUE(executor->Wait(third.Value()).Success());
+    EXPECT_EQ(ReadShard(thirdShard[0]), thirdData);
+}
+
+TEST_F(ExecutorTest, LoadSubmitFailureDoesNotScatterGroup)
+{
+    FakeTransferEndpoint store(8);
+    store.SetData(0, {1, 2, 3, 4, 5, 6, 7, 8});
+    store.SetData(1, {11, 12, 13, 14, 15, 16, 17, 18});
+    store.SetData(2, {21, 22, 23, 24, 25, 26, 27, 28});
+    store.fail_load_index_ = 1;
+    std::vector<DeviceShard> shards{MakeEmptyShard(0), MakeEmptyShard(1), MakeEmptyShard(2)};
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 3, 2);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    auto task = executor->Submit(MakeTask(shards), Operation::LOAD);
+    ASSERT_TRUE(task);
+    EXPECT_TRUE(executor->Wait(task.Value()).Failure());
+    EXPECT_EQ(store.LoadSubmissions(), (std::vector<std::size_t>{0, 1, 2}));
+    const auto calls = store.Calls();
+    ASSERT_EQ(calls.size(), std::size_t{1});
+    EXPECT_EQ(calls[0].shards, (std::vector<std::size_t>{0, 1, 2}));
+    EXPECT_EQ(ReadShard(shards[0]), (std::array<std::uint8_t, 8>{}));
+    EXPECT_EQ(ReadShard(shards[1]), (std::array<std::uint8_t, 8>{}));
+    EXPECT_EQ(ReadShard(shards[2]), (std::array<std::uint8_t, 8>{}));
+}
+
+TEST_F(ExecutorTest, LoadCheckFailureDoesNotScatterGroup)
+{
+    FakeTransferEndpoint store(8);
+    store.fail_load_check_index_ = 0;
+    std::vector<DeviceShard> shards;
+    for (std::size_t index = 0; index < 3; ++index) {
+        shards.push_back(MakeEmptyShard(index));
+        store.SetData(
+            index,
+            {static_cast<std::uint8_t>(index * 10 + 1), static_cast<std::uint8_t>(index * 10 + 2),
+             static_cast<std::uint8_t>(index * 10 + 3), static_cast<std::uint8_t>(index * 10 + 4),
+             static_cast<std::uint8_t>(index * 10 + 5), static_cast<std::uint8_t>(index * 10 + 6),
+             static_cast<std::uint8_t>(index * 10 + 7), static_cast<std::uint8_t>(index * 10 + 8)});
+    }
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 3, 2);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    auto task = executor->Submit(MakeTask(shards), Operation::LOAD);
+    ASSERT_TRUE(task);
+    EXPECT_TRUE(executor->Wait(task.Value()).Failure());
+    EXPECT_EQ(store.CheckedLoadGroups(), (std::vector<std::size_t>{0}));
+    EXPECT_EQ(ReadShard(shards[0]), (std::array<std::uint8_t, 8>{}));
+    EXPECT_EQ(ReadShard(shards[1]), (std::array<std::uint8_t, 8>{}));
+    EXPECT_EQ(ReadShard(shards[2]), (std::array<std::uint8_t, 8>{}));
+}
+
+TEST_F(ExecutorTest, LoadSubmitFailureDoesNotCancelNextTransferGroup)
+{
+    FakeTransferEndpoint store(8);
+    store.BlockFirstStore();
+    store.fail_load_index_ = 0;
+    store.SetData(2, {21, 22, 23, 24, 25, 26, 27, 28});
+
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 3, 2);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    std::vector<DeviceShard> blockerShards{MakeShard(100), MakeShard(101), MakeShard(102)};
+    auto blocker = executor->Submit(MakeTask(blockerShards), Operation::DUMP);
+    ASSERT_TRUE(blocker);
+    const auto storeWaitSeen = store.WaitForStoreWait();
+    if (!storeWaitSeen) { store.ReleaseStore(); }
+    ASSERT_TRUE(storeWaitSeen);
+
+    std::vector<DeviceShard> failedShards{MakeEmptyShard(0), MakeEmptyShard(1)};
+    std::vector<DeviceShard> successfulShards{MakeEmptyShard(2)};
+    auto failed = executor->Submit(MakeTask(failedShards), Operation::LOAD);
+    auto successful = executor->Submit(MakeTask(successfulShards), Operation::LOAD);
+    ASSERT_TRUE(failed);
+    ASSERT_TRUE(successful);
+
+    store.ReleaseStore();
+    EXPECT_TRUE(executor->Wait(blocker.Value()).Success());
+    EXPECT_TRUE(executor->Wait(failed.Value()).Failure());
+    EXPECT_TRUE(executor->Wait(successful.Value()).Success());
+    EXPECT_EQ(store.LoadSubmissions(), (std::vector<std::size_t>{0, 1, 2}));
+    EXPECT_EQ(ReadShard(successfulShards[0]),
+              (std::array<std::uint8_t, 8>{21, 22, 23, 24, 25, 26, 27, 28}));
+}
+
+TEST_F(ExecutorTest, LoadCheckFailureDoesNotFailNextTransferGroup)
+{
+    FakeTransferEndpoint store(8);
+    store.BlockFirstStore();
+    store.fail_load_check_index_ = 0;
+    store.SetData(0, {1, 2, 3, 4, 5, 6, 7, 8});
+    store.SetData(1, {11, 12, 13, 14, 15, 16, 17, 18});
+
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 2, 2);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    std::vector<DeviceShard> blockerShards{MakeShard(100), MakeShard(101)};
+    auto blocker = executor->Submit(MakeTask(blockerShards), Operation::DUMP);
+    ASSERT_TRUE(blocker);
+    const auto storeWaitSeen = store.WaitForStoreWait();
+    if (!storeWaitSeen) { store.ReleaseStore(); }
+    ASSERT_TRUE(storeWaitSeen);
+
+    std::vector<DeviceShard> failedShards{MakeEmptyShard(0)};
+    std::vector<DeviceShard> successfulShards{MakeEmptyShard(1)};
+    auto failed = executor->Submit(MakeTask(failedShards), Operation::LOAD);
+    auto successful = executor->Submit(MakeTask(successfulShards), Operation::LOAD);
+    ASSERT_TRUE(failed);
+    ASSERT_TRUE(successful);
+
+    store.ReleaseStore();
+    EXPECT_TRUE(executor->Wait(blocker.Value()).Success());
+    EXPECT_TRUE(executor->Wait(failed.Value()).Failure());
+    EXPECT_TRUE(executor->Wait(successful.Value()).Success());
+    EXPECT_EQ(store.LoadSubmissions(), (std::vector<std::size_t>{0, 1}));
+    EXPECT_EQ(ReadShard(successfulShards[0]),
+              (std::array<std::uint8_t, 8>{11, 12, 13, 14, 15, 16, 17, 18}));
+}
+
+TEST_F(ExecutorTest, FailureStopsLaterDumpBatchesAndReleasesSlots)
+{
+    FakeTransferEndpoint store(8);
+    store.fail_first_store_ = true;
+    std::vector<DeviceShard> shards{MakeShard(0), MakeShard(1), MakeShard(2), MakeShard(3)};
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 2, 2);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    auto task = executor->Submit(MakeTask(shards), Operation::DUMP);
+    ASSERT_TRUE(task);
+    EXPECT_TRUE(executor->Wait(task.Value()).Failure());
+    EXPECT_EQ(store.StoreBatches(), (std::vector<std::vector<std::size_t>>{
+                                          {0, 1}
+    }));
+
+    store.fail_first_store_ = false;
+    std::vector<DeviceShard> recoveryShards{MakeShard(4), MakeShard(5)};
+    auto recovery = executor->Submit(MakeTask(recoveryShards), Operation::DUMP);
+    ASSERT_TRUE(recovery);
+    EXPECT_TRUE(executor->Wait(recovery.Value()).Success());
+    EXPECT_EQ(store.StoreBatches(), (std::vector<std::vector<std::size_t>>{
+                                          {0, 1},
+                                          {4, 5}
+    }));
+}
+
+TEST_F(ExecutorTest, DumpTransferGroupsSubmitSeparatelyAndIsolateStoreFailures)
+{
+    FakeTransferEndpoint store(8);
+    store.BlockFirstLoad();
+    store.BlockFirstStore();
+    store.fail_dump_submit_index_ = 0;
+    store.fail_dump_wait_index_ = 1;
+    store.SetData(100, {1, 2, 3, 4, 5, 6, 7, 8});
+    store.SetData(101, {11, 12, 13, 14, 15, 16, 17, 18});
+    store.SetData(102, {21, 22, 23, 24, 25, 26, 27, 28});
+
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 3, 2);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    std::vector<DeviceShard> blockerShards{
+        MakeEmptyShard(100), MakeEmptyShard(101), MakeEmptyShard(102)};
+    auto blocker = executor->Submit(MakeTask(blockerShards), Operation::LOAD);
+    ASSERT_TRUE(blocker);
+    const auto loadCheckSeen = store.WaitForLoadGroupCheck(100);
+    if (!loadCheckSeen) { store.ReleaseLoad(); }
+    ASSERT_TRUE(loadCheckSeen);
+
+    std::vector<DeviceShard> submitFailedShards{MakeShard(0)};
+    std::vector<DeviceShard> waitFailedShards{MakeShard(1)};
+    std::vector<DeviceShard> successfulShards{MakeShard(2)};
+    auto submitFailed = executor->Submit(MakeTask(submitFailedShards), Operation::DUMP);
+    auto waitFailed = executor->Submit(MakeTask(waitFailedShards), Operation::DUMP);
+    auto successful = executor->Submit(MakeTask(successfulShards), Operation::DUMP);
+    ASSERT_TRUE(submitFailed);
+    ASSERT_TRUE(waitFailed);
+    ASSERT_TRUE(successful);
+
+    store.ReleaseLoad();
+    EXPECT_TRUE(executor->Wait(blocker.Value()).Success());
+    const auto storeWaitSeen = store.WaitForStoreWait();
+    if (!storeWaitSeen) { store.ReleaseStore(); }
+    ASSERT_TRUE(storeWaitSeen);
+    EXPECT_EQ(store.StoreBatches(), (std::vector<std::vector<std::size_t>>{
+                                          {0},
+                                          {1},
+                                          {2}
+    }));
+    store.ReleaseStore();
+
+    EXPECT_TRUE(executor->Wait(submitFailed.Value()).Failure());
+    EXPECT_TRUE(executor->Wait(waitFailed.Value()).Failure());
+    EXPECT_TRUE(executor->Wait(successful.Value()).Success());
+}
+
+TEST_F(ExecutorTest, LoadRunsBeforeNextDumpBatch)
+{
+    FakeTransferEndpoint store(8);
+    store.BlockFirstStore();
+    store.SetData(4, {41, 42, 43, 44, 45, 46, 47, 48});
+    std::vector<DeviceShard> dumpShards{MakeShard(0), MakeShard(1), MakeShard(2), MakeShard(3)};
+    std::vector<DeviceShard> loadShards{MakeEmptyShard(4)};
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 2, 2);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    auto dump = executor->Submit(MakeTask(dumpShards), Operation::DUMP);
+    ASSERT_TRUE(dump);
+    ASSERT_TRUE(store.WaitForStoreWait());
+    auto load = executor->Submit(MakeTask(loadShards), Operation::LOAD);
+    ASSERT_TRUE(load);
+    store.ReleaseStore();
+    ASSERT_TRUE(executor->Wait(load.Value()).Success());
+    ASSERT_TRUE(executor->Wait(dump.Value()).Success());
+
+    const auto calls = store.Calls();
+    ASSERT_EQ(calls.size(), std::size_t{3});
+    EXPECT_EQ(calls[0].operation, Operation::DUMP);
+    EXPECT_EQ(calls[1].operation, Operation::LOAD);
+    EXPECT_EQ(calls[2].operation, Operation::DUMP);
+}
+
+TEST_F(ExecutorTest, DumpWaitDoesNotBlockLoadWorker)
+{
+    FakeTransferEndpoint store(8);
+    store.BlockFirstStore();
+    store.SetData(1, {11, 12, 13, 14, 15, 16, 17, 18});
+    std::vector<DeviceShard> dumpShards{MakeShard(0)};
+    std::vector<DeviceShard> loadShards{MakeEmptyShard(1)};
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 2, 2);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    auto dump = executor->Submit(MakeTask(dumpShards), Operation::DUMP);
+    ASSERT_TRUE(dump);
+    const auto storeWaitSeen = store.WaitForStoreWait();
+    if (!storeWaitSeen) { store.ReleaseStore(); }
+    ASSERT_TRUE(storeWaitSeen);
+
+    auto load = executor->Submit(MakeTask(loadShards), Operation::LOAD);
+    bool loadCompleted = false;
+    if (load) {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+        while (std::chrono::steady_clock::now() < deadline) {
+            auto checked = executor->Check(load.Value());
+            if (checked && checked.Value()) {
+                loadCompleted = true;
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+    }
+
+    store.ReleaseStore();
+    ASSERT_TRUE(load);
+    EXPECT_TRUE(loadCompleted);
+    EXPECT_TRUE(executor->Wait(load.Value()).Success());
+    EXPECT_TRUE(executor->Wait(dump.Value()).Success());
+    EXPECT_EQ(ReadShard(loadShards[0]),
+              (std::array<std::uint8_t, 8>{11, 12, 13, 14, 15, 16, 17, 18}));
+}
+
+TEST_F(ExecutorTest, TaskLargerThanSlotCountCompletesAcrossBatches)
+{
+    FakeTransferEndpoint store(8);
+    std::vector<DeviceShard> shards{MakeShard(0), MakeShard(1)};
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 1, 1);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    auto task = executor->Submit(MakeTask(shards), Operation::DUMP);
+    ASSERT_TRUE(task);
+    EXPECT_TRUE(executor->Wait(task.Value()).Success());
+    EXPECT_EQ(store.StoreBatches(),
+              (std::vector<std::vector<std::size_t>>{{0}, {1}}));
+}
+
+TEST_F(ExecutorTest, AcceptsTasksWhileAllSlotsAreBusy)
+{
+    constexpr std::size_t taskCount = 32;
+    FakeTransferEndpoint store(8);
+    store.BlockFirstStore();
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 1, 1);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    std::vector<std::vector<DeviceShard>> taskShards;
+    std::vector<Detail::TaskHandle> handles;
+    taskShards.reserve(taskCount);
+    handles.reserve(taskCount);
+
+    taskShards.push_back({MakeShard(0)});
+    auto first = executor->Submit(MakeTask(taskShards.back()), Operation::DUMP);
+    ASSERT_TRUE(first);
+    handles.push_back(first.Value());
+    const auto storeWaitSeen = store.WaitForStoreWait();
+    if (!storeWaitSeen) { store.ReleaseStore(); }
+    ASSERT_TRUE(storeWaitSeen);
+
+    bool allSubmitted = true;
+    for (std::size_t index = 1; index < taskCount; ++index) {
+        taskShards.push_back({MakeShard(index)});
+        auto submitted = executor->Submit(MakeTask(taskShards.back()), Operation::DUMP);
+        if (!submitted) {
+            allSubmitted = false;
+            break;
+        }
+        handles.push_back(submitted.Value());
+    }
+    store.ReleaseStore();
+
+    ASSERT_TRUE(allSubmitted);
+    ASSERT_EQ(handles.size(), taskCount);
+    for (const auto handle : handles) {
+        EXPECT_TRUE(executor->Wait(handle).Success());
+    }
+}
+
+TEST_F(ExecutorTest, ShutdownDrainsCurrentBatchAndCancelsLaterBatches)
+{
+    FakeTransferEndpoint store(8);
+    store.BlockFirstStore();
+    std::vector<DeviceShard> shards{MakeShard(0), MakeShard(1), MakeShard(2)};
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 1, 1);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    auto task = executor->Submit(MakeTask(shards), Operation::DUMP);
+    ASSERT_TRUE(task);
+    ASSERT_TRUE(store.WaitForStoreWait());
+    std::thread shutdown([&executor]() { executor->Shutdown(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    store.ReleaseStore();
+    shutdown.join();
+
+    EXPECT_TRUE(executor->Wait(task.Value()).Failure());
+    EXPECT_EQ(store.StoreBatches(), (std::vector<std::vector<std::size_t>>{{0}}));
+}
+
+TEST_F(ExecutorTest, CreateRejectsInvalidConfiguration)
+{
+    FakeTransferEndpoint store(8);
+
+    auto noSlots = CreateTestExecutor(store, {3, 5}, 0, 0);
+    ASSERT_FALSE(noSlots);
+    EXPECT_EQ(noSlots.Error(), Status::InvalidParam());
+
+    auto noStreams = CreateTestExecutor(store, {3, 5}, 0, 1, 0);
+    ASSERT_FALSE(noStreams);
+    EXPECT_EQ(noStreams.Error(), Status::InvalidParam());
+
+    auto emptyTensors = CreateTestExecutor(store, {}, 0, 1);
+    ASSERT_FALSE(emptyTensors);
+    EXPECT_EQ(emptyTensors.Error(), Status::InvalidParam());
+
+    auto zeroTensor = CreateTestExecutor(store, {3, 0}, 0, 1);
+    ASSERT_FALSE(zeroTensor);
+    EXPECT_EQ(zeroTensor.Error(), Status::InvalidParam());
+
+    auto overflowingTensors =
+        CreateTestExecutor(store, {std::numeric_limits<std::size_t>::max(), 1}, 0, 1);
+    ASSERT_FALSE(overflowingTensors);
+    EXPECT_EQ(overflowingTensors.Error(), Status::InvalidParam());
+}
+
+}  // namespace
+}  // namespace UC::Delegator

--- a/ucm/store/test/case/delegator/delegator_executor_test.cc
+++ b/ucm/store/test/case/delegator/delegator_executor_test.cc
@@ -25,6 +25,7 @@
 #include <acl/acl.h>
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
@@ -67,39 +68,54 @@ public:
     }
 };
 
-class FakeTransferEndpoint final : public TransferEndpoint {
+class FakeStore final : public StoreV1 {
 public:
     struct Call {
         Operation operation;
         std::vector<std::size_t> shards;
     };
 
-    explicit FakeTransferEndpoint(std::size_t payload_size) : payload_size_{payload_size} {}
+    explicit FakeStore(std::size_t payload_size) : payload_size_{payload_size} {}
 
-    Status SetupTransferRegion(const TransferRegion& region) override
+    Status Setup(const Detail::Dictionary&) override { return Status::OK(); }
+
+    std::string Readme() const override { return "FakeStore"; }
+
+    Expected<std::vector<uint8_t>> Lookup(const Detail::BlockId*, size_t num) override
     {
-        if (region.device_addr == nullptr || region.size == 0) {
+        return std::vector<uint8_t>(num, false);
+    }
+
+    Expected<ssize_t> LookupOnPrefix(const Detail::BlockId*, size_t) override { return -1; }
+
+    void Prefetch(const Detail::BlockId*, size_t) override {}
+
+    bool NeedRegisterKVCaches() const override { return true; }
+
+    Status RegisterKVCaches(const KVCacheRegistration* registrations, std::size_t count) override
+    {
+        if (registrations == nullptr || count != 1 || registrations[0].addr == 0 ||
+            registrations[0].size == 0) {
             return Status::InvalidParam();
         }
+        registration_base_ = registrations[0].addr;
+        registration_size_ = registrations[0].size;
         return Status::OK();
     }
 
-    void ResetTransferRegion() noexcept override {}
-
-    Expected<Detail::TaskHandle> SubmitLoad(
-        const std::vector<TransferBuffer>& buffers) override
+    Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override
     {
-        if (buffers.empty()) { return Status::InvalidParam(); }
+        if (task.empty()) { return Status::InvalidParam(); }
 
         std::vector<std::size_t> batch;
         std::vector<std::vector<std::uint8_t>> data;
-        batch.reserve(buffers.size());
-        data.reserve(buffers.size());
+        batch.reserve(task.size());
+        data.reserve(task.size());
         {
             std::lock_guard<std::mutex> lock(mutex_);
-            for (const auto& buffer : buffers) {
-                batch.push_back(buffer.index);
-                load_submissions_.push_back(buffer.index);
+            for (const auto& shard : task) {
+                batch.push_back(shard.index);
+                load_submissions_.push_back(shard.index);
             }
             calls_.push_back(Call{Operation::LOAD, batch});
             if (std::find(batch.begin(), batch.end(), fail_load_index_) != batch.end()) {
@@ -108,49 +124,69 @@ public:
             for (const auto index : batch) { data.push_back(stored_[index]); }
         }
 
-        for (std::size_t index = 0; index < buffers.size(); ++index) {
+        for (std::size_t index = 0; index < task.size(); ++index) {
             if (data[index].size() != payload_size_) {
                 return Status::InvalidParam("missing fake load data");
             }
-            const auto ret = aclrtMemcpy(buffers[index].slot.device_addr, payload_size_,
-                                         data[index].data(),
-                                         data[index].size(), ACL_MEMCPY_HOST_TO_DEVICE);
+            if (task[index].addrs.empty()) { return Status::InvalidParam(); }
+            const auto ret =
+                aclrtMemcpy(task[index].addrs.front(), payload_size_, data[index].data(),
+                            data[index].size(), ACL_MEMCPY_HOST_TO_DEVICE);
             if (ret != ACL_SUCCESS) { return Status::Error("fake load copy failed"); }
         }
-        return NewTask(false, Status::OK(), buffers.front().index);
+        const auto groupIndex = task.front().index;
+        const auto waitStatus = groupIndex == fail_load_wait_index_
+                                    ? Status::Error("injected load wait failure")
+                                    : Status::OK();
+        return NewTask(false, waitStatus, groupIndex);
     }
 
-    Expected<Detail::TaskHandle> SubmitDump(
-        const std::vector<TransferBuffer>& buffers) override
+    Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override
     {
-        if (buffers.empty()) { return Status::InvalidParam(); }
+        if (task.empty()) { return Status::InvalidParam(); }
 
         std::vector<std::size_t> batch;
-        batch.reserve(buffers.size());
-        for (const auto& buffer : buffers) {
+        batch.reserve(task.size());
+        for (const auto& shard : task) {
+            if (shard.addrs.empty()) { return Status::InvalidParam(); }
             std::vector<std::uint8_t> data(payload_size_);
-            const auto ret = aclrtMemcpy(data.data(), data.size(), buffer.slot.device_addr,
-                                         data.size(), ACL_MEMCPY_DEVICE_TO_HOST);
+            const auto ret = aclrtMemcpy(data.data(), data.size(), shard.addrs.front(), data.size(),
+                                         ACL_MEMCPY_DEVICE_TO_HOST);
             if (ret != ACL_SUCCESS) { return Status::Error("fake store copy failed"); }
-            batch.push_back(buffer.index);
+            batch.push_back(shard.index);
 
             std::lock_guard<std::mutex> lock(mutex_);
-            stored_[buffer.index] = std::move(data);
-            dump_slots_.push_back(buffer.slot);
+            stored_[shard.index] = std::move(data);
+            const auto address = reinterpret_cast<std::uintptr_t>(shard.addrs.front());
+            if (address < registration_base_ ||
+                address - registration_base_ > registration_size_ - payload_size_) {
+                return Status::InvalidParam("fake store address is outside registered region");
+            }
+            BufferPool::Slot slot;
+            slot.local_addr = shard.addrs.front();
+            slot.device_addr = shard.addrs.front();
+            slot.length = payload_size_;
+            slot.offset = address - registration_base_;
+            dump_slots_.push_back(slot);
+            std::vector<std::uintptr_t> addresses;
+            addresses.reserve(shard.addrs.size());
+            for (const auto* addr : shard.addrs) {
+                addresses.push_back(reinterpret_cast<std::uintptr_t>(addr));
+            }
+            dump_addresses_.push_back(std::move(addresses));
         }
         {
             std::lock_guard<std::mutex> lock(mutex_);
             calls_.push_back(Call{Operation::DUMP, batch});
             store_batches_.push_back(std::move(batch));
         }
-        const auto groupIndex = buffers.front().index;
+        const auto groupIndex = task.front().index;
         if (groupIndex == fail_dump_submit_index_) {
             return Status::Error("injected dump submission failure");
         }
-        const auto waitStatus =
-            fail_first_store_ || groupIndex == fail_dump_wait_index_
-                ? Status::Error("injected store failure")
-                : Status::OK();
+        const auto waitStatus = fail_first_store_ || groupIndex == fail_dump_wait_index_
+                                    ? Status::Error("injected store failure")
+                                    : Status::OK();
         return NewTask(true, waitStatus, groupIndex);
     }
 
@@ -183,7 +219,6 @@ public:
         if (entry.group_index == fail_load_check_index_) {
             return Status::Error("injected load check failure");
         }
-        if (entry.status.Failure()) { return entry.status; }
         return true;
     }
 
@@ -260,8 +295,15 @@ public:
         return dump_slots_;
     }
 
+    std::vector<std::vector<std::uintptr_t>> DumpAddresses()
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return dump_addresses_;
+    }
+
     std::size_t fail_load_index_{std::numeric_limits<std::size_t>::max()};
     std::size_t fail_load_check_index_{std::numeric_limits<std::size_t>::max()};
+    std::size_t fail_load_wait_index_{std::numeric_limits<std::size_t>::max()};
     std::size_t fail_dump_submit_index_{std::numeric_limits<std::size_t>::max()};
     std::size_t fail_dump_wait_index_{std::numeric_limits<std::size_t>::max()};
     bool fail_first_store_{false};
@@ -293,6 +335,8 @@ private:
     }
 
     std::size_t payload_size_;
+    std::uintptr_t registration_base_{0};
+    std::size_t registration_size_{0};
     std::mutex mutex_;
     std::condition_variable wait_entered_;
     std::condition_variable wait_released_;
@@ -304,6 +348,7 @@ private:
     std::vector<std::size_t> checked_load_groups_;
     std::vector<Call> calls_;
     std::vector<BufferPool::Slot> dump_slots_;
+    std::vector<std::vector<std::uintptr_t>> dump_addresses_;
     bool block_first_store_{false};
     bool block_first_load_{false};
     bool blocked_load_assigned_{false};
@@ -312,47 +357,12 @@ private:
     bool release_load_{false};
 };
 
-class TransferEndpointRef final : public TransferEndpoint {
-public:
-    explicit TransferEndpointRef(TransferEndpoint& endpoint) : endpoint_{endpoint} {}
-
-    Status SetupTransferRegion(const TransferRegion& region) override
-    {
-        return endpoint_.SetupTransferRegion(region);
-    }
-
-    void ResetTransferRegion() noexcept override { endpoint_.ResetTransferRegion(); }
-
-    Expected<Detail::TaskHandle> SubmitLoad(
-        const std::vector<TransferBuffer>& buffers) override
-    {
-        return endpoint_.SubmitLoad(buffers);
-    }
-
-    Expected<Detail::TaskHandle> SubmitDump(
-        const std::vector<TransferBuffer>& buffers) override
-    {
-        return endpoint_.SubmitDump(buffers);
-    }
-
-    Expected<bool> Check(Detail::TaskHandle task) override
-    {
-        return endpoint_.Check(task);
-    }
-
-    Status Wait(Detail::TaskHandle task) override { return endpoint_.Wait(task); }
-
-private:
-    TransferEndpoint& endpoint_;
-};
-
 Expected<std::unique_ptr<Executor>> CreateTestExecutor(
-    FakeTransferEndpoint& endpoint, std::vector<std::size_t> tensor_sizes,
-    std::int32_t device_id, std::size_t slot_num,
-    std::size_t stream_number = Executor::kDefaultStreamNumber)
+    FakeStore& store, std::vector<std::size_t> tensor_sizes, std::int32_t device_id,
+    std::size_t slot_num, std::size_t stream_number = Executor::kDefaultStreamNumber)
 {
-    return Executor::Create(std::make_unique<TransferEndpointRef>(endpoint),
-                            std::move(tensor_sizes), device_id, slot_num,
+    auto backend = std::shared_ptr<StoreV1>(&store, [](StoreV1*) {});
+    return Executor::Create(std::move(backend), std::move(tensor_sizes), device_id, slot_num,
                             stream_number);
 }
 
@@ -378,8 +388,8 @@ DeviceShard MakeShard(std::size_t index, std::uint8_t first_value = 0)
     (void)aclrtMemcpy(shard.second.get(), second.size(), second.data(), second.size(),
                       ACL_MEMCPY_HOST_TO_DEVICE);
     shard.desc = Detail::Shard{
-        {                  },
-        index, { shard.first.get(), shard.second.get()}
+        {},
+        index, {shard.first.get(), shard.second.get()}
     };
     return shard;
 }
@@ -417,9 +427,32 @@ bool WaitForShardData(const DeviceShard& shard, const std::array<std::uint8_t, 8
     return false;
 }
 
+bool WaitForTaskNotFound(Executor& executor, Detail::TaskHandle task)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < deadline) {
+        auto checked = executor.Check(task);
+        if (!checked && checked.Error() == Status::NotFound()) { return true; }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+bool WaitForTaskCompletion(Executor& executor, Detail::TaskHandle task)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < deadline) {
+        auto checked = executor.Check(task);
+        if (checked && checked.Value()) { return true; }
+        if (!checked) { return false; }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
 TEST_F(ExecutorTest, DumpBatchUsesAvailableSlotsAndOneStoreBatch)
 {
-    FakeTransferEndpoint store(8);
+    FakeStore store(8);
     auto created = CreateTestExecutor(store, {3, 5}, 0, 3, 2);
     ASSERT_TRUE(created);
     auto executor = std::move(created).Value();
@@ -432,8 +465,8 @@ TEST_F(ExecutorTest, DumpBatchUsesAvailableSlotsAndOneStoreBatch)
     ASSERT_TRUE(task);
     ASSERT_TRUE(executor->Wait(task.Value()).Success());
     EXPECT_EQ(store.StoreBatches(), (std::vector<std::vector<std::size_t>>{
-                                          {0, 1, 2},
-                                          {3, 4 }
+                                        {0, 1, 2},
+                                        {3, 4}
     }));
 
     const auto slots = store.DumpSlots();
@@ -446,11 +479,18 @@ TEST_F(ExecutorTest, DumpBatchUsesAvailableSlotsAndOneStoreBatch)
     }
     std::sort(firstBatchOffsets.begin(), firstBatchOffsets.end());
     EXPECT_EQ(firstBatchOffsets, (std::vector<std::size_t>{0, 16 * 1024, 32 * 1024}));
+
+    const auto addresses = store.DumpAddresses();
+    ASSERT_EQ(addresses.size(), std::size_t{5});
+    for (const auto& shardAddresses : addresses) {
+        ASSERT_EQ(shardAddresses.size(), std::size_t{2});
+        EXPECT_EQ(shardAddresses[1] - shardAddresses[0], std::size_t{3});
+    }
 }
 
 TEST_F(ExecutorTest, LoadScattersCompletedGroupsWhileFirstIsPending)
 {
-    FakeTransferEndpoint store(8);
+    FakeStore store(8);
     store.BlockFirstLoad();
     store.BlockFirstStore();
     store.SetData(0, {1, 2, 3, 4, 5, 6, 7, 8});
@@ -497,7 +537,7 @@ TEST_F(ExecutorTest, LoadScattersCompletedGroupsWhileFirstIsPending)
 
 TEST_F(ExecutorTest, LoadSubmitFailureDoesNotScatterGroup)
 {
-    FakeTransferEndpoint store(8);
+    FakeStore store(8);
     store.SetData(0, {1, 2, 3, 4, 5, 6, 7, 8});
     store.SetData(1, {11, 12, 13, 14, 15, 16, 17, 18});
     store.SetData(2, {21, 22, 23, 24, 25, 26, 27, 28});
@@ -521,7 +561,7 @@ TEST_F(ExecutorTest, LoadSubmitFailureDoesNotScatterGroup)
 
 TEST_F(ExecutorTest, LoadCheckFailureDoesNotScatterGroup)
 {
-    FakeTransferEndpoint store(8);
+    FakeStore store(8);
     store.fail_load_check_index_ = 0;
     std::vector<DeviceShard> shards;
     for (std::size_t index = 0; index < 3; ++index) {
@@ -546,9 +586,25 @@ TEST_F(ExecutorTest, LoadCheckFailureDoesNotScatterGroup)
     EXPECT_EQ(ReadShard(shards[2]), (std::array<std::uint8_t, 8>{}));
 }
 
+TEST_F(ExecutorTest, LoadWaitFailureDoesNotScatterGroup)
+{
+    FakeStore store(8);
+    store.fail_load_wait_index_ = 0;
+    store.SetData(0, {1, 2, 3, 4, 5, 6, 7, 8});
+    std::vector<DeviceShard> shards{MakeEmptyShard(0)};
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 1, 1);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    auto task = executor->Submit(MakeTask(shards), Operation::LOAD);
+    ASSERT_TRUE(task);
+    EXPECT_TRUE(executor->Wait(task.Value()).Failure());
+    EXPECT_EQ(ReadShard(shards[0]), (std::array<std::uint8_t, 8>{}));
+}
+
 TEST_F(ExecutorTest, LoadSubmitFailureDoesNotCancelNextTransferGroup)
 {
-    FakeTransferEndpoint store(8);
+    FakeStore store(8);
     store.BlockFirstStore();
     store.fail_load_index_ = 0;
     store.SetData(2, {21, 22, 23, 24, 25, 26, 27, 28});
@@ -582,7 +638,7 @@ TEST_F(ExecutorTest, LoadSubmitFailureDoesNotCancelNextTransferGroup)
 
 TEST_F(ExecutorTest, LoadCheckFailureDoesNotFailNextTransferGroup)
 {
-    FakeTransferEndpoint store(8);
+    FakeStore store(8);
     store.BlockFirstStore();
     store.fail_load_check_index_ = 0;
     store.SetData(0, {1, 2, 3, 4, 5, 6, 7, 8});
@@ -617,7 +673,7 @@ TEST_F(ExecutorTest, LoadCheckFailureDoesNotFailNextTransferGroup)
 
 TEST_F(ExecutorTest, FailureStopsLaterDumpBatchesAndReleasesSlots)
 {
-    FakeTransferEndpoint store(8);
+    FakeStore store(8);
     store.fail_first_store_ = true;
     std::vector<DeviceShard> shards{MakeShard(0), MakeShard(1), MakeShard(2), MakeShard(3)};
     auto created = CreateTestExecutor(store, {3, 5}, 0, 2, 2);
@@ -628,7 +684,7 @@ TEST_F(ExecutorTest, FailureStopsLaterDumpBatchesAndReleasesSlots)
     ASSERT_TRUE(task);
     EXPECT_TRUE(executor->Wait(task.Value()).Failure());
     EXPECT_EQ(store.StoreBatches(), (std::vector<std::vector<std::size_t>>{
-                                          {0, 1}
+                                        {0, 1}
     }));
 
     store.fail_first_store_ = false;
@@ -637,14 +693,14 @@ TEST_F(ExecutorTest, FailureStopsLaterDumpBatchesAndReleasesSlots)
     ASSERT_TRUE(recovery);
     EXPECT_TRUE(executor->Wait(recovery.Value()).Success());
     EXPECT_EQ(store.StoreBatches(), (std::vector<std::vector<std::size_t>>{
-                                          {0, 1},
-                                          {4, 5}
+                                        {0, 1},
+                                        {4, 5}
     }));
 }
 
 TEST_F(ExecutorTest, DumpTransferGroupsSubmitSeparatelyAndIsolateStoreFailures)
 {
-    FakeTransferEndpoint store(8);
+    FakeStore store(8);
     store.BlockFirstLoad();
     store.BlockFirstStore();
     store.fail_dump_submit_index_ = 0;
@@ -657,8 +713,8 @@ TEST_F(ExecutorTest, DumpTransferGroupsSubmitSeparatelyAndIsolateStoreFailures)
     ASSERT_TRUE(created);
     auto executor = std::move(created).Value();
 
-    std::vector<DeviceShard> blockerShards{
-        MakeEmptyShard(100), MakeEmptyShard(101), MakeEmptyShard(102)};
+    std::vector<DeviceShard> blockerShards{MakeEmptyShard(100), MakeEmptyShard(101),
+                                           MakeEmptyShard(102)};
     auto blocker = executor->Submit(MakeTask(blockerShards), Operation::LOAD);
     ASSERT_TRUE(blocker);
     const auto loadCheckSeen = store.WaitForLoadGroupCheck(100);
@@ -680,11 +736,7 @@ TEST_F(ExecutorTest, DumpTransferGroupsSubmitSeparatelyAndIsolateStoreFailures)
     const auto storeWaitSeen = store.WaitForStoreWait();
     if (!storeWaitSeen) { store.ReleaseStore(); }
     ASSERT_TRUE(storeWaitSeen);
-    EXPECT_EQ(store.StoreBatches(), (std::vector<std::vector<std::size_t>>{
-                                          {0},
-                                          {1},
-                                          {2}
-    }));
+    EXPECT_EQ(store.StoreBatches(), (std::vector<std::vector<std::size_t>>{{0}, {1}, {2}}));
     store.ReleaseStore();
 
     EXPECT_TRUE(executor->Wait(submitFailed.Value()).Failure());
@@ -694,7 +746,7 @@ TEST_F(ExecutorTest, DumpTransferGroupsSubmitSeparatelyAndIsolateStoreFailures)
 
 TEST_F(ExecutorTest, LoadRunsBeforeNextDumpBatch)
 {
-    FakeTransferEndpoint store(8);
+    FakeStore store(8);
     store.BlockFirstStore();
     store.SetData(4, {41, 42, 43, 44, 45, 46, 47, 48});
     std::vector<DeviceShard> dumpShards{MakeShard(0), MakeShard(1), MakeShard(2), MakeShard(3)};
@@ -721,7 +773,7 @@ TEST_F(ExecutorTest, LoadRunsBeforeNextDumpBatch)
 
 TEST_F(ExecutorTest, DumpWaitDoesNotBlockLoadWorker)
 {
-    FakeTransferEndpoint store(8);
+    FakeStore store(8);
     store.BlockFirstStore();
     store.SetData(1, {11, 12, 13, 14, 15, 16, 17, 18});
     std::vector<DeviceShard> dumpShards{MakeShard(0)};
@@ -759,9 +811,112 @@ TEST_F(ExecutorTest, DumpWaitDoesNotBlockLoadWorker)
               (std::array<std::uint8_t, 8>{11, 12, 13, 14, 15, 16, 17, 18}));
 }
 
+TEST_F(ExecutorTest, WaitClaimsHandleAndDoesNotBlockOtherTaskQueries)
+{
+    FakeStore store(8);
+    store.BlockFirstStore();
+    store.SetData(1, {11, 12, 13, 14, 15, 16, 17, 18});
+    std::vector<DeviceShard> dumpShards{MakeShard(0)};
+    std::vector<DeviceShard> loadShards{MakeEmptyShard(1)};
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 2, 2);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    auto dump = executor->Submit(MakeTask(dumpShards), Operation::DUMP);
+    ASSERT_TRUE(dump);
+    const auto dumpHandle = dump.Value();
+    ASSERT_TRUE(store.WaitForStoreWait());
+
+    auto waitStatus = Status::Error();
+    std::thread waiter(
+        [&executor, dumpHandle, &waitStatus]() { waitStatus = executor->Wait(dumpHandle); });
+
+    const bool handleClaimed = WaitForTaskNotFound(*executor, dumpHandle);
+    const auto secondWaitStatus = handleClaimed ? executor->Wait(dumpHandle) : Status::Error();
+    auto load = executor->Submit(MakeTask(loadShards), Operation::LOAD);
+    const bool loadCompleted = load && WaitForTaskCompletion(*executor, load.Value());
+
+    store.ReleaseStore();
+    waiter.join();
+
+    ASSERT_TRUE(handleClaimed);
+    EXPECT_EQ(secondWaitStatus, Status::NotFound());
+    ASSERT_TRUE(load);
+    EXPECT_TRUE(loadCompleted);
+    EXPECT_TRUE(waitStatus.Success());
+    EXPECT_TRUE(executor->Wait(load.Value()).Success());
+}
+
+TEST_F(ExecutorTest, ConcurrentChecksObserveIncompleteTask)
+{
+    constexpr std::size_t threadCount = 8;
+    constexpr std::size_t checksPerThread = 100;
+
+    FakeStore store(8);
+    store.BlockFirstStore();
+    std::vector<DeviceShard> shards{MakeShard(0)};
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 1, 1);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    auto task = executor->Submit(MakeTask(shards), Operation::DUMP);
+    ASSERT_TRUE(task);
+    const auto taskHandle = task.Value();
+    ASSERT_TRUE(store.WaitForStoreWait());
+
+    std::atomic<bool> checksValid{true};
+    std::vector<std::thread> checkers;
+    checkers.reserve(threadCount);
+    for (std::size_t index = 0; index < threadCount; ++index) {
+        checkers.emplace_back([&executor, taskHandle, &checksValid]() {
+            for (std::size_t check = 0; check < checksPerThread; ++check) {
+                auto result = executor->Check(taskHandle);
+                if (!result || result.Value()) {
+                    checksValid.store(false, std::memory_order_relaxed);
+                    return;
+                }
+            }
+        });
+    }
+    for (auto& checker : checkers) { checker.join(); }
+
+    store.ReleaseStore();
+    EXPECT_TRUE(checksValid.load(std::memory_order_relaxed));
+    EXPECT_TRUE(executor->Wait(taskHandle).Success());
+}
+
+TEST_F(ExecutorTest, ClaimedWaitReturnsCancellationAfterShutdown)
+{
+    FakeStore store(8);
+    store.BlockFirstStore();
+    std::vector<DeviceShard> shards{MakeShard(0), MakeShard(1), MakeShard(2)};
+    auto created = CreateTestExecutor(store, {3, 5}, 0, 1, 1);
+    ASSERT_TRUE(created);
+    auto executor = std::move(created).Value();
+
+    auto task = executor->Submit(MakeTask(shards), Operation::DUMP);
+    ASSERT_TRUE(task);
+    const auto taskHandle = task.Value();
+    ASSERT_TRUE(store.WaitForStoreWait());
+
+    auto waitStatus = Status::OK();
+    std::thread waiter(
+        [&executor, taskHandle, &waitStatus]() { waitStatus = executor->Wait(taskHandle); });
+    const bool handleClaimed = WaitForTaskNotFound(*executor, taskHandle);
+
+    std::thread shutdown([&executor]() { executor->Shutdown(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    store.ReleaseStore();
+    shutdown.join();
+    waiter.join();
+
+    EXPECT_TRUE(handleClaimed);
+    EXPECT_TRUE(waitStatus.Failure());
+}
+
 TEST_F(ExecutorTest, TaskLargerThanSlotCountCompletesAcrossBatches)
 {
-    FakeTransferEndpoint store(8);
+    FakeStore store(8);
     std::vector<DeviceShard> shards{MakeShard(0), MakeShard(1)};
     auto created = CreateTestExecutor(store, {3, 5}, 0, 1, 1);
     ASSERT_TRUE(created);
@@ -770,14 +925,13 @@ TEST_F(ExecutorTest, TaskLargerThanSlotCountCompletesAcrossBatches)
     auto task = executor->Submit(MakeTask(shards), Operation::DUMP);
     ASSERT_TRUE(task);
     EXPECT_TRUE(executor->Wait(task.Value()).Success());
-    EXPECT_EQ(store.StoreBatches(),
-              (std::vector<std::vector<std::size_t>>{{0}, {1}}));
+    EXPECT_EQ(store.StoreBatches(), (std::vector<std::vector<std::size_t>>{{0}, {1}}));
 }
 
 TEST_F(ExecutorTest, AcceptsTasksWhileAllSlotsAreBusy)
 {
     constexpr std::size_t taskCount = 32;
-    FakeTransferEndpoint store(8);
+    FakeStore store(8);
     store.BlockFirstStore();
     auto created = CreateTestExecutor(store, {3, 5}, 0, 1, 1);
     ASSERT_TRUE(created);
@@ -810,14 +964,12 @@ TEST_F(ExecutorTest, AcceptsTasksWhileAllSlotsAreBusy)
 
     ASSERT_TRUE(allSubmitted);
     ASSERT_EQ(handles.size(), taskCount);
-    for (const auto handle : handles) {
-        EXPECT_TRUE(executor->Wait(handle).Success());
-    }
+    for (const auto handle : handles) { EXPECT_TRUE(executor->Wait(handle).Success()); }
 }
 
 TEST_F(ExecutorTest, ShutdownDrainsCurrentBatchAndCancelsLaterBatches)
 {
-    FakeTransferEndpoint store(8);
+    FakeStore store(8);
     store.BlockFirstStore();
     std::vector<DeviceShard> shards{MakeShard(0), MakeShard(1), MakeShard(2)};
     auto created = CreateTestExecutor(store, {3, 5}, 0, 1, 1);
@@ -838,7 +990,7 @@ TEST_F(ExecutorTest, ShutdownDrainsCurrentBatchAndCancelsLaterBatches)
 
 TEST_F(ExecutorTest, CreateRejectsInvalidConfiguration)
 {
-    FakeTransferEndpoint store(8);
+    FakeStore store(8);
 
     auto noSlots = CreateTestExecutor(store, {3, 5}, 0, 0);
     ASSERT_FALSE(noSlots);


### PR DESCRIPTION
## Purpose

Introduce asynchronous buffer delegator executor.

## Modification

<img width="1528" height="1849" alt="image" src="https://github.com/user-attachments/assets/a05bcddd-a479-42f7-91ee-7744c73e7a8f" />

Each task is divided into shards and placed into a global load or dump queue. Available buffer slots determine how many shards may run concurrently. 

Reserved shards are organized as follows:

- `TransferBatch` represents the work acquired in one scheduling round.
- `TransferGroup` contains shards from one task and acts as the backend submission unit.

Load and dump use dedicated workers. Loads are prioritized when reserving new work, while already-running dump operations are not interrupted. Specially for load worker, groups are checked independently so a completed group can scatter its data without waiting for another slower group.

Failures are recorded per group and propagated to the corresponding task as its first error. Once a task fails, its remaining queued shards are completed without additional copying or endpoint I/O. Other tasks in the same batch continue normally.

## Test

<img width="1153" height="969" alt="image" src="https://github.com/user-attachments/assets/4a966c14-15a3-45ba-a110-e15b8a851880" />

