### PR TITLE
[Feat] Support GLM 5.2 layerwise for cuda

### DIFF
--- a/test/suites/Unit/test_kv_cache_layout.py
+++ b/test/suites/Unit/test_kv_cache_layout.py
@@ -426,6 +426,36 @@ class KVCacheLayoutTest(unittest.TestCase):
         )
         self.assertEqual(block_one_addrs[1, 0, 2], 0)
 
+    def test_cuda_shared_indexer_rejects_attention_size_mismatch(self):
+        entries = [
+            ("model.layers.0.self_attn.indexer.k_cache", 8448, 1),
+            ("model.layers.0.self_attn.attn", 73728, 2),
+            ("model.layers.1.self_attn.attn", 65536, 2),
+        ]
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"same Attention slot count and per-block sizes.*"
+            r"expected=\[73728\] from layer 0.*"
+            r"incompatible_layers=\{1: \[65536\]\}",
+        ):
+            _build_cuda_shared_layout(entries)
+
+    def test_cuda_shared_indexer_rejects_attention_slot_count_mismatch(self):
+        entries = [
+            ("model.layers.0.self_attn.indexer.k_cache", 1024, 1),
+            ("model.layers.0.self_attn.attn", 4096, 2, 5),
+            ("model.layers.1.self_attn.attn", 4096, 2),
+        ]
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"same Attention slot count and per-block sizes.*"
+            r"expected=\[4096, 4096\] from layer 0.*"
+            r"incompatible_layers=\{1: \[4096\]\}",
+        ):
+            _build_cuda_shared_layout(entries)
+
     def test_shared_indexer_li_c8_disabled_uses_padding_without_mask(self):
         layout = _build_layout(
             [[131072, 16384, 32768], [131072, 16384]],

--- a/test/suites/Unit/test_kv_cache_layout.py
+++ b/test/suites/Unit/test_kv_cache_layout.py
@@ -258,6 +258,31 @@ class KVCacheLayoutTest(unittest.TestCase):
 
         self.assertTrue(supported)
 
+    def test_cuda_tensor_role_pattern_mapping_is_extensible(self):
+        class ExtendedCUDAKVCacheLayout(SharedIndexerKVCacheLayout):
+            CUDA_TENSOR_ROLE_PATTERNS = {
+                "indexer": (
+                    *SharedIndexerKVCacheLayout.CUDA_TENSOR_ROLE_PATTERNS["indexer"],
+                    re.compile(
+                        r"(?:^|[._])selector[._]cache(?:[._]|$)",
+                        re.IGNORECASE,
+                    ),
+                ),
+            }
+
+        self.assertEqual(
+            SharedIndexerKVCacheLayout._cuda_cache_role(
+                "model.layers.0.self_attn.indexer.k_cache"
+            ),
+            "indexer",
+        )
+        self.assertEqual(
+            SharedIndexerKVCacheLayout._cuda_cache_role(
+                "model.layers.0.self_attn.attn"
+            ),
+            "attention",
+        )
+
     def test_cuda_shared_indexer_uses_semantic_order_and_padding(self):
         layer_2_indexer = "model.layers.2.router.shared_indexer.cache_storage"
         layer_0_indexer = "model.layers.0.self_attn.indexer.k_cache"

--- a/test/suites/Unit/test_kv_cache_layout.py
+++ b/test/suites/Unit/test_kv_cache_layout.py
@@ -47,6 +47,33 @@ class FakeTensor:
         return math.prod(self.shape[dimension + 1 :])
 
 
+class FakeCombinedTensor:
+    def __init__(
+        self,
+        ptr: int,
+        block_stride: int,
+        num_blocks: int = 2,
+        element_size: int = 1,
+    ):
+        component_buffer_size = num_blocks * block_stride
+        self._components = tuple(
+            FakeTensor(
+                ptr + component_id * component_buffer_size,
+                block_stride,
+                num_blocks=num_blocks,
+                element_size=element_size,
+            )
+            for component_id in range(2)
+        )
+        self.shape = (2, *self._components[0].shape)
+
+    def __getitem__(self, index):
+        return self._components[index]
+
+    def dim(self):
+        return len(self.shape)
+
+
 class FakeTorch:
     Tensor = FakeTensor
 
@@ -141,18 +168,29 @@ def _build_layout(
     return layout_cls(kvcaches, ucm_config, vllm_config, kv_cache_config)
 
 
-def _build_cuda_shared_layout(entries: list[tuple[str, int, int]]):
+def _build_cuda_shared_layout(
+    entries: list[tuple[str, int, int] | tuple[str, int, int, int]],
+):
     next_ptr = 0x100000
     kvcaches = {}
     tensor_ptrs = {}
-    for layer_name, block_stride, element_size in entries:
+    for entry in entries:
+        layer_name, block_stride, element_size, *dimension_values = entry
+        dimensions = dimension_values[0] if dimension_values else 3
         tensor_ptrs[layer_name] = next_ptr
-        kvcaches[layer_name] = FakeTensor(
-            next_ptr,
-            block_stride,
-            element_size=element_size,
-            dimensions=3,
-        )
+        if dimensions == 5:
+            kvcaches[layer_name] = FakeCombinedTensor(
+                next_ptr,
+                block_stride,
+                element_size=element_size,
+            )
+        else:
+            kvcaches[layer_name] = FakeTensor(
+                next_ptr,
+                block_stride,
+                element_size=element_size,
+                dimensions=dimensions,
+            )
         next_ptr += 0x100000
 
     layer_ids = {_extract_layer_index(name) for name in kvcaches}
@@ -264,7 +302,7 @@ class KVCacheLayoutTest(unittest.TestCase):
                 "indexer": (
                     *SharedIndexerKVCacheLayout.CUDA_TENSOR_ROLE_PATTERNS["indexer"],
                     re.compile(
-                        r"(?:^|[._])selector[._]cache(?:[._]|$)",
+                        r"(?:^|\.)selector\.cache(?:\.|$)",
                         re.IGNORECASE,
                     ),
                 ),
@@ -284,7 +322,7 @@ class KVCacheLayoutTest(unittest.TestCase):
         )
 
     def test_cuda_shared_indexer_uses_semantic_order_and_padding(self):
-        layer_2_indexer = "model.layers.2.router.shared_indexer.cache_storage"
+        layer_2_indexer = "model.layers.2.router.indexer.cache_storage"
         layer_0_indexer = "model.layers.0.self_attn.indexer.k_cache"
         layer_0_attention = "model.layers.0.self_attn.attn"
         layer_1_attention = "model.layers.1.mla.kv_storage"
@@ -338,6 +376,55 @@ class KVCacheLayoutTest(unittest.TestCase):
             tensor_ptrs[layer_0_indexer] + 8448,
         )
         self.assertEqual(block_one_addrs[1, 0, 1], 0)
+
+    def test_cuda_combined_5d_attention_splits_kv_segments(self):
+        layer_0_indexer = "model.layers.0.self_attn.indexer.k_cache"
+        layer_0_attention = "model.layers.0.self_attn.attn"
+        layer_1_attention = "model.layers.1.self_attn.attn"
+        entries = [
+            (layer_0_indexer, 1024, 1),
+            (layer_0_attention, 4096, 2, 5),
+            (layer_1_attention, 4096, 2, 5),
+        ]
+        layout, tensor_ptrs = _build_cuda_shared_layout(entries)
+
+        expected_sizes = [4096, 4096, 1024]
+        self.assertEqual(layout.tensor_size_list, expected_sizes)
+        self.assertEqual(layout.shard_size, sum(expected_sizes))
+        self.assertEqual(layout.base_ptrs.shape, (2, 3))
+        self.assertEqual(
+            layout.tensor_size_lists.tolist(),
+            [expected_sizes, expected_sizes],
+        )
+
+        layer_0_attention_ptr = tensor_ptrs[layer_0_attention]
+        layer_0_value_ptr = layer_0_attention_ptr + 2 * 4096
+        self.assertEqual(
+            layout.base_ptrs[0].tolist(),
+            [
+                layer_0_attention_ptr,
+                layer_0_value_ptr,
+                tensor_ptrs[layer_0_indexer],
+            ],
+        )
+        self.assertEqual(layout.block_stride_lists[0].tolist(), expected_sizes)
+        self.assertEqual(layout.base_ptrs[1, 2], 0)
+        self.assertEqual(layout.block_stride_lists[1, 2], 0)
+
+        block_one_addrs = layout.extract_block_addrs([1], layer_first=True)
+        self.assertEqual(
+            int(block_one_addrs[0, 0, 0]),
+            layer_0_attention_ptr + 4096,
+        )
+        self.assertEqual(
+            int(block_one_addrs[0, 0, 1]),
+            layer_0_value_ptr + 4096,
+        )
+        self.assertEqual(
+            int(block_one_addrs[0, 0, 2]),
+            tensor_ptrs[layer_0_indexer] + 1024,
+        )
+        self.assertEqual(block_one_addrs[1, 0, 2], 0)
 
     def test_shared_indexer_li_c8_disabled_uses_padding_without_mask(self):
         layout = _build_layout(

--- a/test/suites/Unit/test_kv_cache_layout.py
+++ b/test/suites/Unit/test_kv_cache_layout.py
@@ -20,10 +20,16 @@ class FakeTensor:
         block_stride: int,
         num_blocks: int = 2,
         element_size: int = 1,
+        dimensions: int = 4,
     ):
         self._ptr = ptr
         self._element_size = element_size
-        self.shape = (num_blocks, 1, 1, block_stride // element_size)
+        inner_shape = (
+            (1, block_stride // element_size)
+            if dimensions == 3
+            else (1, 1, block_stride // element_size)
+        )
+        self.shape = (num_blocks, *inner_shape)
 
     def __getitem__(self, _index):
         return self
@@ -36,6 +42,9 @@ class FakeTensor:
 
     def element_size(self):
         return self._element_size
+
+    def stride(self, dimension):
+        return math.prod(self.shape[dimension + 1 :])
 
 
 class FakeTorch:
@@ -61,7 +70,6 @@ def _load_layout_symbols():
     tree = ast.parse(source)
     selected_names = {
         "_has_shared_indexer_layers",
-        "_supports_ascend_shared_indexer_layout",
         "KVCacheSegment",
         "KVCacheTensorInfo",
         "SharedIndexerLayerInfo",
@@ -82,6 +90,7 @@ def _load_layout_symbols():
         "logger": FakeLogger(),
         "math": math,
         "np": np,
+        "re": re,
         "torch": FakeTorch,
         "current_platform": SimpleNamespace(device_type="npu"),
     }
@@ -130,6 +139,48 @@ def _build_layout(
         else KVCacheLayout
     )
     return layout_cls(kvcaches, ucm_config, vllm_config, kv_cache_config)
+
+
+def _build_cuda_shared_layout(entries: list[tuple[str, int, int]]):
+    next_ptr = 0x100000
+    kvcaches = {}
+    tensor_ptrs = {}
+    for layer_name, block_stride, element_size in entries:
+        tensor_ptrs[layer_name] = next_ptr
+        kvcaches[layer_name] = FakeTensor(
+            next_ptr,
+            block_stride,
+            element_size=element_size,
+            dimensions=3,
+        )
+        next_ptr += 0x100000
+
+    layer_ids = {_extract_layer_index(name) for name in kvcaches}
+    hf_text_config = SimpleNamespace(
+        num_hidden_layers=len(layer_ids),
+        indexer_types=["full", "shared"],
+    )
+    vllm_config = SimpleNamespace(
+        additional_config={},
+        parallel_config=SimpleNamespace(pipeline_parallel_size=1),
+        model_config=SimpleNamespace(hf_text_config=hf_text_config),
+    )
+    kv_cache_config = SimpleNamespace(num_blocks=2)
+    ucm_config = {"use_layerwise": True}
+
+    layout_globals = SharedIndexerKVCacheLayout.supports.__func__.__globals__
+    original_platform = layout_globals["current_platform"]
+    layout_globals["current_platform"] = SimpleNamespace(device_type="cuda")
+    try:
+        layout = SharedIndexerKVCacheLayout(
+            kvcaches,
+            ucm_config,
+            vllm_config,
+            kv_cache_config,
+        )
+    finally:
+        layout_globals["current_platform"] = original_platform
+    return layout, tensor_ptrs
 
 
 class KVCacheLayoutTest(unittest.TestCase):
@@ -189,20 +240,79 @@ class KVCacheLayoutTest(unittest.TestCase):
         self.assertIs(type(glm51_layout), KVCacheLayout)
         self.assertIs(type(glm52_layout), SharedIndexerKVCacheLayout)
 
-    def test_shared_indexer_layout_is_restricted_to_ascend(self):
+    def test_shared_indexer_layout_supports_cuda(self):
         supports_globals = SharedIndexerKVCacheLayout.supports.__func__.__globals__
         original_platform = supports_globals["current_platform"]
         supports_globals["current_platform"] = SimpleNamespace(device_type="cuda")
         try:
-            layout = _build_layout(
-                [[8, 4, 2], [8, 4, 2]],
-                use_layerwise=True,
-                shared_indexer=True,
+            vllm_config = SimpleNamespace(
+                model_config=SimpleNamespace(
+                    hf_text_config=SimpleNamespace(indexer_types=["full", "shared"])
+                )
+            )
+            supported = SharedIndexerKVCacheLayout.supports(
+                vllm_config, {"use_layerwise": True}
             )
         finally:
             supports_globals["current_platform"] = original_platform
 
-        self.assertIs(type(layout), KVCacheLayout)
+        self.assertTrue(supported)
+
+    def test_cuda_shared_indexer_uses_semantic_order_and_padding(self):
+        layer_2_indexer = "model.layers.2.router.shared_indexer.cache_storage"
+        layer_0_indexer = "model.layers.0.self_attn.indexer.k_cache"
+        layer_0_attention = "model.layers.0.self_attn.attn"
+        layer_1_attention = "model.layers.1.mla.kv_storage"
+        layer_2_attention = "model.layers.2.mla.kv_storage"
+        entries = [
+            (layer_2_indexer, 8448, 1),
+            (layer_0_indexer, 8448, 1),
+            (layer_0_attention, 73728, 2),
+            (layer_1_attention, 73728, 2),
+            (layer_2_attention, 73728, 2),
+        ]
+        layout, tensor_ptrs = _build_cuda_shared_layout(entries)
+
+        self.assertEqual(layout.first_layer_id, 0)
+        self.assertEqual(layout.tensor_size_list, [73728, 8448])
+        self.assertEqual(layout.shard_size, 82176)
+        self.assertEqual(layout.base_ptrs.shape, (3, 2))
+        self.assertEqual(
+            layout.tensor_size_lists.tolist(),
+            [[73728, 8448], [73728, 8448], [73728, 8448]],
+        )
+
+        self.assertEqual(
+            int(layout.base_ptrs[0, 0]),
+            tensor_ptrs[layer_0_attention],
+        )
+        self.assertEqual(
+            int(layout.base_ptrs[0, 1]),
+            tensor_ptrs[layer_0_indexer],
+        )
+        self.assertEqual(
+            int(layout.base_ptrs[2, 0]),
+            tensor_ptrs[layer_2_attention],
+        )
+        self.assertEqual(
+            int(layout.base_ptrs[2, 1]),
+            tensor_ptrs[layer_2_indexer],
+        )
+
+        self.assertEqual(layout.base_ptrs[1, 1], 0)
+        self.assertEqual(layout.block_stride_lists[1].tolist(), [73728, 0])
+        self.assertEqual(layout.buffer_sizes[1].tolist(), [147456, 0])
+
+        block_one_addrs = layout.extract_block_addrs([1], layer_first=True)
+        self.assertEqual(
+            int(block_one_addrs[0, 0, 0]),
+            tensor_ptrs[layer_0_attention] + 73728,
+        )
+        self.assertEqual(
+            int(block_one_addrs[0, 0, 1]),
+            tensor_ptrs[layer_0_indexer] + 8448,
+        )
+        self.assertEqual(block_one_addrs[1, 0, 1], 0)
 
     def test_shared_indexer_li_c8_disabled_uses_padding_without_mask(self):
         layout = _build_layout(

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -383,6 +383,16 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
     mask behavior to the generic KV cache layout.
     """
 
+    CUDA_TENSOR_ROLE_PATTERNS = {
+        "indexer": (
+            re.compile(
+                r"(?:^|[._])indexer(?:[._]|$)",
+                re.IGNORECASE,
+            ),
+        ),
+    }
+    CUDA_DEFAULT_TENSOR_ROLE = "attention"
+
     @classmethod
     def supports(cls, vllm_config: "VllmConfig", ucm_config: dict) -> bool:
         device_type = getattr(current_platform, "device_type", None)
@@ -444,15 +454,9 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
             return "bf16"
         return "shared"
 
-    @staticmethod
-    def _cuda_cache_role(layer_name: str) -> str:
-        """Classify a CUDA KV cache by semantic path components.
-
-        CUDA model integrations do not expose a stable, shared cache-name
-        suffix. Treat any path component named ``indexer`` as the Indexer
-        cache; the remaining registered cache for that decoder layer is its
-        Attention cache.
-        """
+    @classmethod
+    def _cuda_cache_role(cls, layer_name: str) -> str:
+        """Classify a CUDA cache using the extensible role-pattern mapping."""
         path_components = [
             component
             for component in re.split(r"[^a-zA-Z0-9]+", layer_name.lower())
@@ -462,17 +466,15 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
             if component == "layers" and path_components[index + 1].isdigit():
                 path_components = path_components[index + 2 :]
                 break
-        return "indexer" if "indexer" in path_components else "attention"
+        semantic_name = ".".join(path_components)
+        for role, patterns in cls.CUDA_TENSOR_ROLE_PATTERNS.items():
+            if any(pattern.search(semantic_name) for pattern in patterns):
+                return role
+        return cls.CUDA_DEFAULT_TENSOR_ROLE
 
     @staticmethod
     def _cuda_tensor_info(layer_name: str, tensor: torch.Tensor) -> KVCacheTensorInfo:
         """Describe one CUDA tensor and verify block-contiguous storage."""
-        if tensor.dim() != 3:
-            raise ValueError(
-                "CUDA Shared Indexer KV cache tensors must have shape "
-                "[num_blocks, block_size, head_size]: "
-                f"layer={layer_name}, shape={tuple(tensor.shape)}."
-            )
 
         bytes_per_block = int(tensor.stride(0)) * int(tensor.element_size())
         payload_size = math.prod(int(size) for size in tensor.shape[1:]) * int(

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -85,11 +85,6 @@ def _has_shared_indexer_layers(vllm_config: "VllmConfig") -> bool:
     )
 
 
-def _supports_ascend_shared_indexer_layout(vllm_config: "VllmConfig") -> bool:
-    is_ascend = getattr(current_platform, "device_type", None) == "npu"
-    return is_ascend and _has_shared_indexer_layers(vllm_config)
-
-
 def _normalize_tensor_size_list(tensor_size_list: Any) -> list[int]:
     if isinstance(tensor_size_list, np.ndarray):
         return [int(v) for v in tensor_size_list.reshape(-1).tolist()]
@@ -390,8 +385,11 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
 
     @classmethod
     def supports(cls, vllm_config: "VllmConfig", ucm_config: dict) -> bool:
-        return bool(ucm_config.get("use_layerwise", False)) and (
-            _supports_ascend_shared_indexer_layout(vllm_config)
+        device_type = getattr(current_platform, "device_type", None)
+        return (
+            bool(ucm_config.get("use_layerwise", False))
+            and device_type in ("npu", "cuda")
+            and _has_shared_indexer_layers(vllm_config)
         )
 
     @staticmethod
@@ -446,11 +444,242 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
             return "bf16"
         return "shared"
 
+    @staticmethod
+    def _cuda_cache_role(layer_name: str) -> str:
+        """Classify a CUDA KV cache by semantic path components.
+
+        CUDA model integrations do not expose a stable, shared cache-name
+        suffix. Treat any path component named ``indexer`` as the Indexer
+        cache; the remaining registered cache for that decoder layer is its
+        Attention cache.
+        """
+        path_components = [
+            component
+            for component in re.split(r"[^a-zA-Z0-9]+", layer_name.lower())
+            if component
+        ]
+        for index, component in enumerate(path_components[:-1]):
+            if component == "layers" and path_components[index + 1].isdigit():
+                path_components = path_components[index + 2 :]
+                break
+        return "indexer" if "indexer" in path_components else "attention"
+
+    @staticmethod
+    def _cuda_tensor_info(layer_name: str, tensor: torch.Tensor) -> KVCacheTensorInfo:
+        """Describe one CUDA tensor and verify block-contiguous storage."""
+        if tensor.dim() != 3:
+            raise ValueError(
+                "CUDA Shared Indexer KV cache tensors must have shape "
+                "[num_blocks, block_size, head_size]: "
+                f"layer={layer_name}, shape={tuple(tensor.shape)}."
+            )
+
+        bytes_per_block = int(tensor.stride(0)) * int(tensor.element_size())
+        payload_size = math.prod(int(size) for size in tensor.shape[1:]) * int(
+            tensor.element_size()
+        )
+        if bytes_per_block != payload_size:
+            raise ValueError(
+                "CUDA Shared Indexer KV cache requires contiguous blocks: "
+                f"layer={layer_name}, block_stride={bytes_per_block}, "
+                f"payload_size={payload_size}."
+            )
+
+        return KVCacheTensorInfo(
+            ptr=int(tensor.data_ptr()),
+            bytes_per_block=bytes_per_block,
+            buffer_size=int(tensor.shape[0]) * bytes_per_block,
+        )
+
+    def _build_segment_rows(
+        self,
+        layers: list[SharedIndexerLayerInfo],
+        layout_mode: str,
+        *,
+        indexer_size: int = 0,
+        index_chunk_size: int = 0,
+        scale_size: int = 0,
+    ) -> list[list[KVCacheSegment]]:
+        """Build fixed-width rows shared by CUDA and Ascend layouts."""
+        segment_rows = []
+        for layer in layers:
+            segments = [
+                self._whole_tensor_segment(tensor) for tensor in layer.sfa_tensors
+            ]
+
+            if layout_mode == "bf16":
+                if layer.indexer is not None:
+                    segments.append(self._whole_tensor_segment(layer.indexer))
+                else:
+                    segments.append(self._ghost_segment(indexer_size))
+            elif layout_mode == "li_c8":
+                if layer.scale is not None:
+                    segments.extend(
+                        [
+                            self._whole_tensor_segment(layer.indexer),
+                            self._whole_tensor_segment(layer.scale),
+                        ]
+                    )
+                else:
+                    segments.extend(
+                        [
+                            self._ghost_segment(index_chunk_size),
+                            self._ghost_segment(scale_size),
+                        ]
+                    )
+            elif layout_mode == "mixed" and layer.scale is not None:
+                segments.extend(
+                    [
+                        self._real_segment(
+                            ptr=layer.indexer.ptr,
+                            copy_size=index_chunk_size,
+                            block_stride=layer.indexer.bytes_per_block,
+                            buffer_size=layer.indexer.buffer_size,
+                        ),
+                        self._ghost_segment(index_chunk_size),
+                        self._whole_tensor_segment(layer.scale),
+                    ]
+                )
+            elif layout_mode == "mixed" and layer.indexer is not None:
+                if layer.indexer.bytes_per_block != 2 * index_chunk_size:
+                    raise ValueError(
+                        "Cannot split BF16 Indexer tensor into two C8-sized "
+                        f"segments: bf16_size={layer.indexer.bytes_per_block}, "
+                        f"c8_size={index_chunk_size}."
+                    )
+                segments.extend(
+                    [
+                        self._real_segment(
+                            ptr=layer.indexer.ptr,
+                            copy_size=index_chunk_size,
+                            block_stride=layer.indexer.bytes_per_block,
+                            buffer_size=layer.indexer.buffer_size,
+                        ),
+                        self._real_segment(
+                            ptr=layer.indexer.ptr + index_chunk_size,
+                            copy_size=index_chunk_size,
+                            block_stride=layer.indexer.bytes_per_block,
+                            buffer_size=0,
+                        ),
+                        self._ghost_segment(scale_size),
+                    ]
+                )
+            elif layout_mode == "mixed":
+                segments.extend(
+                    [
+                        self._ghost_segment(index_chunk_size),
+                        self._ghost_segment(index_chunk_size),
+                        self._ghost_segment(scale_size),
+                    ]
+                )
+            else:
+                raise ValueError(
+                    f"Unsupported Shared Indexer layout mode: {layout_mode}."
+                )
+            segment_rows.append(segments)
+        return segment_rows
+
+    def _set_segment_rows(self, segment_rows: list[list[KVCacheSegment]]) -> None:
+        """Materialize segment metadata in the arrays consumed by the Store."""
+        self.base_ptrs = np.asarray(
+            [[segment.ptr for segment in row] for row in segment_rows],
+            dtype=np.uint64,
+        )
+        self.tensor_size_lists = np.asarray(
+            [[segment.copy_size for segment in row] for row in segment_rows],
+            dtype=np.uint64,
+        )
+        self.block_stride_lists = np.asarray(
+            [[segment.block_stride for segment in row] for row in segment_rows],
+            dtype=np.uint64,
+        )
+        self.buffer_sizes = np.asarray(
+            [[segment.buffer_size for segment in row] for row in segment_rows],
+            dtype=np.uint64,
+        )
+
     def _build_layout(self, kvcaches):
+        """Dispatch platform-specific collection into the shared row builder."""
         if not self.use_layerwise:
             super()._build_layout(kvcaches)
             return
 
+        if getattr(current_platform, "device_type", None) == "cuda":
+            self._build_cuda_layout(kvcaches)
+        else:
+            self._build_ascend_layout(kvcaches)
+
+    def _build_cuda_layout(self, kvcaches) -> None:
+        """Build CUDA rows as fixed ``[Attention, Indexer]`` shards.
+
+        Layers without an independent Indexer keep the same copy schema by
+        receiving a metadata-only ghost segment in the Indexer slot.
+        """
+        layer_tensors: dict[int, dict[str, Optional[KVCacheTensorInfo]]] = {}
+        for layer_name, tensor in kvcaches.items():
+            layer_id = self.layer_name_to_id[layer_name]
+            layer = layer_tensors.setdefault(
+                layer_id, {"attention": None, "indexer": None}
+            )
+
+            # Classification is independent of dict order and exact suffixes.
+            slot = self._cuda_cache_role(layer_name)
+            if layer[slot] is not None:
+                raise ValueError(
+                    f"Duplicate CUDA Shared Indexer {slot} cache for "
+                    f"layer {layer_id}: {layer_name}."
+                )
+            layer[slot] = self._cuda_tensor_info(layer_name, tensor)
+
+        row_layer_ids = sorted(layer_tensors)
+        self.first_layer_id = row_layer_ids[0]
+
+        layers = []
+        for layer_id in row_layer_ids:
+            attention = layer_tensors[layer_id]["attention"]
+            if attention is None:
+                raise ValueError(
+                    "CUDA Shared Indexer KV cache layer has no Attention "
+                    f"tensor: layer={layer_id}."
+                )
+            layers.append(
+                SharedIndexerLayerInfo(
+                    layer_id=layer_id,
+                    sfa_tensors=(attention,),
+                    indexer=layer_tensors[layer_id]["indexer"],
+                    scale=None,
+                )
+            )
+
+        attention_size = self._validate_uniform_sizes(
+            [layer.sfa_tensors[0].bytes_per_block for layer in layers],
+            "CUDA Attention block size",
+            [layer.layer_id for layer in layers],
+        )
+        indexer_layers = [layer for layer in layers if layer.indexer is not None]
+        if not indexer_layers:
+            raise ValueError(
+                "CUDA Shared Indexer KV cache layout did not find any "
+                "independent Indexer layer."
+            )
+        indexer_size = self._validate_uniform_sizes(
+            [layer.indexer.bytes_per_block for layer in indexer_layers],
+            "CUDA Indexer block size",
+            [layer.layer_id for layer in indexer_layers],
+        )
+
+        segment_rows = self._build_segment_rows(
+            layers, layout_mode="bf16", indexer_size=indexer_size
+        )
+        self._set_segment_rows(segment_rows)
+        logger.info(
+            "CUDA Shared Indexer layerwise KV cache layout: "
+            f"slot_sizes={[attention_size, indexer_size]}, "
+            f"layer_types={[self._layer_type(layer) for layer in layers]}"
+        )
+
+    def _build_ascend_layout(self, kvcaches) -> None:
+        """Build the existing Ascend SFA C8/BF16/mixed layerwise layout."""
         tensor_rows, row_layer_ids = self._collect_tensor_rows(kvcaches)
         if not tensor_rows or not tensor_rows[0]:
             raise ValueError("KV cache layout must contain at least one tensor")
@@ -513,6 +742,9 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
                 "Shared Indexer KV cache layout did not find any full " "Indexer layer."
             )
 
+        indexer_size = 0
+        index_chunk_size = 0
+        scale_size = 0
         if c8_layers:
             index_chunk_size = self._validate_uniform_sizes(
                 [layer.indexer.bytes_per_block for layer in c8_layers],
@@ -540,95 +772,14 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
             )
             slot_sizes = base_sizes + [indexer_size]
 
-        segment_rows = []
-        for layer in layers:
-            segments = [
-                self._whole_tensor_segment(tensor) for tensor in layer.sfa_tensors
-            ]
-
-            if layout_mode == "bf16":
-                if layer.indexer is not None:
-                    segments.append(self._whole_tensor_segment(layer.indexer))
-                else:
-                    segments.append(self._ghost_segment(indexer_size))
-            elif layout_mode == "li_c8":
-                if layer.scale is not None:
-                    segments.extend(
-                        [
-                            self._whole_tensor_segment(layer.indexer),
-                            self._whole_tensor_segment(layer.scale),
-                        ]
-                    )
-                else:
-                    segments.extend(
-                        [
-                            self._ghost_segment(index_chunk_size),
-                            self._ghost_segment(scale_size),
-                        ]
-                    )
-            elif layer.scale is not None:
-                segments.extend(
-                    [
-                        self._real_segment(
-                            ptr=layer.indexer.ptr,
-                            copy_size=index_chunk_size,
-                            block_stride=layer.indexer.bytes_per_block,
-                            buffer_size=layer.indexer.buffer_size,
-                        ),
-                        self._ghost_segment(index_chunk_size),
-                        self._whole_tensor_segment(layer.scale),
-                    ]
-                )
-            elif layer.indexer is not None:
-                if layer.indexer.bytes_per_block != 2 * index_chunk_size:
-                    raise ValueError(
-                        "Cannot split BF16 Indexer tensor into two C8-sized "
-                        f"segments: bf16_size={layer.indexer.bytes_per_block}, "
-                        f"c8_size={index_chunk_size}."
-                    )
-                segments.extend(
-                    [
-                        self._real_segment(
-                            ptr=layer.indexer.ptr,
-                            copy_size=index_chunk_size,
-                            block_stride=layer.indexer.bytes_per_block,
-                            buffer_size=layer.indexer.buffer_size,
-                        ),
-                        self._real_segment(
-                            ptr=layer.indexer.ptr + index_chunk_size,
-                            copy_size=index_chunk_size,
-                            block_stride=layer.indexer.bytes_per_block,
-                            buffer_size=0,
-                        ),
-                        self._ghost_segment(scale_size),
-                    ]
-                )
-            else:
-                segments.extend(
-                    [
-                        self._ghost_segment(index_chunk_size),
-                        self._ghost_segment(index_chunk_size),
-                        self._ghost_segment(scale_size),
-                    ]
-                )
-            segment_rows.append(segments)
-
-        self.base_ptrs = np.asarray(
-            [[segment.ptr for segment in row] for row in segment_rows],
-            dtype=np.uint64,
+        segment_rows = self._build_segment_rows(
+            layers,
+            layout_mode,
+            indexer_size=indexer_size,
+            index_chunk_size=index_chunk_size,
+            scale_size=scale_size,
         )
-        self.tensor_size_lists = np.asarray(
-            [[segment.copy_size for segment in row] for row in segment_rows],
-            dtype=np.uint64,
-        )
-        self.block_stride_lists = np.asarray(
-            [[segment.block_stride for segment in row] for row in segment_rows],
-            dtype=np.uint64,
-        )
-        self.buffer_sizes = np.asarray(
-            [[segment.buffer_size for segment in row] for row in segment_rows],
-            dtype=np.uint64,
-        )
+        self._set_segment_rows(segment_rows)
 
         logger.info(
             "Shared Indexer layerwise KV cache layout: "

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -679,6 +679,21 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
             )
 
         attention_sizes = [tensor.bytes_per_block for tensor in layers[0].sfa_tensors]
+        incompatible_attention_layers = {}
+        for layer in layers[1:]:
+            current_attention_sizes = [
+                tensor.bytes_per_block for tensor in layer.sfa_tensors
+            ]
+            if current_attention_sizes != attention_sizes:
+                incompatible_attention_layers[layer.layer_id] = current_attention_sizes
+        if incompatible_attention_layers:
+            raise ValueError(
+                "CUDA Shared Indexer layers must have the same Attention slot "
+                "count and per-block sizes: "
+                f"expected={attention_sizes} from layer {layers[0].layer_id}, "
+                f"incompatible_layers={incompatible_attention_layers}."
+            )
+
         indexer_layers = [layer for layer in layers if layer.indexer is not None]
         if not indexer_layers:
             raise ValueError(

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -386,7 +386,7 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
     CUDA_TENSOR_ROLE_PATTERNS = {
         "indexer": (
             re.compile(
-                r"(?:^|[._])indexer(?:[._]|$)",
+                r"(?:^|\.)indexer(?:\.|$)",
                 re.IGNORECASE,
             ),
         ),
@@ -458,9 +458,7 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
     def _cuda_cache_role(cls, layer_name: str) -> str:
         """Classify a CUDA cache using the extensible role-pattern mapping."""
         path_components = [
-            component
-            for component in re.split(r"[^a-zA-Z0-9]+", layer_name.lower())
-            if component
+            component for component in layer_name.lower().split(".") if component
         ]
         for index, component in enumerate(path_components[:-1]):
             if component == "layers" and path_components[index + 1].isdigit():
@@ -473,25 +471,44 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
         return cls.CUDA_DEFAULT_TENSOR_ROLE
 
     @staticmethod
-    def _cuda_tensor_info(layer_name: str, tensor: torch.Tensor) -> KVCacheTensorInfo:
-        """Describe one CUDA tensor and verify block-contiguous storage."""
+    def _cuda_tensor_infos(
+        layer_name: str,
+        tensor: torch.Tensor,
+        role: str,
+    ) -> tuple[KVCacheTensorInfo, ...]:
+        """Describe block-first CUDA tensors, splitting combined K/V caches."""
+        if tensor.dim() == 5:
+            if role != "attention" or tensor.shape[0] != 2:
+                raise ValueError(
+                    "CUDA 5D combined KV cache must be an Attention tensor "
+                    "with shape [2, num_blocks, ...]: "
+                    f"layer={layer_name}, role={role}, shape={tuple(tensor.shape)}."
+                )
+            component_tensors = (tensor[0], tensor[1])
+        else:
+            component_tensors = (tensor,)
 
-        bytes_per_block = int(tensor.stride(0)) * int(tensor.element_size())
-        payload_size = math.prod(int(size) for size in tensor.shape[1:]) * int(
-            tensor.element_size()
-        )
-        if bytes_per_block != payload_size:
-            raise ValueError(
-                "CUDA Shared Indexer KV cache requires contiguous blocks: "
-                f"layer={layer_name}, block_stride={bytes_per_block}, "
-                f"payload_size={payload_size}."
+        tensor_infos = []
+        for component in component_tensors:
+            bytes_per_block = int(component.stride(0)) * int(component.element_size())
+            payload_size = math.prod(int(size) for size in component.shape[1:]) * int(
+                component.element_size()
             )
+            if bytes_per_block != payload_size:
+                raise ValueError(
+                    "CUDA Shared Indexer KV cache requires contiguous blocks: "
+                    f"layer={layer_name}, block_stride={bytes_per_block}, "
+                    f"payload_size={payload_size}."
+                )
 
-        return KVCacheTensorInfo(
-            ptr=int(tensor.data_ptr()),
-            bytes_per_block=bytes_per_block,
-            buffer_size=int(tensor.shape[0]) * bytes_per_block,
-        )
+            tensor_infos.append(
+                KVCacheTensorInfo(
+                    ptr=int(component.data_ptr()),
+                    bytes_per_block=bytes_per_block,
+                    buffer_size=int(component.shape[0]) * bytes_per_block,
+                )
+            )
+        return tuple(tensor_infos)
 
     def _build_segment_rows(
         self,
@@ -617,7 +634,9 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
         Layers without an independent Indexer keep the same copy schema by
         receiving a metadata-only ghost segment in the Indexer slot.
         """
-        layer_tensors: dict[int, dict[str, Optional[KVCacheTensorInfo]]] = {}
+        layer_tensors: dict[int, dict[str, Optional[tuple[KVCacheTensorInfo, ...]]]] = (
+            {}
+        )
         for layer_name, tensor in kvcaches.items():
             layer_id = self.layer_name_to_id[layer_name]
             layer = layer_tensors.setdefault(
@@ -631,7 +650,7 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
                     f"Duplicate CUDA Shared Indexer {slot} cache for "
                     f"layer {layer_id}: {layer_name}."
                 )
-            layer[slot] = self._cuda_tensor_info(layer_name, tensor)
+            layer[slot] = self._cuda_tensor_infos(layer_name, tensor, slot)
 
         row_layer_ids = sorted(layer_tensors)
         self.first_layer_id = row_layer_ids[0]
@@ -644,20 +663,22 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
                     "CUDA Shared Indexer KV cache layer has no Attention "
                     f"tensor: layer={layer_id}."
                 )
+            indexer_tensors = layer_tensors[layer_id]["indexer"]
+            if indexer_tensors is not None and len(indexer_tensors) != 1:
+                raise ValueError(
+                    "CUDA Shared Indexer layer must have one Indexer tensor: "
+                    f"layer={layer_id}, count={len(indexer_tensors)}."
+                )
             layers.append(
                 SharedIndexerLayerInfo(
                     layer_id=layer_id,
-                    sfa_tensors=(attention,),
-                    indexer=layer_tensors[layer_id]["indexer"],
+                    sfa_tensors=attention,
+                    indexer=indexer_tensors[0] if indexer_tensors else None,
                     scale=None,
                 )
             )
 
-        attention_size = self._validate_uniform_sizes(
-            [layer.sfa_tensors[0].bytes_per_block for layer in layers],
-            "CUDA Attention block size",
-            [layer.layer_id for layer in layers],
-        )
+        attention_sizes = [tensor.bytes_per_block for tensor in layers[0].sfa_tensors]
         indexer_layers = [layer for layer in layers if layer.indexer is not None]
         if not indexer_layers:
             raise ValueError(
@@ -676,7 +697,7 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
         self._set_segment_rows(segment_rows)
         logger.info(
             "CUDA Shared Indexer layerwise KV cache layout: "
-            f"slot_sizes={[attention_size, indexer_size]}, "
+            f"slot_sizes={attention_sizes + [indexer_size]}, "
             f"layer_types={[self._layer_type(layer) for layer in layers]}"
         )
 


### PR DESCRIPTION
## Purpose

支持 CUDA 平台 GLM 5.2 Layerwise KV Cache Layout。

## Modifications

- 扩展 `SharedIndexerKVCacheLayout` 的适用范围，使其同时支持 Ascend 和 CUDA 平台的 Shared Indexer 模型。
- 针对 CUDA Shared Indexer KV Cache 引入独立的 Layerwise Layout 构建流程：
  - 基于 KV Cache Tensor 的语义信息识别 Attention 与 Indexer Tensor。
  - 按 Layer 聚合各类 Tensor，并构建统一的 `SharedIndexerLayerInfo`。
  - 校验各 Layer 的 Block Size 一致性，保证 Layerwise Layout 的正确性。
- 针对缺失独立 Indexer Tensor 的 Layer，引入 Ghost Segment 进行占位，保证各 Layer 保持统一的 Slot 布局，简化 Layerwise 地址计算逻辑。
- 新增 CUDA Shared Indexer Layerwise Layout 相关 UT，覆盖 Layout 构建、Tensor 分类、Ghost Segment 补齐及 Block Address 提取等场景。

## Test

- 新增 CUDA Shared Indexer Layerwise Layout 相关单元测试。
- 已通过全部 UT。