### PR TITLE
[Refactor] Adjust register and query

### DIFF
--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -275,9 +275,9 @@ public:
     }
 
     AsuStatus RegisterRegions(const std::vector<UC::ASU::MemoryRegion>& regions,
-                              std::vector<UC::ASU::RegisterResult>& results) override
+                              std::vector<UC::ASU::RegisteredMemory>& registeredRegions) override
     {
-        return client_->RegisterRegions(regions, results);
+        return client_->RegisterRegions(regions, registeredRegions);
     }
 
 private:
@@ -382,8 +382,8 @@ public:
         }
         if (regions.empty()) { return Status::OK(); }
 
-        std::vector<UC::ASU::RegisterResult> results;
-        auto status = backend_->RegisterRegions(regions, results);
+        std::vector<UC::ASU::RegisteredMemory> registeredRegions;
+        auto status = backend_->RegisterRegions(regions, registeredRegions);
         if (!status.ok()) {
             LogAsuStatus("register persistent regions", status);
             return ConvertStatus(status);
@@ -391,8 +391,8 @@ public:
         std::vector<RegisteredPersistentRegion> registered;
         registered.reserve(regions.size());
         for (std::size_t index = 0; index < regions.size(); ++index) {
-            registered.emplace_back(
-                RegisteredPersistentRegion{regions[index], results[index].handle});
+            registered.emplace_back(RegisteredPersistentRegion{registeredRegions[index].region,
+                                                               registeredRegions[index].handle});
         }
 
         {

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -57,8 +57,9 @@ public:
     virtual UC::ASU::Status Check(UC::ASU::TaskId taskId, UC::ASU::TaskResult& result) = 0;
     virtual UC::ASU::Status Wait(UC::ASU::TaskId taskId, std::uint64_t timeoutMs,
                                  UC::ASU::TaskResult& result) = 0;
-    virtual UC::ASU::Status RegisterRegions(const std::vector<UC::ASU::MemoryRegion>& regions,
-                                            std::vector<UC::ASU::RegisterResult>& results) = 0;
+    virtual UC::ASU::Status RegisterRegions(
+        const std::vector<UC::ASU::MemoryRegion>& regions,
+        std::vector<UC::ASU::RegisteredMemory>& registeredRegions) = 0;
 };
 
 }  // namespace UC::AsuStore

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -149,16 +149,17 @@ public:
         return Check(taskId, result);
     }
 
-    UC::ASU::Status RegisterRegions(const std::vector<UC::ASU::MemoryRegion>& regions,
-                                    std::vector<UC::ASU::RegisterResult>& results) override
+    UC::ASU::Status RegisterRegions(
+        const std::vector<UC::ASU::MemoryRegion>& regions,
+        std::vector<UC::ASU::RegisteredMemory>& registeredRegions) override
     {
-        results.clear();
-        results.reserve(regions.size());
+        registeredRegions.clear();
+        registeredRegions.reserve(regions.size());
         state_->registeredRegions.insert(state_->registeredRegions.end(), regions.begin(),
                                          regions.end());
         for (std::size_t index = 0; index < regions.size(); ++index) {
-            results.emplace_back(
-                UC::ASU::RegisterResult{UC::ASU::Status::OK(), MakeTestMrHandle(nextMrHandle_++)});
+            registeredRegions.emplace_back(
+                UC::ASU::RegisteredMemory{regions[index], MakeTestMrHandle(nextMrHandle_++)});
         }
         return UC::ASU::Status::OK();
     }

--- a/ucm/transport/kv/asu/client/include/asu_client/asu_client.h
+++ b/ucm/transport/kv/asu/client/include/asu_client/asu_client.h
@@ -61,7 +61,7 @@ public:
     virtual Status Wait(TaskId taskId, std::uint64_t timeoutMs, TaskResult& result) = 0;
 
     virtual Status RegisterRegions(const std::vector<MemoryRegion>& regions,
-                                   std::vector<RegisterResult>& results) = 0;
+                                   std::vector<RegisteredMemory>& registeredRegions) = 0;
     virtual Status UnregisterRegions(const std::vector<MRHandle>& handles) = 0;
 };
 

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -156,7 +156,7 @@ Status AsuClientImpl::Shutdown()
         config_ = AsuClientConfig{};
         viewServer_.reset();
         transportConfigs_.clear();
-        registeredResources_.clear();
+        registeredRegions_.clear();
         initialized_ = false;
     }
 
@@ -386,10 +386,11 @@ Status AsuClientImpl::RegisterRegionsOnce(const std::vector<MemoryRegion>& regio
         }
     }
 
+    // Remember registered regions for future transport bindings
     if (finalStatus.ok()) {
         std::lock_guard<std::mutex> lock{mutex_};
         for (std::size_t index = 0; index < regions.size(); ++index) {
-            registeredResources_.emplace_back(RegisteredResource{regions[index], results[index]});
+            registeredRegions_.emplace_back(registeredRegions[index]);
         }
     }
     return finalStatus;
@@ -807,13 +808,13 @@ Status AsuClientImpl::UnregisterRegionsOnce(const std::vector<MRHandle>& handles
     }
     if (finalStatus.ok()) {
         std::lock_guard<std::mutex> lock{mutex_};
-        registeredResources_.erase(
-            std::remove_if(registeredResources_.begin(), registeredResources_.end(),
-                           [&handles](const RegisteredResource& resource) {
-                               return std::find(handles.begin(), handles.end(),
-                                                resource.result.handle) != handles.end();
+        registeredRegions_.erase(
+            std::remove_if(registeredRegions_.begin(), registeredRegions_.end(),
+                           [&handles](const RegisteredMemory& region) {
+                               return std::find(handles.begin(), handles.end(), region.handle) !=
+                                      handles.end();
                            }),
-            registeredResources_.end());
+            registeredRegions_.end());
     }
     return finalStatus;
 }
@@ -843,11 +844,11 @@ Status AsuClientImpl::BuildSnapshot(const GlobalView& view,
                                                " asuId=" + std::to_string(asuId));
             }
 
-            status = BindRegisteredResources(asuId, transport);
+            status = BindRegisteredRegions(asuId, transport);
             if (!status.ok()) {
                 transport->Shutdown();
                 return WithContext(
-                    status, "bind registered resources during view refresh, asuIndex=" +
+                    status, "bind registered regions during view refresh, asuIndex=" +
                                 std::to_string(asuIndex) + " asuId=" + std::to_string(asuId));
             }
         }
@@ -899,31 +900,21 @@ Status AsuClientImpl::BuildTransport(AsuId asuId, const AsuInfo& asuInfo,
     return Status::OK();
 }
 
-Status AsuClientImpl::BindRegisteredResources(AsuId asuId,
-                                              const std::shared_ptr<AsuTransport>& transport)
+Status AsuClientImpl::BindRegisteredRegions(AsuId asuId,
+                                            const std::shared_ptr<AsuTransport>& transport)
 {
-    std::vector<RegisteredResource> resources;
+    std::vector<RegisteredMemory> registeredRegions;
     {
         std::lock_guard<std::mutex> lock{mutex_};
-        resources = registeredResources_;
+        registeredRegions = registeredRegions_;
     }
-    if (resources.empty()) { return Status::OK(); }
-
-    std::vector<RegisteredMemory> registeredRegions;
-    registeredRegions.reserve(resources.size());
-    for (const auto& resource : resources) {
-        RegisteredMemory registeredRegion;
-        registeredRegion.region = resource.region;
-        registeredRegion.handle = resource.result.handle;
-        registeredRegion.tokenId = resource.result.tokenId;
-        registeredRegions.emplace_back(registeredRegion);
-    }
+    if (registeredRegions.empty()) { return Status::OK(); }
 
     std::vector<RegisterResult> results;
     auto status = transport->BindRegisteredRegions(registeredRegions, results);
     if (!status.ok()) {
         return WithContext(status, "asuId=" + std::to_string(asuId) +
-                                       " resource_count=" + std::to_string(resources.size()));
+                                       " region_count=" + std::to_string(registeredRegions.size()));
     }
     return Status::OK();
 }

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -306,21 +306,22 @@ Status AsuClientImpl::Wait(TaskId taskId, std::uint64_t timeoutMs, TaskResult& r
 }
 
 Status AsuClientImpl::RegisterRegions(const std::vector<MemoryRegion>& regions,
-                                      std::vector<RegisterResult>& results)
+                                      std::vector<RegisteredMemory>& registeredRegions)
 {
     bool needRefresh = false;
-    auto status = RegisterRegionsOnce(regions, results, needRefresh);
+    auto status = RegisterRegionsOnce(regions, registeredRegions, needRefresh);
     if (needRefresh) { RequestBackgroundRefresh(); }
     return status;
 }
 
 Status AsuClientImpl::RegisterRegionsOnce(const std::vector<MemoryRegion>& regions,
-                                          std::vector<RegisterResult>& results, bool& needRefresh)
+                                          std::vector<RegisteredMemory>& registeredRegions,
+                                          bool& needRefresh)
 {
     auto snapshot = GetSnapshot();
     if (!snapshot) { return NotInitialized(); }
 
-    results.clear();
+    registeredRegions.clear();
     if (snapshot->transports.empty()) { return Status::OK(); }
 
     auto firstIter = snapshot->transports.find(snapshot->asuIds.front());
@@ -330,28 +331,18 @@ Status AsuClientImpl::RegisterRegionsOnce(const std::vector<MemoryRegion>& regio
         return WithContext(status, "asuIndex=0 asuId=" + std::to_string(snapshot->asuIds.front()));
     }
 
-    auto status = firstIter->second->RegisterRegions(regions, results);
+    auto status = firstIter->second->RegisterRegions(regions, registeredRegions);
     if (!status.ok()) {
         MarkRefreshIfNeeded(status, needRefresh);
         return WithContext(status, "asuIndex=0 asuId=" + std::to_string(snapshot->asuIds.front()) +
                                        " region_count=" + std::to_string(regions.size()));
     }
-    if (results.size() != regions.size()) {
+    if (registeredRegions.size() != regions.size()) {
         return WithContext(Status::Error(StatusCode::INTERNAL_ERROR,
                                          "register result count does not match region count"),
                            "asuIndex=0 asuId=" + std::to_string(snapshot->asuIds.front()) +
                                " region_count=" + std::to_string(regions.size()) +
-                               " result_count=" + std::to_string(results.size()));
-    }
-
-    std::vector<RegisteredMemory> registeredRegions;
-    registeredRegions.reserve(regions.size());
-    for (std::size_t index = 0; index < regions.size(); ++index) {
-        RegisteredMemory registeredRegion;
-        registeredRegion.region = regions[index];
-        registeredRegion.handle = results[index].handle;
-        registeredRegion.tokenId = results[index].tokenId;
-        registeredRegions.emplace_back(registeredRegion);
+                               " result_count=" + std::to_string(registeredRegions.size()));
     }
 
     Status finalStatus = Status::OK();
@@ -366,8 +357,7 @@ Status AsuClientImpl::RegisterRegionsOnce(const std::vector<MemoryRegion>& regio
             continue;
         }
 
-        std::vector<RegisterResult> childResults;
-        status = iter->second->BindRegisteredRegions(registeredRegions, childResults);
+        status = iter->second->BindRegisteredRegions(registeredRegions);
         if (!status.ok() && finalStatus.ok()) {
             MarkRefreshIfNeeded(status, needRefresh);
             finalStatus =
@@ -375,23 +365,14 @@ Status AsuClientImpl::RegisterRegionsOnce(const std::vector<MemoryRegion>& regio
                             "asuIndex=" + std::to_string(asuIndex) +
                                 " asuId=" + std::to_string(snapshot->asuIds[asuIndex]) +
                                 " region_count=" + std::to_string(registeredRegions.size()));
-        } else if (status.ok() && childResults.size() != registeredRegions.size() &&
-                   finalStatus.ok()) {
-            finalStatus =
-                WithContext(PartialFailed("one or more asu region bindings failed"),
-                            "asuIndex=" + std::to_string(asuIndex) +
-                                " asuId=" + std::to_string(snapshot->asuIds[asuIndex]) +
-                                " region_count=" + std::to_string(registeredRegions.size()) +
-                                " result_count=" + std::to_string(childResults.size()));
         }
     }
 
-    // Remember registered regions for future transport bindings
+    // Remember registered regions for future transport bindings.
     if (finalStatus.ok()) {
         std::lock_guard<std::mutex> lock{mutex_};
-        for (std::size_t index = 0; index < regions.size(); ++index) {
-            registeredRegions_.emplace_back(registeredRegions[index]);
-        }
+        registeredRegions_.insert(registeredRegions_.end(), registeredRegions.begin(),
+                                  registeredRegions.end());
     }
     return finalStatus;
 }
@@ -910,8 +891,7 @@ Status AsuClientImpl::BindRegisteredRegions(AsuId asuId,
     }
     if (registeredRegions.empty()) { return Status::OK(); }
 
-    std::vector<RegisterResult> results;
-    auto status = transport->BindRegisteredRegions(registeredRegions, results);
+    auto status = transport->BindRegisteredRegions(registeredRegions);
     if (!status.ok()) {
         return WithContext(status, "asuId=" + std::to_string(asuId) +
                                        " region_count=" + std::to_string(registeredRegions.size()));

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -193,68 +193,101 @@ Status AsuClientImpl::QueryOnce(const std::vector<CacheKey>& keys, const QueryOp
     auto snapshot = GetSnapshot();
     if (!snapshot) { return NotInitialized(); }
 
-    if (options.mode == QueryMode::PREFIX) {
-        Status finalStatus = Status::OK();
-        for (const auto& item : snapshot->transports) {
-            QueryResult childResult;
-            auto status = item.second->Query(keys, options, childResult);
-            if (!status.ok()) {
-                MarkRefreshIfNeeded(status, needRefresh);
-                finalStatus = WithContext(PartialFailed("one or more asu prefix queries failed"),
-                                          "asuId=" + std::to_string(item.first));
-                continue;
-            }
-            if (childResult.exists.size() != keys.size()) {
-                return Status::Error(
-                    StatusCode::INTERNAL_ERROR,
-                    "prefix query result size mismatch, asuId=" + std::to_string(item.first) +
-                        " expected=" + std::to_string(keys.size()) +
-                        " actual=" + std::to_string(childResult.exists.size()));
-            }
-            result.prefixHitKeys += childResult.prefixHitKeys;
-            for (std::size_t index = 0;
-                 index < result.exists.size() && index < childResult.exists.size(); ++index) {
-                result.exists[index] = result.exists[index] || childResult.exists[index];
-            }
-        }
-        return finalStatus;
-    }
-
+    const auto timeoutMs =
+        options.timeoutMs == 0 ? config_.defaultWaitTimeoutMs : options.timeoutMs;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+    auto transportOptions = options;
+    transportOptions.mode = QueryMode::PER_KEY;
     auto routes = snapshot->router->RouteKeys(ToRouterKeys(keys));
+    std::vector<PendingQuery> pendingQueries;
+    pendingQueries.reserve(routes.size());
+    bool anyFailed = false;
+
     for (const auto& route : routes) {
         auto transportIter = snapshot->transports.find(route.first);
         if (transportIter == snapshot->transports.end()) {
             auto status = Status::Error(StatusCode::NOT_FOUND, "routed asu transport not found");
             MarkRefreshIfNeeded(status, needRefresh);
-            return WithContext(status, "asuId=" + std::to_string(route.first));
+            UC_ERROR("ASU client query dispatch failed: asuId={} key_count={} code={} message={}.",
+                     route.first, route.second.size(), static_cast<int>(status.code),
+                     status.message);
+            anyFailed = true;
+            continue;
         }
 
-        std::vector<CacheKey> childKeys;
-        childKeys.reserve(route.second.size());
-        for (auto index : route.second) { childKeys.emplace_back(keys[index]); }
+        PendingQuery pending;
+        pending.asuId = route.first;
+        pending.transport = transportIter->second;
+        pending.originalIndices = route.second;
+        pending.keys.reserve(route.second.size());
+        for (auto index : route.second) { pending.keys.emplace_back(keys[index]); }
 
-        QueryResult childResult;
-        auto status = transportIter->second->Query(childKeys, options, childResult);
+        auto status = pending.transport->QueryAsync(pending.keys, transportOptions, pending.taskId);
         if (!status.ok()) {
             MarkRefreshIfNeeded(status, needRefresh);
-            return WithContext(status, "asuId=" + std::to_string(route.first) +
-                                           " key_count=" + std::to_string(childKeys.size()));
-        }
-        if (childResult.exists.size() != childKeys.size()) {
-            return Status::Error(
-                StatusCode::INTERNAL_ERROR,
-                "query result size mismatch, asuId=" + std::to_string(route.first) +
-                    " expected=" + std::to_string(childKeys.size()) +
-                    " actual=" + std::to_string(childResult.exists.size()));
+            UC_ERROR("ASU client query dispatch failed: asuId={} key_count={} code={} message={}.",
+                     pending.asuId, pending.keys.size(), static_cast<int>(status.code),
+                     status.message);
+            anyFailed = true;
+            continue;
         }
 
-        for (std::size_t index = 0; index < route.second.size(); ++index) {
-            result.exists[route.second[index]] = childResult.exists[index];
+        pendingQueries.emplace_back(std::move(pending));
+    }
+
+    for (auto& pending : pendingQueries) {
+        const auto now = std::chrono::steady_clock::now();
+        if (now >= deadline) {
+            UC_ERROR(
+                "ASU client query wait timed out before transport wait: asuId={} key_count={}.",
+                pending.asuId, pending.keys.size());
+            anyFailed = true;
+            continue;
+        }
+
+        const auto remainingMs =
+            std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count();
+        const auto waitMs = static_cast<std::uint64_t>(std::max<std::int64_t>(1, remainingMs));
+        TaskResult taskResult;
+        auto status = pending.transport->Wait(pending.taskId, waitMs, taskResult);
+        if (!status.ok()) {
+            MarkRefreshIfNeeded(status, needRefresh);
+            UC_ERROR("ASU client query wait failed: asuId={} key_count={} code={} message={}.",
+                     pending.asuId, pending.keys.size(), static_cast<int>(status.code),
+                     status.message);
+            anyFailed = true;
+            continue;
+        }
+        if (!taskResult.status.ok()) {
+            MarkRefreshIfNeeded(taskResult.status, needRefresh);
+            UC_ERROR("ASU client query result failed: asuId={} key_count={} code={} message={}.",
+                     pending.asuId, pending.keys.size(), static_cast<int>(taskResult.status.code),
+                     taskResult.status.message);
+            anyFailed = true;
+            continue;
+        }
+        if (!taskResult.queryResult.has_value()) {
+            UC_ERROR("ASU client query result is missing: asuId={} key_count={}.", pending.asuId,
+                     pending.keys.size());
+            anyFailed = true;
+            continue;
+        }
+
+        const auto& childResult = *taskResult.queryResult;
+        if (childResult.exists.size() != pending.keys.size()) {
+            UC_ERROR("ASU client query result size mismatch: asuId={} expected={} actual={}.",
+                     pending.asuId, pending.keys.size(), childResult.exists.size());
+            anyFailed = true;
+            continue;
+        }
+
+        for (std::size_t index = 0; index < pending.originalIndices.size(); ++index) {
+            result.exists[pending.originalIndices[index]] = childResult.exists[index];
         }
         result.prefixHitKeys += childResult.prefixHitKeys;
     }
 
-    return Status::OK();
+    return anyFailed ? PartialFailed("one or more asu queries failed") : Status::OK();
 }
 
 Status AsuClientImpl::LoadAsync(const std::vector<KVBuffer>& entries, TaskId& taskId)

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.h
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.h
@@ -90,6 +90,13 @@ public:
 
 private:
     using ClientTaskContextPtr = std::shared_ptr<ClientTaskContext>;
+    struct PendingQuery {
+        AsuId asuId{0};
+        std::shared_ptr<AsuTransport> transport;
+        std::vector<CacheKey> keys;
+        std::vector<std::size_t> originalIndices;
+        TaskId taskId{kInvalidTaskId};
+    };
 
     // Submits one entry-based client task through the refresh-retry wrapper.
     Status SubmitAsync(ClientOpType opType, const std::vector<KVBuffer>& entries, TaskId& taskId);

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.h
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.h
@@ -84,7 +84,7 @@ public:
 
     // Registers regions and remembers successful resources for future views.
     Status RegisterRegions(const std::vector<MemoryRegion>& regions,
-                           std::vector<RegisterResult>& results) override;
+                           std::vector<RegisteredMemory>& registeredRegions) override;
     // Unregisters regions and forgets successful resources.
     Status UnregisterRegions(const std::vector<MRHandle>& handles) override;
 
@@ -117,7 +117,7 @@ private:
                      QueryResult& result, bool& needRefresh);
     // Performs one register operation on the current snapshot.
     Status RegisterRegionsOnce(const std::vector<MemoryRegion>& regions,
-                               std::vector<RegisterResult>& results, bool& needRefresh);
+                               std::vector<RegisteredMemory>& registeredRegions, bool& needRefresh);
     // Performs one unregister operation on the current snapshot.
     Status UnregisterRegionsOnce(const std::vector<MRHandle>& handles, bool& needRefresh);
 

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.h
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.h
@@ -30,6 +30,7 @@
 #include <unordered_map>
 #include <vector>
 #include "asu_client/asu_client.h"
+#include "asu_transport/types.h"
 #include "client_task_manager.h"
 #include "view_server.h"
 
@@ -90,12 +91,6 @@ public:
 private:
     using ClientTaskContextPtr = std::shared_ptr<ClientTaskContext>;
 
-    // RegisteredResource keeps memory metadata that must be rebound after refresh.
-    struct RegisteredResource {
-        MemoryRegion region;
-        RegisterResult result;
-    };
-
     // Submits one entry-based client task through the refresh-retry wrapper.
     Status SubmitAsync(ClientOpType opType, const std::vector<KVBuffer>& entries, TaskId& taskId);
     // Builds and dispatches one entry-based task attempt on the current snapshot.
@@ -132,8 +127,8 @@ private:
     // Creates and initializes a transport for one ASU.
     Status BuildTransport(AsuId asuId, const AsuInfo& asuInfo,
                           std::shared_ptr<AsuTransport>& transport);
-    // Binds remembered registered resources to a transport.
-    Status BindRegisteredResources(AsuId asuId, const std::shared_ptr<AsuTransport>& transport);
+    // Binds remembered registered regions to a transport.
+    Status BindRegisteredRegions(AsuId asuId, const std::shared_ptr<AsuTransport>& transport);
     // Returns the current immutable snapshot if initialized.
     std::shared_ptr<ViewSnapshot> GetSnapshot() const;
 
@@ -182,8 +177,8 @@ private:
     std::shared_ptr<ViewServer> viewServer_;
     // Transport configs indexed by ASU id for snapshot construction.
     std::unordered_map<AsuId, TransportConfig> transportConfigs_;
-    // Resources registered on the current view and rebound to newly added transports.
-    std::vector<RegisteredResource> registeredResources_;
+    // Regions registered on the current view and rebound to newly added transports.
+    std::vector<RegisteredMemory> registeredRegions_;
     // Current immutable routing and transport snapshot.
     std::shared_ptr<ViewSnapshot> snapshot_;
     // Transports removed from the active snapshot but still needed by old tasks.

--- a/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
@@ -50,12 +50,12 @@ struct TestState {
     bool failFirstDelete{false};
     bool firstDeleteFailed{false};
     std::unordered_map<AsuId, Status> queryFailures;
+    std::unordered_map<AsuId, Status> queryWaitFailures;
     std::unordered_map<AsuId, Status> loadFailures;
     std::unordered_map<AsuId, Status> storeFailures;
     std::unordered_map<AsuId, Status> deleteFailures;
     std::unordered_map<AsuId, std::vector<Status>> checkEntryStatus;
     std::unordered_map<AsuId, Status> checkResultStatus;
-    std::unordered_map<AsuId, QueryResult> prefixQueryResults;
     std::vector<AsuId> registerCalls;
     std::vector<AsuId> bindCalls;
     std::unordered_map<AsuId, std::vector<RegisteredMemory>> boundRegions;
@@ -63,6 +63,9 @@ struct TestState {
     std::vector<AsuId> queryCalls;
     std::unordered_map<AsuId, std::size_t> queryKeyCounts;
     std::unordered_map<AsuId, std::vector<CacheKey>> queryKeys;
+    std::unordered_map<AsuId, QueryMode> queryModes;
+    bool queryWaitStarted{false};
+    std::size_t queryDispatchCountAtFirstWait{0};
     std::vector<AsuId> loadCalls;
     std::vector<AsuId> storeCalls;
     std::vector<AsuId> deleteCalls;
@@ -109,18 +112,11 @@ public:
 
         state_->queryCalls.emplace_back(config_.asuId);
         state_->queryKeyCounts[config_.asuId] += keys.size();
+        state_->queryModes[config_.asuId] = options.mode;
         auto& routedKeys = state_->queryKeys[config_.asuId];
         routedKeys.insert(routedKeys.end(), keys.begin(), keys.end());
         auto failureIter = state_->queryFailures.find(config_.asuId);
         if (failureIter != state_->queryFailures.end()) { return failureIter->second; }
-
-        if (options.mode == QueryMode::PREFIX) {
-            auto iter = state_->prefixQueryResults.find(config_.asuId);
-            if (iter != state_->prefixQueryResults.end()) {
-                result = iter->second;
-                return Status::OK();
-            }
-        }
 
         result.exists.clear();
         result.exists.reserve(keys.size());
@@ -131,9 +127,21 @@ public:
         return Status::OK();
     }
 
-    Status QueryAsync(const std::vector<CacheKey>&, const QueryOptions&, TaskId& taskId) override
+    Status QueryAsync(const std::vector<CacheKey>& keys, const QueryOptions& options,
+                      TaskId& taskId) override
     {
-        taskId = 0;
+        QueryResult queryResult;
+        auto status = Query(keys, options, queryResult);
+        if (!status.ok()) {
+            taskId = kInvalidTaskId;
+            return status;
+        }
+
+        taskId = nextQueryTaskId_++;
+        TaskResult taskResult;
+        taskResult.status = Status::OK();
+        taskResult.queryResult = std::move(queryResult);
+        queryTasks_[taskId] = std::move(taskResult);
         return Status::OK();
     }
 
@@ -211,6 +219,23 @@ public:
     Status Wait(TaskId taskId, std::uint64_t, TaskResult& result) override
     {
         state_->waitCalls.emplace_back(config_.asuId);
+        auto queryTaskIter = queryTasks_.find(taskId);
+        if (queryTaskIter != queryTasks_.end()) {
+            if (!state_->queryWaitStarted) {
+                state_->queryWaitStarted = true;
+                state_->queryDispatchCountAtFirstWait = state_->queryCalls.size();
+            }
+            auto failureIter = state_->queryWaitFailures.find(config_.asuId);
+            if (failureIter != state_->queryWaitFailures.end()) { return failureIter->second; }
+
+            result = queryTaskIter->second;
+            auto statusIter = state_->checkResultStatus.find(config_.asuId);
+            if (statusIter != state_->checkResultStatus.end()) {
+                result.status = statusIter->second;
+            }
+            queryTasks_.erase(queryTaskIter);
+            return Status::OK();
+        }
         return Check(taskId, result);
     }
 
@@ -249,6 +274,8 @@ private:
     std::shared_ptr<TestState> state_;
     TransportConfig config_;
     bool initialized_{false};
+    TaskId nextQueryTaskId_{4000};
+    std::unordered_map<TaskId, TaskResult> queryTasks_;
 };
 
 class FakeViewServer final : public ViewServer {
@@ -589,9 +616,11 @@ TEST(AsuClientImplTest, Query_PerKeyKeepsOriginalOrder)
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(result.exists, std::vector<std::uint8_t>({0, 1, 1}));
+    ExpectSameAsuSet(state->queryCalls, {10, 20});
+    EXPECT_EQ(state->queryDispatchCountAtFirstWait, state->queryCalls.size());
 }
 
-TEST(AsuClientImplTest, Query_PerKeyFailureIncludesAsuContext)
+TEST(AsuClientImplTest, Query_PerKeyDispatchFailureWaitsForOtherTransports)
 {
     auto state = std::make_shared<TestState>();
     state->queryFailures[20] = Status::Error(StatusCode::IO_ERROR, "fake per-key query failure");
@@ -599,14 +628,15 @@ TEST(AsuClientImplTest, Query_PerKeyFailureIncludesAsuContext)
     ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
 
     QueryResult result;
-    auto status = client->Query({MakeCacheKey("k15")}, QueryOptions{}, result);
+    auto status = client->Query({MakeCacheKey("k05"), MakeCacheKey("k15")}, QueryOptions{}, result);
 
-    EXPECT_EQ(status.code, StatusCode::IO_ERROR);
-    EXPECT_NE(status.message.find("asuId=20"), std::string::npos);
-    EXPECT_NE(status.message.find("key_count=1"), std::string::npos);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_EQ(result.exists, std::vector<std::uint8_t>({0, 0}));
+    ExpectSameAsuSet(state->queryCalls, {10, 20});
+    EXPECT_EQ(state->waitCalls, std::vector<AsuId>({10}));
 }
 
-TEST(AsuClientImplTest, Query_PerKeyResultSizeMismatchReturnsInternalError)
+TEST(AsuClientImplTest, Query_PerKeyResultSizeMismatchReturnsPartialFailed)
 {
     class ShortQueryTransport final : public FakeTransport {
     public:
@@ -634,91 +664,41 @@ TEST(AsuClientImplTest, Query_PerKeyResultSizeMismatchReturnsInternalError)
     QueryResult result;
     auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
-    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
-    EXPECT_NE(status.message.find("query result size mismatch"), std::string::npos);
-    EXPECT_NE(status.message.find("asuId=10"), std::string::npos);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
 }
 
-TEST(AsuClientImplTest, Query_PrefixBroadcastsAndMergesResults)
+TEST(AsuClientImplTest, Query_PrefixUsesPerKeyRouting)
 {
     auto state = std::make_shared<TestState>();
-    state->prefixQueryResults[10] = QueryResult{
-        {1, 0, 0},
-        2
-    };
-    state->prefixQueryResults[20] = QueryResult{
-        {0, 1, 0},
-        3
-    };
-    state->prefixQueryResults[30] = QueryResult{
-        {0, 0, 1},
-        5
-    };
     auto client = CreateAsuClient(MakeFactory(state));
-    ASSERT_TRUE(client->Init(MakeConfig({10, 20, 30})).ok());
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
 
     QueryOptions options;
     options.mode = QueryMode::PREFIX;
     QueryResult result;
-    auto status = client->Query(
-        {MakeCacheKey("prefix-a"), MakeCacheKey("prefix-b"), MakeCacheKey("prefix-c")}, options,
-        result);
+    auto status = client->Query({MakeCacheKey("k05"), MakeCacheKey("k15"), MakeCacheKey("k25")},
+                                options, result);
 
     EXPECT_TRUE(status.ok()) << status.message;
-    EXPECT_EQ(result.exists, std::vector<std::uint8_t>({1, 1, 1}));
-    EXPECT_EQ(result.prefixHitKeys, std::uint32_t{10});
-    ExpectSameAsuSet(state->queryCalls, {10, 20, 30});
-    EXPECT_EQ(state->queryKeyCounts[10], std::size_t{3});
-    EXPECT_EQ(state->queryKeyCounts[20], std::size_t{3});
-    EXPECT_EQ(state->queryKeyCounts[30], std::size_t{3});
+    EXPECT_EQ(result.exists, std::vector<std::uint8_t>({0, 1, 1}));
+    ExpectSameAsuSet(state->queryCalls, {10, 20});
+    EXPECT_EQ(state->queryModes[10], QueryMode::PER_KEY);
+    EXPECT_EQ(state->queryModes[20], QueryMode::PER_KEY);
 }
 
-TEST(AsuClientImplTest, Query_PrefixPartialFailureIncludesAsuContext)
+TEST(AsuClientImplTest, Query_WaitFailuresDoNotSkipOtherTransports)
 {
     auto state = std::make_shared<TestState>();
-    state->prefixQueryResults[10] = QueryResult{
-        {1, 0, 0},
-        2
-    };
-    state->queryFailures[20] =
-        Status::Error(StatusCode::INVALID_ARGUMENT, "fake prefix query failure");
-    state->prefixQueryResults[30] = QueryResult{
-        {0, 0, 1},
-        5
-    };
+    state->queryWaitFailures[10] = Status::Error(StatusCode::IO_ERROR, "fake query wait failure");
     auto client = CreateAsuClient(MakeFactory(state));
-    ASSERT_TRUE(client->Init(MakeConfig({10, 20, 30})).ok());
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
 
-    QueryOptions options;
-    options.mode = QueryMode::PREFIX;
     QueryResult result;
-    auto status = client->Query(
-        {MakeCacheKey("prefix-a"), MakeCacheKey("prefix-b"), MakeCacheKey("prefix-c")}, options,
-        result);
+    auto status = client->Query({MakeCacheKey("k05"), MakeCacheKey("k15")}, QueryOptions{}, result);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
-    EXPECT_NE(status.message.find("asuId=20"), std::string::npos);
-    EXPECT_EQ(result.exists, std::vector<std::uint8_t>({1, 0, 1}));
-    EXPECT_EQ(result.prefixHitKeys, std::uint32_t{7});
-    ExpectSameAsuSet(state->queryCalls, {10, 20, 30});
-}
-
-TEST(AsuClientImplTest, Query_PrefixResultSizeMismatchReturnsInternalError)
-{
-    auto state = std::make_shared<TestState>();
-    state->prefixQueryResults[10] = QueryResult{{1}, 1};
-    auto client = CreateAsuClient(MakeFactory(state));
-    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
-
-    QueryOptions options;
-    options.mode = QueryMode::PREFIX;
-    QueryResult result;
-    auto status =
-        client->Query({MakeCacheKey("prefix-a"), MakeCacheKey("prefix-b")}, options, result);
-
-    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
-    EXPECT_NE(status.message.find("prefix query result size mismatch"), std::string::npos);
-    EXPECT_NE(status.message.find("asuId=10"), std::string::npos);
+    ExpectSameAsuSet(state->waitCalls, {10, 20});
+    EXPECT_EQ(result.exists, std::vector<std::uint8_t>({0, 1}));
 }
 
 TEST(AsuClientImplTest, BackgroundRefresh_QueryReturnsErrorWithoutRetry)
@@ -732,7 +712,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryReturnsErrorWithoutRetry)
     QueryResult result;
     auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
-    EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
 
     status = client->Query({MakeCacheKey("k15")}, QueryOptions{}, result);
 
@@ -760,7 +740,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryDoesNotRefreshNonRefreshableError
     QueryResult result;
     auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
-    EXPECT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     EXPECT_EQ(viewServer->FetchCount(), std::size_t{1});
     EXPECT_EQ(state->createdTransports, std::uint32_t{1});
 }
@@ -785,7 +765,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryRefreshesOnIoError)
     QueryResult result;
     auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
-    EXPECT_EQ(status.code, StatusCode::IO_ERROR);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(client->Shutdown().ok());
     EXPECT_EQ(state->createdTransports, std::uint32_t{2});
 }
@@ -810,12 +790,12 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryRefreshesOnTimeout)
     QueryResult result;
     auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
-    EXPECT_EQ(status.code, StatusCode::TIMEOUT);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(client->Shutdown().ok());
     EXPECT_EQ(state->createdTransports, std::uint32_t{2});
 }
 
-TEST(AsuClientImplTest, BackgroundRefresh_QueryKeepsOriginalErrorWhenViewFetchFails)
+TEST(AsuClientImplTest, BackgroundRefresh_QueryReturnsPartialFailedWhenViewFetchFails)
 {
     auto state = std::make_shared<TestState>();
     state->failFirstQuery = true;
@@ -834,7 +814,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryKeepsOriginalErrorWhenViewFetchFa
     QueryResult result;
     auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
-    EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(client->Shutdown().ok());
     EXPECT_EQ(state->createdTransports, std::uint32_t{1});
 }
@@ -940,7 +920,7 @@ TEST(AsuClientImplTest, ViewEpoch_DoesNotPublishSameOrOlderViewEpoch)
 
     QueryResult result;
     auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
-    EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(client->Shutdown().ok());
     EXPECT_EQ(state->createdTransports, std::uint32_t{1});
 }
@@ -958,7 +938,7 @@ TEST(AsuClientImplTest, SnapshotRefresh_BuildFailureKeepsOldSnapshot)
 
     QueryResult result;
     auto status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
-    EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(WaitForFetchCount(viewServer, 2));
 
     status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
@@ -1194,7 +1174,7 @@ TEST(AsuClientImplTest, MemoryRegister_BindFailureDoesNotCacheResource)
     QueryResult queryResult;
     status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, queryResult);
 
-    EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(client->Shutdown().ok());
     EXPECT_EQ(state->createdTransports, std::uint32_t{3});
     EXPECT_EQ(state->bindCalls, std::vector<AsuId>({20}));
@@ -1255,7 +1235,7 @@ TEST(AsuClientImplTest, MemoryRegister_UnregisterRemovesCachedResourceBeforeFutu
     QueryResult queryResult;
     status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, queryResult);
 
-    EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(client->Shutdown().ok());
     EXPECT_EQ(state->createdTransports, std::uint32_t{2});
     EXPECT_TRUE(state->bindCalls.empty());
@@ -1546,7 +1526,7 @@ TEST(AsuClientImplTest, SnapshotRefresh_ReusesExistingTransportAndBindsResources
     QueryResult result;
     status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, result);
 
-    EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(client->Shutdown().ok());
     EXPECT_EQ(state->createdTransports, std::uint32_t{2});
     EXPECT_EQ(state->bindCalls, std::vector<AsuId>({20}));
@@ -1582,7 +1562,7 @@ TEST(AsuClientImplTest,
     state->failFirstQuery = true;
     QueryResult queryResult;
     status = client->Query({MakeCacheKey("k05")}, QueryOptions{}, queryResult);
-    ASSERT_EQ(status.code, StatusCode::CONNECTION_ERROR);
+    ASSERT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(WaitForFetchCount(viewServer, 2));
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 

--- a/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
@@ -215,26 +215,22 @@ public:
     }
 
     Status RegisterRegions(const std::vector<MemoryRegion>& regions,
-                           std::vector<RegisterResult>& results) override
+                           std::vector<RegisteredMemory>& registeredRegions) override
     {
         state_->registerCalls.emplace_back(config_.asuId);
-        results.clear();
+        registeredRegions.clear();
         for (std::size_t index = 0; index < regions.size(); ++index) {
-            results.emplace_back(RegisterResult{Status::OK(), MakeTestMrHandle(500 + index),
-                                                900 + static_cast<std::uint32_t>(index)});
+            registeredRegions.emplace_back(
+                RegisteredMemory{regions[index], MakeTestMrHandle(500 + index),
+                                 900 + static_cast<std::uint32_t>(index)});
         }
         return Status::OK();
     }
 
-    Status BindRegisteredRegions(const std::vector<RegisteredMemory>& regions,
-                                 std::vector<RegisterResult>& results) override
+    Status BindRegisteredRegions(const std::vector<RegisteredMemory>& regions) override
     {
         state_->bindCalls.emplace_back(config_.asuId);
         state_->boundRegions[config_.asuId] = regions;
-        results.clear();
-        for (const auto& region : regions) {
-            results.emplace_back(RegisterResult{Status::OK(), region.handle, region.tokenId});
-        }
         return Status::OK();
     }
 
@@ -482,7 +478,7 @@ TEST(AsuClientImplTest, Input_EmptyRegisterReturnsEmptyResults)
     auto client = CreateAsuClient(MakeFactory(state));
     ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
 
-    std::vector<RegisterResult> results;
+    std::vector<RegisteredMemory> results;
     auto status = client->RegisterRegions({}, results);
 
     EXPECT_TRUE(status.ok()) << status.message;
@@ -978,7 +974,7 @@ TEST(AsuClientImplTest, MemoryRegister_RegisterRegionsRegistersFirstTransportAnd
     auto client = CreateAsuClient(MakeFactory(state));
     ASSERT_TRUE(client->Init(MakeConfig({10, 20, 30})).ok());
 
-    std::vector<RegisterResult> results;
+    std::vector<RegisteredMemory> results;
     auto status = client->RegisterRegions({MemoryRegion{}, MemoryRegion{}}, results);
 
     EXPECT_TRUE(status.ok()) << status.message;
@@ -1007,20 +1003,11 @@ TEST(AsuClientImplTest, MemoryRegister_PartialRegisterFailureDoesNotBindFollower
         {
         }
 
-        Status RegisterRegions(const std::vector<MemoryRegion>& regions,
-                               std::vector<RegisterResult>& results) override
+        Status RegisterRegions(const std::vector<MemoryRegion>&,
+                               std::vector<RegisteredMemory>& registeredRegions) override
         {
             state_->registerCalls.emplace_back(10);
-            results.clear();
-            results.reserve(regions.size());
-            if (!regions.empty()) {
-                results.emplace_back(RegisterResult{Status::OK(), MakeTestMrHandle(500), 900});
-            }
-            if (regions.size() > 1) {
-                results.emplace_back(RegisterResult{
-                    Status::Error(StatusCode::INTERNAL_ERROR, "fake region register failure"),
-                    kInvalidMRHandle});
-            }
+            registeredRegions.clear();
             return Status::Error(StatusCode::PARTIAL_FAILED,
                                  "one or more memory regions failed to register");
         }
@@ -1039,7 +1026,7 @@ TEST(AsuClientImplTest, MemoryRegister_PartialRegisterFailureDoesNotBindFollower
     });
     ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
 
-    std::vector<RegisterResult> results;
+    std::vector<RegisteredMemory> results;
     auto status = client->RegisterRegions({MemoryRegion{}, MemoryRegion{}}, results);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
@@ -1047,9 +1034,7 @@ TEST(AsuClientImplTest, MemoryRegister_PartialRegisterFailureDoesNotBindFollower
     EXPECT_NE(status.message.find("asuId=10"), std::string::npos);
     EXPECT_EQ(state->registerCalls, std::vector<AsuId>({10}));
     EXPECT_TRUE(state->bindCalls.empty());
-    ASSERT_EQ(results.size(), std::size_t{2});
-    EXPECT_TRUE(results[0].status.ok()) << results[0].status.message;
-    EXPECT_EQ(results[1].status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_TRUE(results.empty());
 }
 
 TEST(AsuClientImplTest, MemoryRegister_FirstRegisterFailureIncludesAsuContext)
@@ -1062,7 +1047,7 @@ TEST(AsuClientImplTest, MemoryRegister_FirstRegisterFailureIncludesAsuContext)
         }
 
         Status RegisterRegions(const std::vector<MemoryRegion>&,
-                               std::vector<RegisterResult>&) override
+                               std::vector<RegisteredMemory>&) override
         {
             return Status::Error(StatusCode::BUFFER_NOT_REGISTERED, "fake register failure");
         }
@@ -1084,7 +1069,7 @@ TEST(AsuClientImplTest, MemoryRegister_FirstRegisterFailureIncludesAsuContext)
         MakeViewServerFactory(viewServer));
     ASSERT_TRUE(client->Init(config).ok());
 
-    std::vector<RegisterResult> results;
+    std::vector<RegisteredMemory> results;
     auto status = client->RegisterRegions({MemoryRegion{}}, results);
 
     EXPECT_EQ(status.code, StatusCode::BUFFER_NOT_REGISTERED);
@@ -1105,9 +1090,9 @@ TEST(AsuClientImplTest, MemoryRegister_SuccessWithMismatchedResultCountReturnsIn
         }
 
         Status RegisterRegions(const std::vector<MemoryRegion>&,
-                               std::vector<RegisterResult>& results) override
+                               std::vector<RegisteredMemory>& registeredRegions) override
         {
-            results.clear();
+            registeredRegions.clear();
             return Status::OK();
         }
     };
@@ -1119,7 +1104,7 @@ TEST(AsuClientImplTest, MemoryRegister_SuccessWithMismatchedResultCountReturnsIn
     });
     ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
 
-    std::vector<RegisterResult> results;
+    std::vector<RegisteredMemory> results;
     auto status = client->RegisterRegions({MemoryRegion{}}, results);
 
     EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
@@ -1138,8 +1123,7 @@ TEST(AsuClientImplTest, MemoryRegister_BindFailureIncludesAsuContext)
         {
         }
 
-        Status BindRegisteredRegions(const std::vector<RegisteredMemory>&,
-                                     std::vector<RegisterResult>&) override
+        Status BindRegisteredRegions(const std::vector<RegisteredMemory>&) override
         {
             return Status::Error(StatusCode::CONNECTION_ERROR, "fake bind failure");
         }
@@ -1155,49 +1139,13 @@ TEST(AsuClientImplTest, MemoryRegister_BindFailureIncludesAsuContext)
     });
     ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
 
-    std::vector<RegisterResult> results;
+    std::vector<RegisteredMemory> results;
     auto status = client->RegisterRegions({MemoryRegion{}}, results);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     EXPECT_NE(status.message.find("asuIndex=1"), std::string::npos);
     EXPECT_NE(status.message.find("asuId=20"), std::string::npos);
     EXPECT_NE(status.message.find("region_count=1"), std::string::npos);
-}
-
-TEST(AsuClientImplTest, MemoryRegister_SuccessfulBindWithMismatchedResultCountFails)
-{
-    class MismatchedBindTransport final : public FakeTransport {
-    public:
-        explicit MismatchedBindTransport(std::shared_ptr<TestState> state)
-            : FakeTransport(std::move(state))
-        {
-        }
-
-        Status BindRegisteredRegions(const std::vector<RegisteredMemory>&,
-                                     std::vector<RegisterResult>& results) override
-        {
-            results.clear();
-            return Status::OK();
-        }
-    };
-
-    auto state = std::make_shared<TestState>();
-    auto client = CreateAsuClient([state] {
-        ++state->createdTransports;
-        if (state->createdTransports == 2) {
-            return std::unique_ptr<AsuTransport>(new MismatchedBindTransport(state));
-        }
-        return std::unique_ptr<AsuTransport>(new FakeTransport(state));
-    });
-    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
-
-    std::vector<RegisterResult> results;
-    auto status = client->RegisterRegions({MemoryRegion{}}, results);
-
-    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
-    EXPECT_NE(status.message.find("asuIndex=1"), std::string::npos);
-    EXPECT_NE(status.message.find("region_count=1"), std::string::npos);
-    EXPECT_NE(status.message.find("result_count=0"), std::string::npos);
 }
 
 TEST(AsuClientImplTest, MemoryRegister_BindFailureDoesNotCacheResource)
@@ -1209,8 +1157,7 @@ TEST(AsuClientImplTest, MemoryRegister_BindFailureDoesNotCacheResource)
         {
         }
 
-        Status BindRegisteredRegions(const std::vector<RegisteredMemory>&,
-                                     std::vector<RegisterResult>&) override
+        Status BindRegisteredRegions(const std::vector<RegisteredMemory>&) override
         {
             state_->bindCalls.emplace_back(20);
             return Status::Error(StatusCode::CONNECTION_ERROR, "fake bind failure");
@@ -1239,7 +1186,7 @@ TEST(AsuClientImplTest, MemoryRegister_BindFailureDoesNotCacheResource)
         MakeViewServerFactory(viewServer));
     ASSERT_TRUE(client->Init(config).ok());
 
-    std::vector<RegisterResult> results;
+    std::vector<RegisteredMemory> results;
     auto status = client->RegisterRegions({MemoryRegion{}}, results);
     ASSERT_EQ(status.code, StatusCode::PARTIAL_FAILED);
 
@@ -1296,7 +1243,7 @@ TEST(AsuClientImplTest, MemoryRegister_UnregisterRemovesCachedResourceBeforeFutu
         std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
     ASSERT_TRUE(client->Init(config).ok());
 
-    std::vector<RegisterResult> results;
+    std::vector<RegisteredMemory> results;
     auto status = client->RegisterRegions({MemoryRegion{}}, results);
     ASSERT_TRUE(status.ok()) << status.message;
     ASSERT_EQ(results.size(), std::size_t{1});
@@ -1591,7 +1538,7 @@ TEST(AsuClientImplTest, SnapshotRefresh_ReusesExistingTransportAndBindsResources
         std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
     ASSERT_TRUE(client->Init(config).ok());
 
-    std::vector<RegisterResult> results;
+    std::vector<RegisteredMemory> results;
     auto status = client->RegisterRegions({MemoryRegion{}}, results);
     ASSERT_TRUE(status.ok()) << status.message;
     state->failFirstQuery = true;

--- a/ucm/transport/kv/asu/test/case/asu_client_e2e_metrics_test.cc
+++ b/ucm/transport/kv/asu/test/case/asu_client_e2e_metrics_test.cc
@@ -490,22 +490,18 @@ public:
     }
 
     Status RegisterRegions(const std::vector<MemoryRegion>& regions,
-                           std::vector<RegisterResult>& results) override
+                           std::vector<RegisteredMemory>& registeredRegions) override
     {
-        results.clear();
+        registeredRegions.clear();
         for (std::size_t index = 0; index < regions.size(); ++index) {
-            results.emplace_back(RegisterResult{Status::OK(), MakeTestMrHandle(index + 1)});
+            registeredRegions.emplace_back(
+                RegisteredMemory{regions[index], MakeTestMrHandle(index + 1)});
         }
         return Status::OK();
     }
 
-    Status BindRegisteredRegions(const std::vector<RegisteredMemory>& regions,
-                                 std::vector<RegisterResult>& results) override
+    Status BindRegisteredRegions(const std::vector<RegisteredMemory>&) override
     {
-        results.clear();
-        for (const auto& region : regions) {
-            results.emplace_back(RegisterResult{Status::OK(), region.handle});
-        }
         return Status::OK();
     }
 

--- a/ucm/transport/kv/asu/test/case/asu_smoke_test.cc
+++ b/ucm/transport/kv/asu/test/case/asu_smoke_test.cc
@@ -114,22 +114,17 @@ public:
     }
 
     Status RegisterRegions(const std::vector<MemoryRegion>& regions,
-                           std::vector<RegisterResult>& results) override
+                           std::vector<RegisteredMemory>& registeredRegions) override
     {
-        results.clear();
+        registeredRegions.clear();
         for (std::size_t i = 0; i < regions.size(); ++i) {
-            results.emplace_back(RegisterResult{Status::OK(), MakeTestMrHandle(i + 1)});
+            registeredRegions.emplace_back(RegisteredMemory{regions[i], MakeTestMrHandle(i + 1)});
         }
         return Status::OK();
     }
 
-    Status BindRegisteredRegions(const std::vector<RegisteredMemory>& regions,
-                                 std::vector<RegisterResult>& results) override
+    Status BindRegisteredRegions(const std::vector<RegisteredMemory>&) override
     {
-        results.clear();
-        for (const auto& region : regions) {
-            results.emplace_back(RegisterResult{Status::OK(), region.handle});
-        }
         return Status::OK();
     }
 

--- a/ucm/transport/kv/asu/test/case/asu_smoke_test.cc
+++ b/ucm/transport/kv/asu/test/case/asu_smoke_test.cc
@@ -26,6 +26,7 @@
 #include <cstring>
 #include <gtest/gtest.h>
 #include <string_view>
+#include <unordered_map>
 #include "asu_client_impl.h"
 
 namespace UC::ASU {
@@ -71,9 +72,18 @@ public:
         return Status::OK();
     }
 
-    Status QueryAsync(const std::vector<CacheKey>&, const QueryOptions&, TaskId& taskId) override
+    Status QueryAsync(const std::vector<CacheKey>& keys, const QueryOptions& options,
+                      TaskId& taskId) override
     {
-        taskId = 0;
+        QueryResult queryResult;
+        auto status = Query(keys, options, queryResult);
+        if (!status.ok()) {
+            taskId = kInvalidTaskId;
+            return status;
+        }
+
+        taskId = nextTaskId_++;
+        queryResults_[taskId] = std::move(queryResult);
         return Status::OK();
     }
 
@@ -103,6 +113,11 @@ public:
             return Status::Error(StatusCode::TASK_NOT_FOUND, "task not found");
         }
         result.status = Status::OK();
+        auto queryIter = queryResults_.find(taskId);
+        if (queryIter != queryResults_.end()) {
+            result.queryResult = queryIter->second;
+            return Status::OK();
+        }
         result.entryStatus.assign(1, Status::OK());
         result.queryResult.reset();
         return Status::OK();
@@ -134,6 +149,7 @@ private:
     TransportConfig config_;
     bool initialized_{false};
     TaskId nextTaskId_{1000};
+    std::unordered_map<TaskId, QueryResult> queryResults_;
 };
 
 AsuClientConfig MakeClientConfig()

--- a/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
@@ -114,10 +114,9 @@ public:
     virtual Status Wait(TaskId taskId, std::uint64_t timeoutMs, TaskResult& result) = 0;
 
     virtual Status RegisterRegions(const std::vector<MemoryRegion>& regions,
-                                   std::vector<RegisterResult>& results) = 0;
+                                   std::vector<RegisteredMemory>& registeredRegions) = 0;
 
-    virtual Status BindRegisteredRegions(const std::vector<RegisteredMemory>& regions,
-                                         std::vector<RegisterResult>& results) = 0;
+    virtual Status BindRegisteredRegions(const std::vector<RegisteredMemory>& regions) = 0;
 
     virtual Status UnregisterRegions(const std::vector<MRHandle>& handles) = 0;
 };

--- a/ucm/transport/kv/asu/trans/include/asu_transport/types.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/types.h
@@ -160,13 +160,8 @@ struct KVBuffer {
     std::uint32_t offset{0};  // target buffer offset
 };
 
-struct RegisterResult {
-    Status status;
-    MRHandle handle{kInvalidMRHandle};
-    std::uint32_t tokenId{0};
-};
-
-struct RegisteredMemory {  // 用于绑定已注册的内存
+// Describes a registered memory region returned by registration or reused for binding.
+struct RegisteredMemory {
     MemoryRegion region;
     MRHandle handle{kInvalidMRHandle};
     std::uint32_t tokenId{0};

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -362,19 +362,9 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
     }
 
     std::vector<MRHandle> mrHandles;
-    auto trackReturnedHandles = [&]() {
-        for (std::size_t index = 0; index < mrHandles.size(); ++index) {
-            RegisteredMemory registeredMemory;
-            if (index < regions.size()) { registeredMemory.region = regions[index]; }
-            registeredMemory.handle = mrHandles[index];
-            registeredRegions_[mrHandles[index]] = registeredMemory;
-        }
-        if (!mrHandles.empty()) { ownsRegisteredRegionHandles_ = true; }
-    };
 
     auto status = transProvider_->RegisterMemory(registerDescs, mrHandles);
     if (!status.ok()) {
-        trackReturnedHandles();
         const auto cleanupStatus = UnregisterOwnedRegionHandles(mrHandles);
         return Status::Error(StatusCode::PARTIAL_FAILED,
                              cleanupStatus.ok()
@@ -384,7 +374,6 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
     if (mrHandles.size() != regions.size()) {
         status = Status::Error(StatusCode::INTERNAL_ERROR,
                                "register result count does not match region count");
-        trackReturnedHandles();
         const auto cleanupStatus = UnregisterOwnedRegionHandles(mrHandles);
         return Status::Error(StatusCode::PARTIAL_FAILED,
                              cleanupStatus.ok()
@@ -397,7 +386,6 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
         status = transProvider_->GetMemTokenId(mrHandles[index], tokenIds[index]);
         if (status.ok()) { continue; }
 
-        trackReturnedHandles();
         const auto cleanupStatus = UnregisterOwnedRegionHandles(mrHandles);
         return Status::Error(StatusCode::PARTIAL_FAILED,
                              cleanupStatus.ok()

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -206,15 +206,17 @@ Status AsuTransportImpl::Shutdown()
     }
     {
         std::lock_guard<std::mutex> lock(registeredRegionsMu_);
-        std::vector<MRHandle> handles;
-        handles.reserve(ownedRegisteredRegionHandles_.size());
-        for (auto handle : ownedRegisteredRegionHandles_) { handles.push_back(handle); }
-        if (!handles.empty() && transProvider_) {
-            const auto status = UnregisterOwnedRegionHandles(handles);
-            if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+        if (ownsRegisteredRegionHandles_) {
+            std::vector<MRHandle> handles;
+            handles.reserve(registeredRegions_.size());
+            for (const auto& item : registeredRegions_) { handles.push_back(item.first); }
+            if (!handles.empty() && transProvider_) {
+                const auto status = UnregisterOwnedRegionHandles(handles);
+                if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+            }
         }
         registeredRegions_.clear();
-        ownedRegisteredRegionHandles_.clear();
+        ownsRegisteredRegionHandles_ = false;
     }
     flagBufferManager_.Shutdown();
     sendBufferManager_.Shutdown();
@@ -355,9 +357,19 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
     }
 
     std::vector<MRHandle> mrHandles;
+    auto trackReturnedHandles = [&]() {
+        for (std::size_t index = 0; index < mrHandles.size(); ++index) {
+            RegisteredMemory registeredMemory;
+            if (index < regions.size()) { registeredMemory.region = regions[index]; }
+            registeredMemory.handle = mrHandles[index];
+            registeredRegions_[mrHandles[index]] = registeredMemory;
+        }
+        if (!mrHandles.empty()) { ownsRegisteredRegionHandles_ = true; }
+    };
+
     auto status = transProvider_->RegisterMemory(registerDescs, mrHandles);
     if (!status.ok()) {
-        ownedRegisteredRegionHandles_.insert(mrHandles.begin(), mrHandles.end());
+        trackReturnedHandles();
         const auto cleanupStatus = UnregisterOwnedRegionHandles(mrHandles);
         results.assign(regions.size(), RegisterResult{status, kInvalidMRHandle});
         const auto clearedStatus = Status::Error(
@@ -373,7 +385,7 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
     if (mrHandles.size() != regions.size()) {
         status = Status::Error(StatusCode::INTERNAL_ERROR,
                                "register result count does not match region count");
-        ownedRegisteredRegionHandles_.insert(mrHandles.begin(), mrHandles.end());
+        trackReturnedHandles();
         const auto cleanupStatus = UnregisterOwnedRegionHandles(mrHandles);
         results.assign(regions.size(), RegisterResult{status, kInvalidMRHandle});
         return Status::Error(StatusCode::PARTIAL_FAILED,
@@ -387,7 +399,7 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
         status = transProvider_->GetMemTokenId(mrHandles[index], tokenIds[index]);
         if (status.ok()) { continue; }
 
-        ownedRegisteredRegionHandles_.insert(mrHandles.begin(), mrHandles.end());
+        trackReturnedHandles();
         const auto cleanupStatus = UnregisterOwnedRegionHandles(mrHandles);
         const auto rolledBackStatus = Status::Error(
             StatusCode::PARTIAL_FAILED, "registration was cleared after token lookup failed");
@@ -405,9 +417,9 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
         registeredMemory.handle = mrHandles[index];
         registeredMemory.tokenId = tokenIds[index];
         registeredRegions_[mrHandles[index]] = registeredMemory;
-        ownedRegisteredRegionHandles_.insert(mrHandles[index]);
         results.emplace_back(RegisterResult{Status::OK(), mrHandles[index], tokenIds[index]});
     }
+    ownsRegisteredRegionHandles_ = true;
     return Status::OK();
 }
 
@@ -428,13 +440,12 @@ Status AsuTransportImpl::BindRegisteredRegions(const std::vector<RegisteredMemor
 Status AsuTransportImpl::UnregisterRegions(const std::vector<MRHandle>& handles)
 {
     std::lock_guard<std::mutex> lock(registeredRegionsMu_);
+    if (!ownsRegisteredRegionHandles_) { return Status::OK(); }
     std::vector<MRHandle> ownedHandles;
     ownedHandles.reserve(handles.size());
     for (auto handle : handles) {
         if (handle == kInvalidMRHandle) { continue; }
-        if (ownedRegisteredRegionHandles_.find(handle) == ownedRegisteredRegionHandles_.end()) {
-            continue;
-        }
+        if (registeredRegions_.find(handle) == registeredRegions_.end()) { continue; }
         ownedHandles.push_back(handle);
     }
     return UnregisterOwnedRegionHandles(ownedHandles);
@@ -458,7 +469,6 @@ Status AsuTransportImpl::UnregisterOwnedRegionHandles(const std::vector<MRHandle
     for (std::size_t index = 0; index < handles.size(); ++index) {
         if (index < statuses.size() && statuses[index].ok()) {
             registeredRegions_.erase(handles[index]);
-            ownedRegisteredRegionHandles_.erase(handles[index]);
         } else if (failure.ok()) {
             failure = index < statuses.size()
                           ? statuses[index]
@@ -466,6 +476,7 @@ Status AsuTransportImpl::UnregisterOwnedRegionHandles(const std::vector<MRHandle
                                           "unregister result count does not match handle count");
         }
     }
+    ownsRegisteredRegionHandles_ = !registeredRegions_.empty();
     return failure;
 }
 

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -212,7 +212,12 @@ Status AsuTransportImpl::Shutdown()
             for (const auto& item : registeredRegions_) { handles.push_back(item.first); }
             if (!handles.empty() && transProvider_) {
                 const auto status = UnregisterOwnedRegionHandles(handles);
-                if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+                if (!status.ok()) {
+                    UC_ERROR(
+                        "Transport shutdown ignored memory unregister failure: code={} "
+                        "message={}",
+                        static_cast<int>(status.code), status.message);
+                }
             }
         }
         registeredRegions_.clear();

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -344,10 +344,10 @@ Status AsuTransportImpl::Wait(TaskId taskId, std::uint64_t timeoutMs, TaskResult
 }
 
 Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& regions,
-                                         std::vector<RegisterResult>& results)
+                                         std::vector<RegisteredMemory>& registeredRegions)
 {
-    results.clear();
-    results.reserve(regions.size());
+    registeredRegions.clear();
+    registeredRegions.reserve(regions.size());
     if (regions.empty()) { return Status::OK(); }
 
     std::lock_guard<std::mutex> lock(registeredRegionsMu_);
@@ -376,12 +376,6 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
     if (!status.ok()) {
         trackReturnedHandles();
         const auto cleanupStatus = UnregisterOwnedRegionHandles(mrHandles);
-        results.assign(regions.size(), RegisterResult{status, kInvalidMRHandle});
-        const auto clearedStatus = Status::Error(
-            StatusCode::PARTIAL_FAILED, "registration was cleared after batch registration failed");
-        for (std::size_t index = 0; index < std::min(mrHandles.size(), results.size()); ++index) {
-            results[index].status = clearedStatus;
-        }
         return Status::Error(StatusCode::PARTIAL_FAILED,
                              cleanupStatus.ok()
                                  ? "one or more memory regions failed to register"
@@ -392,7 +386,6 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
                                "register result count does not match region count");
         trackReturnedHandles();
         const auto cleanupStatus = UnregisterOwnedRegionHandles(mrHandles);
-        results.assign(regions.size(), RegisterResult{status, kInvalidMRHandle});
         return Status::Error(StatusCode::PARTIAL_FAILED,
                              cleanupStatus.ok()
                                  ? status.message
@@ -406,10 +399,6 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
 
         trackReturnedHandles();
         const auto cleanupStatus = UnregisterOwnedRegionHandles(mrHandles);
-        const auto rolledBackStatus = Status::Error(
-            StatusCode::PARTIAL_FAILED, "registration was cleared after token lookup failed");
-        results.assign(regions.size(), RegisterResult{rolledBackStatus, kInvalidMRHandle});
-        results[index].status = status;
         return Status::Error(StatusCode::PARTIAL_FAILED,
                              cleanupStatus.ok()
                                  ? "one or more memory region token lookups failed"
@@ -422,23 +411,16 @@ Status AsuTransportImpl::RegisterRegions(const std::vector<MemoryRegion>& region
         registeredMemory.handle = mrHandles[index];
         registeredMemory.tokenId = tokenIds[index];
         registeredRegions_[mrHandles[index]] = registeredMemory;
-        results.emplace_back(RegisterResult{Status::OK(), mrHandles[index], tokenIds[index]});
+        registeredRegions.emplace_back(registeredMemory);
     }
     ownsRegisteredRegionHandles_ = true;
     return Status::OK();
 }
 
-Status AsuTransportImpl::BindRegisteredRegions(const std::vector<RegisteredMemory>& regions,
-                                               std::vector<RegisterResult>& results)
+Status AsuTransportImpl::BindRegisteredRegions(const std::vector<RegisteredMemory>& regions)
 {
-    results.clear();
-    results.reserve(regions.size());
-
     std::lock_guard<std::mutex> lock(registeredRegionsMu_);
-    for (const auto& region : regions) {
-        registeredRegions_[region.handle] = region;
-        results.emplace_back(RegisterResult{Status::OK(), region.handle, region.tokenId});
-    }
+    for (const auto& region : regions) { registeredRegions_[region.handle] = region; }
     return Status::OK();
 }
 

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
@@ -82,10 +82,9 @@ public:
     Status Wait(TaskId taskId, std::uint64_t timeoutMs, TaskResult& result) override;
 
     Status RegisterRegions(const std::vector<MemoryRegion>& regions,
-                           std::vector<RegisterResult>& results) override;
+                           std::vector<RegisteredMemory>& registeredRegions) override;
 
-    Status BindRegisteredRegions(const std::vector<RegisteredMemory>& regions,
-                                 std::vector<RegisterResult>& results) override;
+    Status BindRegisteredRegions(const std::vector<RegisteredMemory>& regions) override;
 
     Status UnregisterRegions(const std::vector<MRHandle>& handles) override;
 

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
@@ -30,7 +30,6 @@
 #include <string>
 #include <thread>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 #include "asu_transport/asu_transport.h"
 #include "buffer_manager.h"
@@ -142,7 +141,7 @@ private:
 
     std::mutex registeredRegionsMu_;
     std::unordered_map<MRHandle, RegisteredMemory> registeredRegions_;
-    std::unordered_set<MRHandle> ownedRegisteredRegionHandles_;
+    bool ownsRegisteredRegionHandles_{false};
 };
 
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
@@ -415,6 +415,28 @@ TEST(AsuTransportRegisterTest, ShutdownUnregistersRegisteredRegions)
     EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
 }
 
+TEST(AsuTransportRegisterTest, ShutdownIgnoresUnregisterFailureWithoutRetry)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    std::vector<RegisterResult> results;
+    ASSERT_TRUE(transport.RegisterRegions({MemoryRegion{}}, results).ok());
+    providerPtr->failUnregister = true;
+
+    EXPECT_TRUE(transport.Shutdown().ok());
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
+
+    providerPtr->failUnregister = false;
+    EXPECT_TRUE(transport.Shutdown().ok());
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
+}
+
 TEST(AsuSubmitFlowTest, SendSubBatchBuffersReportsSendFailures)
 {
     g_sendStatuses = {

--- a/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
@@ -207,7 +207,7 @@ TEST(AsuTransportRegisterTest, RegisterRegionsReturnsPartialFailedAndRollsBackSu
     EXPECT_EQ(providerPtr->registerCallCount, std::uint32_t{1});
     EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
     EXPECT_TRUE(transport.registeredRegions_.empty());
-    EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
 }
 
 TEST(AsuTransportRegisterTest, RegisterDeviceRegionDoesNotRequireConnection)
@@ -230,6 +230,31 @@ TEST(AsuTransportRegisterTest, RegisterDeviceRegionDoesNotRequireConnection)
     ASSERT_EQ(results.size(), std::size_t{1});
     EXPECT_TRUE(results[0].status.ok()) << results[0].status.message;
     EXPECT_EQ(providerPtr->registerCount, std::uint32_t{1});
+    EXPECT_TRUE(transport.ownsRegisteredRegionHandles_);
+}
+
+TEST(AsuTransportRegisterTest, BoundRegionsAreNotOwnedByTransport)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    RegisteredMemory region;
+    region.handle = MRHandle{1};
+    std::vector<RegisterResult> results;
+    ASSERT_TRUE(transport.BindRegisteredRegions({region}, results).ok());
+
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
+    EXPECT_TRUE(transport.UnregisterRegions({region.handle}).ok());
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{0});
+    EXPECT_EQ(transport.registeredRegions_.size(), std::size_t{1});
+
+    EXPECT_TRUE(transport.Shutdown().ok());
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{0});
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
 }
 
 TEST(AsuTransportRegisterTest, RegisterRegionsReturnsAllResultsAfterBatchFailure)
@@ -262,7 +287,7 @@ TEST(AsuTransportRegisterTest, RegisterRegionsReturnsAllResultsAfterBatchFailure
     EXPECT_EQ(providerPtr->registerCount, std::uint32_t{2});
     EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
     EXPECT_TRUE(transport.registeredRegions_.empty());
-    EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
 }
 
 TEST(AsuTransportRegisterTest, RegisterRegionsClearsBatchWhenTokenLookupFails)
@@ -294,7 +319,7 @@ TEST(AsuTransportRegisterTest, RegisterRegionsClearsBatchWhenTokenLookupFails)
     EXPECT_EQ(providerPtr->registerCount, std::uint32_t{3});
     EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{3});
     EXPECT_TRUE(transport.registeredRegions_.empty());
-    EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
 }
 
 TEST(AsuTransportRegisterTest, RegisterRegionsRetainsHandlesWhenBatchCleanupFails)
@@ -321,17 +346,15 @@ TEST(AsuTransportRegisterTest, RegisterRegionsRetainsHandlesWhenBatchCleanupFail
     ASSERT_EQ(results.size(), std::size_t{2});
     EXPECT_EQ(results[0].status.code, StatusCode::PARTIAL_FAILED);
     EXPECT_EQ(results[0].handle, kInvalidMRHandle);
-    EXPECT_TRUE(transport.registeredRegions_.empty());
-    EXPECT_EQ(transport.ownedRegisteredRegionHandles_.size(), std::size_t{1});
-    EXPECT_EQ(transport.ownedRegisteredRegionHandles_.count(
-                  reinterpret_cast<MRHandle>(std::uintptr_t{1})),
-              std::size_t{1});
+    EXPECT_EQ(transport.registeredRegions_.size(), std::size_t{1});
+    EXPECT_TRUE(transport.ownsRegisteredRegionHandles_);
 
     providerPtr->failUnregister = false;
     const auto cleanupStatus =
         transport.UnregisterRegions({reinterpret_cast<MRHandle>(std::uintptr_t{1})});
     EXPECT_TRUE(cleanupStatus.ok()) << cleanupStatus.message;
-    EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
 }
 
 TEST(AsuTransportRegisterTest, UnregisterRegionsRetainsOnlyHandlesThatFailToUnregister)
@@ -356,13 +379,12 @@ TEST(AsuTransportRegisterTest, UnregisterRegionsRetainsOnlyHandlesThatFailToUnre
 
     EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_EQ(transport.registeredRegions_.size(), std::size_t{1});
-    EXPECT_EQ(transport.ownedRegisteredRegionHandles_.size(), std::size_t{1});
     EXPECT_EQ(transport.registeredRegions_.count(results[0].handle), std::size_t{0});
     EXPECT_EQ(transport.registeredRegions_.count(results[1].handle), std::size_t{1});
 
     EXPECT_TRUE(transport.UnregisterRegions({results[1].handle}).ok());
     EXPECT_TRUE(transport.registeredRegions_.empty());
-    EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
 }
 
 TEST(AsuTransportRegisterTest, ShutdownUnregistersRegisteredRegions)
@@ -390,7 +412,7 @@ TEST(AsuTransportRegisterTest, ShutdownUnregistersRegisteredRegions)
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{2});
     EXPECT_TRUE(transport.registeredRegions_.empty());
-    EXPECT_TRUE(transport.ownedRegisteredRegionHandles_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
 }
 
 TEST(AsuSubmitFlowTest, SendSubBatchBuffersReportsSendFailures)

--- a/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
@@ -311,7 +311,7 @@ TEST(AsuTransportRegisterTest, RegisterRegionsClearsBatchWhenTokenLookupFails)
     EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
 }
 
-TEST(AsuTransportRegisterTest, RegisterRegionsRetainsHandlesWhenBatchCleanupFails)
+TEST(AsuTransportRegisterTest, RegisterRegionsDoesNotTrackHandlesWhenBatchCleanupFails)
 {
     auto provider = std::make_unique<StubTransProvider>();
     auto* providerPtr = provider.get();
@@ -333,13 +333,15 @@ TEST(AsuTransportRegisterTest, RegisterRegionsRetainsHandlesWhenBatchCleanupFail
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     EXPECT_NE(status.message.find("cleanup was incomplete"), std::string::npos);
     EXPECT_TRUE(registeredRegions.empty());
-    EXPECT_EQ(transport.registeredRegions_.size(), std::size_t{1});
-    EXPECT_TRUE(transport.ownsRegisteredRegionHandles_);
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
 
     providerPtr->failUnregister = false;
     const auto cleanupStatus =
         transport.UnregisterRegions({reinterpret_cast<MRHandle>(std::uintptr_t{1})});
     EXPECT_TRUE(cleanupStatus.ok()) << cleanupStatus.message;
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
     EXPECT_TRUE(transport.registeredRegions_.empty());
     EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
 }

--- a/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_submit_flow_test.cpp
@@ -195,15 +195,11 @@ TEST(AsuTransportRegisterTest, RegisterRegionsReturnsPartialFailedAndRollsBackSu
     regions[1].addr = 0x2000;
     regions[1].size = 4096;
 
-    std::vector<RegisterResult> results;
-    auto status = transport.RegisterRegions(regions, results);
+    std::vector<RegisteredMemory> registeredRegions;
+    auto status = transport.RegisterRegions(regions, registeredRegions);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
-    ASSERT_EQ(results.size(), std::size_t{2});
-    EXPECT_EQ(results[0].status.code, StatusCode::PARTIAL_FAILED);
-    EXPECT_EQ(results[0].handle, kInvalidMRHandle);
-    EXPECT_EQ(results[1].status.code, StatusCode::INTERNAL_ERROR);
-    EXPECT_EQ(results[1].handle, kInvalidMRHandle);
+    EXPECT_TRUE(registeredRegions.empty());
     EXPECT_EQ(providerPtr->registerCallCount, std::uint32_t{1});
     EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
     EXPECT_TRUE(transport.registeredRegions_.empty());
@@ -223,12 +219,13 @@ TEST(AsuTransportRegisterTest, RegisterDeviceRegionDoesNotRequireConnection)
     region.addr = 0x1000;
     region.size = 4096;
 
-    std::vector<RegisterResult> results;
-    const auto status = transport.RegisterRegions({region}, results);
+    std::vector<RegisteredMemory> registeredRegions;
+    const auto status = transport.RegisterRegions({region}, registeredRegions);
 
     EXPECT_TRUE(status.ok()) << status.message;
-    ASSERT_EQ(results.size(), std::size_t{1});
-    EXPECT_TRUE(results[0].status.ok()) << results[0].status.message;
+    ASSERT_EQ(registeredRegions.size(), std::size_t{1});
+    EXPECT_EQ(registeredRegions[0].region.addr, region.addr);
+    EXPECT_NE(registeredRegions[0].handle, kInvalidMRHandle);
     EXPECT_EQ(providerPtr->registerCount, std::uint32_t{1});
     EXPECT_TRUE(transport.ownsRegisteredRegionHandles_);
 }
@@ -243,8 +240,7 @@ TEST(AsuTransportRegisterTest, BoundRegionsAreNotOwnedByTransport)
 
     RegisteredMemory region;
     region.handle = MRHandle{1};
-    std::vector<RegisterResult> results;
-    ASSERT_TRUE(transport.BindRegisteredRegions({region}, results).ok());
+    ASSERT_TRUE(transport.BindRegisteredRegions({region}).ok());
 
     EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
     EXPECT_TRUE(transport.UnregisterRegions({region.handle}).ok());
@@ -257,7 +253,7 @@ TEST(AsuTransportRegisterTest, BoundRegionsAreNotOwnedByTransport)
     EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
 }
 
-TEST(AsuTransportRegisterTest, RegisterRegionsReturnsAllResultsAfterBatchFailure)
+TEST(AsuTransportRegisterTest, RegisterRegionsReturnsNoRegionsAfterBatchFailure)
 {
     auto provider = std::make_unique<StubTransProvider>();
     auto* providerPtr = provider.get();
@@ -274,15 +270,11 @@ TEST(AsuTransportRegisterTest, RegisterRegionsReturnsAllResultsAfterBatchFailure
     regions[2].addr = 0x3000;
     regions[2].size = 4096;
 
-    std::vector<RegisterResult> results;
-    auto status = transport.RegisterRegions(regions, results);
+    std::vector<RegisteredMemory> registeredRegions;
+    auto status = transport.RegisterRegions(regions, registeredRegions);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
-    ASSERT_EQ(results.size(), std::size_t{3});
-    EXPECT_EQ(results[0].status.code, StatusCode::PARTIAL_FAILED);
-    EXPECT_EQ(results[0].handle, kInvalidMRHandle);
-    EXPECT_EQ(results[1].status.code, StatusCode::INTERNAL_ERROR);
-    EXPECT_EQ(results[2].status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_TRUE(registeredRegions.empty());
     EXPECT_EQ(providerPtr->registerCallCount, std::uint32_t{1});
     EXPECT_EQ(providerPtr->registerCount, std::uint32_t{2});
     EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
@@ -307,14 +299,11 @@ TEST(AsuTransportRegisterTest, RegisterRegionsClearsBatchWhenTokenLookupFails)
     regions[2].addr = 0x3000;
     regions[2].size = 4096;
 
-    std::vector<RegisterResult> results;
-    const auto status = transport.RegisterRegions(regions, results);
+    std::vector<RegisteredMemory> registeredRegions;
+    const auto status = transport.RegisterRegions(regions, registeredRegions);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
-    ASSERT_EQ(results.size(), regions.size());
-    EXPECT_EQ(results[0].status.code, StatusCode::PARTIAL_FAILED);
-    EXPECT_EQ(results[1].status.code, StatusCode::INTERNAL_ERROR);
-    EXPECT_EQ(results[2].status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_TRUE(registeredRegions.empty());
     EXPECT_EQ(providerPtr->registerCallCount, std::uint32_t{1});
     EXPECT_EQ(providerPtr->registerCount, std::uint32_t{3});
     EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{3});
@@ -338,14 +327,12 @@ TEST(AsuTransportRegisterTest, RegisterRegionsRetainsHandlesWhenBatchCleanupFail
     regions[1].addr = 0x2000;
     regions[1].size = 4096;
 
-    std::vector<RegisterResult> results;
-    const auto status = transport.RegisterRegions(regions, results);
+    std::vector<RegisteredMemory> registeredRegions;
+    const auto status = transport.RegisterRegions(regions, registeredRegions);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     EXPECT_NE(status.message.find("cleanup was incomplete"), std::string::npos);
-    ASSERT_EQ(results.size(), std::size_t{2});
-    EXPECT_EQ(results[0].status.code, StatusCode::PARTIAL_FAILED);
-    EXPECT_EQ(results[0].handle, kInvalidMRHandle);
+    EXPECT_TRUE(registeredRegions.empty());
     EXPECT_EQ(transport.registeredRegions_.size(), std::size_t{1});
     EXPECT_TRUE(transport.ownsRegisteredRegionHandles_);
 
@@ -371,18 +358,19 @@ TEST(AsuTransportRegisterTest, UnregisterRegionsRetainsOnlyHandlesThatFailToUnre
     regions[1].addr = 0x2000;
     regions[1].size = 4096;
 
-    std::vector<RegisterResult> results;
-    ASSERT_TRUE(transport.RegisterRegions(regions, results).ok());
+    std::vector<RegisteredMemory> registeredRegions;
+    ASSERT_TRUE(transport.RegisterRegions(regions, registeredRegions).ok());
     providerPtr->failUnregisterAt = 2;
 
-    const auto status = transport.UnregisterRegions({results[0].handle, results[1].handle});
+    const auto status =
+        transport.UnregisterRegions({registeredRegions[0].handle, registeredRegions[1].handle});
 
     EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_EQ(transport.registeredRegions_.size(), std::size_t{1});
-    EXPECT_EQ(transport.registeredRegions_.count(results[0].handle), std::size_t{0});
-    EXPECT_EQ(transport.registeredRegions_.count(results[1].handle), std::size_t{1});
+    EXPECT_EQ(transport.registeredRegions_.count(registeredRegions[0].handle), std::size_t{0});
+    EXPECT_EQ(transport.registeredRegions_.count(registeredRegions[1].handle), std::size_t{1});
 
-    EXPECT_TRUE(transport.UnregisterRegions({results[1].handle}).ok());
+    EXPECT_TRUE(transport.UnregisterRegions({registeredRegions[1].handle}).ok());
     EXPECT_TRUE(transport.registeredRegions_.empty());
     EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
 }
@@ -401,10 +389,10 @@ TEST(AsuTransportRegisterTest, ShutdownUnregistersRegisteredRegions)
     regions[1].addr = 0x2000;
     regions[1].size = 4096;
 
-    std::vector<RegisterResult> results;
-    auto status = transport.RegisterRegions(regions, results);
+    std::vector<RegisteredMemory> registeredRegions;
+    auto status = transport.RegisterRegions(regions, registeredRegions);
     ASSERT_TRUE(status.ok()) << status.message;
-    ASSERT_EQ(results.size(), std::size_t{2});
+    ASSERT_EQ(registeredRegions.size(), std::size_t{2});
     ASSERT_EQ(transport.registeredRegions_.size(), std::size_t{2});
 
     status = transport.Shutdown();
@@ -423,8 +411,8 @@ TEST(AsuTransportRegisterTest, ShutdownIgnoresUnregisterFailureWithoutRetry)
     AsuTransportImpl transport;
     transport.SetTransProvider(std::move(provider));
 
-    std::vector<RegisterResult> results;
-    ASSERT_TRUE(transport.RegisterRegions({MemoryRegion{}}, results).ok());
+    std::vector<RegisteredMemory> registeredRegions;
+    ASSERT_TRUE(transport.RegisterRegions({MemoryRegion{}}, registeredRegions).ok());
     providerPtr->failUnregister = true;
 
     EXPECT_TRUE(transport.Shutdown().ok());

--- a/ucm/transport/kv/kv-test/include/kv_test/kv_test_types.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/kv_test_types.h
@@ -207,7 +207,7 @@ struct BufferSet {
     std::vector<UC::ASU::MemoryRegion> regions;
     std::vector<UC::ASU::KVBuffer> entries;
     std::vector<std::size_t> entryRegionIndexes;
-    std::vector<UC::ASU::RegisterResult> registerResults;
+    std::vector<UC::ASU::RegisteredMemory> registeredRegions;
 };
 
 struct BenchLatencyStats {

--- a/ucm/transport/kv/kv-test/src/asu_client_runner.cpp
+++ b/ucm/transport/kv/kv-test/src/asu_client_runner.cpp
@@ -169,24 +169,19 @@ Status AsuClientRunner::RegisterBuffers(BufferSet& buffers)
         }
     }
 
-    buffers.registerResults.clear();
-    auto status = client_->RegisterRegions(buffers.regions, buffers.registerResults);
+    buffers.registeredRegions.clear();
+    auto status = client_->RegisterRegions(buffers.regions, buffers.registeredRegions);
     if (!status.ok()) { return ToKvTestStatus(status, "register buffers"); }
-    if (buffers.registerResults.size() != buffers.regions.size()) {
+    if (buffers.registeredRegions.size() != buffers.regions.size()) {
         return Status::Error(kExitInvalidArgument,
                              "register buffer result count does not match region count");
-    }
-
-    for (std::size_t index = 0; index < buffers.registerResults.size(); ++index) {
-        const auto& result = buffers.registerResults[index];
-        if (!result.status.ok()) { return ToKvTestStatus(result.status, "register buffer entry"); }
     }
 
     for (std::size_t entryIndex = 0; entryIndex < buffers.entries.size(); ++entryIndex) {
         const auto regionIndex = buffers.entryRegionIndexes.empty()
                                      ? entryIndex
                                      : buffers.entryRegionIndexes[entryIndex];
-        buffers.entries[entryIndex].buffer.handle = buffers.registerResults[regionIndex].handle;
+        buffers.entries[entryIndex].buffer.handle = buffers.registeredRegions[regionIndex].handle;
     }
 
     return Status::Success();
@@ -197,11 +192,12 @@ Status AsuClientRunner::UnregisterBuffers(const BufferSet& buffers)
     if (client_ == nullptr) { return Status::Success(); }
 
     std::vector<UC::ASU::MRHandle> handles;
-    handles.reserve(buffers.registerResults.size());
+    handles.reserve(buffers.registeredRegions.size());
     std::unordered_set<UC::ASU::MRHandle> seen;
-    for (const auto& result : buffers.registerResults) {
-        if (result.handle != UC::ASU::kInvalidMRHandle && seen.insert(result.handle).second) {
-            handles.push_back(result.handle);
+    for (const auto& registeredRegion : buffers.registeredRegions) {
+        if (registeredRegion.handle != UC::ASU::kInvalidMRHandle &&
+            seen.insert(registeredRegion.handle).second) {
+            handles.push_back(registeredRegion.handle);
         }
     }
     if (handles.empty()) { return Status::Success(); }

--- a/ucm/transport/kv/kv-test/src/bench_runner.cpp
+++ b/ucm/transport/kv/kv-test/src/bench_runner.cpp
@@ -262,7 +262,7 @@ Status PrepareBenchBuffers(BenchBufferSlot& slot, std::uint64_t begin, std::size
 
 Status BindRegisteredBuffers(BufferSet& buffers)
 {
-    if (buffers.registerResults.size() != buffers.regions.size()) {
+    if (buffers.registeredRegions.size() != buffers.regions.size()) {
         return Status::Error(kExitInvalidArgument,
                              "registered buffer result count does not match region count");
     }
@@ -270,11 +270,11 @@ Status BindRegisteredBuffers(BufferSet& buffers)
         const auto regionIndex = buffers.entryRegionIndexes.empty()
                                      ? entryIndex
                                      : buffers.entryRegionIndexes[entryIndex];
-        if (regionIndex >= buffers.registerResults.size()) {
+        if (regionIndex >= buffers.registeredRegions.size()) {
             return Status::Error(kExitInvalidArgument,
                                  "registered buffer region index out of range");
         }
-        buffers.entries[entryIndex].buffer.handle = buffers.registerResults[regionIndex].handle;
+        buffers.entries[entryIndex].buffer.handle = buffers.registeredRegions[regionIndex].handle;
     }
     return Status::Success();
 }
@@ -303,10 +303,10 @@ Status UnregisterBenchDeviceBuffers(AsuClientRunner& clientRunner, BenchBufferPo
     Status finalStatus = Status::Success();
     for (auto& slot : pool) {
         auto& buffers = slot.buffers;
-        if (buffers.registerResults.empty()) { continue; }
+        if (buffers.registeredRegions.empty()) { continue; }
         auto status = clientRunner.UnregisterBuffers(buffers);
         if (finalStatus.Ok() && !status.Ok()) { finalStatus = status; }
-        buffers.registerResults.clear();
+        buffers.registeredRegions.clear();
     }
     return finalStatus;
 }


### PR DESCRIPTION
## Purpose
This PR simplifies ASU registered-memory management and improves multi-transport query execution. It removes duplicated ownership and result types, makes cleanup best-effort, and changes Client queries from serial execution to asynchronous fan-out followed by a unified wait phase.

## Modifications 
1. Commit e67f870 replaces ownedRegisteredRegionHandles_with a boolean ownsRegisteredRegionHandles_;
2. Commit 0c44080: Unregister now only logs error when fails;
3. Commit 5979b7b reuses RegisteredMemory in the Client cache;
4. Commit f759cb5 consolidates registration result types;
5. Commit 1bb259e fans out queries before waiting in Client.

## Test
To be examined.