### PR TITLE
[Fix] Avoid GCC 12 -Werror=nonnull false positive in kv_protocol_test

### DIFF
--- a/ucm/store/test/CMakeLists.txt
+++ b/ucm/store/test/CMakeLists.txt
@@ -13,6 +13,10 @@ if(BUILD_UNIT_TESTS)
         list(FILTER UCMSTORE_TEST_SOURCE_FILES EXCLUDE REGEX ".*[/\\\\]dram[/\\\\].*")
     endif()
     add_executable(ucmstore.test ${UCMSTORE_TEST_SOURCE_FILES})
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "12" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "13")
+        set_source_files_properties(case/dram/kv_protocol_test.cc
+            PROPERTIES COMPILE_OPTIONS "-Wno-nonnull")
+    endif()
     target_include_directories(ucmstore.test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/case)
     target_link_libraries(ucmstore.test PRIVATE
         posixstore cachestore fakestore pcstore


### PR DESCRIPTION
## Purpose
GCC 12 optimizer incorrectly infers a null source pointer in the std::copy -> __builtin_memmove inlined path when vector<uint8_t> is assigned via initializer_list. This triggers -Werror=nonnull and breaks the build.

## Modifications
Add set_source_files_properties in ucm/store/test/CMakeLists.txt to suppress -Wno-nonnull for kv_protocol_test.cc, scoped to GCC only.

## Test
[==========] Running 40 tests from 1 test suite.
[  PASSED  ] 40 tests.