### PR TITLE
[Feat] Remove DramPool Connect and Disconnect calls and evict at least one entry

### DIFF
--- a/ucm/store/dram/cc/drampool/completion_poller.cc
+++ b/ucm/store/dram/cc/drampool/completion_poller.cc
@@ -51,7 +51,6 @@ void CompletionPoller::Run(const std::atomic_bool& stop)
         FillPendingWindow();
 
         const bool stopRequested = stop.load(std::memory_order_acquire);
-        if (stopRequested) { disconnectAllTransfers_ = true; }
 
         if (pending_.empty()) {
             if (stopRequested) { break; }
@@ -130,13 +129,16 @@ bool CompletionPoller::PollDataTransfer(CompletionRecord& record)
     }
 
     if (transportStatus == transport::TransferStatus::Waiting) {
-        if (!disconnectAllTransfers_ && !OperationTimedOut(record, SteadyNowMs())) { return false; }
-
-        DisconnectPeer(record.peer_one_sided_id, record.data_handle);
-        SettleDataTransfer(record, transport::TransferStatus::Failed);
-        record.data_handle = transport::kInvalidTransferHandle;
-        record.stage = CompletionStage::SubmitResponse;
-        return true;
+        // A timeout is diagnostic only. The transfer may still own its handle and buffers, and
+        // DramStore is solely responsible for initiating connection teardown.
+        if (!record.timeout_reported && OperationTimedOut(record, SteadyNowMs())) {
+            record.timeout_reported = true;
+            UC_ERROR(
+                "CompletionPoller data transfer timed out, peer={}, handle={}, timeout_ms={}; "
+                "waiting for Store-initiated disconnect or terminal transport status",
+                record.peer_one_sided_id, record.data_handle, g_config.opTimeoutMs);
+        }
+        return false;
     }
 
     // A terminal GetStatus releases the data handle before business state is settled.
@@ -185,6 +187,7 @@ bool CompletionPoller::SubmitResponse(CompletionRecord& record)
 
     record.response_handle = handle;
     record.submit_ms = SteadyNowMs();
+    record.timeout_reported = false;
     record.results.clear();
     record.stage = CompletionStage::PollResponseTransfer;
     return false;
@@ -198,12 +201,15 @@ bool CompletionPoller::PollResponseTransfer(CompletionRecord& record)
         // GetStatus removes failed handles, so the response source buffer is no longer in use.
         UC_ERROR("CompletionPoller response GetStatus failed, handle={}", record.response_handle);
     } else if (transportStatus == transport::TransferStatus::Waiting) {
-        if (!disconnectAllTransfers_ && !OperationTimedOut(record, SteadyNowMs())) { return false; }
-
-        DisconnectPeer(record.peer_one_sided_id, record.response_handle);
-        record.response_handle = transport::kInvalidTransferHandle;
-        ReleaseResponseBuffer(runtime_.flagBufferPool, record);
-        return true;
+        // Keep the response source buffer alive until transport reports a terminal state.
+        if (!record.timeout_reported && OperationTimedOut(record, SteadyNowMs())) {
+            record.timeout_reported = true;
+            UC_ERROR(
+                "CompletionPoller response transfer timed out, peer={}, handle={}, timeout_ms={}; "
+                "waiting for Store-initiated disconnect or terminal transport status",
+                record.peer_one_sided_id, record.response_handle, g_config.opTimeoutMs);
+        }
+        return false;
     } else if (transportStatus != transport::TransferStatus::Completed) {
         UC_ERROR("CompletionPoller response transfer failed, handle={}", record.response_handle);
     }
@@ -262,17 +268,6 @@ bool CompletionPoller::OperationTimedOut(const CompletionRecord& record, std::ui
 {
     if (nowMs < record.submit_ms) { return false; }
     return nowMs - record.submit_ms >= g_config.opTimeoutMs;
-}
-
-void CompletionPoller::DisconnectPeer(const transport::ManagerID& peer, TransportHandle handle)
-{
-    UC_ERROR("CompletionPoller disconnecting peer to fail in-flight transfer, peer={}, handle={}",
-             peer, handle);
-    const auto status = runtime_.transport.Disconnect(transport::TransportProtocol::Hixl, peer);
-    if (status.Failure()) {
-        UC_ERROR("CompletionPoller disconnect peer failed, peer={}, handle={}, error={}", peer,
-                 handle, status);
-    }
 }
 
 }  // namespace UC::DramPool

--- a/ucm/store/dram/cc/drampool/completion_poller.h
+++ b/ucm/store/dram/cc/drampool/completion_poller.h
@@ -46,11 +46,9 @@ private:
     bool PollResponseTransfer(CompletionRecord& record);
     void SettleDataTransfer(CompletionRecord& record, transport::TransferStatus terminalStatus);
     bool OperationTimedOut(const CompletionRecord& record, std::uint64_t nowMs) const;
-    void DisconnectPeer(const transport::ManagerID& peer, TransportHandle handle);
 
     DramPoolRuntime& runtime_;
     std::deque<CompletionRecord> pending_;
-    bool disconnectAllTransfers_{false};
 };
 
 }  // namespace UC::DramPool

--- a/ucm/store/dram/cc/drampool/drampool_types.h
+++ b/ucm/store/dram/cc/drampool/drampool_types.h
@@ -97,6 +97,7 @@ struct CompletionRecord {
     TransportHandle data_handle{transport::kInvalidTransferHandle};
     std::vector<TransferItem> transfer_items;
     std::uint64_t submit_ms{0};
+    bool timeout_reported{false};
 
     // State needed to construct the request's sole response.
     KvOpcode opcode{KvOpcode::None};

--- a/ucm/store/dram/cc/drampool/lru_eviction_policy.h
+++ b/ucm/store/dram/cc/drampool/lru_eviction_policy.h
@@ -81,8 +81,8 @@ public:
         if (!std::isfinite(evictRatio) || evictRatio <= 0.0 || index_.empty()) { return victims; }
 
         const double boundedRatio = std::min(evictRatio, 1.0);
-        const auto target =
-            static_cast<std::size_t>(static_cast<double>(index_.size()) * boundedRatio);
+        const auto target = std::max<std::size_t>(
+            1, static_cast<std::size_t>(static_cast<double>(index_.size()) * boundedRatio));
         const auto now = std::chrono::system_clock::now();
 
         for (auto it = lruList_.rbegin(); it != lruList_.rend() && victims.size() < target; ++it) {

--- a/ucm/store/dram/cc/drampool/pos_eviction_policy.h
+++ b/ucm/store/dram/cc/drampool/pos_eviction_policy.h
@@ -24,6 +24,7 @@
 #ifndef UNIFIEDCACHE_DRAM_STORE_CC_POS_EVICTION_POLICY_H
 #define UNIFIEDCACHE_DRAM_STORE_CC_POS_EVICTION_POLICY_H
 
+#include <algorithm>
 #include <chrono>
 #include <vector>
 #include "entry.h"
@@ -54,10 +55,11 @@ public:
     std::vector<EntryPtr> GetEvictionResults(double evict_ratio) override
     {
         std::vector<EntryPtr> victims;
+        if (evict_ratio == 0.0 || entries_.empty()) { return victims; }
+
         const auto now = std::chrono::system_clock::now();
-        std::size_t target =
-            static_cast<std::size_t>(static_cast<double>(entries_.size()) * evict_ratio);
-        if (target > entries_.size()) { target = entries_.size(); }
+        const auto target = std::max<std::size_t>(
+            1, static_cast<std::size_t>(static_cast<double>(entries_.size()) * evict_ratio));
         for (const auto& entry : entries_) {
             if (victims.size() >= target) { break; }
             if (!entry->TryMarkEvicting(now)) { continue; }

--- a/ucm/store/dram/cc/drampool/task_worker.cc
+++ b/ucm/store/dram/cc/drampool/task_worker.cc
@@ -65,8 +65,8 @@ Status TaskWorker::ProcessOneRequest(RequestTaskPtr task)
     if (!task || !task->request || task->peer_one_sided_id.empty()) {
         return Status::InvalidParam("TaskWorker got an invalid request task");
     }
-    const auto peerStatus = EnsurePeerReady(task->peer_one_sided_id);
-    if (peerStatus.Failure()) { return peerStatus; }
+    // By the time a request reaches DramPool, the store-initiated Connect control request
+    // must already have established the local route.
     const auto& peerOneSidedId = task->peer_one_sided_id;
     const auto& request = task->request;
     switch (request->opcode) {
@@ -89,11 +89,6 @@ Status TaskWorker::ProcessOneRequest(RequestTaskPtr task)
         case KvOpcode::None: break;
     }
     return Status::InvalidParam("TaskWorker got invalid opcode");
-}
-
-Status TaskWorker::EnsurePeerReady(const transport::ManagerID& targetOneSidedId)
-{
-    return runtime_.transport.Connect(transport::TransportProtocol::Hixl, targetOneSidedId);
 }
 
 Status TaskWorker::ProcessDump(const KvDumpRequest& request,

--- a/ucm/store/dram/cc/drampool/task_worker.h
+++ b/ucm/store/dram/cc/drampool/task_worker.h
@@ -38,7 +38,6 @@ public:
 
 private:
     Status ProcessOneRequest(RequestTaskPtr task);
-    Status EnsurePeerReady(const transport::ManagerID& targetOneSidedId);
     Status ProcessDump(const KvDumpRequest& request, const transport::ManagerID& peerOneSidedId);
     Status ProcessLoad(const KvLoadRequest& request, const transport::ManagerID& peerOneSidedId);
     Status ProcessLookup(const KvLookupRequest& request,

--- a/ucm/store/test/case/dram/drampool/completion_poller_test.cc
+++ b/ucm/store/test/case/dram/drampool/completion_poller_test.cc
@@ -61,6 +61,14 @@ using UC::Test::Dram::MakeEntry;
 
 std::uint8_t ResultCode(DumpLoadResult result) { return static_cast<std::uint8_t>(result); }
 
+bool MarkTimeoutReportedForTest(CompletionPoller& poller, CompletionRecord& record,
+                                std::uint64_t nowMs)
+{
+    if (record.timeout_reported || !poller.OperationTimedOut(record, nowMs)) { return false; }
+    record.timeout_reported = true;
+    return true;
+}
+
 class CompletionPollerTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite()
@@ -226,7 +234,6 @@ TEST_F(CompletionPollerTest, RunWithStopSetDrainsAllQueuedFailures)
     EXPECT_TRUE(poller_->pending_.empty());
     CompletionRecord remaining;
     EXPECT_FALSE(completionQueue_.TryPop(remaining));
-    EXPECT_TRUE(poller_->disconnectAllTransfers_);
 }
 
 TEST_F(CompletionPollerTest, DataStatusApiFailureAbortsDumpAndAdvancesToResponse)
@@ -363,11 +370,16 @@ TEST_F(CompletionPollerTest, OperationTimeoutHandlesBoundaryAndClockRollback)
 {
     CompletionRecord record;
     record.submit_ms = 1'000;
+    record.peer_one_sided_id = kUnavailablePeer;
     g_config.opTimeoutMs = 100;
 
     EXPECT_FALSE(poller_->OperationTimedOut(record, 999));
     EXPECT_FALSE(poller_->OperationTimedOut(record, 1'099));
     EXPECT_TRUE(poller_->OperationTimedOut(record, 1'100));
+    EXPECT_FALSE(MarkTimeoutReportedForTest(*poller_, record, 1'099));
+    EXPECT_TRUE(MarkTimeoutReportedForTest(*poller_, record, 1'100));
+    EXPECT_TRUE(record.timeout_reported);
+    EXPECT_FALSE(MarkTimeoutReportedForTest(*poller_, record, 1'200));
 }
 
 TEST_F(CompletionPollerTest, SubmitResponseRejectsMissingPeerAndUnknownOpcode)

--- a/ucm/store/test/case/dram/drampool/dram_lru_eviction_policy_test.cc
+++ b/ucm/store/test/case/dram/drampool/dram_lru_eviction_policy_test.cc
@@ -110,6 +110,19 @@ TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsEvictsOldestEntryFirst)
     EXPECT_EQ(victims[0]->key, k1);
 }
 
+TEST_F(UCLruEvictionPolicyTest, SmallPositiveRatioEvictsAtLeastOneEntry)
+{
+    auto k1 = KeyFromHex("a1");
+    auto k2 = KeyFromHex("a2");
+    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1)).Success());
+    ASSERT_TRUE(policy_.AddKey(k2, MakeEntry(k2)).Success());
+
+    auto victims = policy_.GetEvictionResults(0.1);
+
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(victims[0]->key, k1);
+}
+
 TEST_F(UCLruEvictionPolicyTest, GetEvictionResultsRespectsEvictRatio)
 {
     auto k1 = KeyFromHex("a1");

--- a/ucm/store/test/case/dram/drampool/dram_pos_eviction_policy_test.cc
+++ b/ucm/store/test/case/dram/drampool/dram_pos_eviction_policy_test.cc
@@ -82,6 +82,27 @@ TEST_F(UCPosEvictionPolicyTest, GetEvictionResultsEmptyWhenNoEntries)
     EXPECT_TRUE(policy_.GetEvictionResults(1.0).empty());
 }
 
+TEST_F(UCPosEvictionPolicyTest, GetEvictionResultsEmptyWhenEvictRatioIsZero)
+{
+    auto key = KeyFromHex("a1");
+    ASSERT_TRUE(policy_.AddKey(key, MakeEntry(key, 1, past_)).Success());
+
+    EXPECT_TRUE(policy_.GetEvictionResults(0.0).empty());
+}
+
+TEST_F(UCPosEvictionPolicyTest, SmallPositiveRatioEvictsAtLeastOneEntry)
+{
+    auto k1 = KeyFromHex("a1");
+    auto k2 = KeyFromHex("a2");
+    ASSERT_TRUE(policy_.AddKey(k1, MakeEntry(k1, 1, past_)).Success());
+    ASSERT_TRUE(policy_.AddKey(k2, MakeEntry(k2, 2, past_)).Success());
+
+    auto victims = policy_.GetEvictionResults(0.1);
+
+    ASSERT_EQ(victims.size(), 1UL);
+    EXPECT_EQ(victims[0]->key, k2);
+}
+
 TEST_F(UCPosEvictionPolicyTest, GetEvictionResultsEvictsAllAtFullRatio)
 {
     auto k1 = KeyFromHex("a1");

--- a/ucm/store/test/case/dram/drampool/task_worker_test.cc
+++ b/ucm/store/test/case/dram/drampool/task_worker_test.cc
@@ -167,11 +167,16 @@ TEST_F(TaskWorkerTest, RejectsMalformedTasksBeforeTransport)
     ExpectNoCompletion();
 }
 
-TEST_F(TaskWorkerTest, RealTransportManagerRejectsUnavailablePeer)
+TEST_F(TaskWorkerTest, ProcessesRequestWithoutInitiatingPeerConnection)
 {
     TaskWorker worker(*runtime_);
-    EXPECT_TRUE(worker.EnsurePeerReady(kTargetManager).Failure());
-    ExpectNoCompletion();
+    auto task = std::make_unique<RequestTask>();
+    task->peer_one_sided_id = kTargetManager;
+    task->request = std::make_unique<KvLookupRequest>();
+    task->request->opcode = KvOpcode::Lookup;
+
+    EXPECT_TRUE(worker.ProcessOneRequest(std::move(task)).Success());
+    EXPECT_EQ(PopCompletion().peer_one_sided_id, kTargetManager);
 }
 
 TEST_F(TaskWorkerTest, LookupReturnsHitAndMiss)


### PR DESCRIPTION
## Purpose
Make DramPool follow the Store-initiated transport connection lifecycle and ensure small buffer pools can evict entries when a positive eviction ratio would otherwise truncate the target count to zero.

## Modifications
Remove request-path Connect and timeout/stop-path Disconnect calls from DramPool workers. Keep timed-out transfers pending, log each phase timeout once, and preserve transport handles and owned buffers until transport reports a terminal status or Store initiates teardown.

Set the POSITION and LRU eviction target to at least one when entries exist and the configured eviction ratio is positive. Add regression coverage for passive request handling, timeout reporting, and small positive eviction ratios.

TransportManager::Shutdown retains its generic coordinated disconnect behavior; final process-shutdown semantics are outside this change.

## Test
```
CompletionPollerTest.*:TaskWorkerTest.*:UCPosEvictionPolicyTest.*:UCLruEvictionPolicyTest.*
[==========] Running 65 tests from 4 test suites.
[  PASSED  ] 65 tests.

UCPosEvictionPolicyTest.*:UCLruEvictionPolicyTest.*
[==========] Running 36 tests from 2 test suites.
[  PASSED  ] 36 tests.
```