### PR TITLE
[Feat] Trigger connection recovery after maxErrorCount consecutive failures

### DIFF
--- a/examples/ucm_config_asu.yaml
+++ b/examples/ucm_config_asu.yaml
@@ -31,9 +31,10 @@ ucm_connectors:
       # asu_fake_backend_path: "./asu-fake-backend-store"
       # asu_fake_backend_latency_ms: 1
 
-      # ASU wait and operation timeouts.
+      # ASU wait, operation timeout, and connection recovery.
       asu_default_wait_timeout_ms: 5000
       asu_timeout_ms: 5000
+      asu_max_error_count: 2
       asu_max_inflight_tasks: 1024
 
 enable_event_sync: true

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -173,6 +173,7 @@ UC::ASU::TransportConfig BuildTransportConfig(const Config& config, std::size_t 
     transportConfig.asuName = config.asuNamePrefix + "-" + std::to_string(config.asuIds[index]);
     transportConfig.deviceId = config.deviceId;
     transportConfig.timeoutMs = config.timeoutMs;
+    transportConfig.maxErrorCount = static_cast<std::uint32_t>(config.maxErrorCount);
     transportConfig.maxInflightTasks = static_cast<std::uint32_t>(config.maxInflightTasks);
     transportConfig.maxInflightBytes = config.maxInflightBytes;
     transportConfig.providerType = config.transProviderType;
@@ -469,6 +470,7 @@ private:
         }
         inConfig.GetNumber("asu_default_wait_timeout_ms", config.defaultWaitTimeoutMs);
         inConfig.GetNumber("asu_timeout_ms", config.timeoutMs);
+        inConfig.GetNumber("asu_max_error_count", config.maxErrorCount);
         inConfig.GetNumber("asu_max_inflight_tasks", config.maxInflightTasks);
         inConfig.GetNumber("asu_max_inflight_bytes", config.maxInflightBytes);
         inConfig.GetNumber("shard_size", config.shardSize);
@@ -585,6 +587,10 @@ private:
         }
         if (!config.role.empty() && config.role != "scheduler" && config.role != "worker") {
             return Status::InvalidParam("invalid role({})", config.role);
+        }
+        if (config.maxErrorCount == 0 ||
+            config.maxErrorCount > std::numeric_limits<std::uint32_t>::max()) {
+            return Status::InvalidParam("asu_max_error_count must be in uint32 range and nonzero");
         }
         if (config.maxInflightTasks > std::numeric_limits<std::uint32_t>::max()) {
             return Status::InvalidParam("asu_max_inflight_tasks exceeds uint32 range");

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -24,6 +24,7 @@ struct Config {
     std::uint16_t asuPort{0};
     std::uint64_t defaultWaitTimeoutMs{100};
     std::uint64_t timeoutMs{100};
+    std::uint64_t maxErrorCount{2};
     std::uint64_t maxInflightTasks{1024};
     std::uint64_t maxInflightBytes{1ULL << 30};
     std::vector<std::size_t> tensorSizes;

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -333,6 +333,21 @@ TEST(UCAsuStoreTest, ParsesOperationTimeout)
     EXPECT_EQ(transportConfig.timeoutMs, 321);
 }
 
+TEST(UCAsuStoreTest, PropagatesMaxErrorCountToTransport)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeBackend(store);
+    auto config = MakeBaseConfig();
+    config.SetNumber("asu_max_error_count", std::uint64_t{7});
+
+    ASSERT_TRUE(store.Setup(config).Success());
+    ASSERT_FALSE(state->initConfigs.empty());
+    EXPECT_EQ(state->initConfigs.back().maxErrorCount, std::uint64_t{7});
+
+    auto transportConfig = UC::AsuStore::BuildTransportConfig(state->initConfigs.back(), 0);
+    EXPECT_EQ(transportConfig.maxErrorCount, std::uint32_t{7});
+}
+
 TEST(UCAsuStoreTest, RejectsMissingKvNamespaces)
 {
     UC::AsuStore::AsuStore store;
@@ -380,6 +395,23 @@ TEST(UCAsuStoreTest, RejectsInvalidAsuPort)
 
 TEST(UCAsuStoreTest, RejectsTransportIntegerOverflow)
 {
+    {
+        UC::AsuStore::AsuStore store;
+        auto config = MakeBaseConfig();
+        config.Set("asu_ids", std::vector<ssize_t>{1001});
+        config.SetNumber("asu_max_error_count", std::uint64_t{0});
+
+        EXPECT_TRUE(store.Setup(config).Failure());
+    }
+    {
+        UC::AsuStore::AsuStore store;
+        auto config = MakeBaseConfig();
+        config.Set("asu_ids", std::vector<ssize_t>{1001});
+        config.SetNumber("asu_max_error_count",
+                         std::uint64_t{std::numeric_limits<std::uint32_t>::max()} + 1);
+
+        EXPECT_TRUE(store.Setup(config).Failure());
+    }
     {
         UC::AsuStore::AsuStore store;
         auto config = MakeBaseConfig();

--- a/ucm/transport/kv/asu/client/src/client_config_parser.cpp
+++ b/ucm/transport/kv/asu/client/src/client_config_parser.cpp
@@ -143,6 +143,11 @@ Status LoadAsuClientConfig(const std::string& configPath, AsuClientConfig& confi
             if (ApplyTransportDeviceConfigField(transportConfig, field.first, field.second)) {
                 continue;
             }
+            if (field.first == "maxErrorCount" || field.first == "max_error_count") {
+                transportConfig.maxErrorCount =
+                    static_cast<std::uint32_t>(ParseConfigUint64(field.second));
+                continue;
+            }
             transportConfig.attrs.emplace(field);
         }
 

--- a/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
@@ -615,6 +615,7 @@ TEST(AsuClientImplTest, Lifecycle_PublicInitLoadsClientConfigFile)
         configFile << "transport.delete_io_num=13\n";
         configFile << "transport.query_io_num=14\n";
         configFile << "transport.device_id=6\n";
+        configFile << "transport.max_error_count=5\n";
         configFile << "asuInfo.20=protocol=roce,placement=device,port=6000,"
                    << "local.comm_id=192.168.1.20\n";
     }
@@ -639,6 +640,7 @@ TEST(AsuClientImplTest, Lifecycle_PublicInitLoadsClientConfigFile)
         EXPECT_EQ(state->initConfigs[asuId].asuBatchStoreIoNum, std::size_t{12});
         EXPECT_EQ(state->initConfigs[asuId].asuDeleteIoNum, std::size_t{13});
         EXPECT_EQ(state->initConfigs[asuId].asuQueryIoNum, std::size_t{14});
+        EXPECT_EQ(state->initConfigs[asuId].maxErrorCount, std::uint32_t{5});
     }
 }
 

--- a/ucm/transport/kv/asu/test/case/connection_manager_test.cc
+++ b/ucm/transport/kv/asu/test/case/connection_manager_test.cc
@@ -23,9 +23,11 @@
  * */
 #include "connection_manager.h"
 #include <atomic>
+#include <chrono>
 #include <cstdint>
 #include <gtest/gtest.h>
 #include <set>
+#include <thread>
 #include <vector>
 #include "connection_internal.h"
 #include "trans_provider.h"
@@ -113,6 +115,7 @@ TEST(ConnectionChannelTest, InitialStateIsActiveWithZeroCounters)
 
     EXPECT_EQ(ch.GetState(), ChannelState::ACTIVE);
     EXPECT_EQ(ch.GetInflightCount(), 0u);
+    EXPECT_EQ(ch.GetErrorCount(), 0u);
     EXPECT_EQ(ch.GetChannelId(), 0u);
     EXPECT_EQ(ch.GetGroup(), &group);
     EXPECT_EQ(ch.GetConnection(), handle);
@@ -145,6 +148,19 @@ TEST(ConnectionChannelTest, FetchAddErrorCountAccumulates)
 
     old = ch.FetchAddErrorCount(3);
     EXPECT_EQ(old, 2u);
+}
+
+TEST(ConnectionChannelTest, ErrorCountAccumulatesAndResets)
+{
+    ConnectionGroup group(0, MakeEndpoint());
+    ConnectionChannel ch(0, &group, nullptr, nullptr);
+
+    EXPECT_EQ(ch.FetchAddErrorCount(1), 0u);
+    EXPECT_EQ(ch.FetchAddErrorCount(1), 1u);
+    EXPECT_EQ(ch.GetErrorCount(), 2u);
+
+    ch.ResetErrorCount();
+    EXPECT_EQ(ch.GetErrorCount(), 0u);
 }
 
 TEST(ConnectionChannelTest, MarkForDrainTransitionsActiveToDraining)
@@ -376,6 +392,72 @@ TEST(ConnectionManagerTest, ReportFailureAtThresholdMarksForDrain)
     mgr.ReportFailure(ch);
     mgr.ReportFailure(ch);
     EXPECT_EQ(ch->GetState(), ChannelState::DRAINING);
+}
+
+TEST(ConnectionManagerTest, ReportFailureUsesConfiguredThreshold)
+{
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000, 3);
+    ASSERT_TRUE(mgr.AddGroup(MakeEndpoint(), 1).ok());
+
+    auto ch = mgr.SelectConnection();
+    ASSERT_NE(ch, nullptr);
+
+    mgr.ReportFailure(ch);
+    mgr.ReportFailure(ch);
+    EXPECT_EQ(ch->GetErrorCount(), 2u);
+    EXPECT_EQ(ch->GetState(), ChannelState::ACTIVE);
+
+    mgr.ReportFailure(ch);
+    EXPECT_EQ(ch->GetErrorCount(), 3u);
+    EXPECT_EQ(ch->GetState(), ChannelState::DRAINING);
+}
+
+TEST(ConnectionManagerTest, SuccessfulCompletionResetsErrorCount)
+{
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000, 3);
+    ASSERT_TRUE(mgr.AddGroup(MakeEndpoint(), 1).ok());
+
+    auto ch = mgr.SelectConnection();
+    ASSERT_NE(ch, nullptr);
+
+    mgr.ReportFailure(ch);
+    mgr.ReportFailure(ch);
+    mgr.ReportSuccess(ch);
+    EXPECT_EQ(ch->GetErrorCount(), 0u);
+
+    mgr.ReportFailure(ch);
+    mgr.ReportFailure(ch);
+    EXPECT_EQ(ch->GetState(), ChannelState::ACTIVE);
+}
+
+TEST(ConnectionManagerTest, FailureThresholdRecreatesConnection)
+{
+    g_createCount = 0;
+    g_deleteCount = 0;
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000, 1);
+    ASSERT_TRUE(mgr.AddGroup(MakeEndpoint(), 1).ok());
+    mgr.StartRecoverLoop();
+
+    auto oldChannel = mgr.SelectConnection();
+    ASSERT_NE(oldChannel, nullptr);
+    oldChannel->ReleaseInflight();
+    mgr.ReportFailure(oldChannel);
+    oldChannel.reset();
+
+    std::shared_ptr<ConnectionChannel> newChannel;
+    for (std::uint32_t attempt = 0; attempt < 100 && newChannel == nullptr; ++attempt) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        newChannel = mgr.GetActiveConnection();
+    }
+    mgr.StopRecoverLoop();
+
+    ASSERT_NE(newChannel, nullptr);
+    EXPECT_EQ(newChannel->GetChannelId(), std::uint32_t{1});
+    EXPECT_EQ(g_createCount.load(), 2);
+    EXPECT_EQ(g_deleteCount.load(), 1);
 }
 
 TEST(ConnectionManagerTest, ShutdownClearsAllResources)

--- a/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
@@ -65,6 +65,7 @@ struct TransportConfig {
     std::uint32_t maxStoreInflight{256};
 
     std::uint64_t timeoutMs{100};
+    std::uint32_t maxErrorCount{2};
 
     bool enableDeviceDirect{true};
     bool enableHostFallback{false};

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -139,6 +139,9 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
         return Status::OK();
     }
     config_ = config;
+    if (config_.maxErrorCount == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "maxErrorCount must be greater than 0");
+    }
     ioScheduler_ = IoScheduler(config_);
 
     if (!transProvider_) {
@@ -193,7 +196,8 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
     }
 
     connManager_.reset();
-    connManager_ = std::make_unique<ConnectionManager>(*transProvider_, localIp, timeout);
+    connManager_ = std::make_unique<ConnectionManager>(*transProvider_, localIp, timeout,
+                                                       config_.maxErrorCount);
 
     std::uint32_t qp_num = config_.queryQpNum + config_.loadQpNum + config_.storeQpNum;
     UC_DEBUG("AsuTransportImpl::Init endpoints={} qp_num={}", config_.endpoints.size(), qp_num);
@@ -663,6 +667,7 @@ void AsuTransportImpl::PollTaskCompletions(const TransportTaskContextPtr& ctx)
 
                 std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(),
                           timeoutStatus);
+                connManager_->ReportFailure(subBatchContext.channel);
                 CompleteSubBatch(*ctx, subBatchContext, timeoutStatus);
             }
             ctx->finalStatus = timeoutStatus;
@@ -742,6 +747,8 @@ void AsuTransportImpl::PollTaskCompletions(const TransportTaskContextPtr& ctx)
                 if (status.code == StatusCode::ASU_CQE_INTERNAL_ERROR ||
                     status.code == StatusCode::ASU_CQE_IO_TIMEOUT) {
                     connManager_->ReportFailure(subBatchContext.channel);
+                } else {
+                    connManager_->ReportSuccess(subBatchContext.channel);
                 }
                 CompleteSubBatch(*ctx, subBatchContext, status);
             }

--- a/ucm/transport/kv/asu/trans/src/connection_internal.cpp
+++ b/ucm/transport/kv/asu/trans/src/connection_internal.cpp
@@ -52,6 +52,13 @@ std::uint32_t ConnectionChannel::FetchAddErrorCount(std::uint32_t val)
     return errorCount.fetch_add(val, std::memory_order_relaxed);
 }
 
+std::uint32_t ConnectionChannel::GetErrorCount() const
+{
+    return errorCount.load(std::memory_order_relaxed);
+}
+
+void ConnectionChannel::ResetErrorCount() { errorCount.store(0, std::memory_order_relaxed); }
+
 void ConnectionChannel::IncrementInflight()
 {
     inflightCount.fetch_add(1, std::memory_order_acq_rel);

--- a/ucm/transport/kv/asu/trans/src/connection_internal.h
+++ b/ucm/transport/kv/asu/trans/src/connection_internal.h
@@ -54,6 +54,8 @@ public:
     TransProvider::ConnectionHandle GetConnection() const { return handle_; }
 
     std::uint32_t FetchAddErrorCount(std::uint32_t val);
+    std::uint32_t GetErrorCount() const;
+    void ResetErrorCount();
 
     // Test helper to set state directly
     void SetState(ChannelState s) { state.store(s, std::memory_order_release); }

--- a/ucm/transport/kv/asu/trans/src/connection_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/connection_manager.cpp
@@ -30,8 +30,8 @@
 namespace UC::ASU {
 
 ConnectionManager::ConnectionManager(TransProvider& provider, const std::string& localIp,
-                                     std::uint32_t timeout)
-    : provider_(provider), localIp_(localIp), timeout_(timeout)
+                                     std::uint32_t timeout, std::uint32_t maxErrorCount)
+    : provider_(provider), localIp_(localIp), timeout_(timeout), maxErrorCount_(maxErrorCount)
 {
 }
 
@@ -131,18 +131,19 @@ void ConnectionManager::ReportFailure(const std::shared_ptr<ConnectionChannel>& 
 {
     if (channel == nullptr) { return; }
     if (shuttingDown_.load(std::memory_order_acquire)) { return; }
-    auto old_count = channel->FetchAddErrorCount(1);
+    auto oldCount = channel->FetchAddErrorCount(1);
     UC_DEBUG("ConnectionManager::ReportFailure ch_id={} group_id={} error_count={} threshold={}",
-             channel->GetChannelId(), channel->GetGroup()->GetGroupId(), old_count + 1,
-             kFailureThreshold);
-    if (old_count + 1 < kFailureThreshold) {
+             channel->GetChannelId(), channel->GetGroup()->GetGroupId(), oldCount + 1,
+             maxErrorCount_);
+    if (oldCount + 1 < maxErrorCount_) {
         UC_DEBUG("ConnectionManager::ReportFailure below threshold, skip drain");
         return;
     }
 
     if (!channel->MarkForDrain()) {
         UC_DEBUG(
-            "ConnectionManager::ReportFailure MarkForDrain CAS failed (already draining/failed)");
+            "ConnectionManager::ReportFailure MarkForDrain CAS failed "
+            "(already draining/failed)");
         return;
     }
 
@@ -157,6 +158,12 @@ void ConnectionManager::ReportFailure(const std::shared_ptr<ConnectionChannel>& 
         }
         drainList_.push_back(channel);
     }
+}
+
+void ConnectionManager::ReportSuccess(const std::shared_ptr<ConnectionChannel>& channel)
+{
+    if (channel == nullptr) { return; }
+    channel->ResetErrorCount();
 }
 
 void ConnectionManager::StartRecoverLoop()

--- a/ucm/transport/kv/asu/trans/src/connection_manager.h
+++ b/ucm/transport/kv/asu/trans/src/connection_manager.h
@@ -52,7 +52,8 @@ struct ScatterGatherEntry;
 
 class ConnectionManager {
 public:
-    ConnectionManager(TransProvider& provider, const std::string& localIp, std::uint32_t timeout);
+    ConnectionManager(TransProvider& provider, const std::string& localIp, std::uint32_t timeout,
+                      std::uint32_t maxErrorCount = 2);
     ~ConnectionManager();
 
     Status AddGroup(const AsuEndpoint& endpoint, std::uint32_t qp_num);
@@ -62,6 +63,7 @@ public:
     std::shared_ptr<ConnectionChannel> GetActiveConnection();
     void SetRoutingPolicy(RoutingPolicy policy);
     void ReportFailure(const std::shared_ptr<ConnectionChannel>& channel);
+    void ReportSuccess(const std::shared_ptr<ConnectionChannel>& channel);
 
     void StartRecoverLoop();
     void StopRecoverLoop();
@@ -81,7 +83,6 @@ private:
     std::atomic<std::uint32_t> rrIndex_{0};
     RoutingPolicy routingPolicy_{RoutingPolicy::ROUND_ROBIN};
     static constexpr std::uint32_t kMaxInflightPerChannel = 256;
-    static constexpr std::uint32_t kFailureThreshold = 2;
     static constexpr std::uint64_t kRecoverIntervalMs = 100;
 
     std::thread recoverWorker_;
@@ -93,6 +94,7 @@ private:
     TransProvider& provider_;
     std::string localIp_;
     std::uint32_t timeout_;
+    std::uint32_t maxErrorCount_;
 
     void RecoverLoop();
     void RebuildChannelCache();

--- a/ucm/transport/kv/asu/trans/src/transport_config_parser.cpp
+++ b/ucm/transport/kv/asu/trans/src/transport_config_parser.cpp
@@ -151,6 +151,8 @@ Status LoadTransportConfig(const std::string& configPath, TransportConfig& confi
             }
         } else if (key == "timeoutMs" || key == "timeout_ms") {
             config.timeoutMs = ParseConfigUint64(value);
+        } else if (key == "maxErrorCount" || key == "max_error_count") {
+            config.maxErrorCount = static_cast<std::uint32_t>(ParseConfigUint64(value));
         } else if (key == "maxInflightTasks" || key == "max_inflight_tasks") {
             config.maxInflightTasks = static_cast<std::uint32_t>(ParseConfigUint64(value));
         } else if (key == "maxInflightBytes" || key == "max_inflight_bytes") {

--- a/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/sqe_request_test.cpp
@@ -24,7 +24,9 @@
 #include <acl/acl.h>
 #include <algorithm>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
+#include <fstream>
 #include <gtest/gtest.h>
 #include <memory>
 #include <string>
@@ -42,6 +44,23 @@
 namespace UC::ASU {
 
 namespace {
+
+TEST(TransportConfigParserTest, LoadsMaxErrorCount)
+{
+    constexpr const char* kConfigPath = "asu_transport_max_error_count_test.conf";
+    {
+        std::ofstream configFile{kConfigPath};
+        ASSERT_TRUE(configFile.is_open());
+        configFile << "max_error_count=7\n";
+    }
+
+    TransportConfig config;
+    auto status = LoadTransportConfig(kConfigPath, config);
+    std::remove(kConfigPath);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(config.maxErrorCount, std::uint32_t{7});
+}
 
 CacheKey MakeCacheKey(std::string_view text)
 {

--- a/ucm/transport/kv/asu/trans/test/transport_task_completion_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/transport_task_completion_test.cpp
@@ -114,6 +114,16 @@ protected:
     std::unique_ptr<AsuTransportImpl> transport_;
 };
 
+TEST_F(TransportTaskCompletionTest, InitRejectsZeroMaxErrorCount)
+{
+    TransportConfig config;
+    config.maxErrorCount = 0;
+
+    const auto status = transport_->Init(config);
+
+    EXPECT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
+}
+
 TEST_F(TransportTaskCompletionTest, InitializeCountsAlreadyTerminalSubBatches)
 {
     TransportTaskContext ctx;
@@ -170,6 +180,12 @@ TEST_F(TransportTaskCompletionTest, PollTaskCompletionsReadsDeviceFlagBuffer)
                           kTestBufferSlotNum, provider)
                     .ok());
     deviceTransport.protocolManager_ = std::make_unique<ProtocolManager>();
+    deviceTransport.connManager_ = std::make_unique<ConnectionManager>(*provider, "", 5000, 2);
+    ASSERT_TRUE(deviceTransport.connManager_->AddGroup(AsuEndpoint{}, 1).ok());
+    auto channel = deviceTransport.connManager_->SelectConnection();
+    ASSERT_NE(channel, nullptr);
+    deviceTransport.connManager_->ReportFailure(channel);
+    ASSERT_EQ(channel->GetErrorCount(), std::uint32_t{1});
 
     auto ctx = std::make_shared<TransportTaskContext>();
     ctx->state.store(TransportTaskState::INFLIGHT, std::memory_order_release);
@@ -180,6 +196,7 @@ TEST_F(TransportTaskCompletionTest, PollTaskCompletionsReadsDeviceFlagBuffer)
     subBatchContext.cid = 123;
     subBatchContext.opType = TransportOpType::BATCH_STORE;
     subBatchContext.entryStatus.assign(2, Status::OK());
+    subBatchContext.channel = channel;
     ASSERT_TRUE(
         deviceTransport.flagBufferManager_
             .Allocate((kCqeDwordCount + 1) * sizeof(std::uint32_t), subBatchContext.flagBuffer)
@@ -204,10 +221,52 @@ TEST_F(TransportTaskCompletionTest, PollTaskCompletionsReadsDeviceFlagBuffer)
     EXPECT_TRUE(subBatchContext.entryStatus[0].ok());
     EXPECT_TRUE(subBatchContext.entryStatus[1].ok());
     EXPECT_EQ(subBatchContext.flagBuffer.slot_index, UINT32_MAX);
+    EXPECT_EQ(channel->GetErrorCount(), std::uint32_t{0});
+}
+
+TEST_F(TransportTaskCompletionTest, FailureCqeAccumulatesWithoutSuccessReset)
+{
+    auto* provider = transport_->transProvider_.get();
+    transport_->protocolManager_ = std::make_unique<ProtocolManager>();
+    transport_->connManager_ = std::make_unique<ConnectionManager>(*provider, "", 5000, 3);
+    ASSERT_TRUE(transport_->connManager_->AddGroup(AsuEndpoint{}, 1).ok());
+    auto channel = transport_->connManager_->SelectConnection();
+    ASSERT_NE(channel, nullptr);
+    transport_->connManager_->ReportFailure(channel);
+    ASSERT_EQ(channel->GetErrorCount(), std::uint32_t{1});
+
+    auto ctx = std::make_shared<TransportTaskContext>();
+    ctx->state.store(TransportTaskState::INFLIGHT, std::memory_order_release);
+    ctx->subBatchContexts.resize(1);
+
+    auto& subBatchContext = ctx->subBatchContexts[0];
+    subBatchContext.cid = 123;
+    subBatchContext.opType = TransportOpType::BATCH_STORE;
+    subBatchContext.entryStatus.assign(1, Status::OK());
+    subBatchContext.channel = channel;
+    ASSERT_TRUE(
+        transport_->flagBufferManager_
+            .Allocate((kCqeDwordCount + 1) * sizeof(std::uint32_t), subBatchContext.flagBuffer)
+            .ok());
+
+    auto* cqe = reinterpret_cast<std::uint32_t*>(subBatchContext.flagBuffer.local_addr);
+    cqe[3] = subBatchContext.cid | (0x716U << 17);
+
+    transport_->PollTaskCompletions(ctx);
+
+    EXPECT_EQ(channel->GetErrorCount(), std::uint32_t{2});
+    EXPECT_EQ(channel->GetState(), ChannelState::ACTIVE);
+    EXPECT_EQ(subBatchContext.status.code, StatusCode::ASU_CQE_IO_TIMEOUT);
 }
 
 TEST_F(TransportTaskCompletionTest, PollTaskCompletionsTimesOutAndReleasesResources)
 {
+    auto* provider = transport_->transProvider_.get();
+    transport_->connManager_ = std::make_unique<ConnectionManager>(*provider, "", 5000, 2);
+    ASSERT_TRUE(transport_->connManager_->AddGroup(AsuEndpoint{}, 1).ok());
+    auto channel = transport_->connManager_->SelectConnection();
+    ASSERT_NE(channel, nullptr);
+
     auto ctx = std::make_shared<TransportTaskContext>();
     ctx->taskId = 1;
     ctx->state.store(TransportTaskState::INFLIGHT, std::memory_order_release);
@@ -218,6 +277,7 @@ TEST_F(TransportTaskCompletionTest, PollTaskCompletionsTimesOutAndReleasesResour
     auto& subBatchContext = ctx->subBatchContexts[0];
     subBatchContext.opType = TransportOpType::BATCH_STORE;
     subBatchContext.entryStatus.assign(2, Status::OK());
+    subBatchContext.channel = channel;
     ASSERT_TRUE(transport_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
     ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
 
@@ -238,6 +298,35 @@ TEST_F(TransportTaskCompletionTest, PollTaskCompletionsTimesOutAndReleasesResour
     EXPECT_EQ(callbackResult.entryStatus[1].code, StatusCode::TIMEOUT);
     EXPECT_EQ(subBatchContext.sendSge.slot_index, UINT32_MAX);
     EXPECT_EQ(subBatchContext.flagBuffer.slot_index, UINT32_MAX);
+    EXPECT_EQ(channel->GetErrorCount(), std::uint32_t{1});
+    EXPECT_EQ(channel->GetState(), ChannelState::ACTIVE);
+}
+
+TEST_F(TransportTaskCompletionTest, ExecutionTimeoutCountsEachSubBatch)
+{
+    auto* provider = transport_->transProvider_.get();
+    transport_->connManager_ = std::make_unique<ConnectionManager>(*provider, "", 5000, 2);
+    ASSERT_TRUE(transport_->connManager_->AddGroup(AsuEndpoint{}, 1).ok());
+    auto channel = transport_->connManager_->SelectConnection();
+    ASSERT_NE(channel, nullptr);
+    auto sameChannel = transport_->connManager_->SelectConnection();
+    ASSERT_EQ(sameChannel, channel);
+
+    auto ctx = std::make_shared<TransportTaskContext>();
+    ctx->state.store(TransportTaskState::INFLIGHT, std::memory_order_release);
+    ctx->deadline = std::chrono::steady_clock::now();
+    ctx->entryStatus.assign(2, Status::OK());
+    ctx->subBatchContexts.resize(2);
+    for (auto& subBatchContext : ctx->subBatchContexts) {
+        subBatchContext.channel = channel;
+        subBatchContext.entryStatus.assign(1, Status::OK());
+    }
+
+    transport_->PollTaskCompletions(ctx);
+
+    EXPECT_EQ(channel->GetErrorCount(), std::uint32_t{2});
+    EXPECT_EQ(channel->GetState(), ChannelState::DRAINING);
+    EXPECT_EQ(channel->GetInflightCount(), std::uint32_t{0});
 }
 
 TEST_F(TransportTaskCompletionTest, ReleaseSubBatchResourcesPreservesSubBatchStatus)


### PR DESCRIPTION
## Purpose
Trigger connection recovery after maxErrorCount consecutive failures

## Modifications 
1. Add ReportSuccess to reset error count.
2. Add configuration of maxErrorCount in .yaml file.
