### PR TITLE
[Refactor] Decouple HLA-specific params from UCMDirectConnector._crea…

### DIFF
--- a/ucm/integration/vllm/hla_connector.py
+++ b/ucm/integration/vllm/hla_connector.py
@@ -4,7 +4,7 @@ import os
 import time
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Callable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
 
 import numpy as np
 import torch
@@ -35,11 +35,13 @@ from ucm.integration.vllm.ucm_connector import (
     _drop_null_vllm_blocks,
     _record_counter,
     _short_list,
+    _use_ucm_connector_cpu_affinity,
 )
 from ucm.logger import init_logger
 from ucm.shared.metrics import ucmmetrics
 from ucm.sparse.state import has_ucm_sparse
-from ucm.store.ucmstore_v1 import Task
+from ucm.store.factory_v1 import UcmConnectorFactoryV1
+from ucm.store.ucmstore_v1 import Task, UcmKVStoreBaseV1
 
 if TYPE_CHECKING:
     from vllm.attention.backends.abstract import AttentionMetadata
@@ -110,6 +112,14 @@ def extend_non_null(
             continue
         dst_ucm_block_ids.append(ucm_block_id)
         dst_vllm_block_ids.append(vllm_block_id)
+
+
+def _normalize_tensor_size_list(tensor_size_list: Any) -> list[int]:
+    if isinstance(tensor_size_list, np.ndarray):
+        return [int(v) for v in tensor_size_list.reshape(-1).tolist()]
+    if isinstance(tensor_size_list, (list, tuple)):
+        return [int(v) for v in tensor_size_list]
+    return [int(tensor_size_list)]
 
 
 @dataclass
@@ -793,12 +803,111 @@ class UCMHybridLinearAttentionConnector(UCMDirectConnector, SupportsHMA):
             self._kv_cache_config,
         )
 
+    def _create_store(
+        self,
+        kv_cache_layout: Optional[KVCacheLayout],
+        cpu_affinity_cores: Optional[list[int]] = None,
+        tensor_size_list_override: Optional[list[int]] = None,
+        shard_size_override: Optional[int] = None,
+        block_size_override: Optional[int] = None,
+        unique_id_suffix: str = "",
+    ) -> UcmKVStoreBaseV1:
+        if len(self.connector_configs) != 1:
+            raise RuntimeError(
+                f"Expected exactly one connector config, "
+                f"but got {len(self.connector_configs)}: "
+                f"{self.connector_configs}"
+            )
+
+        name = self.connector_configs[0]["ucm_connector_name"]
+        module_path = self.connector_configs[0].get("ucm_connector_module_path", None)
+        config = copy.deepcopy(self.connector_configs[0]["ucm_connector_config"])
+        config.setdefault("share_buffer_enable", self.is_mla)
+        self._set_default_shm_buffer_capacity(config)
+        if "storage_backends" in config:
+            backends = [path for path in config["storage_backends"].split(":")]
+            config["storage_backends"] = backends
+        config["unique_id"] = f"{self.engine_id}{unique_id_suffix}"
+        if self._role == KVConnectorRole.WORKER:
+            config["device_id"] = self.local_rank
+            tensor_size_list = _normalize_tensor_size_list(
+                tensor_size_list_override
+                if tensor_size_list_override is not None
+                else kv_cache_layout.tensor_size_list
+            )
+            config["tensor_size_list"] = tensor_size_list * self.blocks_per_chunk
+            shard_size = (
+                shard_size_override
+                if shard_size_override is not None
+                else kv_cache_layout.shard_size
+            )
+            block_size = (
+                block_size_override
+                if block_size_override is not None
+                else kv_cache_layout.block_size
+            )
+            config["shard_size"] = shard_size * self.blocks_per_chunk
+            config["block_size"] = block_size * self.blocks_per_chunk
+            config["local_rank_size"] = self.tp_size if self.is_mla else 1
+            buffer_addrs = kv_cache_layout.base_ptrs.reshape(-1).tolist()
+            buffer_sizes = kv_cache_layout.buffer_sizes.reshape(-1).tolist()
+            gpu_kv_buffer_set = set()
+            gpu_kv_buffer_addrs = []
+            gpu_kv_buffer_sizes = []
+            for addr, size in zip(buffer_addrs, buffer_sizes):
+                # Layerwise padding is store metadata only. Never register a
+                # ghost (nullptr, zero-sized) slot as a real device buffer.
+                if int(addr) == 0 or int(size) == 0:
+                    continue
+                key = (int(addr), int(size))
+                if key in gpu_kv_buffer_set:
+                    continue
+                gpu_kv_buffer_set.add(key)
+                gpu_kv_buffer_addrs.append(key[0])
+                gpu_kv_buffer_sizes.append(key[1])
+            config["gpu_kv_buffer_addrs"] = gpu_kv_buffer_addrs
+            config["gpu_kv_buffer_sizes"] = gpu_kv_buffer_sizes
+            if cpu_affinity_cores:
+                config["cpu_affinity_cores"] = list(cpu_affinity_cores)
+        else:
+            config_base = self.block_size * self.element_size * self.head_size
+            config["block_size"] = (
+                config_base
+                * self.num_layers
+                * (1 if self.is_mla else self.num_head * 2)
+                * self.blocks_per_chunk
+            )
+        dp_rank = self._vllm_config.parallel_config.data_parallel_rank
+        config["posix_gc_enable"] = (
+            self._role != KVConnectorRole.WORKER and dp_rank == 0
+        )
+        logger.info(f"create {name} with config: {config}")
+        return UcmConnectorFactoryV1.create_connector(name, config, module_path)
+
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         self.kv_caches = kv_caches
         self.kv_cache_layout = self._create_kv_cache_layout(self.kv_caches)
-        self.store = self._create_store(kv_cache_layout=self.kv_cache_layout)
         self.block_data_size = self.kv_cache_layout.block_size
         self.device = create_device()
+
+        enable_affinity = _use_ucm_connector_cpu_affinity()
+        worker_cores, store_cores = (
+            self.device.split_cores(self.local_rank)
+            if enable_affinity
+            else (None, None)
+        )
+
+        self.store = self._create_store(
+            kv_cache_layout=self.kv_cache_layout,
+            cpu_affinity_cores=store_cores,
+        )
+
+        if worker_cores:
+            try:
+                os.sched_setaffinity(0, worker_cores)
+                logger.info(f"[VLLM CPU Affinity] Worker bound to cores {worker_cores}")
+            except Exception as e:
+                logger.warning(f"Failed to bind worker: {e}")
 
     def get_num_new_matched_tokens(
         self, request: "Request", num_computed_tokens: int
@@ -1369,12 +1478,27 @@ class UCMHybridLinearAttentionLayerWiseConnector(UCMHybridLinearAttentionConnect
 
         self.device = create_device()
 
+        enable_affinity = _use_ucm_connector_cpu_affinity()
+        worker_cores, store_cores = (
+            self.device.split_cores(self.local_rank)
+            if enable_affinity
+            else (None, None)
+        )
+
         self.store = self._create_store(
             kv_cache_layout=self.kv_cache_layout,
+            cpu_affinity_cores=store_cores,
             tensor_size_list_override=row_tensor_size_list,
             shard_size_override=row_shard_size,
             block_size_override=row_shard_size * (max(self.row_ids) + 1),
         )
+
+        if worker_cores:
+            try:
+                os.sched_setaffinity(0, worker_cores)
+                logger.info(f"[VLLM CPU Affinity] Worker bound to cores {worker_cores}")
+            except Exception as e:
+                logger.warning(f"Failed to bind worker: {e}")
 
         row_to_layers: dict[int, list[str]] = defaultdict(list)
         for layer_name, row_id in self.layer_name_to_row.items():

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -85,14 +85,6 @@ def _has_shared_indexer_layers(vllm_config: "VllmConfig") -> bool:
     )
 
 
-def _normalize_tensor_size_list(tensor_size_list: Any) -> list[int]:
-    if isinstance(tensor_size_list, np.ndarray):
-        return [int(v) for v in tensor_size_list.reshape(-1).tolist()]
-    if isinstance(tensor_size_list, (list, tuple)):
-        return [int(v) for v in tensor_size_list]
-    return [int(tensor_size_list)]
-
-
 def _short_list(values: list[int], limit: int = 12) -> list[int]:
     return values[:limit]
 
@@ -338,19 +330,6 @@ class KVCacheLayout:
             vllm_block_ids_np[:, None, None] * self.block_stride_lists[None, :, :]
             + self.base_ptrs[None, :, :]
         )  # (num_blocks, n_layers, n_ptrs)
-
-    def extract_block_addrs_for_row(
-        self, vllm_block_ids: List[int], row_id: int
-    ) -> np.ndarray:
-        if not self.use_layerwise:
-            raise ValueError(
-                "Row address extraction requires a layerwise KV cache layout"
-            )
-        vllm_block_ids_np = np.asarray(vllm_block_ids, dtype=np.uint64)
-        return (
-            vllm_block_ids_np[:, None] * self.block_stride_lists[row_id][None, :]
-            + self.base_ptrs[row_id][None, :]
-        )
 
     @property
     def tensor_size_list(self) -> list[int]:
@@ -1109,10 +1088,6 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self,
         kv_cache_layout: Optional[KVCacheLayout],
         cpu_affinity_cores: Optional[list[int]] = None,
-        tensor_size_list_override: Optional[list[int]] = None,
-        shard_size_override: Optional[int] = None,
-        block_size_override: Optional[int] = None,
-        unique_id_suffix: str = "",
     ) -> UcmKVStoreBaseV1:
         if len(self.connector_configs) != 1:
             raise RuntimeError(
@@ -1129,27 +1104,14 @@ class UCMDirectConnector(KVConnectorBase_V1):
         if "storage_backends" in config:
             backends = [path for path in config["storage_backends"].split(":")]
             config["storage_backends"] = backends
-        config["unique_id"] = f"{self.engine_id}{unique_id_suffix}"
+        config["unique_id"] = f"{self.engine_id}"
         if self._role == KVConnectorRole.WORKER:
             config["device_id"] = self.local_rank
-            tensor_size_list = _normalize_tensor_size_list(
-                tensor_size_list_override
-                if tensor_size_list_override is not None
-                else kv_cache_layout.tensor_size_list
+            config["tensor_size_list"] = (
+                kv_cache_layout.tensor_size_list * self.blocks_per_chunk
             )
-            config["tensor_size_list"] = tensor_size_list * self.blocks_per_chunk
-            shard_size = (
-                shard_size_override
-                if shard_size_override is not None
-                else kv_cache_layout.shard_size
-            )
-            block_size = (
-                block_size_override
-                if block_size_override is not None
-                else kv_cache_layout.block_size
-            )
-            config["shard_size"] = shard_size * self.blocks_per_chunk
-            config["block_size"] = block_size * self.blocks_per_chunk
+            config["shard_size"] = kv_cache_layout.shard_size * self.blocks_per_chunk
+            config["block_size"] = kv_cache_layout.block_size * self.blocks_per_chunk
             config["local_rank_size"] = self.tp_size if self.is_mla else 1
             buffer_addrs = kv_cache_layout.base_ptrs.reshape(-1).tolist()
             buffer_sizes = kv_cache_layout.buffer_sizes.reshape(-1).tolist()


### PR DESCRIPTION
## Purpose
Decouple HLA-specific parameters and helper functions from the parent UCMDirectConnector

## Modifications 
ucm_connector.py — UCMDirectConnector / KVCacheLayout (base classes)
- Removed shard_size_override, block_size_override, unique_id_suffix, and tensor_size_list_override parameters from UCMDirectConnector._create_store; the body now reads shard_size, block_size, tensor_size_list, and unique_id directly from kv_cache_layout / self.engine_id.
- Removed the module-level _normalize_tensor_size_list function (only needed when a raw override value may be a numpy array or scalar — the base class always receives a list[int] from the layout property).
- Removed KVCacheLayout.extract_block_addrs_for_row — only called by the HLA layerwise connector, which already uses the override in HybridLinearAttentionLayout.

## Test
Tested on QwQ-32B、Qwen3.6-35B-A3B