### PR TITLE
[Bugfix] Propagate shared cache load failures across ranks

### DIFF
--- a/ucm/store/cache/cc/load_queue.cc
+++ b/ucm/store/cache/cc/load_queue.cc
@@ -115,6 +115,7 @@ void LoadQueue::DispatchOneTask(TaskPair&& pair)
                 UC_ERROR("Failed({}) to submit load task({}) to backend.", res.Error(), task->id);
                 UC::Metrics::UpdateStats(
                     NAME_TO_METRIC_ID("cache_backend_load_submit_errors_total"), 1.0);
+                shardTask.bufferHandle.MarkFailed(res.Error());
                 task->Fail(res.Error());
                 failureSet_->Insert(task->id);
                 waiter->Done();
@@ -279,16 +280,19 @@ Status LoadQueue::WaitBackendTaskReady(ShardTask& task)
                      task.task->id);
             UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_backend_load_wait_errors_total"),
                                      1.0);
+            task.bufferHandle.MarkFailed(s);
             return s;
         }
         task.bufferHandle.MarkReady();
         return Status::OK();
     }
-    while (!task.bufferHandle.Ready()) {
+    for (;;) {
+        auto state = task.bufferHandle.GetState();
+        if (state == TransBuffer::State::READY) { return Status::OK(); }
+        if (state == TransBuffer::State::FAILED) { return task.bufferHandle.FailureStatus(); }
         if (failureSet_->Contains(task.task->id)) { return task.task->FailureStatus(); }
         std::this_thread::yield();
     }
-    return Status::OK();
 }
 
 Status LoadQueue::HostToDeviceAsync(CopyStream& stream, void* host, void** device)

--- a/ucm/store/cache/cc/trans_buffer.cc
+++ b/ucm/store/cache/cc/trans_buffer.cc
@@ -53,14 +53,16 @@ struct BufferMetaNode {
     size_t hash;
     size_t prev;
     size_t next;
-    bool ready;
+    TransBuffer::State state;
+    int32_t errorCode;
     void Init()
     {
         reference = 0;
         hash = invalidIndex;
         prev = invalidIndex;
         next = invalidIndex;
-        ready = false;
+        state = TransBuffer::State::LOADING;
+        errorCode = Status::OK().Underlying();
     }
 };
 
@@ -254,7 +256,7 @@ protected:
         bool TryLock() { return pthread_spin_trylock(&lock) == 0; }
         void Unlock() { pthread_spin_unlock(&lock); }
     };
-    static constexpr size_t sharedBufferMagic = (('S' << 16) | ('b' << 8) | 1);
+    static constexpr size_t sharedBufferMagic = (('S' << 16) | ('b' << 8) | 2);
     struct BufferHeader {
         std::atomic<size_t> magic;
         ShareLock lock;
@@ -569,6 +571,10 @@ size_t TransBuffer::FindAt(size_t iBucket, const Detail::BlockId& blockId, size_
         strategy_->NodeLock(iNode);
         if (meta->block == blockId && meta->shard == shardIdx) {
             owner = meta->reference == 0;
+            if (owner && meta->state == State::FAILED) {
+                meta->state = State::LOADING;
+                meta->errorCode = Status::OK().Underlying();
+            }
             ++meta->reference;
             strategy_->NodeUnlock(iNode);
             break;
@@ -606,7 +612,8 @@ size_t TransBuffer::Alloc(const Detail::BlockId& blockId, size_t shardIdx, size_
         ++meta->reference;
         meta->block = blockId;
         meta->shard = shardIdx;
-        meta->ready = false;
+        meta->state = State::LOADING;
+        meta->errorCode = Status::OK().Underlying();
         strategy_->NodeUnlock(iNode);
         return iNode;
     }
@@ -668,25 +675,55 @@ void TransBuffer::Release(Index pos)
     strategy_->NodeUnlock(pos);
 }
 
-bool TransBuffer::Ready(Index pos)
+bool TransBuffer::Ready(Index pos) { return GetState(pos) == State::READY; }
+
+TransBuffer::State TransBuffer::GetState(Index pos)
 {
     strategy_->NodeLock(pos);
-    auto ready = strategy_->MetaAt(pos)->ready;
+    auto state = strategy_->MetaAt(pos)->state;
     strategy_->NodeUnlock(pos);
-    return ready;
+    return state;
+}
+
+Status TransBuffer::FailureStatus(Index pos)
+{
+    strategy_->NodeLock(pos);
+    auto errorCode = strategy_->MetaAt(pos)->errorCode;
+    strategy_->NodeUnlock(pos);
+    if (errorCode == Status::OK().Underlying()) {
+        return Status::Error("shared buffer failed without an error status");
+    }
+    return Status{errorCode, {}};
 }
 
 void TransBuffer::MarkReady(Index pos)
 {
     strategy_->NodeLock(pos);
-    strategy_->MetaAt(pos)->ready = true;
+    auto meta = strategy_->MetaAt(pos);
+    if (meta->state == State::LOADING) {
+        meta->state = State::READY;
+        meta->errorCode = Status::OK().Underlying();
+    }
+    strategy_->NodeUnlock(pos);
+}
+
+void TransBuffer::MarkFailed(Index pos, const Status& status)
+{
+    strategy_->NodeLock(pos);
+    auto meta = strategy_->MetaAt(pos);
+    if (meta->state == State::LOADING) {
+        meta->state = State::FAILED;
+        meta->errorCode = status.Underlying();
+    }
     strategy_->NodeUnlock(pos);
 }
 
 void TransBuffer::MarkNotReady(Index pos)
 {
     strategy_->NodeLock(pos);
-    strategy_->MetaAt(pos)->ready = false;
+    auto meta = strategy_->MetaAt(pos);
+    meta->state = State::LOADING;
+    meta->errorCode = Status::OK().Underlying();
     strategy_->NodeUnlock(pos);
 }
 

--- a/ucm/store/cache/cc/trans_buffer.h
+++ b/ucm/store/cache/cc/trans_buffer.h
@@ -41,6 +41,8 @@ class TransBuffer {
     bool bypassHitOnLoad_{false};
 
 public:
+    enum class State : uint8_t { LOADING, READY, FAILED };
+
     class Handle {
     public:
         Handle() = default;
@@ -85,7 +87,10 @@ public:
             return nullptr;
         }
         bool Ready() const { return buf_->Ready(pos_); };
+        State GetState() const { return buf_->GetState(pos_); }
+        Status FailureStatus() const { return buf_->FailureStatus(pos_); }
         void MarkReady() { buf_->MarkReady(pos_); };
+        void MarkFailed(const Status& status) { buf_->MarkFailed(pos_, status); }
 
     private:
         friend class TransBuffer;
@@ -120,7 +125,10 @@ private:
     void Acquire(Index pos);
     void Release(Index pos);
     bool Ready(Index pos);
+    State GetState(Index pos);
+    Status FailureStatus(Index pos);
     void MarkReady(Index pos);
+    void MarkFailed(Index pos, const Status& status);
     void MarkNotReady(Index pos);
 };
 

--- a/ucm/store/test/case/cache/cache_load_queue_test.cc
+++ b/ucm/store/test/case/cache/cache_load_queue_test.cc
@@ -80,12 +80,61 @@ TEST_F(UCCacheLoadQueueTest, LoadSameBlockTwice)
     ASSERT_FALSE(failureSet.Contains(task2->id));
 }
 
+TEST_F(UCCacheLoadQueueTest, SharedFailureStopsNonOwnerWait)
+{
+    using namespace UC::CacheStore;
+    UC::Test::Detail::MockStore backend;
+    EXPECT_CALL(backend, Load).Times(0);
+    UC::HashSet<UC::Detail::TaskHandle> failureSet;
+    Config config;
+    config.storeBackend = &backend;
+    size_t tensorSize = 32768;
+    config.tensorSizes = {tensorSize};
+    config.shardSize = tensorSize;
+    config.blockSize = config.shardSize;
+    config.deviceId = 0;
+    config.bufferCapacity = config.shardSize * 1024;
+    config.uniqueId = rd.RandomString(10);
+    config.shareBufferEnable = true;
+    TransBuffer buffer;
+    LoadQueue loadQ;
+    auto s = buffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    s = loadQ.Setup(config, &failureSet, &buffer);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
+    constexpr size_t shardIdx = 0;
+    auto owner = buffer.Get(blockId, shardIdx, true, true);
+    UC::Test::Detail::DataGenerator data{1, config.blockSize};
+    data.Generate();
+    UC::Detail::TaskDesc desc{
+        {blockId, shardIdx, {data.Buffer()}}
+    };
+    auto task = std::make_shared<TransTask>(TransTask::Type::LOAD, desc);
+    auto waiter = std::make_shared<UC::Latch>();
+    loadQ.Submit(task, waiter);
+
+    owner.MarkFailed(UC::Status::NotFound());
+
+    ASSERT_TRUE(waiter->WaitForDuration(1000));
+    ASSERT_TRUE(failureSet.Contains(task->id));
+    ASSERT_EQ(task->FailureStatus(), UC::Status::NotFound());
+}
+
 TEST_F(UCCacheLoadQueueTest, LoadWhileBackendSubmitFailed)
 {
     using namespace UC::CacheStore;
     using namespace testing;
+    std::promise<void> submitEntered;
+    std::promise<void> allowSubmitFailure;
+    auto allowSubmitFailureFuture = allowSubmitFailure.get_future().share();
     UC::Test::Detail::MockStore backend;
-    EXPECT_CALL(backend, Load).WillOnce(testing::Return(UC::Status::Error()));
+    EXPECT_CALL(backend, Load)
+        .WillOnce(Invoke([&](UC::Detail::TaskDesc) -> UC::Expected<UC::Detail::TaskHandle> {
+            submitEntered.set_value();
+            allowSubmitFailureFuture.wait();
+            return UC::Status::NotFound();
+        }));
     UC::HashSet<UC::Detail::TaskHandle> failureSet;
     Config config;
     config.storeBackend = &backend;
@@ -113,17 +162,32 @@ TEST_F(UCCacheLoadQueueTest, LoadWhileBackendSubmitFailed)
     auto task = std::make_shared<TransTask>(TransTask::Type::LOAD, desc);
     auto waiter = std::make_shared<UC::Latch>();
     loadQ.Submit(task, waiter);
-    waiter->Wait();
+    submitEntered.get_future().wait();
+    auto observer = buffer.Get(blockId, shardIdx, true, true);
+
+    allowSubmitFailure.set_value();
+
+    ASSERT_TRUE(waiter->WaitForDuration(1000));
     ASSERT_TRUE(failureSet.Contains(task->id));
+    ASSERT_EQ(observer.GetState(), TransBuffer::State::FAILED);
+    ASSERT_EQ(observer.FailureStatus(), UC::Status::NotFound());
+    ASSERT_EQ(task->FailureStatus(), UC::Status::NotFound());
 }
 
 TEST_F(UCCacheLoadQueueTest, LoadWhileBackendWaitFailed)
 {
     using namespace UC::CacheStore;
     using namespace testing;
+    std::promise<void> waitEntered;
+    std::promise<void> allowWaitFailure;
+    auto allowWaitFailureFuture = allowWaitFailure.get_future().share();
     UC::Test::Detail::MockStore backend;
     EXPECT_CALL(backend, Load).WillOnce(testing::Invoke(NextId));
-    EXPECT_CALL(backend, Wait).WillOnce(testing::Return(UC::Status::Error()));
+    EXPECT_CALL(backend, Wait).WillOnce(Invoke([&](UC::Detail::TaskHandle) {
+        waitEntered.set_value();
+        allowWaitFailureFuture.wait();
+        return UC::Status::NotFound();
+    }));
     UC::HashSet<UC::Detail::TaskHandle> failureSet;
     Config config;
     config.storeBackend = &backend;
@@ -151,6 +215,14 @@ TEST_F(UCCacheLoadQueueTest, LoadWhileBackendWaitFailed)
     auto task = std::make_shared<TransTask>(TransTask::Type::LOAD, desc);
     auto waiter = std::make_shared<UC::Latch>();
     loadQ.Submit(task, waiter);
-    waiter->Wait();
+    waitEntered.get_future().wait();
+    auto observer = buffer.Get(blockId, shardIdx, true, true);
+
+    allowWaitFailure.set_value();
+
+    ASSERT_TRUE(waiter->WaitForDuration(1000));
     ASSERT_TRUE(failureSet.Contains(task->id));
+    ASSERT_EQ(observer.GetState(), TransBuffer::State::FAILED);
+    ASSERT_EQ(observer.FailureStatus(), UC::Status::NotFound());
+    ASSERT_EQ(task->FailureStatus(), UC::Status::NotFound());
 }

--- a/ucm/store/test/case/cache/cache_trans_buffer_test.cc
+++ b/ucm/store/test/case/cache/cache_trans_buffer_test.cc
@@ -144,6 +144,70 @@ TEST_P(UCCacheTransBufferTest, BackendOnlyLoadCoalescesInFlightEntry)
     ASSERT_EQ(owner.Data(), waiter.Data());
 }
 
+TEST_P(UCCacheTransBufferTest, SharesFailureAndRetriesAfterHandlesAreReleased)
+{
+    using UC::CacheStore::TransBuffer;
+    TransBuffer transBuffer;
+    UC::CacheStore::Config config;
+    config.uniqueId = rd.RandomString(10);
+    config.shardSize = 32768;
+    config.bufferCapacity = config.shardSize * 32768;
+    config.shareBufferEnable = GetParam();
+    config.deviceId = 0;
+    config.loadExclusiveBufferNumber = 0;
+    auto s = transBuffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
+    constexpr size_t shardIdx = 0;
+    void* failedAddr = nullptr;
+    {
+        auto owner = transBuffer.Get(blockId, shardIdx, true, true);
+        auto waiter = transBuffer.Get(blockId, shardIdx, true, true);
+        failedAddr = owner.Data();
+
+        owner.MarkFailed(UC::Status::NotFound());
+
+        ASSERT_EQ(owner.GetState(), TransBuffer::State::FAILED);
+        ASSERT_EQ(waiter.GetState(), TransBuffer::State::FAILED);
+        ASSERT_EQ(waiter.FailureStatus(), UC::Status::NotFound());
+        ASSERT_FALSE(waiter.Ready());
+    }
+
+    auto retry = transBuffer.Get(blockId, shardIdx, true, true);
+    ASSERT_TRUE(retry.Owner());
+    ASSERT_EQ(retry.GetState(), TransBuffer::State::LOADING);
+    ASSERT_EQ(retry.Data(), failedAddr);
+}
+
+TEST(UCCacheTransBufferSharedTest, SharesFailureAcrossMappings)
+{
+    using UC::CacheStore::TransBuffer;
+    UC::Test::Detail::Random rd;
+    UC::CacheStore::Config config;
+    config.uniqueId = rd.RandomString(10);
+    config.shardSize = 32768;
+    config.bufferCapacity = config.shardSize * 32768;
+    config.shareBufferEnable = true;
+    config.deviceId = 0;
+    config.loadExclusiveBufferNumber = 0;
+    TransBuffer ownerBuffer;
+    auto s = ownerBuffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    TransBuffer waiterBuffer;
+    s = waiterBuffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
+    constexpr size_t shardIdx = 0;
+    auto owner = ownerBuffer.Get(blockId, shardIdx, true, true);
+    auto waiter = waiterBuffer.Get(blockId, shardIdx, true, true);
+
+    owner.MarkFailed(UC::Status::NotFound());
+
+    ASSERT_FALSE(waiter.Owner());
+    ASSERT_EQ(waiter.GetState(), TransBuffer::State::FAILED);
+    ASSERT_EQ(waiter.FailureStatus(), UC::Status::NotFound());
+}
+
 TEST_P(UCCacheTransBufferTest, GetReservedNode)
 {
     UC::CacheStore::TransBuffer transBuffer;


### PR DESCRIPTION
## Purpose

In shared-buffer mode, ownership is determined independently for each
`(block, shard)` entry. The rank that first acquires a shard performs the
storage-to-host (S2H) load, while peer ranks wait for the shared buffer before
performing their own host-to-device (H2D) copies.

Previously, if the owner rank failed to submit or complete the backend load, the
shared buffer remained not ready. Other ranks could not observe the owner's
process-local failure and continued waiting until the task timeout.

This change propagates the per-shard load result through shared buffer metadata,
allowing non-owner ranks to fail immediately when the owner reports a backend
load failure.

## Modifications

- Replace the shared buffer `ready` flag with explicit `LOADING`, `READY`, and
  `FAILED` states.
- Store the backend failure status in shared buffer metadata.
- Publish `FAILED` when the owner fails to submit or wait for a backend load.
- Make non-owner ranks stop waiting and return the shared failure status when
  they observe `FAILED`.
- Allow a failed entry to transition back to `LOADING` and retry after all
  existing references have been released.
- Bump the shared-memory metadata version to prevent incompatible processes from
  attaching to the same shared buffer.
- Add unit coverage for:
  - backend load submission failure propagation;
  - backend load wait failure propagation;
  - immediate termination of non-owner waits;
  - failure sharing across shared-memory mappings;
  - retry after failed handles are released.