### PR TITLE
[Refactor] Improve ASU transport connection handling, task completion, and shutdown lifecycle

### DIFF
--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -323,6 +323,7 @@ TEST(UCAsuStoreTest, ParsesOperationTimeout)
     UC::AsuStore::AsuStore store;
     auto state = UseFakeBackend(store);
     auto config = MakeBaseConfig();
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
     config.SetNumber("asu_timeout_ms", std::uint64_t{321});
 
     ASSERT_TRUE(store.Setup(config).Success());

--- a/ucm/transport/kv/asu/test/case/connection_manager_test.cc
+++ b/ucm/transport/kv/asu/test/case/connection_manager_test.cc
@@ -40,15 +40,15 @@ static std::atomic<int> g_createCount{0};
 
 class StubTransProvider : public TransProvider {
 public:
-    std::uint32_t forceReturnCount = 0;
+    Status createStatus{Status::OK()};
 
     Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t qpNum,
                             uint32_t, std::vector<ConnectionHandle>& handles) override
     {
         g_createCount.fetch_add(1);
         handles.clear();
-        std::uint32_t count = (forceReturnCount > 0) ? forceReturnCount : qpNum;
-        for (std::uint32_t i = 0; i < count; ++i) {
+        if (!createStatus.ok()) { return createStatus; }
+        for (std::uint32_t i = 0; i < qpNum; ++i) {
             handles.push_back(reinterpret_cast<ConnectionHandle>(
                 static_cast<uintptr_t>(g_createCount.load() * 100 + i + 1)));
         }
@@ -278,15 +278,16 @@ TEST(ConnectionManagerTest, AddGroupCreatesGroupWithChannels)
     EXPECT_EQ(mgr.TotalInflightCount(), 0);
 }
 
-TEST(ConnectionManagerTest, AddGroupFailsWhenCreateFnReturnsWrongCount)
+TEST(ConnectionManagerTest, AddGroupReturnsProviderCreateError)
 {
     StubTransProvider provider;
-    provider.forceReturnCount = 1;
+    provider.createStatus = Status::Error(StatusCode::IO_ERROR, "provider create failure");
     ConnectionManager mgr(provider, "", 5000);
 
-    auto status = mgr.AddGroup(MakeEndpoint(), 3);
-    EXPECT_FALSE(status.ok());
-    EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
+    const auto status = mgr.AddGroup(MakeEndpoint(), 3);
+
+    EXPECT_EQ(status.code, StatusCode::IO_ERROR);
+    EXPECT_EQ(status.message, "provider create failure");
 }
 
 TEST(ConnectionManagerTest, AddGroupFailsAfterShutdown)
@@ -347,7 +348,6 @@ TEST(ConnectionManagerTest, SelectConnectionLeastLoadedPicksLowestInflight)
 TEST(ConnectionManagerTest, SelectConnectionReturnsNullptrWhenNoChannels)
 {
     StubTransProvider provider;
-    provider.forceReturnCount = 0;
     ConnectionManager mgr(provider, "", 5000);
 
     auto ch = mgr.SelectConnection();

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -118,7 +118,7 @@ void AsuTransportImpl::CompleteSubBatch(TransportTaskContext& task,
     ReleaseSubBatchResources(subBatchContext);
     subBatchContext.state = TransportSubBatchState::COMPLETED;
     subBatchContext.status = status;
-    ++task.completedSubBatchCount;
+    --task.remainingSubBatchCount;
 }
 
 AsuTransportImpl::~AsuTransportImpl() { Shutdown(); }
@@ -231,7 +231,9 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
 
     auto queueDepth = std::max<std::size_t>(2, static_cast<std::size_t>(config_.maxInflightTasks));
     executeQueue_.Setup(queueDepth + 1);
-    stop_.store(false, std::memory_order_release);
+    stopWorker_.store(false, std::memory_order_release);
+    stopCompletionWorker_.store(false, std::memory_order_release);
+    acceptingTasks_.store(true, std::memory_order_release);
     worker_ = std::thread(&AsuTransportImpl::WorkerLoop, this);
     completionWorker_ = std::thread(&AsuTransportImpl::CompletionLoop, this);
     UC_DEBUG("AsuTransportImpl::Init OK: queueDepth={}", queueDepth);
@@ -241,6 +243,31 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
 Status AsuTransportImpl::Shutdown()
 {
     Status finalStatus = Status::OK();
+    {
+        std::lock_guard<std::mutex> lock(producerMu_);
+        acceptingTasks_.store(false, std::memory_order_release);
+        stopWorker_.store(true, std::memory_order_release);
+    }
+
+    if (worker_.joinable()) { worker_.join(); }
+
+    if (completionWorker_.joinable() && config_.timeoutMs != 0) {
+        bool hasInflightTask = false;
+        for (const auto& ctx : taskManager_.GetAll()) {
+            if (ctx != nullptr &&
+                ctx->state.load(std::memory_order_acquire) == TransportTaskState::INFLIGHT) {
+                hasInflightTask = true;
+                break;
+            }
+        }
+        if (hasInflightTask) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(config_.timeoutMs));
+        }
+    }
+
+    stopCompletionWorker_.store(true, std::memory_order_release);
+    if (completionWorker_.joinable()) { completionWorker_.join(); }
+
     for (const auto& ctx : taskManager_.GetAll()) {
         if (ctx == nullptr) { continue; }
         {
@@ -256,18 +283,11 @@ Status AsuTransportImpl::Shutdown()
             }
             ctx->finalStatus = canceledStatus;
             ReleaseAllSubBatchResources(ctx->subBatchContexts);
-            ctx->state.store(TransportTaskState::CANCELED, std::memory_order_release);
+            ctx->state.store(TransportTaskState::COMPLETED, std::memory_order_release);
         }
         taskManager_.NotifyCompletion(ctx);
         ctx->cv.notify_all();
     }
-
-    stop_.store(true, std::memory_order_release);
-    if (worker_.joinable()) {
-        UC_DEBUG("AsuTransportImpl::Shutdown stopping worker thread");
-        worker_.join();
-    }
-    if (completionWorker_.joinable()) { completionWorker_.join(); }
     for (const auto& ctx : taskManager_.GetAll()) {
         if (ctx != nullptr) { (void)taskManager_.Remove(ctx->taskId); }
     }
@@ -377,7 +397,7 @@ Status AsuTransportImpl::Cancel(TaskId taskId)
         }
         ctx->finalStatus = canceledStatus;
         ReleaseAllSubBatchResources(ctx->subBatchContexts);
-        ctx->state.store(TransportTaskState::CANCELED, std::memory_order_release);
+        ctx->state.store(TransportTaskState::COMPLETED, std::memory_order_release);
     }
     taskManager_.NotifyCompletion(ctx);
     ctx->cv.notify_all();
@@ -526,9 +546,10 @@ std::uint16_t AsuTransportImpl::AllocateRequestCid()
 
 Status AsuTransportImpl::SubmitAsync(std::unique_ptr<TransportTaskContext> ctx, TaskId& taskId)
 {
-    if (!worker_.joinable()) {
+    std::lock_guard<std::mutex> lock(producerMu_);
+    if (!acceptingTasks_.load(std::memory_order_acquire) || !worker_.joinable()) {
         taskId = kInvalidTaskId;
-        return Status::Error(StatusCode::NOT_INITIALIZED, "transport worker is not running");
+        return Status::Error(StatusCode::NOT_INITIALIZED, "transport is not accepting tasks");
     }
 
     auto status = taskManager_.Submit(std::move(ctx), taskId);
@@ -540,7 +561,6 @@ Status AsuTransportImpl::SubmitAsync(std::unique_ptr<TransportTaskContext> ctx, 
         return Status::Error(StatusCode::INTERNAL_ERROR, "transport task disappeared after submit");
     }
 
-    std::lock_guard<std::mutex> lock(producerMu_);
     if (!executeQueue_.TryPush(std::move(rawCtx))) {
         taskManager_.Remove(taskId);
         taskId = kInvalidTaskId;
@@ -551,7 +571,7 @@ Status AsuTransportImpl::SubmitAsync(std::unique_ptr<TransportTaskContext> ctx, 
 
 void AsuTransportImpl::WorkerLoop()
 {
-    executeQueue_.ConsumerLoop(stop_, [this](TransportTaskContextPtr ctx) {
+    executeQueue_.ConsumerLoop(stopWorker_, [this](TransportTaskContextPtr ctx) {
         if (!ctx) { return; }
         ProcessTask(ctx);
     });
@@ -559,7 +579,7 @@ void AsuTransportImpl::WorkerLoop()
 
 void AsuTransportImpl::CompletionLoop()
 {
-    while (!stop_.load(std::memory_order_acquire)) {
+    while (!stopCompletionWorker_.load(std::memory_order_acquire)) {
         for (const auto& ctx : taskManager_.GetAll()) { PollTaskCompletions(ctx); }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
@@ -594,9 +614,6 @@ void AsuTransportImpl::ProcessTask(const TransportTaskContextPtr& ctx)
     TransportTaskState expected = TransportTaskState::PENDING;
     if (!ctx->state.compare_exchange_strong(expected, TransportTaskState::INFLIGHT,
                                             std::memory_order_acq_rel)) {
-        if (ctx->state.load(std::memory_order_acquire) == TransportTaskState::CANCELED) {
-            ctx->cv.notify_all();
-        }
         return;
     }
 
@@ -616,17 +633,16 @@ void AsuTransportImpl::ProcessTask(const TransportTaskContextPtr& ctx)
     bool done = false;
     {
         std::lock_guard<std::mutex> lock(ctx->waitMu);
-        if (ctx->state.load(std::memory_order_acquire) == TransportTaskState::CANCELED) {
+        if (ctx->Done()) {
             UC_DEBUG(
                 "AsuTransportImpl::ProcessTask canceled during process task_id={} sub_batches={}",
                 ctx->taskId, subBatchContexts.size());
             ReleaseAllSubBatchResources(subBatchContexts);
-            ctx->cv.notify_all();
             return;
         }
 
         if (hasSubBatches) { ctx->subBatchContexts = std::move(subBatchContexts); }
-        ctx->InitializeTerminalSubBatchCount();
+        ctx->InitializeRemainingSubBatchCount();
         ctx->TryFinalizeFromSubBatches();
         UC_DEBUG(
             "AsuTransportImpl::ProcessTask submitted task_id={} op_type={} entries={} keys={} "

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -233,7 +233,6 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
     executeQueue_.Setup(queueDepth + 1);
     stopWorker_.store(false, std::memory_order_release);
     stopCompletionWorker_.store(false, std::memory_order_release);
-    acceptingTasks_.store(true, std::memory_order_release);
     worker_ = std::thread(&AsuTransportImpl::WorkerLoop, this);
     completionWorker_ = std::thread(&AsuTransportImpl::CompletionLoop, this);
     UC_DEBUG("AsuTransportImpl::Init OK: queueDepth={}", queueDepth);
@@ -245,7 +244,6 @@ Status AsuTransportImpl::Shutdown()
     Status finalStatus = Status::OK();
     {
         std::lock_guard<std::mutex> lock(producerMu_);
-        acceptingTasks_.store(false, std::memory_order_release);
         stopWorker_.store(true, std::memory_order_release);
     }
 
@@ -547,7 +545,7 @@ std::uint16_t AsuTransportImpl::AllocateRequestCid()
 Status AsuTransportImpl::SubmitAsync(std::unique_ptr<TransportTaskContext> ctx, TaskId& taskId)
 {
     std::lock_guard<std::mutex> lock(producerMu_);
-    if (!acceptingTasks_.load(std::memory_order_acquire) || !worker_.joinable()) {
+    if (stopWorker_.load(std::memory_order_acquire) || !worker_.joinable()) {
         taskId = kInvalidTaskId;
         return Status::Error(StatusCode::NOT_INITIALIZED, "transport is not accepting tasks");
     }

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
@@ -132,7 +132,9 @@ private:
 
     std::thread worker_;
     std::thread completionWorker_;
-    std::atomic_bool stop_{false};
+    std::atomic_bool acceptingTasks_{false};
+    std::atomic_bool stopWorker_{false};
+    std::atomic_bool stopCompletionWorker_{false};
     std::atomic<std::uint16_t> nextRequestCid_{1};
 
     std::mutex registeredRegionsMu_;

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
@@ -132,7 +132,6 @@ private:
 
     std::thread worker_;
     std::thread completionWorker_;
-    std::atomic_bool acceptingTasks_{false};
     std::atomic_bool stopWorker_{false};
     std::atomic_bool stopCompletionWorker_{false};
     std::atomic<std::uint16_t> nextRequestCid_{1};

--- a/ucm/transport/kv/asu/trans/src/connection_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/connection_manager.cpp
@@ -47,20 +47,14 @@ Status ConnectionManager::AddGroup(const AsuEndpoint& endpoint, std::uint32_t qp
     std::vector<TransProvider::ConnectionHandle> handles;
     auto createStatus =
         provider_.CreateConnection(localIp_, endpoint.ip, endpoint.port, qp_num, timeout_, handles);
-    if (!createStatus.ok() || handles.size() != qp_num) {
-        UC_DEBUG("ConnectionManager::AddGroup FAILED: got {} handles, expected {}", handles.size(),
-                 qp_num);
-        if (!handles.empty()) { provider_.DeleteConnections(handles); }
-        return Status::Error(StatusCode::CONNECTION_ERROR,
-                             "CreateConnection returned wrong number of handles");
-    }
+    if (!createStatus.ok()) { return createStatus; }
 
     {
         std::lock_guard<std::mutex> cacheLock(channelCacheMu_);
         std::unique_lock<std::shared_mutex> lock(structureMu_);
         auto gid = static_cast<std::uint32_t>(groups_.size());
         auto group = std::make_unique<ConnectionGroup>(gid, endpoint);
-        for (auto& handle : handles) { group->AddChannel(std::move(handle), &provider_); }
+        for (auto handle : handles) { group->AddChannel(handle, &provider_); }
         groups_.push_back(std::move(group));
 
         for (const auto& channel : groups_.back()->GetChannels()) {
@@ -203,7 +197,7 @@ void ConnectionManager::RecoverLoop()
             auto createStatus =
                 provider_.CreateConnection(localIp_, ep.ip, ep.port, 1, timeout_, new_handles);
 
-            if (!createStatus.ok() || new_handles.empty()) {
+            if (!createStatus.ok()) {
                 UC_DEBUG(
                     "ConnectionManager::RecoverLoop RebuildChannel FAILED, keep in drain_list for "
                     "retry group_id={}",
@@ -216,7 +210,7 @@ void ConnectionManager::RecoverLoop()
             {
                 std::unique_lock<std::shared_mutex> lock(structureMu_);
                 grp->RemoveChannel(channel.get());
-                auto new_ch = grp->AddChannel(std::move(new_handles[0]), &provider_);
+                auto new_ch = grp->AddChannel(new_handles[0], &provider_);
                 UC_DEBUG(
                     "ConnectionManager::RecoverLoop RebuildChannel OK: new_ch_id={} group_id={}",
                     new_ch->GetChannelId(), gid);

--- a/ucm/transport/kv/asu/trans/src/trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/trans_provider.h
@@ -15,6 +15,7 @@ public:
 
     virtual ~TransProvider() = default;
 
+    // On success, connectionHandles contains exactly qpNum handles. On failure, it is empty.
     virtual Status CreateConnection(const std::string& localIp, const std::string& remoteIp,
                                     uint32_t port, uint32_t qpNum, uint32_t timeout,
                                     std::vector<ConnectionHandle>& connectionHandles) = 0;

--- a/ucm/transport/kv/asu/trans/src/transport_task_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/transport_task_manager.cpp
@@ -6,8 +6,7 @@ namespace UC::ASU {
 
 bool TransportTaskContext::Done() const
 {
-    auto s = state.load(std::memory_order_acquire);
-    return s == TransportTaskState::COMPLETED || s == TransportTaskState::CANCELED;
+    return state.load(std::memory_order_acquire) == TransportTaskState::COMPLETED;
 }
 
 bool TransportTaskContext::NotifyCompletion(TaskResult result)
@@ -30,14 +29,11 @@ Status TransportTaskContext::BuildFinalStatus() const
     return Status::OK();
 }
 
-void TransportTaskContext::InitializeTerminalSubBatchCount()
+void TransportTaskContext::InitializeRemainingSubBatchCount()
 {
-    // At submit completion time, terminal sub-batches are usually submit/send failures.
-    completedSubBatchCount = 0;
+    remainingSubBatchCount = 0;
     for (const auto& subBatchContext : subBatchContexts) {
-        if (subBatchContext.state != TransportSubBatchState::COMPLETED) { continue; }
-
-        ++completedSubBatchCount;
+        if (subBatchContext.state == TransportSubBatchState::PENDING) { ++remainingSubBatchCount; }
     }
 }
 
@@ -49,7 +45,7 @@ void TransportTaskContext::TryFinalizeFromSubBatches()
         return;
     }
 
-    if (completedSubBatchCount != static_cast<std::uint32_t>(subBatchContexts.size())) { return; }
+    if (remainingSubBatchCount != 0) { return; }
 
     finalStatus = BuildFinalStatus();
     state.store(TransportTaskState::COMPLETED, std::memory_order_release);

--- a/ucm/transport/kv/asu/trans/src/transport_task_manager.h
+++ b/ucm/transport/kv/asu/trans/src/transport_task_manager.h
@@ -53,7 +53,6 @@ enum class TransportTaskState {
     PENDING = 0,
     INFLIGHT = 1,
     COMPLETED = 2,
-    CANCELED = 3,
 };
 
 enum class TransportSubBatchState {
@@ -103,7 +102,7 @@ struct TransportTaskContext {
     QueryResult queryResult;
     std::vector<Status> entryStatus;
     std::vector<TransportSubBatchContext> subBatchContexts;
-    std::uint32_t completedSubBatchCount{0};
+    std::uint32_t remainingSubBatchCount{0};
     std::chrono::steady_clock::time_point deadline{std::chrono::steady_clock::time_point::max()};
     TaskCompletionCallback onComplete;
     std::atomic<bool> completionNotified{false};
@@ -119,7 +118,7 @@ struct TransportTaskContext {
     bool Done() const;
     bool NotifyCompletion(TaskResult result);
     Status BuildFinalStatus() const;
-    void InitializeTerminalSubBatchCount();
+    void InitializeRemainingSubBatchCount();
     void TryFinalizeFromSubBatches();
 };
 

--- a/ucm/transport/kv/asu/trans/test/transport_task_completion_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/transport_task_completion_test.cpp
@@ -114,17 +114,7 @@ protected:
     std::unique_ptr<AsuTransportImpl> transport_;
 };
 
-TEST_F(TransportTaskCompletionTest, InitRejectsZeroMaxErrorCount)
-{
-    TransportConfig config;
-    config.maxErrorCount = 0;
-
-    const auto status = transport_->Init(config);
-
-    EXPECT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
-}
-
-TEST_F(TransportTaskCompletionTest, InitializeCountsAlreadyTerminalSubBatches)
+TEST_F(TransportTaskCompletionTest, InitializeCountsOnlyPendingSubBatches)
 {
     TransportTaskContext ctx;
     ctx.subBatchContexts.resize(3);
@@ -133,9 +123,9 @@ TEST_F(TransportTaskCompletionTest, InitializeCountsAlreadyTerminalSubBatches)
     ctx.subBatchContexts[2].state = TransportSubBatchState::COMPLETED;
     ctx.subBatchContexts[2].status = Status::Error(StatusCode::IO_ERROR, "fake error");
 
-    ctx.InitializeTerminalSubBatchCount();
+    ctx.InitializeRemainingSubBatchCount();
 
-    EXPECT_EQ(ctx.completedSubBatchCount, std::uint32_t{2});
+    EXPECT_EQ(ctx.remainingSubBatchCount, std::uint32_t{1});
 }
 
 TEST_F(TransportTaskCompletionTest, CompleteSubBatchOnlyCountsPendingSubBatchOnce)
@@ -143,11 +133,12 @@ TEST_F(TransportTaskCompletionTest, CompleteSubBatchOnlyCountsPendingSubBatchOnc
     TransportTaskContext ctx;
     TransportSubBatchContext subBatchContext;
     const auto status = Status::Error(StatusCode::IO_ERROR, "fake error");
+    ctx.remainingSubBatchCount = 1;
 
     transport_->CompleteSubBatch(ctx, subBatchContext, status);
     transport_->CompleteSubBatch(ctx, subBatchContext, status);
 
-    EXPECT_EQ(ctx.completedSubBatchCount, std::uint32_t{1});
+    EXPECT_EQ(ctx.remainingSubBatchCount, std::uint32_t{0});
     EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
     EXPECT_EQ(subBatchContext.status.code, StatusCode::IO_ERROR);
 }
@@ -190,7 +181,7 @@ TEST_F(TransportTaskCompletionTest, PollTaskCompletionsReadsDeviceFlagBuffer)
     auto ctx = std::make_shared<TransportTaskContext>();
     ctx->state.store(TransportTaskState::INFLIGHT, std::memory_order_release);
     ctx->subBatchContexts.resize(1);
-    ctx->completedSubBatchCount = 0;
+    ctx->remainingSubBatchCount = 1;
 
     auto& subBatchContext = ctx->subBatchContexts[0];
     subBatchContext.cid = 123;
@@ -212,7 +203,7 @@ TEST_F(TransportTaskCompletionTest, PollTaskCompletionsReadsDeviceFlagBuffer)
 
     deviceTransport.PollTaskCompletions(ctx);
 
-    EXPECT_EQ(ctx->completedSubBatchCount, std::uint32_t{1});
+    EXPECT_EQ(ctx->remainingSubBatchCount, std::uint32_t{0});
     EXPECT_EQ(ctx->state.load(std::memory_order_acquire), TransportTaskState::COMPLETED);
     EXPECT_TRUE(ctx->finalStatus.ok()) << ctx->finalStatus.message;
     EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
@@ -396,7 +387,7 @@ TEST_F(TransportTaskCompletionTest, TryFinalizeWaitsUntilAllSubBatchesFinish)
 {
     TransportTaskContext ctx;
     ctx.subBatchContexts.resize(2);
-    ctx.completedSubBatchCount = 1;
+    ctx.remainingSubBatchCount = 1;
     ctx.state.store(TransportTaskState::INFLIGHT, std::memory_order_release);
 
     ctx.TryFinalizeFromSubBatches();
@@ -412,7 +403,7 @@ TEST_F(TransportTaskCompletionTest, TryFinalizeAggregatesSuccessAndFailure)
     ctx.subBatchContexts[0].status = Status::OK();
     ctx.subBatchContexts[1].state = TransportSubBatchState::COMPLETED;
     ctx.subBatchContexts[1].status = Status::Error(StatusCode::IO_ERROR, "sub-batch failed");
-    ctx.completedSubBatchCount = 2;
+    ctx.remainingSubBatchCount = 0;
 
     ctx.TryFinalizeFromSubBatches();
 
@@ -423,7 +414,7 @@ TEST_F(TransportTaskCompletionTest, TryFinalizeAggregatesSuccessAndFailure)
     successCtx.subBatchContexts.resize(1);
     successCtx.subBatchContexts[0].state = TransportSubBatchState::COMPLETED;
     successCtx.subBatchContexts[0].status = Status::OK();
-    successCtx.completedSubBatchCount = 1;
+    successCtx.remainingSubBatchCount = 0;
 
     successCtx.TryFinalizeFromSubBatches();
 
@@ -503,10 +494,13 @@ TEST_F(TransportTaskCompletionTest, CancelInvokesCallbackOutsideTaskLock)
     TaskId taskId = kInvalidTaskId;
     bool callbackInvoked = false;
     bool taskLockAvailable = false;
+    bool terminalState = false;
     auto ctx = std::make_unique<TransportTaskContext>();
     auto* rawCtx = ctx.get();
     ctx->onComplete = [&](TaskResult result) {
         callbackInvoked = result.status.code == StatusCode::CANCELED;
+        terminalState =
+            rawCtx->state.load(std::memory_order_acquire) == TransportTaskState::COMPLETED;
         taskLockAvailable = rawCtx->waitMu.try_lock();
         if (taskLockAvailable) { rawCtx->waitMu.unlock(); }
     };
@@ -516,6 +510,7 @@ TEST_F(TransportTaskCompletionTest, CancelInvokesCallbackOutsideTaskLock)
 
     EXPECT_TRUE(callbackInvoked);
     EXPECT_TRUE(taskLockAvailable);
+    EXPECT_TRUE(terminalState);
     EXPECT_EQ(transport_->taskManager_.Get(taskId), nullptr);
 }
 
@@ -553,6 +548,69 @@ TEST_F(TransportTaskCompletionTest, FailedSubmissionDoesNotInvokeCallback)
     EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
     EXPECT_EQ(taskId, kInvalidTaskId);
     EXPECT_EQ(callbackCount, std::uint32_t{0});
+}
+
+TEST_F(TransportTaskCompletionTest, ShutdownCallbackCannotSubmitNewTask)
+{
+    std::vector<KVBuffer> entries(1);
+    std::uint32_t callbackCount = 0;
+    std::uint32_t nestedCallbackCount = 0;
+    TaskId nestedTaskId = 123;
+    Status nestedSubmitStatus = Status::OK();
+
+    auto ctx = std::make_unique<TransportTaskContext>();
+    ctx->onComplete = [&](TaskResult result) {
+        ++callbackCount;
+        EXPECT_EQ(result.status.code, StatusCode::CANCELED);
+        nestedSubmitStatus = transport_->LoadAsync(
+            entries, nestedTaskId, [&nestedCallbackCount](TaskResult) { ++nestedCallbackCount; });
+    };
+
+    TaskId taskId = kInvalidTaskId;
+    ASSERT_TRUE(transport_->taskManager_.Submit(std::move(ctx), taskId).ok());
+
+    EXPECT_TRUE(transport_->Shutdown().ok());
+
+    EXPECT_EQ(callbackCount, std::uint32_t{1});
+    EXPECT_EQ(nestedSubmitStatus.code, StatusCode::NOT_INITIALIZED);
+    EXPECT_EQ(nestedTaskId, kInvalidTaskId);
+    EXPECT_EQ(nestedCallbackCount, std::uint32_t{0});
+}
+
+TEST_F(TransportTaskCompletionTest, ShutdownDrainsInflightTaskBeforeCanceling)
+{
+    transport_->protocolManager_ = std::make_unique<ProtocolManager>();
+    auto ctx = std::make_unique<TransportTaskContext>();
+    ctx->entryStatus.assign(1, Status::OK());
+    ctx->subBatchContexts.resize(1);
+    ctx->remainingSubBatchCount = 1;
+    auto& subBatchContext = ctx->subBatchContexts[0];
+    subBatchContext.cid = 123;
+    subBatchContext.opType = TransportOpType::BATCH_STORE;
+    subBatchContext.entryStatus.assign(1, Status::OK());
+    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
+    auto* cqe = reinterpret_cast<std::uint32_t*>(subBatchContext.flagBuffer.local_addr);
+    cqe[3] = subBatchContext.cid;
+
+    std::uint32_t callbackCount = 0;
+    Status callbackStatus = Status::Error(StatusCode::INTERNAL_ERROR, "callback not invoked");
+    ctx->onComplete = [&](TaskResult result) {
+        ++callbackCount;
+        callbackStatus = std::move(result.status);
+    };
+
+    TaskId taskId = kInvalidTaskId;
+    ASSERT_TRUE(transport_->taskManager_.Submit(std::move(ctx), taskId).ok());
+    auto submittedCtx = transport_->taskManager_.Get(taskId);
+    ASSERT_NE(submittedCtx, nullptr);
+    submittedCtx->state.store(TransportTaskState::INFLIGHT, std::memory_order_release);
+    transport_->completionWorker_ =
+        std::thread(&AsuTransportImpl::CompletionLoop, transport_.get());
+
+    EXPECT_TRUE(transport_->Shutdown().ok());
+
+    EXPECT_EQ(callbackCount, std::uint32_t{1});
+    EXPECT_TRUE(callbackStatus.ok()) << callbackStatus.message;
 }
 
 TEST_F(TransportTaskCompletionTest, CancelReleasesResourcesBeforeInvokingCallbackOnce)


### PR DESCRIPTION
## Purpose
Harden ASU transport task lifecycle and shutdown behavior so task cancellation, sub-batch completion, concurrent submission, and in-flight task draining are handled consistently and safely.
<img width="400" height="auto" alt="image" src="https://github.com/user-attachments/assets/c39ddc2a-077c-412b-800a-7942ef4f2bca" />

## Modifications

- Unify task terminal state as COMPLETED and represent cancellation through the final task status.
- Track remaining sub-batches with idempotent completion and reliable task finalization.
- Serialize task submission against shutdown and reject submissions after the acceptance gate closes.
- Stop the request worker first while allowing the completion worker to process in-flight tasks for a bounded timeout.
- Simplify connection handling according to the documented provider contract.
- Add lifecycle, shutdown callback, in-flight completion, and sub-batch completion unit-test coverage.
- Add an ASU transport porting guide documenting the required behavior and shutdown ordering.

## Test
Unit tests are all passed.
A UCM offline inference is passed. (MLA/GQA+TP2+Layerwise(ture/false))