### PR TITLE
[Bugfix] Propagate shared cache load failures

### DIFF
--- a/ucm/store/cache/cc/dump_queue.cc
+++ b/ucm/store/cache/cc/dump_queue.cc
@@ -139,7 +139,10 @@ Status DumpQueue::DumpOneTask(CopyStream& stream, TaskPtr task)
             }
             copiedShards++;
         }
-        backendTaskDesc.push_back(Detail::Shard{shard.owner, shard.index, {handle.Data()}});
+        Detail::Shard backendShard{shard.owner, shard.index, {handle.Data()}};
+        // Keep the cache buffer referenced until the backend task releases the shard.
+        backendShard.cacheLifeHolder = std::make_shared<TransBuffer::Handle>(handle);
+        backendTaskDesc.push_back(std::move(backendShard));
         dumpCtx.bufferHandles.push_back(std::move(handle));
     }
     auto tpMakeBuffer = NowTime::Now();

--- a/ucm/store/cache/cc/load_queue.cc
+++ b/ucm/store/cache/cc/load_queue.cc
@@ -46,6 +46,7 @@ Status LoadQueue::Setup(const Config& config, TaskIdSet* failureSet, TransBuffer
     useGdr_ = config.useGdr;
     cacheSdmaDirect_ = config.cacheSdmaDirect;
     sdmaDirectLaunchGranularity_ = config.sdmaDirectLaunchGranularity;
+    timeoutMs_ = config.timeoutMs;
     cpuAffinityCores_ = config.cpuAffinityCores;
     waiting_.Setup(config.waitingQueueDepth);
     running_.Setup(config.runningQueueDepth);
@@ -106,18 +107,32 @@ void LoadQueue::DispatchOneTask(TaskPair&& pair)
         shardTask.bufferHandle = buffer_->Get(shard.owner, shard.index, true, true);
         shardTask.backendTaskHandle = 0;
         if (shardTask.bufferHandle.Owner() && !shardTask.bufferHandle.Ready()) {
-            Detail::TaskDesc backendTask{
-                Detail::Shard{shard.owner, shard.index, {shardTask.bufferHandle.Data()}}
-            };
+            Detail::Shard backendShard{shard.owner, shard.index, {shardTask.bufferHandle.Data()}};
+            // Keep the cache buffer referenced until the backend task releases the shard.
+            backendShard.cacheLifeHolder =
+                std::make_shared<TransBuffer::Handle>(shardTask.bufferHandle);
+            Detail::TaskDesc backendTask{std::move(backendShard)};
             backendTask.brief = "Backend2Cache";
             auto res = backend_->Load(std::move(backendTask));
             if (!res) [[unlikely]] {
                 UC_ERROR("Failed({}) to submit load task({}) to backend.", res.Error(), task->id);
                 UC::Metrics::UpdateStats(
                     NAME_TO_METRIC_ID("cache_backend_load_submit_errors_total"), 1.0);
+                shardTask.bufferHandle.MarkFailed(res.Error());
                 task->Fail(res.Error());
                 failureSet_->Insert(task->id);
-                waiter->Done();
+                if (taskLaunch) {
+                    // cleanup logic is in TransferOneTask, ensure sdma task enter it
+                    for (auto& readyTask : readyTasks) { running_.Push(std::move(readyTask)); }
+                    for (auto& pendingTask : pendingTasks) {
+                        running_.Push(std::move(pendingTask));
+                    }
+                }
+                // if failed, do not submit following shards, let this shard be last one
+                shardTask.task = task;
+                shardTask.shard = std::move(shard);
+                shardTask.waiter = waiter;
+                running_.Push(std::move(shardTask));
                 return;
             }
             shardTask.backendTaskHandle = res.Value();
@@ -181,19 +196,18 @@ void LoadQueue::TransferOneTask(CopyStream& stream, ShardTask&& task)
 {
     auto parentTask = task.task;
     const auto taskHandle = parentTask->id;
-    if (failureSet_->Contains(taskHandle)) {
-        if (task.waiter) {
-            ClearSdmaDirectHolders();
-            task.waiter->Done();
-        }
-        return;
-    }
     auto s = Status::OK();
     auto waiter = task.waiter;
+    // no loop, only for easier coding, use break to skip some actions
     do {
         auto tpBackendWait = NowTime::Now();
         s = WaitBackendTaskReady(task);
         if (s.Failure()) [[unlikely]] { break; }
+        // if parent task has failed, skip h2d
+        if (failureSet_->Contains(taskHandle)) {
+            s = parentTask->FailureStatus();
+            break;
+        }
         auto tpBackendReady = NowTime::Now();
         UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_shard_backend_wait_ms"),
                                  (tpBackendReady - tpBackendWait) * 1e3);
@@ -207,8 +221,7 @@ void LoadQueue::TransferOneTask(CopyStream& stream, ShardTask&& task)
                 UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2d_errors_total"), 1.0);
                 break;
             }
-            if (waiter) { waiter->Done(); }
-            return;
+            break;
         }
 
         if (cacheSdmaDirect_) {
@@ -263,19 +276,31 @@ void LoadQueue::TransferOneTask(CopyStream& stream, ShardTask&& task)
         }
     } while (0);
     if (s.Failure()) [[unlikely]] {
-        parentTask->Fail(s);
-        failureSet_->Insert(taskHandle);
+        if (task.bufferHandle && task.bufferHandle.Owner() &&
+            task.bufferHandle.GetState() == TransBuffer::State::LOADING) {
+            task.bufferHandle.MarkFailed(s);
+        }
+        if (!failureSet_->Contains(taskHandle)) {
+            parentTask->Fail(s);
+            failureSet_->Insert(taskHandle);
+        }
+        auto syncStatus = SynchronizeAndClearHolders(stream);
+        if (syncStatus.Failure()) {
+            UC_ERROR("Failed({}) to synchronize stream for failed task({}).", syncStatus,
+                     taskHandle);
+        }
     }
-    if (UseSdmaDirectTaskLaunch()) { ClearSdmaDirectHolders(); }
     if (waiter) { waiter->Done(); }
 }
 
 Status LoadQueue::WaitBackendTaskReady(ShardTask& task)
 {
     if (task.backendTaskHandle != 0) {
-        auto s = backend_->Wait(task.backendTaskHandle);
+        auto backendTaskHandle = task.backendTaskHandle;
+        task.backendTaskHandle = 0;
+        auto s = backend_->Wait(backendTaskHandle);
         if (s.Failure()) [[unlikely]] {
-            UC_ERROR("Failed({}) to wait backend({}) for task({}).", s, task.backendTaskHandle,
+            UC_ERROR("Failed({}) to wait backend({}) for task({}).", s, backendTaskHandle,
                      task.task->id);
             UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_backend_load_wait_errors_total"),
                                      1.0);
@@ -284,11 +309,20 @@ Status LoadQueue::WaitBackendTaskReady(ShardTask& task)
         task.bufferHandle.MarkReady();
         return Status::OK();
     }
-    while (!task.bufferHandle.Ready()) {
+    // add timeout for the wait, in case the state transfer has error
+    const auto deadline = NowTime::Now() + static_cast<double>(timeoutMs_) / 1000.0;
+    for (;;) {
+        auto state = task.bufferHandle.GetState();
+        if (state == TransBuffer::State::READY) { return Status::OK(); }
+        if (state == TransBuffer::State::FAILED) { return task.bufferHandle.FailureStatus(); }
         if (failureSet_->Contains(task.task->id)) { return task.task->FailureStatus(); }
+        if (timeoutMs_ != 0 && NowTime::Now() >= deadline) {
+            UC_ERROR("Timed out waiting for shared buffer for task({}) after {} ms.", task.task->id,
+                     timeoutMs_);
+            return Status::Timeout();
+        }
         std::this_thread::yield();
     }
-    return Status::OK();
 }
 
 Status LoadQueue::HostToDeviceAsync(CopyStream& stream, void* host, void** device)
@@ -327,6 +361,16 @@ Status LoadQueue::FlushSdmaDirectTaskBatch(CopyStream& stream)
     auto h2dSyncMs = (NowTime::Now() - tpH2dSyncStart) * 1e3;
     RecordH2dSyncMetrics(h2dSyncMs);
     ClearSdmaDirectHolders();
+    return s;
+}
+
+Status LoadQueue::SynchronizeAndClearHolders(CopyStream& stream)
+{
+    auto tpH2dSyncStart = NowTime::Now();
+    auto s = stream.Synchronize();
+    auto h2dSyncMs = (NowTime::Now() - tpH2dSyncStart) * 1e3;
+    RecordH2dSyncMetrics(h2dSyncMs);
+    if (!holder_.empty()) { ClearSdmaDirectHolders(); }
     return s;
 }
 

--- a/ucm/store/cache/cc/load_queue.h
+++ b/ucm/store/cache/cc/load_queue.h
@@ -47,11 +47,10 @@ class LoadQueue {
         TaskPtr task;
         Detail::Shard shard;
         TransBuffer::Handle bufferHandle;
-        Detail::TaskHandle backendTaskHandle;
+        Detail::TaskHandle backendTaskHandle{0};
         WaiterPtr waiter;
         bool launchBoundary{false};
     };
-
 private:
     alignas(64) std::atomic_bool stop_{false};
     TaskIdSet* failureSet_{nullptr};
@@ -63,6 +62,7 @@ private:
     bool useGdr_{false};
     bool cacheSdmaDirect_{false};
     std::string sdmaDirectLaunchGranularity_{kSdmaDirectLaunchShard};
+    size_t timeoutMs_{0};
     std::vector<ssize_t> cpuAffinityCores_{};
     SpscRingQueue<TaskPair> waiting_;
     SpscRingQueue<ShardTask> running_;
@@ -84,6 +84,7 @@ private:
     Status HostToDeviceAsync(CopyStream& stream, void* host, void** device);
     Status HostToDeviceTaskAsync(CopyStream& stream, std::vector<ShardTask>& tasks);
     Status FlushSdmaDirectTaskBatch(CopyStream& stream);
+    Status SynchronizeAndClearHolders(CopyStream& stream);
     void RecordH2dSyncMetrics(double h2dSyncMs) const;
     void ClearSdmaDirectHolders() noexcept;
     bool UseSdmaDirectTaskLaunch() const noexcept;

--- a/ucm/store/cache/cc/trans_buffer.cc
+++ b/ucm/store/cache/cc/trans_buffer.cc
@@ -53,14 +53,16 @@ struct BufferMetaNode {
     size_t hash;
     size_t prev;
     size_t next;
-    bool ready;
+    TransBuffer::State state;
+    int32_t errorCode;
     void Init()
     {
         reference = 0;
         hash = invalidIndex;
         prev = invalidIndex;
         next = invalidIndex;
-        ready = false;
+        state = TransBuffer::State::LOADING;
+        errorCode = Status::OK().Underlying();
     }
 };
 
@@ -569,6 +571,10 @@ size_t TransBuffer::FindAt(size_t iBucket, const Detail::BlockId& blockId, size_
         strategy_->NodeLock(iNode);
         if (meta->block == blockId && meta->shard == shardIdx) {
             owner = meta->reference == 0;
+            if (owner && meta->state == State::FAILED) {
+                meta->state = State::LOADING;
+                meta->errorCode = Status::OK().Underlying();
+            }
             ++meta->reference;
             strategy_->NodeUnlock(iNode);
             break;
@@ -606,7 +612,8 @@ size_t TransBuffer::Alloc(const Detail::BlockId& blockId, size_t shardIdx, size_
         ++meta->reference;
         meta->block = blockId;
         meta->shard = shardIdx;
-        meta->ready = false;
+        meta->state = State::LOADING;
+        meta->errorCode = Status::OK().Underlying();
         strategy_->NodeUnlock(iNode);
         return iNode;
     }
@@ -668,25 +675,53 @@ void TransBuffer::Release(Index pos)
     strategy_->NodeUnlock(pos);
 }
 
-bool TransBuffer::Ready(Index pos)
+bool TransBuffer::Ready(Index pos) { return GetState(pos) == State::READY; }
+
+TransBuffer::State TransBuffer::GetState(Index pos)
 {
     strategy_->NodeLock(pos);
-    auto ready = strategy_->MetaAt(pos)->ready;
+    auto state = strategy_->MetaAt(pos)->state;
     strategy_->NodeUnlock(pos);
-    return ready;
+    return state;
+}
+
+Status TransBuffer::FailureStatus(Index pos)
+{
+    strategy_->NodeLock(pos);
+    auto meta = strategy_->MetaAt(pos);
+    auto errorCode = meta->errorCode;
+    strategy_->NodeUnlock(pos);
+    return Status{errorCode, {}};
 }
 
 void TransBuffer::MarkReady(Index pos)
 {
     strategy_->NodeLock(pos);
-    strategy_->MetaAt(pos)->ready = true;
+    auto meta = strategy_->MetaAt(pos);
+    if (meta->state == State::LOADING) {
+        meta->state = State::READY;
+        meta->errorCode = Status::OK().Underlying();
+    }
+    strategy_->NodeUnlock(pos);
+}
+
+void TransBuffer::MarkFailed(Index pos, const Status& status)
+{
+    strategy_->NodeLock(pos);
+    auto meta = strategy_->MetaAt(pos);
+    if (meta->state == State::LOADING) {
+        meta->state = State::FAILED;
+        meta->errorCode = status.Underlying();
+    }
     strategy_->NodeUnlock(pos);
 }
 
 void TransBuffer::MarkNotReady(Index pos)
 {
     strategy_->NodeLock(pos);
-    strategy_->MetaAt(pos)->ready = false;
+    auto meta = strategy_->MetaAt(pos);
+    meta->state = State::LOADING;
+    meta->errorCode = Status::OK().Underlying();
     strategy_->NodeUnlock(pos);
 }
 

--- a/ucm/store/cache/cc/trans_buffer.h
+++ b/ucm/store/cache/cc/trans_buffer.h
@@ -41,6 +41,8 @@ class TransBuffer {
     bool bypassHitOnLoad_{false};
 
 public:
+    enum class State : uint8_t { LOADING, READY, FAILED };
+
     class Handle {
     public:
         Handle() = default;
@@ -85,7 +87,10 @@ public:
             return nullptr;
         }
         bool Ready() const { return buf_->Ready(pos_); };
+        State GetState() const { return buf_->GetState(pos_); }
+        Status FailureStatus() const { return buf_->FailureStatus(pos_); }
         void MarkReady() { buf_->MarkReady(pos_); };
+        void MarkFailed(const Status& status) { buf_->MarkFailed(pos_, status); }
 
     private:
         friend class TransBuffer;
@@ -120,7 +125,10 @@ private:
     void Acquire(Index pos);
     void Release(Index pos);
     bool Ready(Index pos);
+    State GetState(Index pos);
+    Status FailureStatus(Index pos);
     void MarkReady(Index pos);
+    void MarkFailed(Index pos, const Status& status);
     void MarkNotReady(Index pos);
 };
 

--- a/ucm/store/detail/type/types.h
+++ b/ucm/store/detail/type/types.h
@@ -25,6 +25,7 @@
 #define UNIFIEDCACHE_STORE_DETAIL_TYPE_TYPES_H
 
 #include <array>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -51,6 +52,7 @@ struct Shard {
     BlockId owner;            /* Parent block identifier */
     std::size_t index;        /* Shard index inside the block */
     std::vector<void*> addrs; /* Device-side buffer addresses */
+    std::shared_ptr<void> cacheLifeHolder{};
 };
 
 /**

--- a/ucm/store/mooncakestore/cc/mooncake_store.cc
+++ b/ucm/store/mooncakestore/cc/mooncake_store.cc
@@ -312,7 +312,8 @@ private:
                                       config_.tensorSizeList.begin() + count);
 
             out.shards.push_back(TransShard{std::move(key), shard.owner, shard.index,
-                                            std::move(addrs), std::move(sizes)});
+                                            std::move(addrs), std::move(sizes),
+                                            shard.cacheLifeHolder});
         }
     }
 

--- a/ucm/store/mooncakestore/cc/trans_task.h
+++ b/ucm/store/mooncakestore/cc/trans_task.h
@@ -40,6 +40,7 @@ struct TransShard {
     size_t index;
     std::vector<void*> addrs;
     std::vector<size_t> sizes;
+    std::shared_ptr<void> cacheLifeHolder;
 };
 
 struct TransTask {

--- a/ucm/store/posix/cc/aio_impl.cc
+++ b/ucm/store/posix/cc/aio_impl.cc
@@ -211,7 +211,9 @@ Status AioImpl::Setup(size_t timeoutMs)
 Status AioImpl::ReadAsync(Io&& io)
 {
     auto cb = std::make_unique<struct iocb>();
-    auto data = std::make_unique<Callback>(std::move(io.callback));
+    auto data = std::make_unique<Callback>(
+        [callback = std::move(io.callback), cacheLifeHolder = std::move(io.cacheLifeHolder)](
+            Result result) mutable { callback(result); });
     AioPrepareRead(cb.get(), io.fd, io.buffer, io.length, io.offset);
     cb->aio_data = (uintptr_t)(void*)data.get();
     Track(io.tag, cb.get());
@@ -228,7 +230,9 @@ Status AioImpl::ReadAsync(Io&& io)
 Status AioImpl::WriteAsync(Io&& io)
 {
     auto cb = std::make_unique<struct iocb>();
-    auto data = std::make_unique<Callback>(std::move(io.callback));
+    auto data = std::make_unique<Callback>(
+        [callback = std::move(io.callback), cacheLifeHolder = std::move(io.cacheLifeHolder)](
+            Result result) mutable { callback(result); });
     AioPrepareWrite(cb.get(), io.fd, io.buffer, io.length, io.offset);
     cb->aio_data = (uintptr_t)(void*)data.get();
     Track(io.tag, cb.get());

--- a/ucm/store/posix/cc/aio_impl.h
+++ b/ucm/store/posix/cc/aio_impl.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <functional>
 #include <linux/aio_abi.h>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <unordered_map>
@@ -60,6 +61,7 @@ public:
         void* buffer;
         Callback callback;
         uint64_t tag{0};
+        std::shared_ptr<void> cacheLifeHolder;
     };
     using SweepFn = std::function<void()>;
 

--- a/ucm/store/posix/cc/io_engine_aio.h
+++ b/ucm/store/posix/cc/io_engine_aio.h
@@ -157,6 +157,7 @@ private:
         io.length = shardSize_;
         io.buffer = shard.addrs.front();
         io.tag = tid;
+        io.cacheLifeHolder = shard.cacheLifeHolder;
         io.callback = [this, task, w, fd = result.fd, last, id](AioImpl::Result ioResult) {
             OnIoCallback<dump>(task, w, fd, last, id, ioResult);
         };

--- a/ucm/store/test/case/cache/cache_dump_queue_test.cc
+++ b/ucm/store/test/case/cache/cache_dump_queue_test.cc
@@ -116,3 +116,43 @@ TEST_F(UCCacheDumpQueueTest, DumpBlockWhileBackendSubmitFailed)
     waiter->Wait();
     ASSERT_TRUE(failureSet.Contains(task->id));
 }
+
+TEST_F(UCCacheDumpQueueTest, SkipDumpWhileFailedBufferIsReferenced)
+{
+    using namespace UC::CacheStore;
+    UC::Test::Detail::MockStore backend;
+    EXPECT_CALL(backend, Dump).Times(0);
+    UC::HashSet<UC::Detail::TaskHandle> failureSet;
+    Config config;
+    config.storeBackend = &backend;
+    size_t tensorSize = 32768;
+    config.tensorSizes = {tensorSize};
+    config.shardSize = tensorSize;
+    config.blockSize = config.shardSize;
+    config.deviceId = 0;
+    config.bufferCapacity = config.shardSize * 1024;
+    config.uniqueId = rd.RandomString(10);
+    config.shareBufferEnable = true;
+    TransBuffer buffer;
+    DumpQueue dumpQ;
+    auto s = buffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    s = dumpQ.Setup(config, &failureSet, &buffer);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
+    constexpr size_t shardIdx = 0;
+    auto failedHandle = buffer.Get(blockId, shardIdx, true, true);
+    failedHandle.MarkFailed(UC::Status::Timeout());
+    UC::Test::Detail::DataGenerator data{1, config.blockSize};
+    data.Generate();
+    UC::Detail::TaskDesc desc{
+        {blockId, shardIdx, {data.Buffer()}}
+    };
+    auto task = std::make_shared<TransTask>(TransTask::Type::DUMP, desc);
+    auto waiter = std::make_shared<UC::Latch>();
+
+    dumpQ.Submit(task, waiter);
+    waiter->Wait();
+
+    ASSERT_FALSE(failureSet.Contains(task->id));
+}

--- a/ucm/store/test/case/cache/cache_load_queue_test.cc
+++ b/ucm/store/test/case/cache/cache_load_queue_test.cc
@@ -154,3 +154,250 @@ TEST_F(UCCacheLoadQueueTest, LoadWhileBackendWaitFailed)
     waiter->Wait();
     ASSERT_TRUE(failureSet.Contains(task->id));
 }
+
+TEST_F(UCCacheLoadQueueTest, SharedFailureStopsNonOwnerWait)
+{
+    using namespace UC::CacheStore;
+    using namespace testing;
+    UC::Test::Detail::MockStore backend;
+    EXPECT_CALL(backend, Load).Times(0);
+    UC::HashSet<UC::Detail::TaskHandle> failureSet;
+    Config config;
+    config.storeBackend = &backend;
+    size_t tensorSize = 32768;
+    config.tensorSizes = {tensorSize};
+    config.shardSize = tensorSize;
+    config.blockSize = config.shardSize;
+    config.deviceId = 0;
+    config.bufferCapacity = config.shardSize * 1024;
+    config.uniqueId = rd.RandomString(10);
+    config.shareBufferEnable = true;
+    TransBuffer buffer;
+    LoadQueue loadQ;
+    auto s = buffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    s = loadQ.Setup(config, &failureSet, &buffer);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
+    constexpr size_t shardIdx = 0;
+    auto owner = buffer.Get(blockId, shardIdx, true, true);
+    UC::Test::Detail::DataGenerator data{1, config.blockSize};
+    data.Generate();
+    UC::Detail::TaskDesc desc{
+        {blockId, shardIdx, {data.Buffer()}}
+    };
+    auto task = std::make_shared<TransTask>(TransTask::Type::LOAD, desc);
+    auto waiter = std::make_shared<UC::Latch>();
+    loadQ.Submit(task, waiter);
+
+    owner.MarkFailed(UC::Status::NotFound());
+
+    ASSERT_TRUE(waiter->WaitForDuration(1000));
+    ASSERT_TRUE(failureSet.Contains(task->id));
+    ASSERT_EQ(task->FailureStatus(), UC::Status::NotFound());
+}
+
+TEST_F(UCCacheLoadQueueTest, NonOwnerWaitTimesOut)
+{
+    using namespace UC::CacheStore;
+    using namespace testing;
+    UC::Test::Detail::MockStore backend;
+    EXPECT_CALL(backend, Load).Times(0);
+    UC::HashSet<UC::Detail::TaskHandle> failureSet;
+    Config config;
+    config.storeBackend = &backend;
+    size_t tensorSize = 32768;
+    config.tensorSizes = {tensorSize};
+    config.shardSize = tensorSize;
+    config.blockSize = config.shardSize;
+    config.deviceId = 0;
+    config.bufferCapacity = config.shardSize * 1024;
+    config.uniqueId = rd.RandomString(10);
+    config.shareBufferEnable = true;
+    config.timeoutMs = 50;
+    TransBuffer buffer;
+    LoadQueue loadQ;
+    auto s = buffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    s = loadQ.Setup(config, &failureSet, &buffer);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
+    constexpr size_t shardIdx = 0;
+    auto owner = buffer.Get(blockId, shardIdx, true, true);
+    UC::Test::Detail::DataGenerator data{1, config.blockSize};
+    data.Generate();
+    UC::Detail::TaskDesc desc{
+        {blockId, shardIdx, {data.Buffer()}}
+    };
+    auto task = std::make_shared<TransTask>(TransTask::Type::LOAD, desc);
+    auto waiter = std::make_shared<UC::Latch>();
+    loadQ.Submit(task, waiter);
+
+    ASSERT_TRUE(waiter->WaitForDuration(1000));
+    ASSERT_TRUE(failureSet.Contains(task->id));
+    ASSERT_EQ(task->FailureStatus(), UC::Status::Timeout());
+    ASSERT_EQ(owner.GetState(), TransBuffer::State::LOADING);
+}
+
+TEST_F(UCCacheLoadQueueTest, PublishesBackendSubmitFailure)
+{
+    using namespace UC::CacheStore;
+    using namespace testing;
+    std::promise<void> submitEntered;
+    std::promise<void> allowSubmitFailure;
+    auto allowSubmitFailureFuture = allowSubmitFailure.get_future().share();
+    UC::Test::Detail::MockStore backend;
+    EXPECT_CALL(backend, Load)
+        .WillOnce(Invoke([&](UC::Detail::TaskDesc) -> UC::Expected<UC::Detail::TaskHandle> {
+            submitEntered.set_value();
+            allowSubmitFailureFuture.wait();
+            return UC::Status::NotFound();
+        }));
+    UC::HashSet<UC::Detail::TaskHandle> failureSet;
+    Config config;
+    config.storeBackend = &backend;
+    size_t tensorSize = 32768;
+    config.tensorSizes = {tensorSize};
+    config.shardSize = tensorSize;
+    config.blockSize = config.shardSize;
+    config.deviceId = 0;
+    config.bufferCapacity = config.shardSize * 1024;
+    config.uniqueId = rd.RandomString(10);
+    config.shareBufferEnable = true;
+    TransBuffer buffer;
+    LoadQueue loadQ;
+    auto s = buffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    s = loadQ.Setup(config, &failureSet, &buffer);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
+    constexpr size_t shardIdx = 0;
+    UC::Test::Detail::DataGenerator data{1, config.blockSize};
+    data.Generate();
+    UC::Detail::TaskDesc desc{
+        {blockId, shardIdx, {data.Buffer()}}
+    };
+    auto task = std::make_shared<TransTask>(TransTask::Type::LOAD, desc);
+    auto waiter = std::make_shared<UC::Latch>();
+    loadQ.Submit(task, waiter);
+    submitEntered.get_future().wait();
+    auto observer = buffer.Get(blockId, shardIdx, true, true);
+
+    allowSubmitFailure.set_value();
+
+    ASSERT_TRUE(waiter->WaitForDuration(1000));
+    ASSERT_EQ(observer.FailureStatus(), UC::Status::NotFound());
+    ASSERT_EQ(task->FailureStatus(), UC::Status::NotFound());
+}
+
+TEST_F(UCCacheLoadQueueTest, PublishesBackendWaitFailure)
+{
+    using namespace UC::CacheStore;
+    using namespace testing;
+    std::promise<void> waitEntered;
+    std::promise<void> allowWaitFailure;
+    auto allowWaitFailureFuture = allowWaitFailure.get_future().share();
+    UC::Test::Detail::MockStore backend;
+    EXPECT_CALL(backend, Load).WillOnce(Invoke(NextId));
+    EXPECT_CALL(backend, Wait).WillOnce(Invoke([&](UC::Detail::TaskHandle) {
+        waitEntered.set_value();
+        allowWaitFailureFuture.wait();
+        return UC::Status::NotFound();
+    }));
+    UC::HashSet<UC::Detail::TaskHandle> failureSet;
+    Config config;
+    config.storeBackend = &backend;
+    size_t tensorSize = 32768;
+    config.tensorSizes = {tensorSize};
+    config.shardSize = tensorSize;
+    config.blockSize = config.shardSize;
+    config.deviceId = 0;
+    config.bufferCapacity = config.shardSize * 1024;
+    config.uniqueId = rd.RandomString(10);
+    config.shareBufferEnable = true;
+    TransBuffer buffer;
+    LoadQueue loadQ;
+    auto s = buffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    s = loadQ.Setup(config, &failureSet, &buffer);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
+    constexpr size_t shardIdx = 0;
+    UC::Test::Detail::DataGenerator data{1, config.blockSize};
+    data.Generate();
+    UC::Detail::TaskDesc desc{
+        {blockId, shardIdx, {data.Buffer()}}
+    };
+    auto task = std::make_shared<TransTask>(TransTask::Type::LOAD, desc);
+    auto waiter = std::make_shared<UC::Latch>();
+    loadQ.Submit(task, waiter);
+    waitEntered.get_future().wait();
+    auto observer = buffer.Get(blockId, shardIdx, true, true);
+
+    allowWaitFailure.set_value();
+
+    ASSERT_TRUE(waiter->WaitForDuration(1000));
+    ASSERT_EQ(observer.FailureStatus(), UC::Status::NotFound());
+    ASSERT_EQ(task->FailureStatus(), UC::Status::NotFound());
+}
+
+TEST_F(UCCacheLoadQueueTest, WaitsForSubmittedShardAfterParentFailure)
+{
+    using namespace UC::CacheStore;
+    using namespace testing;
+    std::promise<void> loadEntered;
+    std::promise<void> allowLoad;
+    auto allowLoadFuture = allowLoad.get_future().share();
+    std::promise<void> waitEntered;
+    std::promise<void> allowWait;
+    auto allowWaitFuture = allowWait.get_future().share();
+    size_t tensorSize = 32768;
+    UC::Test::Detail::MockStore backend;
+    EXPECT_CALL(backend, Load).WillOnce(Invoke([&](UC::Detail::TaskDesc) {
+        loadEntered.set_value();
+        allowLoadFuture.wait();
+        return NextId();
+    }));
+    EXPECT_CALL(backend, Wait).WillOnce(Invoke([&](UC::Detail::TaskHandle) {
+        waitEntered.set_value();
+        allowWaitFuture.wait();
+        return UC::Status::OK();
+    }));
+    UC::HashSet<UC::Detail::TaskHandle> failureSet;
+    Config config;
+    config.storeBackend = &backend;
+    config.tensorSizes = {tensorSize};
+    config.shardSize = tensorSize;
+    config.blockSize = config.shardSize;
+    config.deviceId = 0;
+    config.bufferCapacity = config.shardSize * 1024;
+    config.uniqueId = rd.RandomString(10);
+    config.shareBufferEnable = true;
+    TransBuffer buffer;
+    LoadQueue loadQ;
+    auto s = buffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    s = loadQ.Setup(config, &failureSet, &buffer);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
+    UC::Test::Detail::DataGenerator data{1, config.blockSize};
+    data.Generate();
+    UC::Detail::TaskDesc desc{
+        {blockId, 0, {data.Buffer()}},
+    };
+    auto task = std::make_shared<TransTask>(TransTask::Type::LOAD, desc);
+    auto waiter = std::make_shared<UC::Latch>();
+    loadQ.Submit(task, waiter);
+    loadEntered.get_future().wait();
+    task->Fail(UC::Status::NotFound());
+    failureSet.Insert(task->id);
+    allowLoad.set_value();
+    waitEntered.get_future().wait();
+    auto finishedBeforeSubmittedShard = waiter->WaitForDuration(100);
+    allowWait.set_value();
+    auto finishedAfterSubmittedShard = waiter->WaitForDuration(1000);
+
+    ASSERT_FALSE(finishedBeforeSubmittedShard);
+    ASSERT_TRUE(finishedAfterSubmittedShard);
+    ASSERT_EQ(task->FailureStatus(), UC::Status::NotFound());
+}

--- a/ucm/store/test/case/cache/cache_trans_buffer_test.cc
+++ b/ucm/store/test/case/cache/cache_trans_buffer_test.cc
@@ -22,6 +22,8 @@
  * SOFTWARE.
  * */
 #include <gtest/gtest.h>
+#include <sys/wait.h>
+#include <unistd.h>
 #include "cache/cc/trans_buffer.h"
 #include "detail/random.h"
 #include "detail/types_helper.h"
@@ -142,6 +144,165 @@ TEST_P(UCCacheTransBufferTest, BackendOnlyLoadCoalescesInFlightEntry)
     ASSERT_TRUE(waiter);
     ASSERT_FALSE(waiter.Owner());
     ASSERT_EQ(owner.Data(), waiter.Data());
+}
+
+TEST_P(UCCacheTransBufferTest, SharesFailureWithReferencedHandles)
+{
+    UC::CacheStore::TransBuffer transBuffer;
+    UC::CacheStore::Config config;
+    config.uniqueId = rd.RandomString(10);
+    config.shardSize = 32768;
+    config.bufferCapacity = config.shardSize * 32768;
+    config.shareBufferEnable = GetParam();
+    config.deviceId = 0;
+    config.loadExclusiveBufferNumber = 0;
+    auto s = transBuffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
+    constexpr size_t shardIdx = 0;
+    auto owner = transBuffer.Get(blockId, shardIdx, true, true);
+    auto waiter = transBuffer.Get(blockId, shardIdx, true, true);
+
+    owner.MarkFailed(UC::Status::NotFound());
+
+    ASSERT_EQ(owner.FailureStatus(), UC::Status::NotFound());
+    ASSERT_EQ(waiter.FailureStatus(), UC::Status::NotFound());
+    ASSERT_FALSE(waiter.Ready());
+    ASSERT_TRUE(transBuffer.Exist(blockId, shardIdx));
+}
+
+TEST_P(UCCacheTransBufferTest, KeepsFailureUntilReferencedHandlesAreReleased)
+{
+    UC::CacheStore::TransBuffer transBuffer;
+    UC::CacheStore::Config config;
+    config.uniqueId = rd.RandomString(10);
+    config.shardSize = 32768;
+    config.bufferCapacity = config.shardSize * 32768;
+    config.shareBufferEnable = GetParam();
+    config.deviceId = 0;
+    config.loadExclusiveBufferNumber = 0;
+    auto s = transBuffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
+    constexpr size_t shardIdx = 0;
+    auto owner = transBuffer.Get(blockId, shardIdx, true, true);
+    auto waiter = transBuffer.Get(blockId, shardIdx, true, true);
+    owner.MarkFailed(UC::Status::NotFound());
+    owner = {};
+
+    auto lateWaiter = transBuffer.Get(blockId, shardIdx, true, true);
+
+    ASSERT_FALSE(lateWaiter.Owner());
+    ASSERT_EQ(lateWaiter.FailureStatus(), UC::Status::NotFound());
+}
+
+TEST_P(UCCacheTransBufferTest, RetriesFailureAfterAllHandlesAreReleased)
+{
+    UC::CacheStore::TransBuffer transBuffer;
+    UC::CacheStore::Config config;
+    config.uniqueId = rd.RandomString(10);
+    config.shardSize = 32768;
+    config.bufferCapacity = config.shardSize * 32768;
+    config.shareBufferEnable = GetParam();
+    config.deviceId = 0;
+    config.loadExclusiveBufferNumber = 0;
+    auto s = transBuffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
+    constexpr size_t shardIdx = 0;
+    void* failedAddr = nullptr;
+    {
+        auto owner = transBuffer.Get(blockId, shardIdx, true, true);
+        failedAddr = owner.Data();
+        owner.MarkFailed(UC::Status::NotFound());
+    }
+
+    auto retry = transBuffer.Get(blockId, shardIdx, true, true);
+
+    ASSERT_TRUE(retry.Owner());
+    ASSERT_EQ(retry.GetState(), UC::CacheStore::TransBuffer::State::LOADING);
+    ASSERT_FALSE(retry.Ready());
+    ASSERT_EQ(retry.Data(), failedAddr);
+}
+
+TEST(UCCacheTransBufferSharedTest, SharesFailureAcrossBufferMappings)
+{
+    UC::Test::Detail::Random rd;
+    UC::CacheStore::Config config;
+    config.uniqueId = rd.RandomString(10);
+    config.shardSize = 32768;
+    config.bufferCapacity = config.shardSize * 32768;
+    config.shareBufferEnable = true;
+    config.deviceId = 0;
+    config.loadExclusiveBufferNumber = 0;
+    UC::CacheStore::TransBuffer ownerBuffer;
+    auto s = ownerBuffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    UC::CacheStore::TransBuffer waiterBuffer;
+    s = waiterBuffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
+    constexpr size_t shardIdx = 0;
+    auto owner = ownerBuffer.Get(blockId, shardIdx, true, true);
+    auto waiter = waiterBuffer.Get(blockId, shardIdx, true, true);
+
+    owner.MarkFailed(UC::Status::NotFound());
+
+    ASSERT_FALSE(waiter.Owner());
+    ASSERT_EQ(waiter.FailureStatus(), UC::Status::NotFound());
+}
+
+TEST(UCCacheTransBufferSharedTest, SharesFailureAcrossProcesses)
+{
+    UC::Test::Detail::Random rd;
+    UC::CacheStore::Config config;
+    config.uniqueId = rd.RandomString(10);
+    config.shardSize = 32768;
+    config.bufferCapacity = config.shardSize * 32768;
+    config.shareBufferEnable = true;
+    config.deviceId = 0;
+    config.loadExclusiveBufferNumber = 0;
+    UC::CacheStore::TransBuffer transBuffer;
+    auto s = transBuffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
+    constexpr size_t shardIdx = 0;
+    auto owner = transBuffer.Get(blockId, shardIdx, true, true);
+    int childReady[2];
+    int failureReady[2];
+    ASSERT_EQ(pipe(childReady), 0);
+    ASSERT_EQ(pipe(failureReady), 0);
+    auto pid = fork();
+    ASSERT_GE(pid, 0);
+    if (pid == 0) {
+        close(childReady[0]);
+        close(failureReady[1]);
+        bool success = false;
+        {
+            auto waiter = transBuffer.Get(blockId, shardIdx, true, true);
+            char signal = 1;
+            if (write(childReady[1], &signal, sizeof(signal)) != sizeof(signal) ||
+                read(failureReady[0], &signal, sizeof(signal)) != sizeof(signal)) {
+                _exit(1);
+            }
+            success = !waiter.Owner() &&
+                      waiter.GetState() == UC::CacheStore::TransBuffer::State::FAILED &&
+                      waiter.FailureStatus() == UC::Status::NotFound();
+        }
+        _exit(success ? 0 : 1);
+    }
+    close(childReady[1]);
+    close(failureReady[0]);
+    char signal = 0;
+    ASSERT_EQ(read(childReady[0], &signal, sizeof(signal)), sizeof(signal));
+    owner.MarkFailed(UC::Status::NotFound());
+    ASSERT_EQ(write(failureReady[1], &signal, sizeof(signal)), sizeof(signal));
+    int childStatus = 0;
+    ASSERT_EQ(waitpid(pid, &childStatus, 0), pid);
+    ASSERT_TRUE(WIFEXITED(childStatus));
+    ASSERT_EQ(WEXITSTATUS(childStatus), 0);
+    close(childReady[0]);
+    close(failureReady[1]);
 }
 
 TEST_P(UCCacheTransBufferTest, GetReservedNode)

--- a/ucm/store/test/case/posix/posix_store_test.cc
+++ b/ucm/store/test/case/posix/posix_store_test.cc
@@ -59,7 +59,7 @@ UC::Detail::Dictionary MakeAioConfig(const std::string& path, size_t timeoutMs =
     return config;
 }
 
-UC::Detail::Dictionary MakePsyncConfig(const std::string& path)
+UC::Detail::Dictionary MakePsyncConfig(const std::string& path, size_t timeoutMs = 30000)
 {
     UC::Detail::Dictionary config;
     config.SetNumber("device_id", 0);
@@ -69,6 +69,7 @@ UC::Detail::Dictionary MakePsyncConfig(const std::string& path)
     config.SetNumber("block_size", AIO_TEST_DATA_SIZE);
     config.Set("posix_io_engine", std::string("psync"));
     config.Set("io_direct", false);
+    config.SetNumber("timeout_ms", timeoutMs);
     config.SetNumber("data_dir_shard_bytes", size_t(0));
     return config;
 }
@@ -527,6 +528,97 @@ TEST(UCAioImplTest, SubmitEagainHonorsDeadline)
     ASSERT_EQ(status, UC::Status::Timeout());
     ASSERT_GE(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 20);
     ASSERT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 1000);
+}
+
+TEST_F(UCPosixStoreTest, AioRetainsShardLifetimeUntilCompletionCallbackReturns)
+{
+    using namespace UC::PosixStore;
+    AioImpl aio;
+    ASSERT_EQ(aio.Setup(1000), UC::Status::OK());
+    auto path = Path() + "/aio-lifetime";
+    auto fd = ::open(path.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0600);
+    ASSERT_GE(fd, 0);
+    auto source = MakeAlignedBuffer(9);
+    auto target = MakeAlignedBuffer(0);
+    ASSERT_NE(source, nullptr);
+    ASSERT_NE(target, nullptr);
+    ASSERT_EQ(::write(fd, source.get(), AIO_TEST_DATA_SIZE),
+              static_cast<ssize_t>(AIO_TEST_DATA_SIZE));
+
+    std::promise<void> callbackEntered;
+    std::promise<void> allowCallback;
+    auto allowCallbackFuture = allowCallback.get_future().share();
+    auto cacheLifeHolder = std::make_shared<int>(1);
+    std::weak_ptr<int> weakLifetime = cacheLifeHolder;
+    AioImpl::Io io;
+    io.fd = fd;
+    io.offset = 0;
+    io.length = AIO_TEST_DATA_SIZE;
+    io.buffer = target.get();
+    io.cacheLifeHolder = cacheLifeHolder;
+    io.callback = [&](AioImpl::Result result) {
+        EXPECT_EQ(result.error, 0);
+        callbackEntered.set_value();
+        allowCallbackFuture.wait();
+    };
+    ASSERT_EQ(aio.ReadAsync(std::move(io)), UC::Status::OK());
+    cacheLifeHolder.reset();
+    callbackEntered.get_future().wait();
+
+    EXPECT_FALSE(weakLifetime.expired());
+    allowCallback.set_value();
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (!weakLifetime.expired() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    EXPECT_TRUE(weakLifetime.expired());
+    ::close(fd);
+}
+
+TEST_F(UCPosixStoreTest, PsyncRetainsShardLifetimeAfterWaitTimeout)
+{
+    using namespace UC::PosixStore;
+    PosixStore store;
+    ASSERT_EQ(store.Setup(MakePsyncConfig(Path(), 50)), UC::Status::OK());
+    auto block = UC::Test::Detail::TypesHelper::MakeBlockIdRandomly();
+    Config layoutConfig;
+    layoutConfig.storageBackends = {Path()};
+    layoutConfig.dataDirShardBytes = 0;
+    SpaceLayout layout;
+    ASSERT_EQ(layout.Setup(layoutConfig), UC::Status::OK());
+    auto path = layout.DataFilePath(block, false);
+    std::filesystem::create_directories(std::filesystem::path(path).parent_path());
+    ASSERT_EQ(::mkfifo(path.c_str(), 0600), 0);
+    auto target = MakeAlignedBuffer(0);
+    ASSERT_NE(target, nullptr);
+    auto cacheLifeHolder = std::make_shared<int>(1);
+    std::weak_ptr<int> weakLifetime = cacheLifeHolder;
+    auto desc = MakeDumpDesc("PsyncLifetime", block, target.get());
+    desc[0].cacheLifeHolder = cacheLifeHolder;
+    auto handle = store.Load(std::move(desc));
+    ASSERT_TRUE(handle.HasValue());
+    cacheLifeHolder.reset();
+
+    ASSERT_EQ(store.Wait(handle.Value()), UC::Status::Timeout());
+    EXPECT_FALSE(weakLifetime.expired());
+
+    auto source = MakeAlignedBuffer(7);
+    ASSERT_NE(source, nullptr);
+    std::thread writer([&] {
+        auto writerFd = ::open(path.c_str(), O_WRONLY);
+        EXPECT_GE(writerFd, 0);
+        if (writerFd >= 0) {
+            EXPECT_EQ(::write(writerFd, source.get(), AIO_TEST_DATA_SIZE),
+                      static_cast<ssize_t>(AIO_TEST_DATA_SIZE));
+            ::close(writerFd);
+        }
+    });
+    writer.join();
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(1);
+    while (!weakLifetime.expired() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    EXPECT_TRUE(weakLifetime.expired());
 }
 
 TEST_F(UCPosixStoreTest, AioQueuedTasksTimeOutWhileOpenWorkerIsStuck)


### PR DESCRIPTION
## Purpose

Prevent shared Cache buffers from being reused while an asynchronous backend still accesses them, and propagate backend load failures to every rank waiting on the same shared entry.

## Modifications

- replace the shared cache ready bit with `LOADING`/`READY`/`FAILED` state and retain the backend failure status
- keep a cache buffer reference in backend task shards through Posix AIO/psync and Mooncake task lifetimes
- make non-owner loads consume the shared success or failure result with a bounded wait
- drain submitted backend tasks before releasing cache task state
- add unit coverage for cross-mapping failure propagation, retry after references are released, backend lifetime retention, timeout, and cleanup paths

## User impact

When one rank owns a shared Cache load and the backend fails or times out, peer ranks now observe the same failure instead of waiting indefinitely or treating incomplete KV data as ready. Backend IO also cannot outlive and silently overwrite a reused cache buffer.

## Verification

- `git diff --check`
- clang-format 20 check on changed lines
- codespell 2.4.1 on changed files
- A2, latest `origin/develop`: Debug/Ascend build passed; `ucmstore.test` 89/89 passed
- A2 `ucmshared.test`: 35/37 in the full run; the two logger ordering tests passed 2/2 when rerun together in isolation
- A2 DeepSeek-V2-Lite, TP2, `Cache|Posix`, AIO, O_DIRECT, layerwise, recompute: after truncating one Posix KV file and injecting delayed reads, only the owning rank issued backend loads, the peer consumed the shared failure, recovery completed, and generated token IDs matched the baseline