### PR TITLE
[Fix] Fix the logic of AsuClient Check.

### DIFF
--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -275,10 +275,7 @@ public:
         return client_->DeleteAsync(keys, taskId);
     }
 
-    AsuStatus Check(UC::ASU::TaskId taskId, UC::ASU::TaskResult& result) override
-    {
-        return client_->Check(taskId, result);
-    }
+    bool Check(UC::ASU::TaskId taskId) override { return client_->Check(taskId); }
 
     AsuStatus Wait(UC::ASU::TaskId taskId, std::uint64_t timeoutMs,
                    UC::ASU::TaskResult& result) override
@@ -432,16 +429,7 @@ public:
 
     Expected<bool> Check(Detail::TaskHandle taskId) override
     {
-        UC::ASU::TaskResult result;
-        auto status = backend_->Check(static_cast<UC::ASU::TaskId>(taskId), result);
-        if (!status.ok()) {
-            LogAsuStatus("check task", status);
-            return ConvertStatus(status);
-        }
-        if (!result.status.ok() && result.status.code != AsuStatusCode::IN_PROGRESS) {
-            LogAsuStatus("task result check", result.status);
-        }
-        return result.status.code != AsuStatusCode::IN_PROGRESS;
+        return backend_->Check(static_cast<UC::ASU::TaskId>(taskId));
     }
 
     Status Wait(Detail::TaskHandle taskId) override

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -53,7 +53,7 @@ public:
                                        UC::ASU::TaskId& taskId) = 0;
     virtual UC::ASU::Status DeleteAsync(const std::vector<UC::ASU::CacheKey>& keys,
                                         UC::ASU::TaskId& taskId) = 0;
-    virtual UC::ASU::Status Check(UC::ASU::TaskId taskId, UC::ASU::TaskResult& result) = 0;
+    virtual bool Check(UC::ASU::TaskId taskId) = 0;
     virtual UC::ASU::Status Wait(UC::ASU::TaskId taskId, std::uint64_t timeoutMs,
                                  UC::ASU::TaskResult& result) = 0;
     virtual UC::ASU::Status RegisterRegions(

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -128,8 +128,18 @@ public:
         return Submit(keys.size(), taskId);
     }
 
-    UC::ASU::Status Check(UC::ASU::TaskId taskId, UC::ASU::TaskResult& result) override
+    bool Check(UC::ASU::TaskId taskId) override
     {
+        if (!initialized_) { return true; }
+        auto iter = taskResults_.find(taskId);
+        return iter == taskResults_.end() ||
+               iter->second.status.code != UC::ASU::StatusCode::IN_PROGRESS;
+    }
+
+    UC::ASU::Status Wait(UC::ASU::TaskId taskId, std::uint64_t timeoutMs,
+                         UC::ASU::TaskResult& result) override
+    {
+        (void)timeoutMs;
         if (!initialized_) { return NotInitialized(); }
 
         auto iter = taskResults_.find(taskId);
@@ -139,14 +149,8 @@ public:
         }
 
         result = iter->second;
-        return UC::ASU::Status::OK();
-    }
-
-    UC::ASU::Status Wait(UC::ASU::TaskId taskId, std::uint64_t timeoutMs,
-                         UC::ASU::TaskResult& result) override
-    {
-        (void)timeoutMs;
-        return Check(taskId, result);
+        taskResults_.erase(iter);
+        return result.status;
     }
 
     UC::ASU::Status RegisterRegions(

--- a/ucm/transport/kv/asu/client/include/asu_client/asu_client.h
+++ b/ucm/transport/kv/asu/client/include/asu_client/asu_client.h
@@ -57,7 +57,8 @@ public:
     virtual Status StoreAsync(const std::vector<KVBuffer>& entries, TaskId& taskId) = 0;
     virtual Status DeleteAsync(const std::vector<CacheKey>& keys, TaskId& taskId) = 0;
 
-    virtual Status Check(TaskId taskId, TaskResult& result) = 0;
+    // Returns false only while the task is still in progress. Wait retrieves the final result.
+    virtual bool Check(TaskId taskId) = 0;
     virtual Status Wait(TaskId taskId, std::uint64_t timeoutMs, TaskResult& result) = 0;
 
     virtual Status RegisterRegions(const std::vector<MemoryRegion>& regions,

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -160,16 +160,7 @@ Status AsuClientImpl::DeleteAsync(const std::vector<CacheKey>& keys, TaskId& tas
     return SubmitAsync(ClientOpType::DELETE, keys, config_.timeoutMs, taskId);
 }
 
-Status AsuClientImpl::Check(TaskId taskId, TaskResult& result)
-{
-    auto status = taskManager_.Check(taskId, result);
-    if (status.code == StatusCode::TASK_NOT_FOUND) { return status; }
-    if (viewServer_ != nullptr &&
-        (viewServer_->ShouldRefreshView(status) || viewServer_->ShouldRefreshView(result))) {
-        RequestBackgroundRefresh();
-    }
-    return status;
-}
+bool AsuClientImpl::Check(TaskId taskId) { return taskManager_.Check(taskId); }
 
 Status AsuClientImpl::Wait(TaskId taskId, std::uint64_t timeoutMs, TaskResult& result)
 {

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.h
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.h
@@ -79,7 +79,7 @@ public:
     Status DeleteAsync(const std::vector<CacheKey>& keys, TaskId& taskId) override;
 
     // Checks an aggregate task.
-    Status Check(TaskId taskId, TaskResult& result) override;
+    bool Check(TaskId taskId) override;
     // Waits for an aggregate task.
     Status Wait(TaskId taskId, std::uint64_t timeoutMs, TaskResult& result) override;
 

--- a/ucm/transport/kv/asu/client/src/client_task_manager.cpp
+++ b/ucm/transport/kv/asu/client/src/client_task_manager.cpp
@@ -110,20 +110,10 @@ bool ClientTask::AllTransportTasksCompleted() const
     return remainingTransportTasks.load(std::memory_order_acquire) == 0;
 }
 
-Status ClientTaskManager::Check(TaskId taskId, TaskResult& result)
+bool ClientTaskManager::Check(TaskId taskId)
 {
     auto task = Get(taskId);
-    if (!task) { return Status::Error(StatusCode::TASK_NOT_FOUND, "task not found"); }
-
-    Status status;
-    bool done = false;
-    {
-        std::lock_guard<std::mutex> lock(task->waitMu);
-        status = BuildResult(task, result);
-        done = task->Done();
-    }
-    if (done) { (void)Remove(taskId); }
-    return status;
+    return !task || task->Done();
 }
 
 Status ClientTaskManager::Wait(TaskId taskId, std::uint64_t waitTimeoutMs, TaskResult& result)

--- a/ucm/transport/kv/asu/client/src/client_task_manager.h
+++ b/ucm/transport/kv/asu/client/src/client_task_manager.h
@@ -35,7 +35,7 @@ class ClientTaskManager : public TaskManagerBase<ClientTask, ClientTaskState> {
 public:
     ClientTaskManager() : TaskManagerBase(ClientTaskState::PENDING, "client") {}
 
-    Status Check(TaskId taskId, TaskResult& result);
+    bool Check(TaskId taskId);
     Status Wait(TaskId taskId, std::uint64_t waitTimeoutMs, TaskResult& result);
     Status Drain(std::uint64_t waitTimeoutMs);
     Status Process(const ClientTaskPtr& task);

--- a/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
@@ -378,15 +378,13 @@ bool WaitForFetchCount(const std::shared_ptr<FakeViewServer>& viewServer,
     return false;
 }
 
-Status CheckUntilComplete(AsuClient& client, TaskId taskId, TaskResult& result)
+bool CheckUntilComplete(AsuClient& client, TaskId taskId)
 {
-    Status status;
     for (std::uint32_t attempt = 0; attempt < 100; ++attempt) {
-        status = client.Check(taskId, result);
-        if (status.code != StatusCode::IN_PROGRESS) { return status; }
+        if (client.Check(taskId)) { return true; }
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }
-    return status;
+    return false;
 }
 
 ViewServerFactory MakeViewServerFactory(const std::shared_ptr<ViewServer>& viewServer)
@@ -479,9 +477,7 @@ TEST(AsuClientImplTest, Lifecycle_OperationsBeforeInitReturnExpectedErrors)
         taskId);
     EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
 
-    TaskResult taskResult;
-    status = client->Check(1, taskResult);
-    EXPECT_EQ(status.code, StatusCode::TASK_NOT_FOUND);
+    EXPECT_TRUE(client->Check(1));
 }
 
 TEST(AsuClientImplTest, Lifecycle_InitTwiceReturnsResourceBusy)
@@ -515,9 +511,7 @@ TEST(AsuClientImplTest, Lifecycle_ShutdownClearsTasksAndRejectsFutureOperations)
     status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, queryResult);
     EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
 
-    TaskResult taskResult;
-    status = client->Check(taskId, taskResult);
-    EXPECT_EQ(status.code, StatusCode::TASK_NOT_FOUND);
+    EXPECT_TRUE(client->Check(taskId));
 }
 
 TEST(AsuClientImplTest, Input_EmptyQueryReturnsEmptyResult)
@@ -708,9 +702,7 @@ TEST(AsuClientImplTest, QueryAsync_CompletesThroughTransportCallback)
     ASSERT_TRUE(status.ok()) << status.message;
     ASSERT_NE(taskId, kInvalidTaskId);
 
-    TaskResult result;
-    status = client->Check(taskId, result);
-    EXPECT_EQ(status.code, StatusCode::IN_PROGRESS);
+    EXPECT_FALSE(client->Check(taskId));
 
     ASSERT_TRUE(WaitForPendingCompletion(state, 10));
     TaskResult completionResult;
@@ -719,6 +711,7 @@ TEST(AsuClientImplTest, QueryAsync_CompletesThroughTransportCallback)
     completionResult.queryResult = QueryResult{{1}, 0};
     ASSERT_TRUE(InvokePendingCompletion(state, 10, std::move(completionResult)));
 
+    TaskResult result;
     status = client->Wait(taskId, 100, result);
     ASSERT_TRUE(status.ok()) << status.message;
     ASSERT_TRUE(result.queryResult.has_value());
@@ -1360,7 +1353,7 @@ TEST(AsuClientImplTest, MemoryRegister_UnregisterRemovesCachedResourceBeforeFutu
     EXPECT_TRUE(state->bindCalls.empty());
 }
 
-TEST(AsuClientImplTest, Task_CheckRemovesTaskAfterCompletion)
+TEST(AsuClientImplTest, Task_CheckKeepsTaskForWait)
 {
     auto state = std::make_shared<TestState>();
     auto client = CreateAsuClient(MakeFactory(state));
@@ -1374,11 +1367,14 @@ TEST(AsuClientImplTest, Task_CheckRemovesTaskAfterCompletion)
         taskId);
     ASSERT_TRUE(status.ok()) << status.message;
 
+    ASSERT_TRUE(CheckUntilComplete(*client, taskId));
+    EXPECT_TRUE(client->Check(taskId));
+
     TaskResult result;
-    status = CheckUntilComplete(*client, taskId, result);
+    status = client->Wait(taskId, 100, result);
     ASSERT_TRUE(status.ok()) << status.message;
 
-    status = client->Check(taskId, result);
+    status = client->Wait(taskId, 100, result);
     EXPECT_EQ(status.code, StatusCode::TASK_NOT_FOUND);
 }
 
@@ -1473,23 +1469,24 @@ TEST(AsuClientImplTest, Task_CheckUsesClientStateUntilCompletionCallback)
         taskId);
     ASSERT_TRUE(status.ok()) << status.message;
 
-    TaskResult result;
-    status = client->Check(taskId, result);
-    EXPECT_EQ(status.code, StatusCode::IN_PROGRESS);
+    EXPECT_FALSE(client->Check(taskId));
 
     ASSERT_TRUE(WaitForPendingCompletion(state, 10));
     TaskResult completionResult;
     completionResult.status = Status::OK();
     completionResult.entryStatus = {Status::OK()};
     ASSERT_TRUE(InvokePendingCompletion(state, 10, std::move(completionResult)));
-    status = client->Check(taskId, result);
+    EXPECT_TRUE(client->Check(taskId));
+
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
     ASSERT_TRUE(status.ok()) << status.message;
 
-    status = client->Check(taskId, result);
+    status = client->Wait(taskId, 100, result);
     EXPECT_EQ(status.code, StatusCode::TASK_NOT_FOUND);
 }
 
-TEST(AsuClientImplTest, Task_CheckRefreshesViewOnRefreshableChildFailure)
+TEST(AsuClientImplTest, Task_CheckThenWaitHandlesRefreshableChildFailure)
 {
     auto state = std::make_shared<TestState>();
     state->checkResultStatus[10] = Status::Error(StatusCode::IO_ERROR, "fake child io error");
@@ -1511,6 +1508,10 @@ TEST(AsuClientImplTest, Task_CheckRefreshesViewOnRefreshableChildFailure)
     },
         taskId);
     ASSERT_TRUE(status.ok()) << status.message;
+
+    ASSERT_TRUE(CheckUntilComplete(*client, taskId));
+    EXPECT_TRUE(client->Check(taskId));
+    EXPECT_EQ(viewServer->FetchCount(), std::size_t{1});
 
     TaskResult result;
     status = client->Wait(taskId, 100, result);
@@ -1601,8 +1602,7 @@ TEST(AsuClientImplTest, Task_WaitTimeoutRemovesTask)
     status = client->Wait(taskId, 100, result);
     EXPECT_EQ(status.code, StatusCode::TIMEOUT);
 
-    status = client->Check(taskId, result);
-    EXPECT_EQ(status.code, StatusCode::TASK_NOT_FOUND);
+    EXPECT_TRUE(client->Check(taskId));
 
     ASSERT_TRUE(WaitForPendingCompletion(state, 10));
     TaskResult completionResult;
@@ -1763,7 +1763,8 @@ TEST(AsuClientImplTest,
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     TaskResult taskResult;
-    status = CheckUntilComplete(*client, taskId, taskResult);
+    ASSERT_TRUE(CheckUntilComplete(*client, taskId));
+    status = client->Wait(taskId, 100, taskResult);
     EXPECT_TRUE(status.ok()) << status.message;
     ASSERT_EQ(state->storeCalls, std::vector<AsuId>({20}));
 

--- a/ucm/transport/kv/asu/test/case/asu_smoke_test.cc
+++ b/ucm/transport/kv/asu/test/case/asu_smoke_test.cc
@@ -192,9 +192,7 @@ void ExpectCompleted(AsuClient& client, TaskId taskId, std::size_t entryCount)
         EXPECT_TRUE(entryStatus.ok()) << entryStatus.message;
     }
 
-    TaskResult checkResult;
-    status = client.Check(taskId, checkResult);
-    ASSERT_EQ(status.code, StatusCode::TASK_NOT_FOUND);
+    ASSERT_TRUE(client.Check(taskId));
 }
 
 Status QueryAndWait(AsuClient& client, const std::vector<CacheKey>& keys,


### PR DESCRIPTION
## Purpose
Modify AsuClient Check.

## Modifications 
1. Check API removes *result*.
2. Check only returns whether a task is in-progress/pending (false) or elsewise (true).

## Test
Offline inference test is passed.
Unit tests are all passed.