### PR TITLE
chore: bump version to 0.7.0.dev0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -243,7 +243,7 @@ def inject_pth():
 
 setup(
     name="uc-manager",
-    version="0.6.0",
+    version="0.7.0.dev0",
     description="Unified Cache Management",
     author="Unified Cache Team",
     packages=[


### PR DESCRIPTION
## Purpose

Bump `uc-manager` version from `0.6.0` to `0.7.0.dev0`, marking the start of development for the `0.7.0` release cycle.

## Modifications

**File:** `setup.py`

**Before:**
```python
version="0.6.0",
```

**After:**
```python
version="0.7.0.dev0",
```

## Test

- [ ] Run `python setup.py --version`, verify output is `0.7.0.dev0`
- [ ] Run `pip install -e .`, verify installation succeeds without errors
- [ ] Ensure existing unit tests pass
- [ ] Run `python setup.py sdist bdist_wheel`, verify generated package name contains the correct version