### PR TITLE
[FEAT] Add dramstore transport and reply poller

### DIFF
--- a/ucm/shared/CMakeLists.txt
+++ b/ucm/shared/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(vendor)
 add_subdirectory(infra)
 add_subdirectory(trans)
-if(RUNTIME_ENVIRONMENT STREQUAL "ascend")
+if(RUNTIME_ENVIRONMENT STREQUAL "ascend" OR RUNTIME_ENVIRONMENT STREQUAL "simu")
     add_subdirectory(pool)
 endif()
 add_subdirectory(metrics)

--- a/ucm/shared/pool/buffer_pool.cc
+++ b/ucm/shared/pool/buffer_pool.cc
@@ -22,11 +22,11 @@
  * SOFTWARE.
  * */
 #include "pool/buffer_pool.h"
-#include <acl/acl.h>
 #include <cstring>
 #include <limits>
 #include <utility>
-#include "trans/ascend/ascend_buffer.h"
+#include "trans/detail/reserved_buffer.h"
+#include "trans/device.h"
 
 namespace UC {
 
@@ -41,10 +41,11 @@ bool BufferPool::ComputeSlotStride(std::size_t capacity, std::size_t alignment, 
 
 Status BufferPool::BufferRegion::Create(MemoryType type, std::size_t size, BufferRegion& region)
 {
-    Trans::AscendBuffer ascendBuffer;
+    auto buffer = UC::Trans::Device{}.MakeBuffer();
+    if (!buffer) { return Status::Error("failed to create runtime buffer"); }
     switch (type) {
         case MemoryType::HOST: {
-            auto owner = ascendBuffer.MakeHostBuffer(size);
+            auto owner = buffer->MakeHostBuffer(size);
             if (!owner) { return Status::Error("failed to allocate host memory"); }
             region.owner = std::move(owner);
             region.local_addr = region.owner.get();
@@ -53,7 +54,7 @@ Status BufferPool::BufferRegion::Create(MemoryType type, std::size_t size, Buffe
         }
         case MemoryType::HOST_PINNED: {
             void* deviceAddr = nullptr;
-            auto owner = ascendBuffer.MakeHostPinnedBuffer(size, &deviceAddr);
+            auto owner = buffer->MakeHostPinnedBuffer(size, &deviceAddr);
             if (!owner || !deviceAddr) {
                 return Status::Error("failed to allocate host-pinned memory");
             }
@@ -63,7 +64,7 @@ Status BufferPool::BufferRegion::Create(MemoryType type, std::size_t size, Buffe
             return Status::OK();
         }
         case MemoryType::ASCEND_DEVICE: {
-            auto owner = ascendBuffer.MakeDeviceBuffer(size);
+            auto owner = buffer->MakeDeviceBuffer(size);
             if (!owner) { return Status::Error("failed to allocate device memory"); }
             region.owner = std::move(owner);
             region.local_addr = region.owner.get();
@@ -182,9 +183,8 @@ bool BufferPool::IsValidPointer(const void* ptr) const
 Status BufferPool::ZeroMemory(void* ptr, std::size_t size) const
 {
     if (memory_type_ == MemoryType::ASCEND_DEVICE) {
-        if (aclrtMemset(ptr, size, 0, size) != ACL_SUCCESS) {
-            return Status::Error(name_ + ": failed to zero device memory");
-        }
+        const auto status = UC::Trans::ZeroDeviceMemory(ptr, size);
+        if (status.Failure()) { return Status::Error(name_ + ": failed to zero device memory"); }
     } else {
         std::memset(ptr, 0, size);
     }

--- a/ucm/shared/trans/ascend/ascend_buffer.cc
+++ b/ucm/shared/trans/ascend/ascend_buffer.cc
@@ -204,4 +204,12 @@ Status Buffer::RegisterHostBuffer(void* host, size_t size, void** pDevice)
 
 void Buffer::UnregisterHostBuffer(void* host) { aclrtHostUnregister(host); }
 
+Status ZeroDeviceMemory(void* ptr, std::size_t size)
+{
+    if (aclrtMemset(ptr, size, 0, size) != ACL_SUCCESS) {
+        return Status::Error("aclrtMemset failed to zero device memory");
+    }
+    return Status::OK();
+}
+
 }  // namespace UC::Trans

--- a/ucm/shared/trans/detail/reserved_buffer.h
+++ b/ucm/shared/trans/detail/reserved_buffer.h
@@ -24,7 +24,9 @@
 #ifndef UNIFIEDCACHE_TRANS_RESERVED_BUFFER_H
 #define UNIFIEDCACHE_TRANS_RESERVED_BUFFER_H
 
+#include <cstddef>
 #include <fmt/format.h>
+#include <memory>
 #include "indexer.h"
 #include "trans/buffer.h"
 
@@ -104,6 +106,8 @@ public:
         return this->MakeHostBuffer(size);
     }
 };
+
+Status ZeroDeviceMemory(void* ptr, std::size_t size);
 
 }  // namespace UC::Trans
 

--- a/ucm/shared/trans/simu/simu_buffer.cc
+++ b/ucm/shared/trans/simu/simu_buffer.cc
@@ -75,4 +75,10 @@ Status Buffer::RegisterHostBuffer(void* host, size_t size, void** pDevice)
 
 void Buffer::UnregisterHostBuffer(void* host) {}
 
-} // namespace UC::Trans
+Status ZeroDeviceMemory(void* ptr, std::size_t size)
+{
+    std::memset(ptr, 0, size);
+    return Status::OK();
+}
+
+}  // namespace UC::Trans

--- a/ucm/store/dram/CMakeLists.txt
+++ b/ucm/store/dram/CMakeLists.txt
@@ -3,14 +3,24 @@ set(UCM_DRAM_STORE_CC_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/cc/kv_protocol.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/cc/config.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/cc/dram_fatal.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/cc/transport_executor.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/cc/reply_service.cc
 )
+if(RUNTIME_ENVIRONMENT STREQUAL "ascend")
+    list(APPEND UCM_DRAM_STORE_CC_SOURCE_FILES
+        ${CMAKE_CURRENT_SOURCE_DIR}/cc/transport_manager_backend.cc)
+endif()
 add_library(dramstore SHARED ${UCM_DRAM_STORE_CC_SOURCE_FILES})
 target_include_directories(dramstore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/cc)
 target_include_directories(dramstore PUBLIC
+    ${CMAKE_SOURCE_DIR}/ucm/transport/p2p/include
     ${CMAKE_SOURCE_DIR}/ucm/transport/p2p/include/one_sided)
 target_include_directories(dramstore PUBLIC ${CMAKE_SOURCE_DIR}/ucm/shared)
 
-target_link_libraries(dramstore PUBLIC storeintf infra_logger infra_thread kv_common)
+target_link_libraries(dramstore PUBLIC storeintf infra_logger infra_thread kv_common buffer_pool)
+if(RUNTIME_ENVIRONMENT STREQUAL "ascend")
+    target_link_libraries(dramstore PUBLIC ucm_p2p_transport)
+endif()
 file(RELATIVE_PATH INSTALL_REL_PATH ${UCM_ROOT_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
 install(TARGETS dramstore LIBRARY DESTINATION ${INSTALL_REL_PATH} COMPONENT ucm)
 

--- a/ucm/store/dram/cc/reply_service.cc
+++ b/ucm/store/dram/cc/reply_service.cc
@@ -1,0 +1,302 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "reply_service.h"
+#include <atomic>
+#include <limits>
+#include <system_error>
+
+namespace UC::Dram {
+
+ReplyService::ReplyService(Options options) : options_(std::move(options)) {}
+
+Expected<std::unique_ptr<ReplyService>> ReplyService::Create(Options options)
+{
+    auto service = std::unique_ptr<ReplyService>(new ReplyService(std::move(options)));
+    auto status = service->Init();
+    if (status.Failure()) { return status; }
+    return service;
+}
+
+Status ReplyService::Init()
+{
+    if (options_.slotSize == 0 || options_.slotCount == 0 || options_.pollInterval.count() <= 0 ||
+        !options_.publishEvent) {
+        return Status::InvalidParam("invalid ReplyService options");
+    }
+    auto status = buffers_.Init("dram_reply_slots", BufferPool::MemoryType::HOST, options_.slotSize,
+                                options_.slotCount, true);
+    if (status.Failure()) { return status; }
+    slotContexts_ = std::make_unique<SlotContext[]>(options_.slotCount);
+    activeLeaseIndices_.reserve(options_.slotCount);
+    activeLeasePositions_.assign(options_.slotCount, kNoIndex);
+    return Status::OK();
+}
+
+UC::DramPool::KvOpcode ReplyService::ToOpcode(OpType op) noexcept
+{
+    switch (op) {
+        case OpType::LOOKUP: return DramPool::KvOpcode::Lookup;
+        case OpType::DUMP: return DramPool::KvOpcode::Dump;
+        case OpType::LOAD: return DramPool::KvOpcode::Load;
+    }
+    return DramPool::KvOpcode::None;
+}
+
+std::size_t ReplyService::ReplyPayloadSize(OpType op, std::size_t entryCount) const noexcept
+{
+    if (entryCount == 0 || entryCount > kMaxProtocolBatchEntries) { return 0; }
+    const auto opcode = ToOpcode(op);
+    return opcode == DramPool::KvOpcode::None ? 0
+                                              : protocol_.GetPackedResponseSize(opcode, entryCount);
+}
+
+bool ReplyService::CompletionReady(const Lease& lease) const noexcept
+{
+    if (lease.slot.local_addr == nullptr || lease.payloadSize == 0 ||
+        lease.payloadSize > lease.slot.length) {
+        return false;
+    }
+    bool ready = false;
+    const auto status = protocol_.IsResponseReady(lease.slot.local_addr, ready);
+    if (status.Failure() || !ready) { return false; }
+    std::atomic_thread_fence(std::memory_order_acquire);
+    return true;
+}
+
+Status ReplyService::DecodeReply(const Lease& lease, std::vector<EntryResult>* entryResults)
+{
+    if (entryResults == nullptr || lease.entryCount > kMaxProtocolBatchEntries) {
+        return Status::InvalidParam("invalid DramPool reply metadata");
+    }
+    DramPool::KvResponse response;
+    auto status = protocol_.UnpackResponse(lease.slot.local_addr, ToOpcode(lease.op),
+                                           static_cast<std::uint16_t>(lease.entryCount), response);
+    if (status.Failure()) { return status; }
+    if (response.results.size() != lease.entryCount) { return Status::DeserializeFailed(); }
+
+    entryResults->clear();
+    entryResults->reserve(lease.entryCount);
+    for (std::size_t index = 0; index < lease.entryCount; ++index) {
+        const auto code = static_cast<std::int32_t>(response.results[index]);
+        const auto found = lease.op == OpType::LOOKUP ? code != 0 : code == 0;
+        entryResults->push_back(EntryResult{index, found, code});
+    }
+    return Status::OK();
+}
+
+ReplyService::~ReplyService() { (void)Shutdown(); }
+
+ReplyMemoryRegion ReplyService::MemoryRegion() const noexcept
+{
+    return ReplyMemoryRegion{buffers_.GetLocalAddr(), buffers_.GetTotalSize()};
+}
+
+std::size_t ReplyService::Available() const
+{
+    std::lock_guard lock(activeLeasesMutex_);
+    return options_.slotCount - activeLeaseIndices_.size();
+}
+
+Status ReplyService::Start()
+{
+    if (acceptingLeases_.exchange(true, std::memory_order_acq_rel)) {
+        return Status::DuplicateKey();
+    }
+    try {
+        worker_ = std::thread([this] { Run(); });
+        return Status::OK();
+    } catch (const std::system_error& error) {
+        acceptingLeases_.store(false, std::memory_order_release);
+        return Status::Error(fmt::format("failed to start ReplyService: {}", error.what()));
+    }
+}
+
+Expected<ReplySlot> ReplyService::Acquire(const RequestToken& token, OpType op,
+                                          std::size_t entryCount)
+{
+    const auto payloadSize = ReplyPayloadSize(op, entryCount);
+    if (token.nodeId == std::numeric_limits<NodeId>::max() ||
+        token.epoch == kInvalidConnectionEpoch || token.requestId == kInvalidRequestId ||
+        entryCount == 0 || payloadSize == 0 || payloadSize > options_.slotSize) {
+        return Status::InvalidParam("invalid reply lease request");
+    }
+
+    ReplySlot slot;
+    if (!acceptingLeases_.load(std::memory_order_acquire)) {
+        return Status::Error("ReplyService is stopping");
+    }
+
+    const auto allocated = buffers_.Allocate(slot);
+    if (allocated == Status::NoSpace()) {
+        return Status::Error("ReplyService slot capacity invariant violated");
+    }
+    if (allocated.Failure()) { return allocated; }
+    if (slot.slot_index >= options_.slotCount || slot.local_addr == nullptr || slot.length == 0 ||
+        !buffers_.IsValidPointer(slot.local_addr)) {
+        (void)buffers_.Free(slot.slot_index);
+        return Status::Error("reply buffer pool returned an invalid slot");
+    }
+
+    {
+        auto& context = slotContexts_[slot.slot_index];
+        std::lock_guard slotLock(context.mutex);
+        {
+            std::unique_lock registryLock(activeLeasesMutex_);
+            if (!acceptingLeases_.load(std::memory_order_acquire)) {
+                registryLock.unlock();
+                const auto released = buffers_.Free(slot.slot_index);
+                if (released.Failure()) { return released; }
+                return Status::Error("ReplyService is stopping");
+            }
+            if (context.lease.has_value() || activeLeasePositions_[slot.slot_index] != kNoIndex) {
+                registryLock.unlock();
+                (void)buffers_.Free(slot.slot_index);
+                return Status::Error("reply buffer pool returned an invalid slot");
+            }
+
+            context.lease = Lease{token, slot, op, entryCount, payloadSize, false};
+            activeLeasePositions_[slot.slot_index] = activeLeaseIndices_.size();
+            activeLeaseIndices_.push_back(slot.slot_index);
+            ++activeLeaseVersion_;
+        }
+    }
+    wake_.notify_one();
+    return slot;
+}
+
+Status ReplyService::Release(const RequestToken& token, const ReplySlot& slot) noexcept
+{
+    try {
+        const auto index = static_cast<std::size_t>(slot.slot_index);
+        if (index >= options_.slotCount) {
+            return Status::InvalidParam("reply slot is not leased");
+        }
+
+        auto& context = slotContexts_[index];
+        std::unique_lock slotLock(context.mutex);
+        if (!context.lease.has_value()) { return Status::InvalidParam("reply slot is not leased"); }
+        const auto& lease = *context.lease;
+        if (lease.token != token || lease.slot.local_addr != slot.local_addr ||
+            lease.slot.length != slot.length) {
+            return Status::InvalidParam("reply slot ownership mismatch");
+        }
+
+        {
+            std::lock_guard registryLock(activeLeasesMutex_);
+            const auto activePosition = activeLeasePositions_[index];
+            if (activePosition >= activeLeaseIndices_.size() ||
+                activeLeaseIndices_[activePosition] != index) {
+                return Status::Error("reply active-lease index invariant violated");
+            }
+        }
+
+        // Free may clear the complete slot. Keep only this slot locked while it
+        // does so; a concurrent Acquire of the same index will wait for slotLock.
+        auto result = buffers_.Free(slot.slot_index);
+        if (result.Failure()) { return result; }
+
+        {
+            std::lock_guard registryLock(activeLeasesMutex_);
+            const auto activePosition = activeLeasePositions_[index];
+            if (activePosition >= activeLeaseIndices_.size() ||
+                activeLeaseIndices_[activePosition] != index) {
+                AbortDramStore(
+                    Status::Error("reply active-lease index changed unexpectedly during release"));
+            }
+            const auto lastIndex = activeLeaseIndices_.back();
+            activeLeaseIndices_[activePosition] = lastIndex;
+            activeLeasePositions_[lastIndex] = activePosition;
+            activeLeaseIndices_.pop_back();
+            activeLeasePositions_[index] = kNoIndex;
+            context.lease.reset();
+            ++activeLeaseVersion_;
+        }
+        return result;
+    } catch (...) {
+        AbortDramStore(Status::Error("ReplyService failed to release a reply lease"));
+    }
+}
+
+void ReplyService::Run() noexcept
+{
+    try {
+        std::vector<std::size_t> activeLeaseSnapshot;
+        activeLeaseSnapshot.reserve(options_.slotCount);
+        while (acceptingLeases_.load(std::memory_order_acquire)) {
+            std::uint64_t observedActiveLeaseVersion = 0;
+            {
+                std::lock_guard lock(activeLeasesMutex_);
+                activeLeaseSnapshot.assign(activeLeaseIndices_.begin(), activeLeaseIndices_.end());
+                observedActiveLeaseVersion = activeLeaseVersion_;
+            }
+            bool progress = false;
+            for (const auto index : activeLeaseSnapshot) {
+                std::optional<ReplyObserved> observed;
+                RequestToken token;
+                {
+                    auto& context = slotContexts_[index];
+                    std::lock_guard slotLock(context.mutex);
+                    auto& current = context.lease;
+                    if (!current.has_value() || current->delivered) { continue; }
+                    if (!CompletionReady(*current)) { continue; }
+                    ReplyObserved event;
+                    event.token = current->token;
+                    event.status = DecodeReply(*current, &event.entryResults);
+                    if (event.status == Status::Retry()) { continue; }
+                    token = current->token;
+                    observed.emplace(std::move(event));
+                    current->delivered = true;
+                }
+
+                options_.publishEvent(token.nodeId, NodeEvent{std::move(*observed)});
+                progress = true;
+            }
+
+            if (!progress) {
+                std::unique_lock lock(activeLeasesMutex_);
+                wake_.wait_for(lock, options_.pollInterval, [this, observedActiveLeaseVersion] {
+                    return !acceptingLeases_.load(std::memory_order_acquire) ||
+                           activeLeaseVersion_ != observedActiveLeaseVersion;
+                });
+            }
+        }
+    } catch (...) {
+        AbortDramStore(Status::Error("ReplyService observer stopped unexpectedly"));
+    }
+}
+
+Status ReplyService::Shutdown()
+{
+    acceptingLeases_.store(false, std::memory_order_release);
+    wake_.notify_all();
+    if (worker_.joinable()) { worker_.join(); }
+
+    std::lock_guard lock(activeLeasesMutex_);
+    if (!activeLeaseIndices_.empty()) {
+        return Status::Error("ReplyService stopped with active reply leases");
+    }
+    return Status::OK();
+}
+
+}  // namespace UC::Dram

--- a/ucm/store/dram/cc/reply_service.h
+++ b/ucm/store/dram/cc/reply_service.h
@@ -1,0 +1,117 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#ifndef UNIFIEDCACHE_DRAM_STORE_CC_REPLY_SERVICE_H
+#define UNIFIEDCACHE_DRAM_STORE_CC_REPLY_SERVICE_H
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <vector>
+#include "kv_protocol.h"
+#include "messages.h"
+#include "pool/buffer_pool.h"
+#include "status/status.h"
+
+namespace UC::Dram {
+
+struct ReplyMemoryRegion final {
+    void* address{nullptr};
+    std::size_t length{0};
+};
+
+// ReplyService is the single owner of reply-slot allocation and observation.
+// A slot is reusable only after NodeActor releases it at a safe terminal point
+// (reply observed, definitely-not-transmitted, or epoch fenced). That safety rule makes
+// a separate slot generation unnecessary.
+class ReplyService final {
+public:
+    struct Options {
+        std::uint32_t slotSize{0};
+        std::size_t slotCount{0};
+        std::chrono::microseconds pollInterval{0};
+        NodeEventPublisher publishEvent;
+    };
+
+    static Expected<std::unique_ptr<ReplyService>> Create(Options options);
+    ~ReplyService();
+
+    ReplyService(const ReplyService&) = delete;
+    ReplyService& operator=(const ReplyService&) = delete;
+
+    Status Start();
+    Status Shutdown();
+
+    Expected<ReplySlot> Acquire(const RequestToken& token, OpType op, std::size_t entryCount);
+    Status Release(const RequestToken& token, const ReplySlot& slot) noexcept;
+
+    ReplyMemoryRegion MemoryRegion() const noexcept;
+    std::size_t Available() const;
+
+private:
+    static constexpr std::size_t kNoIndex = std::numeric_limits<std::size_t>::max();
+
+    struct Lease {
+        RequestToken token;
+        ReplySlot slot;
+        OpType op{OpType::LOOKUP};
+        std::size_t entryCount{0};
+        std::size_t payloadSize{0};
+        bool delivered{false};
+    };
+
+    struct SlotContext {
+        std::mutex mutex;
+        std::optional<Lease> lease;
+    };
+
+    explicit ReplyService(Options options);
+    Status Init();
+    static DramPool::KvOpcode ToOpcode(OpType op) noexcept;
+    std::size_t ReplyPayloadSize(OpType op, std::size_t entryCount) const noexcept;
+    bool CompletionReady(const Lease& lease) const noexcept;
+    Status DecodeReply(const Lease& lease, std::vector<EntryResult>* entryResults);
+    void Run() noexcept;
+
+    Options options_;
+    DramPool::ProtocolManager protocol_;
+    BufferPool buffers_;
+    mutable std::mutex activeLeasesMutex_;
+    std::condition_variable wake_;
+    std::unique_ptr<SlotContext[]> slotContexts_;
+    std::vector<std::size_t> activeLeaseIndices_;
+    std::vector<std::size_t> activeLeasePositions_;
+    std::uint64_t activeLeaseVersion_{0};
+    std::thread worker_;
+    // False rejects new leases and asks the polling worker to stop.
+    std::atomic<bool> acceptingLeases_{false};
+};
+
+}  // namespace UC::Dram
+
+#endif  // UNIFIEDCACHE_DRAM_STORE_CC_REPLY_SERVICE_H

--- a/ucm/store/dram/cc/transport_executor.cc
+++ b/ucm/store/dram/cc/transport_executor.cc
@@ -1,0 +1,203 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "transport_executor.h"
+#include <exception>
+#include <limits>
+#include <optional>
+#include <type_traits>
+
+namespace UC::Dram {
+namespace {
+
+NodeId CommandNode(const TransportCommand& command) noexcept
+{
+    return std::visit(
+        [](const auto& value) -> NodeId {
+            using Command = std::decay_t<decltype(value)>;
+            if constexpr (std::is_same_v<Command, Transmit>) {
+                return value.token.nodeId;
+            } else {
+                return value.nodeId;
+            }
+        },
+        command);
+}
+
+bool IsFence(const TransportCommand& command) noexcept
+{
+    return std::holds_alternative<FenceEpoch>(command);
+}
+
+}  // namespace
+
+TransportExecutor::TransportExecutor(Options options) : options_(std::move(options)) {}
+
+TransportExecutor::~TransportExecutor() { (void)Shutdown(); }
+
+void TransportExecutor::Execute(TransportCommand command) noexcept
+{
+    try {
+        std::visit(
+            [this](auto&& value) {
+                using Command = std::decay_t<decltype(value)>;
+                NodeId nodeId = 0;
+                NodeEvent event;
+                if constexpr (std::is_same_v<Command, Transmit>) {
+                    nodeId = value.token.nodeId;
+                    event = NodeEvent{options_.backend->Transmit(value)};
+                } else if constexpr (std::is_same_v<Command, Connect>) {
+                    nodeId = value.nodeId;
+                    event = NodeEvent{
+                        ConnectCompleted{value.nodeId, value.laneId, value.epoch,
+                                         options_.backend->Connect(value)}
+                    };
+                } else if constexpr (std::is_same_v<Command, FenceEpoch>) {
+                    nodeId = value.nodeId;
+                    event = NodeEvent{
+                        FenceCompleted{value.nodeId, value.laneId, value.epoch,
+                                       options_.backend->Fence(value)}
+                    };
+                }
+                options_.publishEvent(nodeId, std::move(event));
+            },
+            std::move(command));
+    } catch (...) {
+        AbortDramStore(
+            Status::Error("TransportExecutor failed while publishing a command completion"));
+    }
+}
+
+void TransportExecutor::Run(Worker& worker) noexcept
+{
+    for (;;) {
+        std::optional<TransportCommand> command;
+        {
+            std::unique_lock lock(worker.mutex);
+            worker.wake.wait(lock, [this, &worker] {
+                return !worker.queue.Empty() || !acceptingCommands_.load(std::memory_order_acquire);
+            });
+            if (worker.queue.Empty() && !acceptingCommands_.load(std::memory_order_acquire)) {
+                return;
+            }
+            command.emplace(worker.queue.Pop());
+        }
+        {
+            std::lock_guard lock(admissionMutex_);
+            if (IsFence(*command)) {
+                --queuedFences_;
+            } else {
+                --queuedCommands_;
+            }
+        }
+        Execute(std::move(*command));
+    }
+}
+
+Status TransportExecutor::Start()
+{
+    if (options_.workerCount == 0 || options_.nodeCount == 0 ||
+        options_.maxInflightRequestsPerNode == 0 ||
+        options_.maxInflightRequestsPerNode > std::numeric_limits<std::size_t>::max() - 2 ||
+        options_.nodeCount >
+            std::numeric_limits<std::size_t>::max() / (options_.maxInflightRequestsPerNode + 2) ||
+        !options_.backend || !options_.publishEvent) {
+        return Status::InvalidParam("invalid TransportExecutor options");
+    }
+    commandQueueCapacity_ = options_.nodeCount * (options_.maxInflightRequestsPerNode + 1);
+    fenceQueueCapacity_ = options_.nodeCount;
+    if (acceptingCommands_.exchange(true, std::memory_order_acq_rel)) {
+        return Status::DuplicateKey();
+    }
+    try {
+        workers_.reserve(options_.workerCount);
+        for (std::size_t index = 0; index < options_.workerCount; ++index) {
+            workers_.push_back(
+                std::make_unique<Worker>(commandQueueCapacity_ + fenceQueueCapacity_));
+        }
+        for (auto& worker : workers_) {
+            worker->thread = std::thread([this, worker = worker.get()] { Run(*worker); });
+        }
+        return Status::OK();
+    } catch (const std::exception& error) {
+        acceptingCommands_.store(false, std::memory_order_release);
+        for (auto& worker : workers_) { worker->wake.notify_all(); }
+        for (auto& worker : workers_) {
+            if (worker->thread.joinable()) { worker->thread.join(); }
+        }
+        workers_.clear();
+        auto backend = std::move(options_.backend);
+        const auto stopStatus = backend->Stop();
+        if (stopStatus.Failure()) { return stopStatus; }
+        return Status::Error(fmt::format("failed to start TransportExecutor: {}", error.what()));
+    }
+}
+
+Status TransportExecutor::TryPost(TransportCommand& command)
+{
+    if (!acceptingCommands_.load(std::memory_order_acquire)) {
+        return Status::Error("TransportExecutor is stopping");
+    }
+    const auto nodeId = CommandNode(command);
+    const bool isFence = IsFence(command);
+    const auto workerIndex = std::hash<NodeId>{}(nodeId) % workers_.size();
+    auto& worker = *workers_[workerIndex];
+
+    std::lock_guard admission_lock(admissionMutex_);
+    if (!acceptingCommands_.load(std::memory_order_acquire)) {
+        return Status::Error("TransportExecutor is stopping");
+    }
+    if ((isFence && queuedFences_ >= fenceQueueCapacity_) ||
+        (!isFence && queuedCommands_ >= commandQueueCapacity_)) {
+        return Status::Error("TransportExecutor queue full");
+    }
+
+    auto staged = std::move(command);
+    {
+        std::lock_guard queue_lock(worker.mutex);
+        if (!worker.queue.Push(staged)) {
+            command = std::move(staged);
+            return Status::Error("TransportExecutor worker queue invariant violated");
+        }
+    }
+    if (isFence) {
+        ++queuedFences_;
+    } else {
+        ++queuedCommands_;
+    }
+    worker.wake.notify_one();
+    return Status::OK();
+}
+
+Status TransportExecutor::Shutdown()
+{
+    acceptingCommands_.store(false, std::memory_order_release);
+    for (auto& worker : workers_) { worker->wake.notify_all(); }
+    for (auto& worker : workers_) {
+        if (worker->thread.joinable()) { worker->thread.join(); }
+    }
+    auto backend = std::move(options_.backend);
+    return backend ? backend->Stop() : Status::OK();
+}
+
+}  // namespace UC::Dram

--- a/ucm/store/dram/cc/transport_executor.h
+++ b/ucm/store/dram/cc/transport_executor.h
@@ -1,0 +1,107 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#ifndef UNIFIEDCACHE_DRAM_STORE_CC_TRANSPORT_EXECUTOR_H
+#define UNIFIEDCACHE_DRAM_STORE_CC_TRANSPORT_EXECUTOR_H
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+#include "bounded_queue.h"
+#include "messages.h"
+#include "status/status.h"
+
+namespace UC::Dram {
+
+using MemoryHandle = std::uint64_t;
+
+enum class MemoryRegionType : std::uint8_t {
+    HOST = 0,
+    DEVICE,
+};
+
+class ITransportBackend {
+public:
+    virtual ~ITransportBackend() = default;
+    virtual Expected<MemoryHandle> RegisterMemory(void* address, std::size_t length,
+                                                  MemoryRegionType type) = 0;
+    virtual Status UnregisterMemory(MemoryHandle handle) = 0;
+    virtual TransmitCompleted Transmit(const ::UC::Dram::Transmit& command) noexcept = 0;
+    virtual Status Connect(const ::UC::Dram::Connect& command) noexcept = 0;
+    // Success synchronously proves that the old epoch can no longer access client memory.
+    virtual Status Fence(const ::UC::Dram::FenceEpoch& command) noexcept = 0;
+    virtual Status Stop() noexcept = 0;
+};
+
+class TransportExecutor final {
+public:
+    struct Options {
+        std::size_t workerCount{1};
+        std::size_t nodeCount{0};
+        std::size_t maxInflightRequestsPerNode{0};
+        std::shared_ptr<ITransportBackend> backend;
+        NodeEventPublisher publishEvent;
+    };
+
+    explicit TransportExecutor(Options options);
+    ~TransportExecutor();
+
+    TransportExecutor(const TransportExecutor&) = delete;
+    TransportExecutor& operator=(const TransportExecutor&) = delete;
+
+    Status Start();
+    Status Shutdown();
+
+    // Consumes on success.
+    Status TryPost(TransportCommand& command);
+
+private:
+    struct Worker {
+        explicit Worker(std::size_t capacity) : queue(capacity) {}
+
+        std::mutex mutex;
+        std::condition_variable wake;
+        BoundedQueue<TransportCommand> queue;
+        std::thread thread;
+    };
+
+    void Execute(TransportCommand command) noexcept;
+    void Run(Worker& worker) noexcept;
+
+    Options options_;
+    std::size_t commandQueueCapacity_{0};
+    std::size_t fenceQueueCapacity_{0};
+    std::vector<std::unique_ptr<Worker>> workers_;
+    std::mutex admissionMutex_;
+    std::size_t queuedCommands_{0};
+    std::size_t queuedFences_{0};
+    std::atomic<bool> acceptingCommands_{false};
+};
+
+}  // namespace UC::Dram
+
+#endif  // UNIFIEDCACHE_DRAM_STORE_CC_TRANSPORT_EXECUTOR_H

--- a/ucm/store/dram/cc/transport_manager_backend.cc
+++ b/ucm/store/dram/cc/transport_manager_backend.cc
@@ -1,0 +1,154 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "transport_manager_backend.h"
+#include <utility>
+#include "core/transport_init_attrs.h"
+
+namespace UC::Dram {
+
+TransportManagerBackend::TransportManagerBackend(TransportManagerBackendOptions options)
+    : options_(std::move(options)), manager_(options_.localTransportManagerId)
+{
+}
+
+TransportManagerBackend::~TransportManagerBackend() = default;
+
+Status TransportManagerBackend::Init()
+{
+    if (options_.deviceId < 0 || options_.connectTimeoutMs <= 0 ||
+        options_.transferTimeoutMs <= 0 || options_.localHost.empty() ||
+        options_.localControlHost.empty() || options_.localControlPort == 0 ||
+        options_.localTransportManagerId.empty() || options_.nodes.empty()) {
+        return Status::InvalidParam("invalid TransportManager backend options");
+    }
+    localControl_ = transport::Endpoint{options_.localControlHost, options_.localControlPort};
+
+    // TODO: make transport backend configurable
+    transport::HixlInitAttrs attrs;
+    attrs.ip = options_.localHost;
+    attrs.instances.push_back(transport::HixlInitAttrs::Instance{-1, options_.deviceId, {}});
+    attrs.connect_timeout_ms = options_.connectTimeoutMs;
+    attrs.transfer_timeout_ms = options_.transferTimeoutMs;
+    auto transportStatus = manager_.Init();
+    if (transportStatus.Failure()) { return transportStatus; }
+    transportStatus = manager_.InstallTransport(transport::TransportProtocol::Hixl, attrs);
+    if (transportStatus.Failure()) { return transportStatus; }
+    transportStatus = control_.Init(localControl_);
+    if (transportStatus.Failure()) { return transportStatus; }
+    for (const auto& node : options_.nodes) {
+        if (!nodes_.emplace(node.nodeId, node).second) {
+            return Status::InvalidParam("duplicate DramPool node");
+        }
+    }
+    return Status::OK();
+}
+
+Expected<MemoryHandle> TransportManagerBackend::RegisterMemory(void* address, std::size_t length,
+                                                               MemoryRegionType type)
+{
+    transport::MemoryRegion region;
+    region.addr = address;
+    region.length = length;
+    region.type = type == MemoryRegionType::DEVICE ? transport::MemoryType::Device
+                                                   : transport::MemoryType::Host;
+    region.device_id = type == MemoryRegionType::DEVICE ? options_.deviceId : -1;
+    transport::MemoryHandle handle = transport::kInvalidMemoryHandle;
+    const auto status = manager_.RegisterMemory(region, handle);
+    if (status.Failure()) { return status; }
+    return static_cast<MemoryHandle>(handle);
+}
+
+Status TransportManagerBackend::UnregisterMemory(MemoryHandle handle)
+{
+    return manager_.UnregisterMemory(static_cast<transport::MemoryHandle>(handle));
+}
+
+TransmitCompleted TransportManagerBackend::Transmit(const ::UC::Dram::Transmit& command) noexcept
+{
+    const auto found = nodes_.find(command.token.nodeId);
+    if (found == nodes_.end() || command.payload.empty()) {
+        return TransmitCompleted{command.token, Status::InvalidParam("invalid transmit")};
+    }
+    try {
+        const transport::Endpoint endpoint{found->second.controlHost, found->second.controlPort};
+        const auto status = control_.Send(endpoint, command.payload.data(), command.payload.size());
+        if (status.Success()) { return TransmitCompleted{command.token, Status::OK()}; }
+        return TransmitCompleted{command.token, status};
+    } catch (...) {
+        return TransmitCompleted{command.token, Status::Error("TCP transmit threw an exception")};
+    }
+}
+
+Status TransportManagerBackend::Connect(const ::UC::Dram::Connect& command) noexcept
+{
+    if (command.transportManagerId.empty()) {
+        return Status::InvalidParam("remote TransportManager id is missing");
+    }
+    try {
+        auto status = manager_.ExchangeMetadata(command.transportManagerId);
+        if (status.Failure()) { return status; }
+        status = manager_.Connect(transport::TransportProtocol::Hixl, command.transportManagerId);
+        return status;
+    } catch (...) {
+        return Status::Error("TransportManager connect threw an exception");
+    }
+}
+
+Status TransportManagerBackend::Fence(const ::UC::Dram::FenceEpoch& command) noexcept
+{
+    const auto found = nodes_.find(command.nodeId);
+    if (found == nodes_.end()) { return Status::InvalidParam("unknown DramPool node"); }
+    try {
+        // The transport Manager contract guarantees that successful Disconnect
+        // synchronously revokes old-connection access to local registered memory.
+        return manager_.Disconnect(transport::TransportProtocol::Hixl,
+                                   found->second.transportManagerId);
+    } catch (...) {
+        return Status::Error("TransportManager disconnect threw an exception");
+    }
+}
+
+Status TransportManagerBackend::Stop() noexcept
+{
+    std::lock_guard lock(stopMutex_);
+    if (stopped_) { return Status::OK(); }
+    const auto controlStatus = control_.Shutdown();
+    const auto managerStatus = manager_.Shutdown();
+    stopped_ = true;
+    if (controlStatus.Failure()) { return controlStatus; }
+    return managerStatus;
+}
+
+Expected<std::shared_ptr<ITransportBackend>> CreateTransportManagerBackend(
+    TransportManagerBackendOptions options)
+{
+    auto backend =
+        std::shared_ptr<TransportManagerBackend>(new TransportManagerBackend(std::move(options)));
+    const auto status = backend->Init();
+    if (status.Failure()) { return status; }
+    std::shared_ptr<ITransportBackend> result = std::move(backend);
+    return result;
+}
+
+}  // namespace UC::Dram

--- a/ucm/store/dram/cc/transport_manager_backend.h
+++ b/ucm/store/dram/cc/transport_manager_backend.h
@@ -1,0 +1,87 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#ifndef UNIFIEDCACHE_DRAM_STORE_CC_TRANSPORT_MANAGER_BACKEND_H
+#define UNIFIEDCACHE_DRAM_STORE_CC_TRANSPORT_MANAGER_BACKEND_H
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "core/transport_manager.h"
+#include "transport_executor.h"
+#include "two_sided/tcp/tcp_message_channel.h"
+#include "types.h"
+
+namespace UC::Dram {
+
+struct TransportManagerBackendOptions {
+    std::string localControlHost;
+    std::uint16_t localControlPort{0};
+    std::string localTransportManagerId;
+    std::string localHost;
+    std::int32_t deviceId{0};
+    std::int32_t connectTimeoutMs{1000};
+    std::int32_t transferTimeoutMs{5000};
+    std::vector<NodeEndpoint> nodes;
+};
+
+Expected<std::shared_ptr<ITransportBackend>> CreateTransportManagerBackend(
+    TransportManagerBackendOptions options);
+
+class TransportManagerBackend final : public ITransportBackend {
+public:
+    ~TransportManagerBackend() override;
+
+    TransportManagerBackend(const TransportManagerBackend&) = delete;
+    TransportManagerBackend& operator=(const TransportManagerBackend&) = delete;
+
+    Expected<MemoryHandle> RegisterMemory(void* address, std::size_t length,
+                                          MemoryRegionType type) override;
+    Status UnregisterMemory(MemoryHandle handle) override;
+    TransmitCompleted Transmit(const ::UC::Dram::Transmit& command) noexcept override;
+    Status Connect(const ::UC::Dram::Connect& command) noexcept override;
+    Status Fence(const ::UC::Dram::FenceEpoch& command) noexcept override;
+    Status Stop() noexcept override;
+
+private:
+    friend Expected<std::shared_ptr<ITransportBackend>> CreateTransportManagerBackend(
+        TransportManagerBackendOptions options);
+
+    explicit TransportManagerBackend(TransportManagerBackendOptions options);
+    Status Init();
+
+    TransportManagerBackendOptions options_;
+    transport::Endpoint localControl_;
+    transport::TransportManager manager_;
+    transport::TcpMessageChannel control_;
+    std::unordered_map<NodeId, NodeEndpoint> nodes_;
+    std::mutex stopMutex_;
+    bool stopped_{false};
+};
+
+}  // namespace UC::Dram
+
+#endif  // UNIFIEDCACHE_DRAM_STORE_CC_TRANSPORT_MANAGER_BACKEND_H

--- a/ucm/store/test/case/detail/path_base.h
+++ b/ucm/store/test/case/detail/path_base.h
@@ -38,12 +38,18 @@ public:
         std::string testCaseName = info->test_case_name();
         std::string testName = info->name();
         this->path_ = "./" + testCaseName + "_" + testName + "_" + this->rd_.RandomString(20) + "/";
-        system((std::string("rm -rf ") + this->path_).c_str());
-        system((std::string("mkdir -p ") + this->path_).c_str());
+        if (system((std::string("rm -rf ") + this->path_).c_str())) {
+            FAIL() << "Failed to remove existing directory";
+        }
+        if (system((std::string("mkdir -p ") + this->path_).c_str())) {
+            FAIL() << "Failed to create test directory";
+        }
     }
     void TearDown() override
     {
-        system((std::string("rm -rf ") + this->path_).c_str());
+        if (system((std::string("rm -rf ") + this->path_).c_str())) {
+            FAIL() << "Failed to remove test directory";
+        }
         testing::Test::TearDown();
     }
     std::string Path() const { return this->path_; }

--- a/ucm/store/test/case/dram/dram_reply_service_polling_test.cc
+++ b/ucm/store/test/case/dram/dram_reply_service_polling_test.cc
@@ -1,0 +1,246 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <future>
+#include <gtest/gtest.h>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <vector>
+#include "reply_service.h"
+
+namespace UC::Dram {
+namespace {
+
+Status PackReply(const ReplySlot& slot, DramPool::KvOpcode opcode,
+                 std::vector<std::uint8_t> results)
+{
+    DramPool::ProtocolManager protocol;
+    return protocol.PackResponse(slot.local_addr, opcode, DramPool::KvResponse{std::move(results)});
+}
+
+class EventCollector final {
+public:
+    void Publish(NodeId node_id, NodeEvent event)
+    {
+        std::lock_guard lock(mutex_);
+        node_id_ = node_id;
+        event_ = std::move(event);
+        changed_.notify_all();
+    }
+
+    std::optional<NodeEvent> Wait(std::chrono::milliseconds timeout)
+    {
+        std::unique_lock lock(mutex_);
+        if (!changed_.wait_for(lock, timeout, [this] { return event_.has_value(); })) {
+            return std::nullopt;
+        }
+        return std::move(event_);
+    }
+
+    NodeId node_id() const
+    {
+        std::lock_guard lock(mutex_);
+        return node_id_;
+    }
+
+private:
+    mutable std::mutex mutex_;
+    std::condition_variable changed_;
+    NodeId node_id_{0};
+    std::optional<NodeEvent> event_;
+};
+
+TEST(ReplyServicePollingTest, PublishesObservedReplyAndKeepsLeaseUntilActorRelease)
+{
+    EventCollector collector;
+    auto created = ReplyService::Create(ReplyService::Options{
+        64,
+        1,
+        std::chrono::microseconds{50},
+        [&collector](NodeId node, NodeEvent event) { collector.Publish(node, std::move(event)); },
+    });
+    ASSERT_TRUE(created);
+    auto service = std::move(created).Value();
+    ASSERT_TRUE(service->Start().Success());
+
+    const RequestToken token{7, kDefaultLaneId, 9, 42};
+    auto acquired = service->Acquire(token, OpType::LOOKUP, 2);
+    ASSERT_TRUE(acquired);
+    auto slot = acquired.Value();
+    ASSERT_TRUE(PackReply(slot, DramPool::KvOpcode::Lookup, {1, 0}).Success());
+
+    auto event = collector.Wait(std::chrono::milliseconds{500});
+    ASSERT_TRUE(event.has_value());
+    ASSERT_TRUE(std::holds_alternative<ReplyObserved>(*event));
+    auto observed = std::get<ReplyObserved>(std::move(*event));
+    EXPECT_EQ(collector.node_id(), token.nodeId);
+    EXPECT_TRUE(observed.token == token);
+    EXPECT_TRUE(observed.status.Success());
+    EXPECT_EQ(observed.entryResults.size(), std::size_t{2});
+    EXPECT_TRUE(observed.entryResults[0].found);
+    EXPECT_FALSE(observed.entryResults[1].found);
+
+    // Observation does not free the slot. NodeActor releases it only after consuming
+    // this event, preserving the safe-terminal/fence rule without a generation field.
+    EXPECT_EQ(service->Available(), std::size_t{0});
+    EXPECT_TRUE(service->Release(token, slot).Success());
+    EXPECT_EQ(service->Available(), std::size_t{1});
+    EXPECT_TRUE(service->Shutdown().Success());
+}
+
+TEST(ReplyServicePollingTest, ReusesSlotWhilePreviousReplyEventIsBeingPublished)
+{
+    std::mutex mutex;
+    std::condition_variable changed;
+    bool firstPublishEntered = false;
+    bool allowFirstPublish = false;
+    std::vector<RequestToken> published;
+    const RequestToken firstToken{7, kDefaultLaneId, 9, 42};
+    const RequestToken secondToken{7, kDefaultLaneId, 9, 43};
+
+    auto created = ReplyService::Create(ReplyService::Options{
+        64,
+        1,
+        std::chrono::microseconds{50},
+        [&](NodeId, NodeEvent event) {
+            const auto& observed = std::get<ReplyObserved>(event);
+            std::unique_lock lock(mutex);
+            published.push_back(observed.token);
+            if (observed.token == firstToken) {
+                firstPublishEntered = true;
+                changed.notify_all();
+                changed.wait(lock, [&] { return allowFirstPublish; });
+            }
+            changed.notify_all();
+        },
+    });
+    ASSERT_TRUE(created);
+    auto service = std::move(created).Value();
+    ASSERT_TRUE(service->Start().Success());
+
+    auto first = service->Acquire(firstToken, OpType::LOOKUP, 1);
+    ASSERT_TRUE(first);
+    ASSERT_TRUE(PackReply(first.Value(), DramPool::KvOpcode::Lookup, {1}).Success());
+    bool publishEntered = false;
+    {
+        std::unique_lock lock(mutex);
+        publishEntered = changed.wait_for(lock, std::chrono::milliseconds{500},
+                                          [&] { return firstPublishEntered; });
+    }
+
+    auto firstRelease = Status::Error();
+    Expected<ReplySlot> second{Status::Error()};
+    auto secondPack = Status::Error();
+    if (publishEntered) {
+        firstRelease = service->Release(firstToken, first.Value());
+        second = service->Acquire(secondToken, OpType::LOOKUP, 1);
+        if (second) { secondPack = PackReply(second.Value(), DramPool::KvOpcode::Lookup, {1}); }
+    }
+
+    {
+        std::lock_guard lock(mutex);
+        allowFirstPublish = true;
+    }
+    changed.notify_all();
+
+    bool secondPublished = false;
+    if (secondPack.Success()) {
+        std::unique_lock lock(mutex);
+        secondPublished = changed.wait_for(lock, std::chrono::milliseconds{500}, [&] {
+            return std::find(published.begin(), published.end(), secondToken) != published.end();
+        });
+    }
+
+    Status cleanup = Status::OK();
+    if (second) {
+        cleanup = service->Release(secondToken, second.Value());
+    } else if (firstRelease.Failure()) {
+        cleanup = service->Release(firstToken, first.Value());
+    }
+    const auto shutdown = service->Shutdown();
+
+    EXPECT_TRUE(publishEntered);
+    EXPECT_TRUE(firstRelease.Success());
+    ASSERT_TRUE(second);
+    EXPECT_EQ(second.Value().slot_index, first.Value().slot_index);
+    EXPECT_TRUE(secondPack.Success());
+    EXPECT_TRUE(secondPublished);
+    EXPECT_TRUE(cleanup.Success());
+    EXPECT_TRUE(shutdown.Success());
+}
+
+TEST(ReplyServicePollingTest, RejectsShutdownWithActiveLease)
+{
+    auto created = ReplyService::Create(ReplyService::Options{
+        64,
+        1,
+        std::chrono::microseconds{50},
+        [](NodeId, NodeEvent) {},
+    });
+    ASSERT_TRUE(created);
+    auto service = std::move(created).Value();
+    ASSERT_TRUE(service->Start().Success());
+    auto acquired = service->Acquire(RequestToken{1, kDefaultLaneId, 1, 1}, OpType::LOOKUP, 1);
+    ASSERT_TRUE(acquired);
+    EXPECT_TRUE(service->Shutdown().Failure());
+}
+
+TEST(ReplyServicePollingTest, EventPublisherExceptionIsFatal)
+{
+    EXPECT_DEATH(
+        {
+            std::promise<void> publishAttempted;
+            auto publishAttemptedFuture = publishAttempted.get_future();
+            auto created = ReplyService::Create(ReplyService::Options{
+                64,
+                1,
+                std::chrono::microseconds{50},
+                [&publishAttempted](NodeId, NodeEvent) {
+                    publishAttempted.set_value();
+                    throw std::runtime_error("event receiver failed");
+                },
+            });
+            if (created) {
+                auto service = std::move(created).Value();
+                auto acquired =
+                    service->Start().Success()
+                        ? service->Acquire(RequestToken{3, kDefaultLaneId, 1, 9}, OpType::LOOKUP, 1)
+                        : Expected<ReplySlot>{Status::Error()};
+                if (acquired &&
+                    PackReply(acquired.Value(), DramPool::KvOpcode::Lookup, {1}).Success()) {
+                    publishAttemptedFuture.wait();
+                }
+                (void)service->Shutdown();
+            }
+        },
+        "");
+}
+
+}  // namespace
+}  // namespace UC::Dram

--- a/ucm/store/test/case/dram/dram_reply_service_test.cc
+++ b/ucm/store/test/case/dram/dram_reply_service_test.cc
@@ -1,0 +1,152 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <thread>
+#include <vector>
+#include "reply_service.h"
+
+namespace UC::Dram {
+namespace {
+
+constexpr std::uint32_t kSlotSize = 64;
+
+RequestToken Token(NodeId node, RequestId request)
+{
+    return RequestToken{node, kDefaultLaneId, 1, request};
+}
+
+Expected<std::unique_ptr<ReplyService>> CreateService(std::size_t slots,
+                                                      std::uint32_t slotSize = kSlotSize)
+{
+    return ReplyService::Create(ReplyService::Options{
+        slotSize,
+        slots,
+        std::chrono::microseconds{100},
+        [](NodeId, NodeEvent) {},
+    });
+}
+
+TEST(ReplyServiceTest, SharesSlotsAcrossRequestsAndValidatesOwnership)
+{
+    auto created = CreateService(3);
+    ASSERT_TRUE(created);
+    auto service = std::move(created).Value();
+    ASSERT_TRUE(service->Start().Success());
+
+    const auto first_token = Token(11, 1);
+    const auto second_token = Token(22, 2);
+    const auto third_token = Token(11, 3);
+    auto first = service->Acquire(first_token, OpType::LOOKUP, 1);
+    auto second = service->Acquire(second_token, OpType::DUMP, 1);
+    auto third = service->Acquire(third_token, OpType::LOAD, 1);
+    ASSERT_TRUE(first);
+    ASSERT_TRUE(second);
+    ASSERT_TRUE(third);
+    EXPECT_EQ(first.Value().slot_index, std::uint32_t{0});
+    EXPECT_EQ(second.Value().slot_index, std::uint32_t{1});
+    EXPECT_EQ(third.Value().slot_index, std::uint32_t{2});
+    EXPECT_NE(second.Value().local_addr, first.Value().local_addr);
+    const auto replyMemory = service->MemoryRegion();
+    const auto replyBegin = reinterpret_cast<std::uintptr_t>(replyMemory.address);
+    const auto secondAddress = reinterpret_cast<std::uintptr_t>(second.Value().local_addr);
+    EXPECT_GE(secondAddress, replyBegin);
+    EXPECT_LT(secondAddress, replyBegin + replyMemory.length);
+    EXPECT_EQ(second.Value().length, kSlotSize);
+    EXPECT_EQ(service->Available(), std::size_t{0});
+    auto exhausted = service->Acquire(Token(33, 4), OpType::LOOKUP, 1);
+    ASSERT_FALSE(exhausted);
+    EXPECT_EQ(exhausted.Error(), Status::Error());
+
+    EXPECT_EQ(service->Release(Token(22, 999), second.Value()), Status::InvalidParam());
+    EXPECT_EQ(service->Available(), std::size_t{0});
+    ASSERT_TRUE(service->Release(second_token, second.Value()).Success());
+
+    auto reused = service->Acquire(Token(33, 4), OpType::LOOKUP, 1);
+    ASSERT_TRUE(reused);
+    EXPECT_EQ(reused.Value().slot_index, second.Value().slot_index);
+    // No slot generation is required: the old token cannot release a slot after reuse.
+    EXPECT_EQ(service->Release(second_token, second.Value()), Status::InvalidParam());
+    EXPECT_TRUE(service->Release(Token(33, 4), reused.Value()).Success());
+    EXPECT_TRUE(service->Release(first_token, first.Value()).Success());
+    EXPECT_TRUE(service->Release(third_token, third.Value()).Success());
+    EXPECT_TRUE(service->Shutdown().Success());
+}
+
+TEST(ReplyServiceTest, RejectsReplyPayloadLargerThanSlot)
+{
+    auto created = CreateService(1, 1);
+    ASSERT_TRUE(created);
+    auto service = std::move(created).Value();
+    ASSERT_TRUE(service->Start().Success());
+    EXPECT_FALSE(service->Acquire(Token(1, 1), OpType::LOOKUP, 1));
+    EXPECT_TRUE(service->Shutdown().Success());
+}
+
+TEST(ReplyServiceTest, ShutdownStopsNewLeases)
+{
+    auto created = CreateService(1);
+    ASSERT_TRUE(created);
+    auto service = std::move(created).Value();
+    ASSERT_TRUE(service->Start().Success());
+    ASSERT_TRUE(service->Shutdown().Success());
+    EXPECT_FALSE(service->Acquire(Token(1, 1), OpType::LOOKUP, 1));
+}
+
+TEST(ReplyServiceTest, SupportsConcurrentLeases)
+{
+    constexpr std::size_t kSlotCount = 8;
+    constexpr std::size_t kOwnerCount = 8;
+    constexpr std::size_t kIterations = 1000;
+    auto created = CreateService(kSlotCount);
+    ASSERT_TRUE(created);
+    auto service = std::move(created).Value();
+    ASSERT_TRUE(service->Start().Success());
+
+    std::atomic<bool> failed{false};
+    std::vector<std::thread> owners;
+    owners.reserve(kOwnerCount);
+    for (std::size_t owner = 0; owner < kOwnerCount; ++owner) {
+        owners.emplace_back([&, owner] {
+            for (std::size_t iteration = 0; iteration < kIterations; ++iteration) {
+                const auto token = Token(owner + 1, owner * kIterations + iteration + 1);
+                auto slot = service->Acquire(token, OpType::LOOKUP, 1);
+                if (!slot || service->Release(token, slot.Value()).Failure()) {
+                    failed.store(true, std::memory_order_relaxed);
+                    return;
+                }
+            }
+        });
+    }
+    for (auto& owner : owners) { owner.join(); }
+
+    EXPECT_FALSE(failed.load(std::memory_order_relaxed));
+    EXPECT_EQ(service->Available(), kSlotCount);
+    EXPECT_TRUE(service->Shutdown().Success());
+}
+
+}  // namespace
+}  // namespace UC::Dram

--- a/ucm/store/test/case/dram/dram_transport_backend_test.cc
+++ b/ucm/store/test/case/dram/dram_transport_backend_test.cc
@@ -1,0 +1,205 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include "transport_executor.h"
+
+namespace UC::Dram {
+namespace {
+
+class MockTransportBackend final : public ITransportBackend {
+public:
+    Expected<MemoryHandle> RegisterMemory(void* address, std::size_t length,
+                                          MemoryRegionType) override
+    {
+        if (address == nullptr || length == 0) {
+            return Status::InvalidParam("invalid memory registration");
+        }
+        auto handle = nextRegistration_.fetch_add(1, std::memory_order_relaxed);
+        if (handle == 0) { return Status::Error("memory handle exhausted"); }
+        return handle;
+    }
+
+    Status UnregisterMemory(MemoryHandle handle) override
+    {
+        return handle == 0 ? Status::InvalidParam("invalid memory registration handle")
+                           : Status::OK();
+    }
+
+    TransmitCompleted Transmit(const ::UC::Dram::Transmit& command) noexcept override
+    {
+        return TransmitCompleted{
+            command.token, Status::Error("no production DramStore transport backend is installed")};
+    }
+
+    Status Connect(const ::UC::Dram::Connect& command) noexcept override
+    {
+        return command.transportManagerId.empty()
+                   ? Status::InvalidParam("remote TransportManager id is missing")
+                   : Status::OK();
+    }
+    Status Fence(const ::UC::Dram::FenceEpoch&) noexcept override { return Status::OK(); }
+    Status Stop() noexcept override { return Status::OK(); }
+
+private:
+    std::atomic<MemoryHandle> nextRegistration_{1};
+};
+
+std::shared_ptr<ITransportBackend> CreateMockTransportBackend()
+{
+    return std::make_shared<MockTransportBackend>();
+}
+
+std::string TestManagerId(std::uint16_t port) { return "127.0.0.1:" + std::to_string(port); }
+
+TEST(TransportBackendTest, ConnectionRequiresTransportManagerId)
+{
+    auto backend = CreateMockTransportBackend();
+    Connect command{1, kDefaultLaneId, 1, TestManagerId(1234)};
+    EXPECT_TRUE(backend->Connect(command).Success());
+    command.transportManagerId.clear();
+    EXPECT_EQ(backend->Connect(command), Status::InvalidParam());
+}
+
+TEST(TransportBackendTest, RegistrationReturnsOpaqueHandle)
+{
+    auto backend = CreateMockTransportBackend();
+    std::uint32_t memory = 0;
+    auto registration = backend->RegisterMemory(&memory, sizeof(memory), MemoryRegionType::HOST);
+    ASSERT_TRUE(registration);
+    EXPECT_NE(registration.Value(), MemoryHandle{0});
+    EXPECT_TRUE(backend->UnregisterMemory(registration.Value()).Success());
+}
+
+TEST(TransportExecutorTest, PublisherIsConstructorDependency)
+{
+    TransportExecutor invalid(
+        TransportExecutor::Options{1, 1, 1, CreateMockTransportBackend(), {}});
+    EXPECT_TRUE(invalid.Start().Failure());
+
+    TransportExecutor executor(TransportExecutor::Options{1, 1, 1, CreateMockTransportBackend(),
+                                                          [](NodeId, NodeEvent) {}});
+    ASSERT_TRUE(executor.Start().Success());
+    EXPECT_TRUE(executor.Shutdown().Success());
+}
+
+TEST(TransportExecutorTest, ShutdownStopsNewCommands)
+{
+    TransportExecutor executor(TransportExecutor::Options{1, 1, 1, CreateMockTransportBackend(),
+                                                          [](NodeId, NodeEvent) {}});
+    ASSERT_TRUE(executor.Start().Success());
+    ASSERT_TRUE(executor.Shutdown().Success());
+
+    TransportCommand command{
+        Connect{1, kDefaultLaneId, 1, TestManagerId(1234)}
+    };
+    EXPECT_TRUE(executor.TryPost(command).Failure());
+}
+
+TEST(TransportExecutorTest, EventPublisherExceptionIsFatal)
+{
+    EXPECT_DEATH(
+        {
+            TransportExecutor executor(TransportExecutor::Options{
+                1, 1, 1, CreateMockTransportBackend(),
+                [](NodeId, NodeEvent) { throw std::runtime_error("event receiver failed"); }});
+            (void)executor.Start();
+            TransportCommand command(Connect{1, kDefaultLaneId, 1, TestManagerId(1234)});
+            (void)executor.TryPost(command);
+            (void)executor.Shutdown();
+        },
+        "");
+}
+
+TEST(TransportExecutorTest, RequestLimitsDeriveSeparateCommandAndFenceBudgets)
+{
+    std::mutex mutex;
+    std::condition_variable changed;
+    bool publisherEntered = false;
+    bool releasePublisher = false;
+    TransportExecutor executor(
+        TransportExecutor::Options{1, 1, 1, CreateMockTransportBackend(), [&](NodeId, NodeEvent) {
+                                       std::unique_lock lock(mutex);
+                                       publisherEntered = true;
+                                       changed.notify_all();
+                                       changed.wait(lock, [&] { return releasePublisher; });
+                                   }});
+    ASSERT_TRUE(executor.Start().Success());
+
+    TransportCommand executing{
+        Connect{1, kDefaultLaneId, 1, TestManagerId(1234)}
+    };
+    ASSERT_TRUE(executor.TryPost(executing).Success());
+    bool entered = false;
+    {
+        std::unique_lock lock(mutex);
+        entered = changed.wait_for(lock, std::chrono::seconds{1}, [&] { return publisherEntered; });
+    }
+
+    TransportCommand firstCommand{
+        Connect{1, kDefaultLaneId, 2, TestManagerId(1234)}
+    };
+    TransportCommand secondCommand{
+        Connect{1, kDefaultLaneId, 3, TestManagerId(1234)}
+    };
+    TransportCommand commandOverflow{
+        Connect{1, kDefaultLaneId, 4, TestManagerId(1234)}
+    };
+    TransportCommand fence{
+        FenceEpoch{1, kDefaultLaneId, 1}
+    };
+    TransportCommand fenceOverflow{
+        FenceEpoch{1, kDefaultLaneId, 2}
+    };
+    const auto firstStatus = executor.TryPost(firstCommand);
+    const auto secondStatus = executor.TryPost(secondCommand);
+    const auto commandOverflowStatus = executor.TryPost(commandOverflow);
+    const auto fenceStatus = executor.TryPost(fence);
+    const auto fenceOverflowStatus = executor.TryPost(fenceOverflow);
+
+    {
+        std::lock_guard lock(mutex);
+        releasePublisher = true;
+    }
+    changed.notify_all();
+
+    EXPECT_TRUE(entered);
+    EXPECT_TRUE(firstStatus.Success());
+    EXPECT_TRUE(secondStatus.Success());
+    EXPECT_EQ(commandOverflowStatus, Status::Error());
+    EXPECT_TRUE(fenceStatus.Success());
+    EXPECT_EQ(fenceOverflowStatus, Status::Error());
+    EXPECT_TRUE(executor.Shutdown().Success());
+}
+
+}  // namespace
+}  // namespace UC::Dram

--- a/ucm/store/test/case/posix/posix_file_test.cc
+++ b/ucm/store/test/case/posix/posix_file_test.cc
@@ -30,7 +30,9 @@ class UCPosixFileTest : public UC::Test::Detail::PathBase {};
 TEST_F(UCPosixFileTest, DirCreateAndRemove)
 {
     using namespace UC::PosixStore;
-    system((std::string("rm -rf ") + this->Path()).c_str());
+    if (system((std::string("rm -rf ") + this->Path()).c_str())) {
+        FAIL() << "Failed to remove existing directory";
+    }
     PosixFile dir(this->Path());
     ASSERT_EQ(dir.Access(PosixFile::AccessMode::EXIST), UC::Status::NotFound());
     ASSERT_EQ(dir.MkDir(), UC::Status::OK());

--- a/ucm/transport/p2p/src/two_sided/tcp/tcp_message_channel.cpp
+++ b/ucm/transport/p2p/src/two_sided/tcp/tcp_message_channel.cpp
@@ -357,7 +357,7 @@ void TcpMessageChannel::HandleConnectionEvent(int epoll_fd, std::unordered_set<S
         receive_status = ReceiveAvailableFrames(socket, it->second.receive_buffer, frames,
                                                 kMaxFrameSize, closed);
     }
-    if (receive_status != Status::OK() || closed) {
+    if (receive_status != Status::OK()) {
         RemoveConnection(epoll_fd, registered, socket);
         return;
     }
@@ -384,7 +384,7 @@ void TcpMessageChannel::HandleConnectionEvent(int epoll_fd, std::unordered_set<S
         }
         receive_cv_.notify_one();
     }
-    if (drop_socket) { RemoveConnection(epoll_fd, registered, socket); }
+    if (closed || drop_socket) { RemoveConnection(epoll_fd, registered, socket); }
 }
 
 void TcpMessageChannel::RemoveConnection(int epoll_fd, std::unordered_set<Socket>& registered,


### PR DESCRIPTION
## Purpose
Add trans executor & reply poller for dramstore:
- TransportExecutor — a sharded, bounded-queue worker pool that drives the backend and publishes completion events, with separate command/fence admission budgets per node.
- ReplyService — the single owner of reply-slot allocation and polling; decodes DramPool responses and publishes ReplyObserved events, releasing a slot only at a safe terminal point.

## Modifications 

## Test
tested on mocked ibverbs