### PR TITLE
[bugfix]align buffer size

### DIFF
--- a/test/suites/Unit/test_kv_cache_layout.py
+++ b/test/suites/Unit/test_kv_cache_layout.py
@@ -96,6 +96,7 @@ def _load_layout_symbols():
     source = CONNECTOR_PATH.read_text(encoding="utf-8-sig")
     tree = ast.parse(source)
     selected_names = {
+        "_get_store_io_sizes",
         "_has_shared_indexer_layers",
         "KVCacheSegment",
         "KVCacheTensorInfo",
@@ -126,6 +127,7 @@ def _load_layout_symbols():
 
 
 LAYOUT_SYMBOLS = _load_layout_symbols()
+get_store_io_sizes = LAYOUT_SYMBOLS["_get_store_io_sizes"]
 KVCacheLayout = LAYOUT_SYMBOLS["KVCacheLayout"]
 SharedIndexerKVCacheLayout = LAYOUT_SYMBOLS["SharedIndexerKVCacheLayout"]
 
@@ -222,6 +224,24 @@ def _build_cuda_shared_layout(
 
 
 class KVCacheLayoutTest(unittest.TestCase):
+    def test_store_io_sizes_align_unconditionally(self):
+        shard_size, block_size = get_store_io_sizes(
+            116992,
+            9242368,
+        )
+
+        self.assertEqual(shard_size, 118784)
+        self.assertEqual(block_size, 9383936)
+
+    def test_store_io_sizes_preserve_aligned_layout(self):
+        shard_size, block_size = get_store_io_sizes(
+            118784,
+            9383936,
+        )
+
+        self.assertEqual(shard_size, 118784)
+        self.assertEqual(block_size, 9383936)
+
     def test_direct_layout_flattens_only_real_tensors(self):
         layout = _build_layout(
             [[8, 4, 2], [8]],

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -91,6 +91,32 @@ def _short_list(values: list[int], limit: int = 12) -> list[int]:
     return values[:limit]
 
 
+def _get_store_io_sizes(
+    logical_shard_size: int,
+    logical_block_size: int,
+    alignment: int = 4096,
+) -> tuple[int, int]:
+    """Return aligned physical Store sizes."""
+    if alignment <= 0:
+        raise ValueError(f"Store I/O alignment must be positive, got {alignment}.")
+    if logical_shard_size <= 0 or logical_block_size <= 0:
+        raise ValueError(
+            "Store shard_size and block_size must be positive, "
+            f"got shard_size={logical_shard_size}, "
+            f"block_size={logical_block_size}."
+        )
+    shard_count, remainder = divmod(logical_block_size, logical_shard_size)
+    if remainder:
+        raise ValueError(
+            "Store block_size must be divisible by shard_size, "
+            f"got shard_size={logical_shard_size}, "
+            f"block_size={logical_block_size}."
+        )
+
+    physical_shard_size = (logical_shard_size + alignment - 1) // alignment * alignment
+    return physical_shard_size, physical_shard_size * shard_count
+
+
 def _drop_null_vllm_blocks(
     ucm_block_ids: list[bytes],
     vllm_block_ids: list[int],
@@ -1157,11 +1183,24 @@ class UCMDirectConnector(KVConnectorBase_V1):
         config["unique_id"] = f"{self.unique_id}"
         if self._role == KVConnectorRole.WORKER:
             config["device_id"] = self.local_rank
-            config["tensor_size_list"] = (
-                kv_cache_layout.tensor_size_list * self.blocks_per_chunk
+            tensor_size_list = kv_cache_layout.tensor_size_list * self.blocks_per_chunk
+            logical_shard_size = kv_cache_layout.shard_size * self.blocks_per_chunk
+            logical_block_size = kv_cache_layout.block_size * self.blocks_per_chunk
+            store_shard_size, store_block_size = _get_store_io_sizes(
+                logical_shard_size,
+                logical_block_size,
             )
-            config["shard_size"] = kv_cache_layout.shard_size * self.blocks_per_chunk
-            config["block_size"] = kv_cache_layout.block_size * self.blocks_per_chunk
+            config["tensor_size_list"] = tensor_size_list
+            config["shard_size"] = store_shard_size
+            config["block_size"] = store_block_size
+            if store_shard_size != logical_shard_size:
+                logger.info(
+                    "Pad Store sizes for I/O alignment: "
+                    f"logical_shard_size={logical_shard_size}, "
+                    f"store_shard_size={store_shard_size}, "
+                    f"logical_block_size={logical_block_size}, "
+                    f"store_block_size={store_block_size}."
+                )
             config["local_rank_size"] = self.tp_size if self.is_mla else 1
             buffer_addrs = kv_cache_layout.base_ptrs.reshape(-1).tolist()
             buffer_sizes = kv_cache_layout.buffer_sizes.reshape(-1).tolist()


### PR DESCRIPTION
## Purpose

Fix Store I/O failures caused by unaligned KV cache shard sizes.

For GLM5.2 W4A8C8, the shared-indexer layout produces a logical shard size of
116,992 bytes. This size is not aligned to the storage I/O boundary and may cause
PosixStore operations to fail with `EINVAL`.

Normalize the physical Store layout to a 4 KiB boundary while keeping the logical
KV tensor layout unchanged.

## Modifications

- Add a helper to align the physical Store shard size to 4 KiB.
- Apply alignment consistently, regardless of the configured I/O engine or
  `io_direct` setting.
- Recalculate the physical Store block size using the aligned shard size while
  preserving the original number of shards per block.
- Keep `tensor_size_list`, device addresses, tensor copy sizes, and KV cache
  strides unchanged.
- Add a startup log showing the logical and aligned Store sizes.
- Add unit tests covering unaligned and already-aligned Store layouts.

For the GLM5.2 W4A8C8 mixed layout:

- Logical shard size: `116992`
- Physical Store shard size: `118784`
- Physical Store block size for 79 shards: `9383936`
