### PR TITLE
[Opt] All DP ranks within a single node use the same shared memory for MLA models.

### DIFF
--- a/ucm/integration/vllm/hla_connector.py
+++ b/ucm/integration/vllm/hla_connector.py
@@ -827,7 +827,7 @@ class UCMHybridLinearAttentionConnector(UCMDirectConnector, SupportsHMA):
         if "storage_backends" in config:
             backends = [path for path in config["storage_backends"].split(":")]
             config["storage_backends"] = backends
-        config["unique_id"] = f"{self.engine_id}{unique_id_suffix}"
+        config["unique_id"] = f"{self.unique_id}{unique_id_suffix}"
         if self._role == KVConnectorRole.WORKER:
             config["device_id"] = self.local_rank
             tensor_size_list = _normalize_tensor_size_list(

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -380,9 +380,9 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         self.load_tokens_threshold = self.launch_config.get("load_tokens_threshold", 0)
 
         if role == KVConnectorRole.SCHEDULER:
-            self.store = self._create_fa_store(None)
-            self.fa_store = self.store
+            self.fa_store = self._create_fa_store(None)
             self.wa_store = self._create_wa_store(None)
+
         group_meta_summary = tuple(
             {
                 "group_id": meta.group_id,
@@ -668,7 +668,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
             config["storage_backends"] = [
                 path for path in config["storage_backends"].split(":")
             ]
-        config["unique_id"] = f"{self.engine_id}_fawa_{store_suffix}"
+        config["unique_id"] = f"{self.unique_id}_fawa_{store_suffix}"
         self._namespace_storage_backends(config, store_suffix)
         dp_rank = self._vllm_config.parallel_config.data_parallel_rank
         config["posix_gc_enable"] = (

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -1,10 +1,12 @@
 ﻿import copy
+import glob
 import hashlib
 import math
 import os
 import pickle
 import re
 import time
+import uuid
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, List, Optional, Tuple
@@ -123,6 +125,45 @@ def _use_ucm_connector_cpu_affinity() -> bool:
     return (
         os.getenv("VLLM_CPU_AFFINITY") == "1"
         and getattr(current_platform, "device_type", None) != "npu"
+    )
+
+
+def _worker_generate_unique_id() -> str:
+    """Worker-side: broadcast a uuid and write to a per-instance file."""
+    world_group = get_world_group()
+    if world_group.rank_in_group == 0:
+        now = time.time()
+        for f in glob.glob("/dev/shm/ucm_uniqueid_*"):
+            try:
+                if now - os.path.getmtime(f) > 600:
+                    os.remove(f)
+            except OSError:
+                pass
+        local_uid = uuid.uuid4().hex
+    else:
+        local_uid = None
+    uid = world_group.broadcast_object(local_uid, src=0)
+    path = f"/dev/shm/ucm_uniqueid_{os.getppid()}"
+    tmp = f"{path}.tmp.{os.getpid()}"
+    with open(tmp, "w") as f:
+        f.write(uid)
+    os.replace(tmp, path)
+    return uid
+
+
+def _scheduler_read_unique_id() -> str:
+    """Scheduler-side: read the uuid from the per-instance file."""
+    for pid in (os.getpid(), os.getppid()):
+        path = f"/dev/shm/ucm_uniqueid_{pid}"
+        try:
+            with open(path) as f:
+                uid = f.read().strip()
+            if uid:
+                return uid
+        except FileNotFoundError:
+            continue
+    raise RuntimeError(
+        "scheduler-side UCM initialization failed: unique_id file not found"
     )
 
 
@@ -957,18 +998,27 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self.requests_meta: dict[str, RequestMeta] = {}
 
         ucm_config = Config(vllm_config.kv_transfer_config)
-        dp_engine_id_suffix = re.compile(r"_dp\d+$")
-        self.engine_id = dp_engine_id_suffix.sub(
-            "", vllm_config.kv_transfer_config.engine_id
-        )
+        self.engine_id = vllm_config.kv_transfer_config.engine_id.rsplit("_dp", 1)[0]
         self.launch_config = ucm_config.get_config()
         self.connector_configs = self.launch_config.get("ucm_connectors", [])
+        assert len(self.connector_configs) > 0, "no storage connector name in config."
+        share_buffer_enable = (
+            self.connector_configs[0]
+            .get("ucm_connector_config", {})
+            .get("share_buffer_enable", self.is_mla)
+        )
+        if share_buffer_enable:
+            if role == KVConnectorRole.WORKER:
+                self.unique_id = _worker_generate_unique_id()
+            else:
+                self.unique_id = _scheduler_read_unique_id()
+        else:
+            self.unique_id = self.engine_id
         self.enable_event_sync = self.launch_config.get("enable_event_sync", True)
         self.enable_record_traces = self.launch_config.get(
             "enable_record_traces", False
         )
         self._skip_null_vllm_blocks = False
-        assert len(self.connector_configs) > 0, "no storage connector name in config."
 
         self.chunk_size = self.block_size
         self.blocks_per_chunk = self.chunk_size // self.block_size
@@ -979,7 +1029,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
             self.request_hasher = RequestHasher(vllm_config, 0)
             self._other_rank_hashers = self._make_other_rank_hashers(vllm_config)
             self._seed = self.request_hasher("UCM_HASH_SEED")
-            # init scheduler-size connector
+            # init scheduler-side connector
             if not defer_scheduler_store:
                 self.store = self._create_store(None)
         else:
@@ -1104,7 +1154,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
         if "storage_backends" in config:
             backends = [path for path in config["storage_backends"].split(":")]
             config["storage_backends"] = backends
-        config["unique_id"] = f"{self.engine_id}"
+        config["unique_id"] = f"{self.unique_id}"
         if self._role == KVConnectorRole.WORKER:
             config["device_id"] = self.local_rank
             config["tensor_size_list"] = (
@@ -2333,7 +2383,7 @@ class UCMCPConnector(UCMLayerWiseConnector):
             self.request_hasher = RequestHasher(vllm_config, 0)
             self._other_rank_hashers = self._make_other_rank_hashers(vllm_config)
             self._seed = self.request_hasher("UCM_HASH_SEED")
-            # init scheduler-size connector
+            # init scheduler-side connector
             self.store = self._create_store(None)
         else:
             self.request_hasher = RequestHasher(vllm_config, self.tp_rank)
@@ -2601,10 +2651,7 @@ class UCMConnector(KVConnectorBase_V1, SupportsHMA):
         )
         self.connector: KVConnectorBase_V1
         ucm_config = Config(vllm_config.kv_transfer_config)
-        dp_engine_id_suffix = re.compile(r"_dp\d+$")
-        self.engine_id = dp_engine_id_suffix.sub(
-            "", vllm_config.kv_transfer_config.engine_id
-        )
+        self.engine_id = vllm_config.kv_transfer_config.engine_id.rsplit("_dp", 1)[0]
         self.launch_config = ucm_config.get_config()
         self._worker_rank = (
             get_world_group().rank


### PR DESCRIPTION
## Purpose
external LB 多 DP 下，vllm-ascend 给每个进程追加随机 uuid（platform.py:484），导致 UCM 各进程 unique_id 不同、无法共用同一块 shm。本 PR 改用 uuid.uuid4().hex 作为 unique_id，worker 经 world group 广播后写入 /dev/shm/ucm_uniqueid_{ppid}，scheduler 从对应文件读取。文件名以 engine-core PID 做后缀实现 per-instance 隔离，单节点多实例无碰撞；scheduler 依次尝试 getpid() 和 getppid() 兼容 multiproc（在线）与 uniproc（离线 TP=1）两种执行模式。仅对 share_buffer_enable=true 的部署启用，其余路径继续使用原engine_id，不引入 /dev/shm 依赖。

## Modifications
- 新增 _worker_generate_unique_id()：worker 用 get_world_group().broadcast_object(src=0) 同步时间戳（一次广播覆盖所有 TP/DP/PP），所有 rank 用 tmp + os.replace 原子写到 /dev/shm/ucm_timestamp_{ppid}；rank 0 在写前清理 10 分钟前的旧文件防止堆积。
- 新增 _scheduler_read_unique_id()：scheduler 从 /dev/shm/ucm_timestamp_{pid} 读时间戳（pid 即 engine-core PID，与 worker 的 os.getppid() 一致），读不到即 raise（worker 先 init）。
- self.engine_id → self.unique_id（_create_store 的 config["unique_id"]），hma/hla 同步。

## Test
A3 + DeepSeek-v4-Flash，external LB DP8×TP1：8 个 DP 共用同一块 /dev/shm/uc_shm_pcstore_{timestamp}、unique_id 一致；重启后用新时间戳、新 shm 段（无脏数据残留）；推理与 prefix cache 行为正常。