### PR TITLE
Fix model path issue in ucm_connector.py. 

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -835,7 +835,7 @@ class RequestHasher:
         sparse_sfa_c8 = bool(additional_config.get("enable_sparse_sfa_c8", False))
         sparse_li_c8 = bool(additional_config.get("enable_sparse_li_c8", False))
         sparse_c8_info = f":sfa_c8={int(sparse_sfa_c8)}:li_c8={int(sparse_li_c8)}"
-        model_name=vllm_config.model_config.model.split('/')[-1]
+        model_name = vllm_config.model_config.model.split("/")[-1]
         meta = (
             f"{model_name}:"
             f"{vllm_config.parallel_config.tensor_parallel_size}:"

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -835,8 +835,9 @@ class RequestHasher:
         sparse_sfa_c8 = bool(additional_config.get("enable_sparse_sfa_c8", False))
         sparse_li_c8 = bool(additional_config.get("enable_sparse_li_c8", False))
         sparse_c8_info = f":sfa_c8={int(sparse_sfa_c8)}:li_c8={int(sparse_li_c8)}"
+        model_name=vllm_config.model_config.model.split('/')[-1]
         meta = (
-            f"{vllm_config.model_config.model}:"
+            f"{model_name}:"
             f"{vllm_config.parallel_config.tensor_parallel_size}:"
             f"{vllm_config.model_config.dtype}:{rank_id}{spec_info}{sparse_c8_info}"
         )

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -835,7 +835,7 @@ class RequestHasher:
         sparse_sfa_c8 = bool(additional_config.get("enable_sparse_sfa_c8", False))
         sparse_li_c8 = bool(additional_config.get("enable_sparse_li_c8", False))
         sparse_c8_info = f":sfa_c8={int(sparse_sfa_c8)}:li_c8={int(sparse_li_c8)}"
-        model_name = vllm_config.model_config.model.split("/")[-1]
+        model_name = vllm_config.model_config.model.rstrip("/").split("/")[-1]
         meta = (
             f"{model_name}:"
             f"{vllm_config.parallel_config.tensor_parallel_size}:"

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -838,7 +838,6 @@ class RequestHasher:
         model_name = vllm_config.model_config.model.split("/")[-1]
         meta = (
             f"{model_name}:"
-            f"{model_name}:"
             f"{vllm_config.parallel_config.tensor_parallel_size}:"
             f"{vllm_config.model_config.dtype}:{rank_id}{spec_info}{sparse_c8_info}"
         )


### PR DESCRIPTION
## Modifications 
The original configuration caused different cache hashes for the same model when loaded from different paths. After the fix, the specific path is decoupled; as long as the final model name in the path is identical, the hash is considered consistent, and the cache is stored in the same location.

## Test
test on cuda Qwen2.5 succeed