### PR TITLE
[Feat] Support multiple HIXL devices in DramPool

### DIFF
--- a/examples/drampool.yaml
+++ b/examples/drampool.yaml
@@ -5,7 +5,8 @@
 #   --kvcache-block-proportions, --ttl-minutes, and --config.
 
 transport:
-  device_id: 0
+  device_ids:
+    - 0
   # Cluster-wide request-channel to transport-endpoint routing.
   endpoints:
     - two_sided: "127.0.0.1:9000"

--- a/ucm/store/dram/cc/drampool/drampool_config.h
+++ b/ucm/store/dram/cc/drampool/drampool_config.h
@@ -57,7 +57,7 @@ struct DramPoolConfig {
     std::uint64_t defaultDumpTtlMs{kDefaultDumpTtlMs};
 
     // Transport internals are loaded from the runtime YAML file.
-    std::int32_t transportDeviceId{0};
+    std::vector<std::int32_t> transportDeviceIds{0};
     // Cluster-wide routing from the request channel address to the transport identity.
     std::unordered_map<std::string, transport::ManagerID> twoSidedToOneSided{};
 

--- a/ucm/store/dram/cc/drampool/drampool_server.cc
+++ b/ucm/store/dram/cc/drampool/drampool_server.cc
@@ -25,6 +25,7 @@
 #include <acl/acl.h>
 #include <chrono>
 #include <exception>
+#include <random>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -140,6 +141,14 @@ void DramPoolServer::Stop()
 
 Status DramPoolServer::InitializeAclRuntime()
 {
+    if (g_config.transportDeviceIds.empty()) {
+        return Status::InvalidParam("transport.device_ids must not be empty");
+    }
+    std::mt19937 generator(std::random_device{}());
+    std::uniform_int_distribution<std::size_t> distribution(0,
+                                                            g_config.transportDeviceIds.size() - 1);
+    const auto deviceId = g_config.transportDeviceIds[distribution(generator)];
+
     const auto initStatus = aclInit(nullptr);
     if (initStatus == ACL_SUCCESS) {
         aclRuntimeOwned_ = true;
@@ -147,8 +156,11 @@ Status DramPoolServer::InitializeAclRuntime()
         return Status::Error("aclInit failed: " + std::to_string(initStatus));
     }
 
-    const auto setDeviceStatus = aclrtSetDevice(g_config.transportDeviceId);
-    if (setDeviceStatus == ACL_SUCCESS) { return Status::OK(); }
+    const auto setDeviceStatus = aclrtSetDevice(deviceId);
+    if (setDeviceStatus == ACL_SUCCESS) {
+        aclDeviceId_ = deviceId;
+        return Status::OK();
+    }
 
     if (aclRuntimeOwned_) {
         (void)aclFinalize();
@@ -244,10 +256,13 @@ Status DramPoolServer::StartTransportService()
         return status;
     }
     attrs.ip = managerEndpoint.host;
-    transport::HixlInitAttrs::Instance instance;
-    instance.port = -1;
-    instance.device_id = g_config.transportDeviceId;
-    attrs.instances.push_back(std::move(instance));
+    attrs.instances.reserve(g_config.transportDeviceIds.size());
+    for (const auto deviceId : g_config.transportDeviceIds) {
+        transport::HixlInitAttrs::Instance instance;
+        instance.port = -1;
+        instance.device_id = deviceId;
+        attrs.instances.push_back(std::move(instance));
+    }
     attrs.connect_timeout_ms = static_cast<std::int32_t>(g_config.opTimeoutMs);
     attrs.transfer_timeout_ms = static_cast<std::int32_t>(g_config.opTimeoutMs);
     auto status = transportManager_->InstallTransport(transport::TransportProtocol::Hixl, attrs);
@@ -531,10 +546,11 @@ void DramPoolServer::ResetInitializedComponents()
     bufferManager_.reset();
     transportManager_.reset();
     if (aclRuntimeOwned_) {
-        (void)aclrtResetDevice(g_config.transportDeviceId);
+        if (aclDeviceId_) { (void)aclrtResetDevice(*aclDeviceId_); }
         (void)aclFinalize();
         aclRuntimeOwned_ = false;
     }
+    aclDeviceId_.reset();
 }
 
 }  // namespace UC::DramPool

--- a/ucm/store/dram/cc/drampool/drampool_server.h
+++ b/ucm/store/dram/cc/drampool/drampool_server.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include "buffer_manager.h"
@@ -119,6 +120,7 @@ private:
     std::unique_ptr<DramPoolRuntime> runtime_;
     std::unique_ptr<TaskWorker> taskWorker_;
     std::unique_ptr<CompletionPoller> completionPoller_;
+    std::optional<std::int32_t> aclDeviceId_;
     bool aclRuntimeOwned_{false};
 
     ServerState state_{ServerState::New};

--- a/ucm/store/dram/cc/drampool/drampool_yaml_config.cc
+++ b/ucm/store/dram/cc/drampool/drampool_yaml_config.cc
@@ -53,7 +53,7 @@ struct EndpointEntry {
 };
 
 constexpr const char* kRequiredRuntimeConfigKeys[] = {
-    "transport.device_id",
+    "transport.device_ids",
     "queue.request_depth",
     "queue.completion_depth",
     "request_receiver.idle_wait_us",
@@ -261,9 +261,6 @@ Status CommitEndpointEntry(EndpointEntry& entry, DramPoolConfig& config,
 Status ApplyRuntimeConfigValue(DramPoolConfig& config, const std::string& key,
                                const std::string& value)
 {
-    if (key == "transport.device_id") {
-        return ParseInt32Value(key, value, config.transportDeviceId);
-    }
     if (key == "queue.request_depth") {
         return ParseUint32Value(key, value, config.requestQueueDepth);
     }
@@ -330,8 +327,18 @@ Status ValidateRuntimeConfig(DramPoolConfig& config)
                 "transport endpoint cannot be both two_sided and one_sided: {}", endpoint.second);
         }
     }
-    if (config.transportDeviceId < 0) {
-        return Status::InvalidParam("transport.device_id must not be negative");
+    if (config.transportDeviceIds.empty()) {
+        return Status::InvalidParam("transport.device_ids must not be empty");
+    }
+    std::unordered_set<std::int32_t> deviceIds;
+    for (const auto deviceId : config.transportDeviceIds) {
+        if (deviceId < 0) {
+            return Status::InvalidParam("transport.device_ids must not contain negative values");
+        }
+        if (!deviceIds.insert(deviceId).second) {
+            return Status::InvalidParam("transport.device_ids contains duplicate device ID: {}",
+                                        deviceId);
+        }
     }
     if (config.requestQueueDepth < 2 || config.completionQueueDepth < 2) {
         return Status::InvalidParam("queue depths must be at least 2");
@@ -426,6 +433,7 @@ Status ParseYamlConfig(const std::string& path, DramPoolConfig& config)
 
     // Keep the caller's launch configuration intact if YAML parsing fails.
     DramPoolConfig loadedConfig = config;
+    loadedConfig.transportDeviceIds.clear();
     loadedConfig.twoSidedToOneSided.clear();
     std::vector<YamlSection> sections;
     std::unordered_set<std::string> configuredKeys;
@@ -457,6 +465,21 @@ Status ParseYamlConfig(const std::string& path, DramPoolConfig& config)
         }
 
         if (content.rfind("- ", 0) == 0) {
+            if (sectionPath == "transport.device_ids") {
+                auto itemToken = Trim(content.substr(2));
+                if (itemToken.empty()) {
+                    return Status::InvalidParam("empty transport.device_ids entry at line {}",
+                                                lineNumber);
+                }
+                std::string itemValue;
+                auto status = ParseYamlScalar("transport.device_ids", itemToken, itemValue);
+                if (status.Failure()) { return status; }
+                std::int32_t deviceId = 0;
+                status = ParseInt32Value("transport.device_ids", itemValue, deviceId);
+                if (status.Failure()) { return status; }
+                loadedConfig.transportDeviceIds.push_back(deviceId);
+                continue;
+            }
             if (sectionPath != "transport.endpoints") {
                 return Status::InvalidParam("YAML sequence is unsupported at line {}", lineNumber);
             }
@@ -496,9 +519,12 @@ Status ParseYamlConfig(const std::string& path, DramPoolConfig& config)
         }
         if (!hasScalar) {
             sections.push_back(YamlSection{indent, key});
-            if (BuildSectionPath(sections) == "transport.endpoints") {
-                endpointsSectionSeen = true;
+            const auto newSectionPath = BuildSectionPath(sections);
+            if (newSectionPath == "transport.device_ids" &&
+                !configuredKeys.insert(newSectionPath).second) {
+                return Status::InvalidParam("duplicate YAML key: {}", newSectionPath);
             }
+            if (newSectionPath == "transport.endpoints") { endpointsSectionSeen = true; }
             continue;
         }
 

--- a/ucm/store/test/case/dram/drampool/completion_poller_test.cc
+++ b/ucm/store/test/case/dram/drampool/completion_poller_test.cc
@@ -132,7 +132,7 @@ protected:
         CompletionRecord record;
         record.stage = CompletionStage::SubmitResponse;
         record.opcode = opcode;
-        record.response_addr = 0x9000;
+        record.remote_resp_addr = 0x9000;
         record.peer_one_sided_id = kUnavailablePeer;
         record.results = {1, 0, 1};
         return record;
@@ -154,18 +154,18 @@ TEST_F(CompletionPollerTest, FillPendingWindowHonorsConfiguredDepthAndQueueOrder
 {
     for (std::uint64_t index = 1; index <= 3; ++index) {
         auto record = MakeResponseRecord();
-        record.response_addr = index;
+        record.remote_resp_addr = index;
         completionQueue_.Push(std::move(record));
     }
 
     poller_->FillPendingWindow();
     ASSERT_EQ(poller_->pending_.size(), 2U);
-    EXPECT_EQ(poller_->pending_[0].response_addr, 1U);
-    EXPECT_EQ(poller_->pending_[1].response_addr, 2U);
+    EXPECT_EQ(poller_->pending_[0].remote_resp_addr, 1U);
+    EXPECT_EQ(poller_->pending_[1].remote_resp_addr, 2U);
 
     CompletionRecord remaining;
     ASSERT_TRUE(completionQueue_.TryPop(remaining));
-    EXPECT_EQ(remaining.response_addr, 3U);
+    EXPECT_EQ(remaining.remote_resp_addr, 3U);
 }
 
 TEST_F(CompletionPollerTest, FillPendingWindowDoesNothingWhenDepthIsZero)
@@ -181,7 +181,7 @@ TEST_F(CompletionPollerTest, FillPendingWindowDoesNothingWhenDepthIsZero)
 
 TEST_F(CompletionPollerTest, PollPendingRemovesEveryTerminalFailureAndInvalidStage)
 {
-    InitFlagBuffer();
+    InitFlagBuffer(kFlagSlotSize, 4);
 
     CompletionRecord dataRecord;
     dataRecord.stage = CompletionStage::PollDataTransfer;
@@ -193,7 +193,7 @@ TEST_F(CompletionPollerTest, PollPendingRemovesEveryTerminalFailureAndInvalidSta
     CompletionRecord responseRecord;
     responseRecord.stage = CompletionStage::PollResponseTransfer;
     responseRecord.response_handle = transport::kInvalidTransferHandle;
-    ASSERT_TRUE(flagBufferPool_.Allocate(responseRecord.resp_buffer).Success());
+    ASSERT_TRUE(flagBufferPool_.Allocate(responseRecord.local_resp_slot).Success());
 
     CompletionRecord invalidRecord;
     invalidRecord.stage = static_cast<CompletionStage>(255);
@@ -213,6 +213,7 @@ TEST_F(CompletionPollerTest, PollPendingRemovesEveryTerminalFailureAndInvalidSta
 TEST_F(CompletionPollerTest, RunWithStopSetDrainsAllQueuedFailures)
 {
     constexpr std::size_t kRecordCount = 5;
+    InitFlagBuffer(kFlagSlotSize, kRecordCount);
     for (std::size_t index = 0; index < kRecordCount; ++index) {
         auto record = MakeResponseRecord();
         record.peer_one_sided_id.clear();
@@ -371,25 +372,26 @@ TEST_F(CompletionPollerTest, OperationTimeoutHandlesBoundaryAndClockRollback)
 
 TEST_F(CompletionPollerTest, SubmitResponseRejectsMissingPeerAndUnknownOpcode)
 {
+    InitFlagBuffer();
     auto missingPeer = MakeResponseRecord();
     missingPeer.peer_one_sided_id.clear();
-    EXPECT_TRUE(poller_->SubmitResponse(missingPeer).Failure());
+    EXPECT_TRUE(poller_->SubmitResponse(missingPeer));
 
     auto unknownOpcode = MakeResponseRecord(KvOpcode::None);
-    EXPECT_TRUE(poller_->SubmitResponse(unknownOpcode).Failure());
-    EXPECT_EQ(unknownOpcode.resp_buffer.local_addr, nullptr);
+    EXPECT_TRUE(poller_->SubmitResponse(unknownOpcode));
+    EXPECT_EQ(unknownOpcode.local_resp_slot.local_addr, nullptr);
 }
 
 TEST_F(CompletionPollerTest, SubmitResponseRejectsAlreadyOwnedBuffer)
 {
     InitFlagBuffer();
     auto record = MakeResponseRecord();
-    ASSERT_TRUE(flagBufferPool_.Allocate(record.resp_buffer).Success());
+    ASSERT_TRUE(flagBufferPool_.Allocate(record.local_resp_slot).Success());
 
-    EXPECT_TRUE(poller_->SubmitResponse(record).Failure());
+    EXPECT_FALSE(poller_->SubmitResponse(record));
 
-    EXPECT_NE(record.resp_buffer.local_addr, nullptr);
-    EXPECT_TRUE(flagBufferPool_.Free(record.resp_buffer.slot_index).Success());
+    EXPECT_NE(record.local_resp_slot.local_addr, nullptr);
+    EXPECT_TRUE(flagBufferPool_.Free(record.local_resp_slot.slot_index).Success());
 }
 
 TEST_F(CompletionPollerTest, SubmitResponseReleasesUndersizedBuffer)
@@ -398,9 +400,9 @@ TEST_F(CompletionPollerTest, SubmitResponseReleasesUndersizedBuffer)
     auto record = MakeResponseRecord();
     ASSERT_GT(protocols_.GetPackedResponseSize(record.opcode, record.results.size()), 1U);
 
-    EXPECT_TRUE(poller_->SubmitResponse(record).Failure());
+    EXPECT_TRUE(poller_->SubmitResponse(record));
 
-    EXPECT_EQ(record.resp_buffer.local_addr, nullptr);
+    EXPECT_EQ(record.local_resp_slot.local_addr, nullptr);
     BufferPool::Slot reused;
     ASSERT_TRUE(flagBufferPool_.Allocate(reused).Success());
     EXPECT_TRUE(flagBufferPool_.Free(reused.slot_index).Success());
@@ -414,9 +416,9 @@ TEST_F(CompletionPollerTest, SubmitResponseReleasesBufferWhenProtocolRejectsResu
         auto record = MakeResponseRecord();
         record.results = results;
 
-        EXPECT_TRUE(poller_->SubmitResponse(record).Failure());
+        EXPECT_TRUE(poller_->SubmitResponse(record));
 
-        EXPECT_EQ(record.resp_buffer.local_addr, nullptr);
+        EXPECT_EQ(record.local_resp_slot.local_addr, nullptr);
         BufferPool::Slot reused;
         ASSERT_TRUE(flagBufferPool_.Allocate(reused).Success());
         EXPECT_TRUE(flagBufferPool_.Free(reused.slot_index).Success());
@@ -428,25 +430,25 @@ TEST_F(CompletionPollerTest, SubmitResponseReleasesBufferWhenRealTransportReject
     InitFlagBuffer();
     auto record = MakeResponseRecord();
 
-    EXPECT_TRUE(poller_->SubmitResponse(record).Failure());
+    EXPECT_TRUE(poller_->SubmitResponse(record));
 
-    EXPECT_EQ(record.resp_buffer.local_addr, nullptr);
+    EXPECT_EQ(record.local_resp_slot.local_addr, nullptr);
     EXPECT_EQ(record.response_handle, transport::kInvalidTransferHandle);
     BufferPool::Slot reused;
     ASSERT_TRUE(flagBufferPool_.Allocate(reused).Success());
     EXPECT_TRUE(flagBufferPool_.Free(reused.slot_index).Success());
 }
 
-TEST_F(CompletionPollerTest, SubmitResponseReportsNoSpaceWithoutMutatingRecord)
+TEST_F(CompletionPollerTest, SubmitResponseReturnsFalseOnNoSpaceWithoutMutatingRecord)
 {
     InitFlagBuffer();
     BufferPool::Slot occupied;
     ASSERT_TRUE(flagBufferPool_.Allocate(occupied).Success());
     auto record = MakeResponseRecord();
 
-    EXPECT_EQ(poller_->SubmitResponse(record), Status::NoSpace());
+    EXPECT_FALSE(poller_->SubmitResponse(record));
 
-    EXPECT_EQ(record.resp_buffer.local_addr, nullptr);
+    EXPECT_EQ(record.local_resp_slot.local_addr, nullptr);
     EXPECT_TRUE(flagBufferPool_.Free(occupied.slot_index).Success());
 }
 
@@ -456,11 +458,11 @@ TEST_F(CompletionPollerTest, ResponseStatusApiFailureReleasesOwnedBuffer)
     CompletionRecord record;
     record.stage = CompletionStage::PollResponseTransfer;
     record.response_handle = transport::kInvalidTransferHandle;
-    ASSERT_TRUE(flagBufferPool_.Allocate(record.resp_buffer).Success());
+    ASSERT_TRUE(flagBufferPool_.Allocate(record.local_resp_slot).Success());
 
     EXPECT_TRUE(poller_->PollResponseTransfer(record));
 
-    EXPECT_EQ(record.resp_buffer.local_addr, nullptr);
+    EXPECT_EQ(record.local_resp_slot.local_addr, nullptr);
     BufferPool::Slot reused;
     ASSERT_TRUE(flagBufferPool_.Allocate(reused).Success());
     EXPECT_TRUE(flagBufferPool_.Free(reused.slot_index).Success());
@@ -472,7 +474,7 @@ TEST_F(CompletionPollerTest, ResponseBufferReleaseFailureIsStillTerminal)
     record.response_handle = transport::kInvalidTransferHandle;
 
     EXPECT_TRUE(poller_->PollResponseTransfer(record));
-    EXPECT_EQ(record.resp_buffer.local_addr, nullptr);
+    EXPECT_EQ(record.local_resp_slot.local_addr, nullptr);
 }
 
 }  // namespace

--- a/ucm/store/test/case/dram/drampool/drampool_yaml_config_test.cc
+++ b/ucm/store/test/case/dram/drampool/drampool_yaml_config_test.cc
@@ -59,7 +59,9 @@ private:
 std::string ValidRuntimeYaml()
 {
     return R"(transport:
-  device_id: 0
+  device_ids:
+    - 0
+    - 2
   endpoints:
     - two_sided: "127.0.0.1:9000"
       one_sided: "127.0.0.1:4501"
@@ -137,7 +139,7 @@ TEST(DramPoolRuntimeYamlTest, LoadsEveryRuntimeFieldAndPreservesLaunchFields)
     ASSERT_EQ(config.twoSidedToOneSided.size(), 2U);
     EXPECT_EQ(config.twoSidedToOneSided.at("127.0.0.1:9000"), "127.0.0.1:4501");
     EXPECT_EQ(config.twoSidedToOneSided.at("127.0.0.1:9001"), "127.0.0.1:4502");
-    EXPECT_EQ(config.transportDeviceId, 0);
+    EXPECT_EQ(config.transportDeviceIds, (std::vector<std::int32_t>{0, 2}));
     EXPECT_EQ(config.requestQueueDepth, 65536U);
     EXPECT_EQ(config.completionQueueDepth, 65536U);
     EXPECT_EQ(config.requestReceiverIdleWaitUs, 100U);
@@ -180,7 +182,7 @@ TEST(DramPoolRuntimeYamlTest, RejectsMissingUnknownAndDuplicateKeys)
     const std::vector<std::pair<std::string, std::string>> cases = {
         {ReplaceOnce(ValidRuntimeYaml(), "  max_size_mb: 5\n", ""), "missing required key"},
         {ValidRuntimeYaml() + "unknown: 1\n", "unknown DramPool runtime YAML key"},
-        {ValidRuntimeYaml() + "transport:\n  device_id: 0\n", "duplicate YAML key"},
+        {ValidRuntimeYaml() + "transport:\n  device_ids:\n    - 1\n", "duplicate YAML key"},
     };
     for (const auto& item : cases) {
         auto config = LaunchConfig();
@@ -194,12 +196,12 @@ TEST(DramPoolRuntimeYamlTest, RejectsMissingUnknownAndDuplicateKeys)
 TEST(DramPoolRuntimeYamlTest, FailureDoesNotPartiallyModifyConfiguration)
 {
     auto config = LaunchConfig();
-    config.transportDeviceId = 37;
+    config.transportDeviceIds = {37, 38};
     RuntimeYamlFile yaml(ReplaceOnce(ValidRuntimeYaml(), "  max_size_mb: 5", "  max_size_mb: 0"));
 
     EXPECT_TRUE(ParseYamlConfig(yaml.Path().string(), config).Failure());
 
-    EXPECT_EQ(config.transportDeviceId, 37);
+    EXPECT_EQ(config.transportDeviceIds, (std::vector<std::int32_t>{37, 38}));
     EXPECT_TRUE(config.twoSidedToOneSided.empty());
     EXPECT_EQ(config.poolSizeGb, 7U);
 }
@@ -227,7 +229,10 @@ INSTANTIATE_TEST_SUITE_P(
                         "one_sided: \"127.0.0.1:4501\"", "duplicate transport one_sided"},
         InvalidYamlCase{"EndpointInBothRoles", "one_sided: \"127.0.0.1:4502\"",
                         "one_sided: \"127.0.0.1:9000\"", "both two_sided and one_sided"},
-        InvalidYamlCase{"NegativeDevice", "device_id: 0", "device_id: -1", "must not be negative"},
+        InvalidYamlCase{"EmptyDeviceIds", "  device_ids:\n    - 0\n    - 2\n", "  device_ids:\n",
+                        "must not be empty"},
+        InvalidYamlCase{"NegativeDevice", "    - 0", "    - -1", "negative values"},
+        InvalidYamlCase{"DuplicateDevice", "    - 2", "    - 0", "duplicate device ID"},
         InvalidYamlCase{"QueueTooShallow", "request_depth: 65536", "request_depth: 1",
                         "at least 2"},
         InvalidYamlCase{"ZeroPollerPendingDepth", "pending_depth: 64", "pending_depth: 0",


### PR DESCRIPTION
## Purpose
Allow one DramPool process to start one HIXL instance per configured transport device while selecting one configured device for the ACL runtime.

## Modifications
1. Replace transport.device_id with the transport.device_ids YAML sequence and validate that the list is non-empty, non-negative, and unique.
2. Create one HIXL instance for every configured device ID and randomly select an ACL device during initialization.
3. Track the selected ACL device so shutdown resets the same device, and update the example configuration and YAML tests.

## Test
```
[==========] Running 116 tests from 13 test suites.
[----------] Global test environment set-up.
[----------] 17 tests from CompletionPollerTest
[ RUN      ] CompletionPollerTest.FillPendingWindowHonorsConfiguredDepthAndQueueOrder
[       OK ] CompletionPollerTest.FillPendingWindowHonorsConfiguredDepthAndQueueOrder (1 ms)
[ RUN      ] CompletionPollerTest.FillPendingWindowDoesNothingWhenDepthIsZero
[       OK ] CompletionPollerTest.FillPendingWindowDoesNothingWhenDepthIsZero (1 ms)

```
