### PR TITLE
[Refactor] Remove useless ClientBackend

### DIFF
--- a/examples/ucm_config_asu.yaml
+++ b/examples/ucm_config_asu.yaml
@@ -33,6 +33,7 @@ ucm_connectors:
 
       # ASU wait, operation timeout, and connection recovery.
       asu_default_wait_timeout_ms: 5000
+      asu_query_timeout_ms: 500
       asu_timeout_ms: 5000
       asu_max_error_count: 2
       asu_max_inflight_tasks: 1024

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -213,99 +213,34 @@ UC::ASU::TransportConfig BuildTransportConfig(const Config& config, std::size_t 
     return transportConfig;
 }
 
-class ClientBackend final : public AsuBackend {
-public:
-    AsuStatus Init(const Config& config) override
-    {
-        client_ = UC::ASU::CreateAsuClient();
-        UC::ASU::AsuClientConfig asuConfig;
-        asuConfig.clientId = config.clientId;
-        asuConfig.viewServiceAddrs = config.viewServiceAddrs;
-        asuConfig.defaultWaitTimeoutMs = config.defaultWaitTimeoutMs;
-        asuConfig.timeoutMs = config.timeoutMs;
-        asuConfig.attrs = config.clientAttrs;
-        asuConfig.transportConfigs.reserve(config.asuIds.size());
-        for (std::size_t i = 0; i < config.asuIds.size(); ++i) {
-            asuConfig.transportConfigs.emplace_back(BuildTransportConfig(config, i));
-        }
-        return client_->Init(asuConfig);
+UC::ASU::AsuClientConfig BuildAsuClientConfig(const Config& config)
+{
+    UC::ASU::AsuClientConfig asuConfig;
+    asuConfig.clientId = config.clientId;
+    asuConfig.viewServiceAddrs = config.viewServiceAddrs;
+    asuConfig.defaultWaitTimeoutMs = config.defaultWaitTimeoutMs;
+    asuConfig.timeoutMs = config.timeoutMs;
+    asuConfig.attrs = config.clientAttrs;
+    asuConfig.transportConfigs.reserve(config.asuIds.size());
+    for (std::size_t i = 0; i < config.asuIds.size(); ++i) {
+        asuConfig.transportConfigs.emplace_back(BuildTransportConfig(config, i));
     }
-
-    AsuStatus Init(const std::string& configPath) override
-    {
-        client_ = UC::ASU::CreateAsuClient();
-        return client_->Init(configPath);
-    }
-
-    AsuStatus Shutdown() override { return client_ ? client_->Shutdown() : AsuStatus::OK(); }
-
-    AsuStatus Query(const std::vector<UC::ASU::CacheKey>& keys,
-                    const UC::ASU::QueryOptions& options, UC::ASU::QueryResult& result) override
-    {
-        UC::ASU::TaskId taskId = UC::ASU::kInvalidTaskId;
-        auto status = client_->QueryAsync(keys, options, taskId);
-        if (!status.ok()) { return status; }
-
-        UC::ASU::TaskResult taskResult;
-        status = client_->Wait(taskId, options.timeoutMs, taskResult);
-        if (taskResult.queryResult.has_value()) {
-            result = std::move(*taskResult.queryResult);
-        } else if (status.ok()) {
-            return AsuStatus::Error(UC::ASU::StatusCode::INTERNAL_ERROR,
-                                    "client query result is missing");
-        }
-        return status;
-    }
-
-    AsuStatus LoadAsync(const std::vector<UC::ASU::KVBuffer>& entries,
-                        UC::ASU::TaskId& taskId) override
-    {
-        return client_->LoadAsync(entries, taskId);
-    }
-
-    AsuStatus StoreAsync(const std::vector<UC::ASU::KVBuffer>& entries,
-                         UC::ASU::TaskId& taskId) override
-    {
-        return client_->StoreAsync(entries, taskId);
-    }
-
-    AsuStatus DeleteAsync(const std::vector<UC::ASU::CacheKey>& keys,
-                          UC::ASU::TaskId& taskId) override
-    {
-        return client_->DeleteAsync(keys, taskId);
-    }
-
-    bool Check(UC::ASU::TaskId taskId) override { return client_->Check(taskId); }
-
-    AsuStatus Wait(UC::ASU::TaskId taskId, std::uint64_t timeoutMs,
-                   UC::ASU::TaskResult& result) override
-    {
-        return client_->Wait(taskId, timeoutMs, result);
-    }
-
-    AsuStatus RegisterRegions(const std::vector<UC::ASU::MemoryRegion>& regions,
-                              std::vector<UC::ASU::RegisteredMemory>& registeredRegions) override
-    {
-        return client_->RegisterRegions(regions, registeredRegions);
-    }
-
-private:
-    std::unique_ptr<UC::ASU::AsuClient> client_;
-};
+    return asuConfig;
+}
 
 class AsuStore final : public StoreV1 {
 public:
 #ifdef ASU_BUILD_TESTS
-    using BackendFactory = std::function<std::unique_ptr<AsuBackend>(const Config&)>;
+    using ClientFactory = std::function<std::unique_ptr<UC::ASU::AsuClient>(const Config&)>;
 
-    void SetBackendFactory(BackendFactory factory) { backendFactory_ = std::move(factory); }
+    void SetClientFactory(ClientFactory factory) { clientFactory_ = std::move(factory); }
 #endif
 
     ~AsuStore() override
     {
-        if (backend_) {
-            auto status = backend_->Shutdown();
-            if (!status.ok()) { UC_ERROR("Failed to shutdown ASU backend: {}.", status.message); }
+        if (client_) {
+            auto status = client_->Shutdown();
+            if (!status.ok()) { UC_ERROR("Failed to shutdown ASU client: {}.", status.message); }
         }
     }
 
@@ -318,13 +253,13 @@ public:
 
         tensorLayout_ = ParseTensorLayout(config.tensorLayout);
         config_ = std::move(config);
-        backend_ = CreateBackend(config_);
+        client_ = CreateClient(config_);
 
-        auto asuStatus = config_.configPath.empty() ? backend_->Init(config_)
-                                                    : backend_->Init(config_.configPath);
+        auto asuStatus = config_.configPath.empty() ? client_->Init(BuildAsuClientConfig(config_))
+                                                    : client_->Init(config_.configPath);
         if (!asuStatus.ok()) {
-            UC_ERROR("Failed to init ASU backend: {}.", asuStatus.message);
-            backend_.reset();
+            UC_ERROR("Failed to init ASU client: {}.", asuStatus.message);
+            client_.reset();
             return ConvertStatus(asuStatus);
         }
 
@@ -336,23 +271,17 @@ public:
 
     Expected<std::vector<uint8_t>> Lookup(const Detail::BlockId* blocks, size_t num) override
     {
-        UC::ASU::QueryOptions options;
-        options.mode = UC::ASU::QueryMode::PER_KEY;
-        options.timeoutMs = config_.timeoutMs;
-        return QueryBlocks(blocks, num, options);
+        return QueryBlocks(blocks, num);
     }
 
     Expected<ssize_t> LookupOnPrefix(const Detail::BlockId* blocks, size_t num) override
     {
         if (num == 0) { return static_cast<ssize_t>(-1); }
 
-        UC::ASU::QueryOptions options;
-        options.mode = UC::ASU::QueryMode::PREFIX;
-        options.timeoutMs = config_.timeoutMs;
-
         auto keys = BuildBlockKeys(blocks, num);
         UC::ASU::QueryResult queryResult;
-        auto status = backend_->Query(keys, options, queryResult);
+        auto status = Query(keys, queryResult);
+        if (status.code == AsuStatusCode::TIMEOUT) { return static_cast<ssize_t>(-1); }
         if (!status.ok()) {
             LogAsuStatus("prefix query", status);
             return ConvertStatus(status);
@@ -376,7 +305,7 @@ public:
     Status RegisterKVCaches(const UC::KVCacheRegistration* registrations,
                             std::size_t count) override
     {
-        if (!backend_) { return Status::Error("ASU backend is not initialized"); }
+        if (!client_) { return Status::Error("ASU client is not initialized"); }
 
         std::vector<UC::ASU::MemoryRegion> regions;
         regions.reserve(count);
@@ -392,7 +321,7 @@ public:
         if (regions.empty()) { return Status::OK(); }
 
         std::vector<UC::ASU::RegisteredMemory> registeredRegions;
-        auto status = backend_->RegisterRegions(regions, registeredRegions);
+        auto status = client_->RegisterRegions(regions, registeredRegions);
         if (!status.ok()) {
             LogAsuStatus("register persistent regions", status);
             return ConvertStatus(status);
@@ -414,7 +343,7 @@ public:
 
     Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override
     {
-        return Submit(std::move(task), &AsuBackend::LoadAsync);
+        return Submit(std::move(task), &UC::ASU::AsuClient::LoadAsync);
     }
 
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override
@@ -424,19 +353,19 @@ public:
             LogAsuStatus("wait prerequisite event", status);
             return ConvertStatus(status);
         }
-        return Submit(std::move(task), &AsuBackend::StoreAsync);
+        return Submit(std::move(task), &UC::ASU::AsuClient::StoreAsync);
     }
 
     Expected<bool> Check(Detail::TaskHandle taskId) override
     {
-        return backend_->Check(static_cast<UC::ASU::TaskId>(taskId));
+        return client_->Check(static_cast<UC::ASU::TaskId>(taskId));
     }
 
     Status Wait(Detail::TaskHandle taskId) override
     {
         UC::ASU::TaskResult result;
-        auto status = backend_->Wait(static_cast<UC::ASU::TaskId>(taskId),
-                                     config_.defaultWaitTimeoutMs, result);
+        auto status = client_->Wait(static_cast<UC::ASU::TaskId>(taskId),
+                                    config_.defaultWaitTimeoutMs, result);
         if (!status.ok()) {
             LogAsuStatus("wait task", status);
             return ConvertStatus(status);
@@ -446,8 +375,8 @@ public:
     }
 
 private:
-    using SubmitFunc = AsuStatus (AsuBackend::*)(const std::vector<UC::ASU::KVBuffer>&,
-                                                 UC::ASU::TaskId&);
+    using SubmitFunc = AsuStatus (UC::ASU::AsuClient::*)(const std::vector<UC::ASU::KVBuffer>&,
+                                                         UC::ASU::TaskId&);
 
     Config ParseConfig(const Detail::Dictionary& inConfig)
     {
@@ -471,6 +400,7 @@ private:
         }
         inConfig.GetNumber("asu_default_wait_timeout_ms", config.defaultWaitTimeoutMs);
         inConfig.GetNumber("asu_timeout_ms", config.timeoutMs);
+        inConfig.GetNumber("asu_query_timeout_ms", config.queryTimeoutMs);
         inConfig.GetNumber("asu_max_error_count", config.maxErrorCount);
         inConfig.GetNumber("asu_max_inflight_tasks", config.maxInflightTasks);
         inConfig.GetNumber("asu_max_inflight_bytes", config.maxInflightBytes);
@@ -596,6 +526,9 @@ private:
         if (config.timeoutMs == 0) {
             return Status::InvalidParam("asu_timeout_ms must be greater than zero");
         }
+        if (config.queryTimeoutMs == 0) {
+            return Status::InvalidParam("asu_query_timeout_ms must be greater than zero");
+        }
         if (config.maxInflightTasks > std::numeric_limits<std::uint32_t>::max()) {
             return Status::InvalidParam("asu_max_inflight_tasks exceeds uint32 range");
         }
@@ -628,14 +561,12 @@ private:
         return Status::OK();
     }
 
-    std::unique_ptr<AsuBackend> CreateBackend(const Config& config)
+    std::unique_ptr<UC::ASU::AsuClient> CreateClient(const Config& config)
     {
 #ifdef ASU_BUILD_TESTS
-        if (backendFactory_) { return backendFactory_(config); }
+        if (clientFactory_) { return clientFactory_(config); }
 #endif
-        // Keep asu_mode for configuration validation, but route all store operations through
-        // the ASU client backend.
-        return std::make_unique<ClientBackend>();
+        return UC::ASU::CreateAsuClient();
     }
 
     std::size_t ShardsPerBlock() const { return config_.blockSize / config_.shardSize; }
@@ -701,15 +632,32 @@ private:
         throw std::logic_error("unhandled ASU tensor layout");
     }
 
-    Expected<std::vector<uint8_t>> QueryBlocks(const Detail::BlockId* blocks, std::size_t num,
-                                               const UC::ASU::QueryOptions& options) const
+    AsuStatus Query(const std::vector<UC::ASU::CacheKey>& keys, UC::ASU::QueryResult& result) const
+    {
+        UC::ASU::TaskId taskId = UC::ASU::kInvalidTaskId;
+        auto status = client_->QueryAsync(keys, taskId);
+        if (!status.ok()) { return status; }
+
+        UC::ASU::TaskResult taskResult;
+        status = client_->Wait(taskId, config_.queryTimeoutMs, taskResult);
+        if (taskResult.queryResult.has_value()) {
+            result = std::move(*taskResult.queryResult);
+        } else if (status.ok()) {
+            return AsuStatus::Error(UC::ASU::StatusCode::INTERNAL_ERROR,
+                                    "client query result is missing");
+        }
+        return status;
+    }
+
+    Expected<std::vector<uint8_t>> QueryBlocks(const Detail::BlockId* blocks, std::size_t num) const
     {
         std::vector<uint8_t> result(num, false);
         if (num == 0) { return result; }
 
         auto keys = BuildBlockKeys(blocks, num);
         UC::ASU::QueryResult queryResult;
-        auto status = backend_->Query(keys, options, queryResult);
+        auto status = Query(keys, queryResult);
+        if (status.code == AsuStatusCode::TIMEOUT) { return result; }
         if (!status.ok()) {
             LogAsuStatus("query blocks", status);
             return ConvertStatus(status);
@@ -739,7 +687,7 @@ private:
         if (!entries) { return entries.Error(); }
 
         UC::ASU::TaskId taskId = UC::ASU::kInvalidTaskId;
-        auto status = ((*backend_).*submit)(entries.Value(), taskId);
+        auto status = ((*client_).*submit)(entries.Value(), taskId);
         if (!status.ok()) {
             LogAsuStatus("submit task", status);
             return ConvertStatus(status);
@@ -819,11 +767,11 @@ private:
 
     Config config_;
     TensorLayout tensorLayout_{TensorLayout::MLA};
-    std::unique_ptr<AsuBackend> backend_;
+    std::unique_ptr<UC::ASU::AsuClient> client_;
     mutable std::mutex persistentRegionsMu_;
     std::vector<RegisteredPersistentRegion> persistentRegions_;
 #ifdef ASU_BUILD_TESTS
-    BackendFactory backendFactory_;
+    ClientFactory clientFactory_;
 #endif
 };
 

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -24,6 +24,7 @@ struct Config {
     std::uint16_t asuPort{0};
     std::uint64_t defaultWaitTimeoutMs{100};
     std::uint64_t timeoutMs{100};
+    std::uint64_t queryTimeoutMs{500};
     std::uint64_t maxErrorCount{2};
     std::uint64_t maxInflightTasks{1024};
     std::uint64_t maxInflightBytes{1ULL << 30};
@@ -36,29 +37,6 @@ struct Config {
     std::string fakeBackendPath;
     std::uint64_t fakeBackendLatencyMs{1};
     std::unordered_map<std::string, std::string> clientAttrs;
-};
-
-class AsuBackend {
-public:
-    virtual ~AsuBackend() = default;
-    virtual UC::ASU::Status Init(const Config& config) = 0;
-    virtual UC::ASU::Status Init(const std::string& configPath) = 0;
-    virtual UC::ASU::Status Shutdown() = 0;
-    virtual UC::ASU::Status Query(const std::vector<UC::ASU::CacheKey>& keys,
-                                  const UC::ASU::QueryOptions& options,
-                                  UC::ASU::QueryResult& result) = 0;
-    virtual UC::ASU::Status LoadAsync(const std::vector<UC::ASU::KVBuffer>& entries,
-                                      UC::ASU::TaskId& taskId) = 0;
-    virtual UC::ASU::Status StoreAsync(const std::vector<UC::ASU::KVBuffer>& entries,
-                                       UC::ASU::TaskId& taskId) = 0;
-    virtual UC::ASU::Status DeleteAsync(const std::vector<UC::ASU::CacheKey>& keys,
-                                        UC::ASU::TaskId& taskId) = 0;
-    virtual bool Check(UC::ASU::TaskId taskId) = 0;
-    virtual UC::ASU::Status Wait(UC::ASU::TaskId taskId, std::uint64_t timeoutMs,
-                                 UC::ASU::TaskResult& result) = 0;
-    virtual UC::ASU::Status RegisterRegions(
-        const std::vector<UC::ASU::MemoryRegion>& regions,
-        std::vector<UC::ASU::RegisteredMemory>& registeredRegions) = 0;
 };
 
 }  // namespace UC::AsuStore

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -51,31 +51,27 @@ UC::ASU::MRHandle MakeTestMrHandle(std::uintptr_t value)
     return reinterpret_cast<UC::ASU::MRHandle>(value);
 }
 
-struct FakeAsuBackendState {
-    std::vector<UC::ASU::QueryMode> queryModes;
+struct FakeAsuClientState {
     std::vector<UC::AsuStore::Config> initConfigs;
     std::vector<UC::ASU::KVBuffer> lastLoadEntries;
     std::vector<UC::ASU::KVBuffer> lastStoreEntries;
     std::vector<UC::ASU::MemoryRegion> registeredRegions;
 };
 
-class FakeAsuBackend final : public UC::AsuStore::AsuBackend {
+class FakeAsuClient final : public UC::ASU::AsuClient {
 public:
-    explicit FakeAsuBackend(std::shared_ptr<FakeAsuBackendState> state) : state_(std::move(state))
-    {
-    }
+    explicit FakeAsuClient(std::shared_ptr<FakeAsuClientState> state) : state_(std::move(state)) {}
 
-    UC::ASU::Status Init(const UC::AsuStore::Config& config) override
+    UC::ASU::Status Init(const UC::ASU::AsuClientConfig& config) override
     {
-        config_ = config;
-        state_->initConfigs.emplace_back(config);
+        (void)config;
         initialized_ = true;
         return UC::ASU::Status::OK();
     }
 
     UC::ASU::Status Init(const std::string& configPath) override
     {
-        configPath_ = configPath;
+        (void)configPath;
         initialized_ = true;
         return UC::ASU::Status::OK();
     }
@@ -86,23 +82,26 @@ public:
         return UC::ASU::Status::OK();
     }
 
-    UC::ASU::Status Query(const std::vector<UC::ASU::CacheKey>& keys,
-                          const UC::ASU::QueryOptions& options,
-                          UC::ASU::QueryResult& result) override
+    UC::ASU::Status QueryAsync(const std::vector<UC::ASU::CacheKey>& keys,
+                               UC::ASU::TaskId& taskId) override
     {
         if (!initialized_) { return NotInitialized(); }
 
-        state_->queryModes.emplace_back(options.mode);
+        UC::ASU::TaskResult taskResult;
+        taskResult.status = UC::ASU::Status::OK();
+        taskResult.entryStatus.assign(keys.size(), UC::ASU::Status::OK());
+        UC::ASU::QueryResult result;
         result.exists.clear();
         result.exists.reserve(keys.size());
         for (const auto& key : keys) { result.exists.emplace_back(storedKeys_.count(key) != 0); }
         result.prefixHitKeys = 0;
-        if (options.mode == UC::ASU::QueryMode::PREFIX) {
-            for (auto exists : result.exists) {
-                if (exists == 0) { break; }
-                ++result.prefixHitKeys;
-            }
+        for (auto exists : result.exists) {
+            if (exists == 0) { break; }
+            ++result.prefixHitKeys;
         }
+        taskResult.queryResult = std::move(result);
+        taskId = nextTaskId_++;
+        taskResults_.emplace(taskId, std::move(taskResult));
         return UC::ASU::Status::OK();
     }
 
@@ -168,6 +167,12 @@ public:
         return UC::ASU::Status::OK();
     }
 
+    UC::ASU::Status UnregisterRegions(const std::vector<UC::ASU::MRHandle>& handles) override
+    {
+        (void)handles;
+        return UC::ASU::Status::OK();
+    }
+
 private:
     UC::ASU::Status Submit(const std::vector<UC::ASU::KVBuffer>& entries, UC::ASU::TaskId& taskId)
     {
@@ -189,12 +194,10 @@ private:
     static UC::ASU::Status NotInitialized()
     {
         return UC::ASU::Status::Error(UC::ASU::StatusCode::NOT_INITIALIZED,
-                                      "fake ASU backend is not initialized");
+                                      "fake ASU client is not initialized");
     }
 
-    UC::AsuStore::Config config_;
-    std::string configPath_;
-    std::shared_ptr<FakeAsuBackendState> state_;
+    std::shared_ptr<FakeAsuClientState> state_;
     bool initialized_{false};
     UC::ASU::TaskId nextTaskId_{1};
     std::uintptr_t nextMrHandle_{1};
@@ -202,11 +205,13 @@ private:
     std::unordered_map<UC::ASU::TaskId, UC::ASU::TaskResult> taskResults_;
 };
 
-std::shared_ptr<FakeAsuBackendState> UseFakeBackend(UC::AsuStore::AsuStore& store)
+std::shared_ptr<FakeAsuClientState> UseFakeClient(UC::AsuStore::AsuStore& store)
 {
-    auto state = std::make_shared<FakeAsuBackendState>();
-    store.SetBackendFactory(
-        [state](const UC::AsuStore::Config&) { return std::make_unique<FakeAsuBackend>(state); });
+    auto state = std::make_shared<FakeAsuClientState>();
+    store.SetClientFactory([state](const UC::AsuStore::Config& config) {
+        state->initConfigs.emplace_back(config);
+        return std::make_unique<FakeAsuClient>(state);
+    });
     return state;
 }
 
@@ -221,6 +226,7 @@ UC::Detail::Dictionary MakeBaseConfig()
     config.SetNumber("shard_size", std::size_t{64});
     config.SetNumber("block_size", std::size_t{64});
     config.SetNumber("asu_default_wait_timeout_ms", std::uint64_t{1000});
+    config.SetNumber("asu_query_timeout_ms", std::uint64_t{500});
     config.SetNumber("asu_timeout_ms", std::uint64_t{1000});
     config.SetNumber("asu_max_inflight_tasks", std::uint64_t{16});
     config.Set("kv_ns_ids", std::vector<ssize_t>{100});
@@ -293,7 +299,7 @@ TEST(UCAsuStoreTest, ParsesKvNamespaces)
 {
     {
         UC::AsuStore::AsuStore store;
-        auto state = UseFakeBackend(store);
+        auto state = UseFakeClient(store);
         auto config = MakeBaseConfig();
         config.Set("asu_ids", std::vector<ssize_t>{1001});
         ASSERT_TRUE(store.Setup(config).Success());
@@ -309,7 +315,7 @@ TEST(UCAsuStoreTest, ParsesKvNamespaces)
     };
     for (const auto& [suffix, expected] : cases) {
         UC::AsuStore::AsuStore store;
-        auto state = UseFakeBackend(store);
+        auto state = UseFakeClient(store);
         auto config = MakeBaseConfig();
         config.Set("asu_ids", std::vector<ssize_t>{1001});
         config.Set("unique_id", std::string{"engine_fawa_"} + suffix);
@@ -325,7 +331,7 @@ TEST(UCAsuStoreTest, ParsesKvNamespaces)
 TEST(UCAsuStoreTest, ParsesOperationTimeout)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_ids", std::vector<ssize_t>{1001});
     config.SetNumber("asu_timeout_ms", std::uint64_t{321});
@@ -348,11 +354,35 @@ TEST(UCAsuStoreTest, RejectsZeroOperationTimeout)
     EXPECT_TRUE(store.Setup(config).Failure());
 }
 
+TEST(UCAsuStoreTest, ParsesQueryTimeout)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeClient(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.SetNumber("asu_query_timeout_ms", std::uint64_t{321});
+
+    ASSERT_TRUE(store.Setup(config).Success());
+    ASSERT_FALSE(state->initConfigs.empty());
+    EXPECT_EQ(state->initConfigs.back().queryTimeoutMs, 321);
+}
+
+TEST(UCAsuStoreTest, RejectsZeroQueryTimeout)
+{
+    UC::AsuStore::AsuStore store;
+    auto config = MakeBaseConfig();
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.SetNumber("asu_query_timeout_ms", std::uint64_t{0});
+
+    EXPECT_TRUE(store.Setup(config).Failure());
+}
+
 TEST(UCAsuStoreTest, PropagatesMaxErrorCountToTransport)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
     config.SetNumber("asu_max_error_count", std::uint64_t{7});
 
     ASSERT_TRUE(store.Setup(config).Success());
@@ -459,7 +489,7 @@ TEST(UCAsuStoreTest, AivRequiresDeviceId)
     }
     {
         UC::AsuStore::AsuStore store;
-        UseFakeBackend(store);
+        UseFakeClient(store);
         auto config = MakeBaseConfig();
         config.Set("asu_ids", std::vector<ssize_t>{1001});
         config.Set("asu_trans_provider_backend", std::string{"aiv"});
@@ -491,7 +521,7 @@ TEST(UCAsuStoreTest, PropagatesKvNamespaceToEveryTransport)
 TEST(UCAsuStoreTest, SchedulerUsesConfiguredDeviceId)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("role", std::string{"scheduler"});
     config.Set("asu_ids", std::vector<ssize_t>{1001});
@@ -505,7 +535,7 @@ TEST(UCAsuStoreTest, SchedulerUsesConfiguredDeviceId)
 TEST(UCAsuStoreTest, WorkerUsesLocalRankDeviceId)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("role", std::string{"worker"});
     config.Set("asu_ids", std::vector<ssize_t>{1001});
@@ -519,7 +549,7 @@ TEST(UCAsuStoreTest, WorkerUsesLocalRankDeviceId)
 TEST(UCAsuStoreTest, TransportModeSmoke)
 {
     UC::AsuStore::AsuStore store;
-    UseFakeBackend(store);
+    UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_mode", std::string{"transport"});
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
@@ -534,7 +564,7 @@ TEST(UCAsuStoreTest, TransportModeSmoke)
 TEST(UCAsuStoreTest, ClientModeSmoke)
 {
     UC::AsuStore::AsuStore store;
-    UseFakeBackend(store);
+    UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1", "127.0.0.2"});
     config.Set("asu_ids", std::vector<ssize_t>{1001, 1002});
@@ -548,7 +578,7 @@ TEST(UCAsuStoreTest, ClientModeSmoke)
 TEST(UCAsuStoreTest, AllowsQueryOnlyConfigWithoutTensorSizes)
 {
     UC::AsuStore::AsuStore store;
-    UseFakeBackend(store);
+    UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.SetNumber("tensor_size", std::size_t{0});
     config.Set("asu_ids", std::vector<ssize_t>{1001});
@@ -564,7 +594,7 @@ TEST(UCAsuStoreTest, AllowsQueryOnlyConfigWithoutTensorSizes)
 TEST(UCAsuStoreTest, SchedulerRoleSkipsTransferLayoutValidation)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("role", std::string{"scheduler"});
     config.Set("asu_ids", std::vector<ssize_t>{1001});
@@ -594,7 +624,7 @@ TEST(UCAsuStoreTest, WorkerRoleRequiresTensorSizes)
 TEST(UCAsuStoreTest, UsesPersistentRegionHandleBeforeSubmitAndKeepsItAfterWait)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
     config.Set("asu_ids", std::vector<ssize_t>{1001});
@@ -616,7 +646,7 @@ TEST(UCAsuStoreTest, UsesPersistentRegionHandleBeforeSubmitAndKeepsItAfterWait)
 TEST(UCAsuStoreTest, PersistentRegionHandleIsSharedByEntriesAndNotReleasedPerTask)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
     config.Set("asu_ids", std::vector<ssize_t>{1001});
@@ -653,7 +683,7 @@ TEST(UCAsuStoreTest, PersistentRegionHandleIsSharedByEntriesAndNotReleasedPerTas
 TEST(UCAsuStoreTest, ResolvesEachEntryToItsContainingPersistentRegion)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
     config.Set("asu_ids", std::vector<ssize_t>{1001});
@@ -686,10 +716,10 @@ TEST(UCAsuStoreTest, ResolvesEachEntryToItsContainingPersistentRegion)
     EXPECT_NE(state->lastStoreEntries[0].buffer.handle, state->lastStoreEntries[1].buffer.handle);
 }
 
-TEST(UCAsuStoreTest, LookupOnPrefixUsesPrefixQueryMode)
+TEST(UCAsuStoreTest, LookupOnPrefixReturnsLastContiguousHit)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1", "127.0.0.2"});
     config.Set("asu_ids", std::vector<ssize_t>{1001, 1002});
@@ -709,8 +739,6 @@ TEST(UCAsuStoreTest, LookupOnPrefixUsesPrefixQueryMode)
     auto prefix = store.LookupOnPrefix(blocks.data(), blocks.size());
     ASSERT_TRUE(prefix.HasValue()) << prefix.Error().ToString();
     ASSERT_EQ(prefix.Value(), 0);
-    ASSERT_FALSE(state->queryModes.empty());
-    EXPECT_EQ(state->queryModes.back(), UC::ASU::QueryMode::PREFIX);
 }
 
 TEST(UCAsuStoreTest, ClientModeConfigPathSmoke)
@@ -725,7 +753,7 @@ TEST(UCAsuStoreTest, ClientModeConfigPathSmoke)
     }
 
     UC::AsuStore::AsuStore store;
-    UseFakeBackend(store);
+    UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_config_path", std::string{kConfigPath});
     auto setupStatus = store.Setup(config);
@@ -750,7 +778,7 @@ TEST(UCAsuStoreTest, TransportModeConfigPathSmoke)
     }
 
     UC::AsuStore::AsuStore store;
-    UseFakeBackend(store);
+    UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_mode", std::string{"transport"});
     config.Set("asu_config_path", std::string{kConfigPath});
@@ -783,7 +811,7 @@ TEST(UCAsuStoreTest, RejectsOddMultiTensorLayout)
 TEST(UCAsuStoreTest, UsesNonLayerwiseMlaTensorOffsets)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_mode", std::string{"transport"});
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
@@ -831,7 +859,7 @@ TEST(UCAsuStoreTest, UsesNonLayerwiseMlaTensorOffsets)
 TEST(UCAsuStoreTest, UsesHmaTensorOffsetsInConnectorOrder)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_mode", std::string{"transport"});
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
@@ -873,7 +901,7 @@ TEST(UCAsuStoreTest, UsesHmaTensorOffsetsInConnectorOrder)
 TEST(UCAsuStoreTest, UsesLayerwiseMlaTensorOffsets)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_mode", std::string{"transport"});
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
@@ -912,7 +940,7 @@ TEST(UCAsuStoreTest, UsesMultiSegmentLayerwiseMlaTensorOffsets)
     constexpr std::size_t alignedShardSize = alignment * 2;
 
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_mode", std::string{"transport"});
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
@@ -960,7 +988,7 @@ TEST(UCAsuStoreTest, UsesMultiSegmentLayerwiseMlaTensorOffsets)
 TEST(UCAsuStoreTest, AlignsTensorSizeAndDerivesShardBlockSize)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_mode", std::string{"transport"});
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
@@ -1000,7 +1028,7 @@ TEST(UCAsuStoreTest, AlignsTensorSizeAndDerivesShardBlockSize)
 TEST(UCAsuStoreTest, AllowsMultipleShardsPerBlock)
 {
     UC::AsuStore::AsuStore store;
-    UseFakeBackend(store);
+    UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_mode", std::string{"transport"});
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
@@ -1014,7 +1042,7 @@ TEST(UCAsuStoreTest, AllowsMultipleShardsPerBlock)
 TEST(UCAsuStoreTest, UsesLayerwiseGqaKeyValueOffsets)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_mode", std::string{"transport"});
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
@@ -1056,7 +1084,7 @@ TEST(UCAsuStoreTest, UsesLayerwiseGqaKeyValueOffsets)
 TEST(UCAsuStoreTest, UsesNonLayerwiseGqaKeyValueOffsets)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_mode", std::string{"transport"});
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
@@ -1098,7 +1126,7 @@ TEST(UCAsuStoreTest, UsesNonLayerwiseGqaKeyValueOffsets)
 TEST(UCAsuStoreTest, RegistersKvCacheRegions)
 {
     UC::AsuStore::AsuStore store;
-    auto state = UseFakeBackend(store);
+    auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_ids", std::vector<ssize_t>{1001});
     ASSERT_TRUE(store.Setup(config).Success());

--- a/ucm/transport/kv/asu/client/include/asu_client/asu_client.h
+++ b/ucm/transport/kv/asu/client/include/asu_client/asu_client.h
@@ -51,8 +51,7 @@ public:
     virtual Status Init(const std::string& configPath) = 0;
     virtual Status Shutdown() = 0;
 
-    virtual Status QueryAsync(const std::vector<CacheKey>& keys, const QueryOptions& options,
-                              TaskId& taskId) = 0;
+    virtual Status QueryAsync(const std::vector<CacheKey>& keys, TaskId& taskId) = 0;
     virtual Status LoadAsync(const std::vector<KVBuffer>& entries, TaskId& taskId) = 0;
     virtual Status StoreAsync(const std::vector<KVBuffer>& entries, TaskId& taskId) = 0;
     virtual Status DeleteAsync(const std::vector<CacheKey>& keys, TaskId& taskId) = 0;

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -137,10 +137,9 @@ Status AsuClientImpl::Shutdown()
     return finalStatus;
 }
 
-Status AsuClientImpl::QueryAsync(const std::vector<CacheKey>& keys, const QueryOptions& options,
-                                 TaskId& taskId)
+Status AsuClientImpl::QueryAsync(const std::vector<CacheKey>& keys, TaskId& taskId)
 {
-    auto status = SubmitAsync(ClientOpType::QUERY, keys, options.timeoutMs, taskId);
+    auto status = SubmitAsync(ClientOpType::QUERY, keys, taskId);
     if (IsRefreshNeeded(status)) { RequestBackgroundRefresh(); }
     return status;
 }
@@ -157,7 +156,7 @@ Status AsuClientImpl::StoreAsync(const std::vector<KVBuffer>& entries, TaskId& t
 
 Status AsuClientImpl::DeleteAsync(const std::vector<CacheKey>& keys, TaskId& taskId)
 {
-    return SubmitAsync(ClientOpType::DELETE, keys, config_.timeoutMs, taskId);
+    return SubmitAsync(ClientOpType::DELETE, keys, taskId);
 }
 
 bool AsuClientImpl::Check(TaskId taskId) { return taskManager_.Check(taskId); }
@@ -290,7 +289,7 @@ Status AsuClientImpl::SubmitAsync(ClientOpType opType, const std::vector<KVBuffe
 }
 
 Status AsuClientImpl::SubmitAsync(ClientOpType opType, const std::vector<CacheKey>& keys,
-                                  std::uint64_t timeoutMs, TaskId& taskId)
+                                  TaskId& taskId)
 {
     auto snapshot = GetSnapshot();
     if (!snapshot || !snapshot->router || snapshot->transports.empty()) {
@@ -310,7 +309,6 @@ Status AsuClientImpl::SubmitAsync(ClientOpType opType, const std::vector<CacheKe
     ctx->keys = keys;
     ctx->entryStatus.assign(keys.size(), Status::OK());
     ctx->queryResult.exists.assign(opType == ClientOpType::QUERY ? keys.size() : 0, 0);
-    ctx->timeoutMs = timeoutMs;
 
     auto status = taskManager_.Submit(std::move(ctx), taskId);
     if (!status.ok()) { return status; }

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.h
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.h
@@ -69,8 +69,7 @@ public:
     Status Shutdown() override;
 
     // Submits query operations to routed transports.
-    Status QueryAsync(const std::vector<CacheKey>& keys, const QueryOptions& options,
-                      TaskId& taskId) override;
+    Status QueryAsync(const std::vector<CacheKey>& keys, TaskId& taskId) override;
     // Submits load operations to routed transports.
     Status LoadAsync(const std::vector<KVBuffer>& entries, TaskId& taskId) override;
     // Submits store operations to routed transports.
@@ -93,8 +92,7 @@ private:
     // Creates and queues one entry-based client task.
     Status SubmitAsync(ClientOpType opType, const std::vector<KVBuffer>& entries, TaskId& taskId);
     // Creates and queues one key-based client task.
-    Status SubmitAsync(ClientOpType opType, const std::vector<CacheKey>& keys,
-                       std::uint64_t timeoutMs, TaskId& taskId);
+    Status SubmitAsync(ClientOpType opType, const std::vector<CacheKey>& keys, TaskId& taskId);
 
     // Runs queued tasks until shutdown and the queue are both complete.
     void WorkerLoop();

--- a/ucm/transport/kv/asu/client/src/client_task_manager.cpp
+++ b/ucm/transport/kv/asu/client/src/client_task_manager.cpp
@@ -189,7 +189,6 @@ void ClientTaskManager::CompleteTransportTask(const ClientTaskPtr& task,
                 task->queryResult.exists[transportTask->originalIndices[index]] =
                     result.queryResult->exists[index];
             }
-            task->queryResult.prefixHitKeys += result.queryResult->prefixHitKeys;
         }
     }
 
@@ -232,6 +231,14 @@ void ClientTaskManager::CompleteUndispatchedTransportTasks(const ClientTaskPtr& 
 
 void ClientTaskManager::Finalize(const ClientTaskPtr& task)
 {
+    if (task->opType == ClientOpType::QUERY) {
+        task->queryResult.prefixHitKeys = 0;
+        for (auto exists : task->queryResult.exists) {
+            if (exists == 0) { break; }
+            ++task->queryResult.prefixHitKeys;
+        }
+    }
+
     const bool anyFailed =
         std::any_of(task->transportTasks.begin(), task->transportTasks.end(),
                     [](const TransportTaskPtr& transportTask) {
@@ -282,7 +289,6 @@ Status ClientTaskManager::BuildTransportTasks(const ClientTaskPtr& task)
                 transportTask->originalIndices.push_back(index);
             }
         }
-        transportTask->timeoutMs = task->timeoutMs;
         task->transportTasks.push_back(std::move(transportTask));
     }
     std::vector<KVBuffer>{}.swap(task->entries);

--- a/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/client/test/asu_client_impl_test.cpp
@@ -75,7 +75,6 @@ struct TestState {
     std::vector<AsuId> loadCalls;
     std::vector<AsuId> storeCalls;
     std::vector<AsuId> deleteCalls;
-    std::unordered_map<AsuId, std::uint64_t> deleteTimeouts;
     std::vector<AsuId> cancelCalls;
     std::unordered_map<AsuId, TaskId> childTaskIds;
     std::unordered_map<AsuId, TaskCompletionCallback> pendingCompletionCallbacks;
@@ -212,7 +211,6 @@ public:
                 if (failureIter != state_->deleteFailures.end()) { return failureIter->second; }
 
                 state_->deleteCalls.emplace_back(config_.asuId);
-                state_->deleteTimeouts[config_.asuId] = task->timeoutMs;
                 task->taskId = 3000 + config_.asuId;
                 state_->childTaskIds[config_.asuId] = task->taskId;
                 Complete(task->keys.size(), std::move(task->onComplete));
@@ -418,15 +416,15 @@ void ExpectSameAsuSet(std::vector<AsuId> actual, std::vector<AsuId> expected)
     EXPECT_EQ(actual, expected);
 }
 
-Status QueryAndWait(AsuClient& client, const std::vector<CacheKey>& keys,
-                    const QueryOptions& options, QueryResult& result)
+Status QueryAndWait(AsuClient& client, const std::vector<CacheKey>& keys, QueryResult& result,
+                    std::uint64_t timeoutMs = 0)
 {
     TaskId taskId{kInvalidTaskId};
-    auto status = client.QueryAsync(keys, options, taskId);
+    auto status = client.QueryAsync(keys, taskId);
     if (!status.ok()) { return status; }
 
     TaskResult taskResult;
-    status = client.Wait(taskId, options.timeoutMs, taskResult);
+    status = client.Wait(taskId, timeoutMs, taskResult);
     if (taskResult.queryResult.has_value()) {
         result = std::move(*taskResult.queryResult);
     } else if (status.ok()) {
@@ -466,7 +464,7 @@ TEST(AsuClientImplTest, Lifecycle_OperationsBeforeInitReturnExpectedErrors)
     auto client = CreateAsuClient(MakeFactory(state));
 
     QueryResult queryResult;
-    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, queryResult);
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, queryResult);
     EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
 
     TaskId taskId = kInvalidTaskId;
@@ -508,7 +506,7 @@ TEST(AsuClientImplTest, Lifecycle_ShutdownClearsTasksAndRejectsFutureOperations)
     ASSERT_TRUE(client->Shutdown().ok());
 
     QueryResult queryResult;
-    status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, queryResult);
+    status = QueryAndWait(*client, {MakeCacheKey("k05")}, queryResult);
     EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
 
     EXPECT_TRUE(client->Check(taskId));
@@ -521,7 +519,7 @@ TEST(AsuClientImplTest, Input_EmptyQueryReturnsEmptyResult)
     ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
 
     QueryResult result;
-    auto status = QueryAndWait(*client, {}, QueryOptions{}, result);
+    auto status = QueryAndWait(*client, {}, result);
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_TRUE(result.exists.empty());
@@ -681,12 +679,12 @@ TEST(AsuClientImplTest, Query_PerKeyKeepsOriginalOrder)
     ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
 
     QueryResult result;
-    auto status =
-        QueryAndWait(*client, {MakeCacheKey("k05"), MakeCacheKey("k15"), MakeCacheKey("k25")},
-                     QueryOptions{}, result);
+    auto status = QueryAndWait(
+        *client, {MakeCacheKey("k05"), MakeCacheKey("k15"), MakeCacheKey("k25")}, result);
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(result.exists, std::vector<std::uint8_t>({0, 1, 1}));
+    EXPECT_EQ(result.prefixHitKeys, std::uint32_t{0});
     ExpectSameAsuSet(state->queryCalls, {10, 20});
 }
 
@@ -698,7 +696,7 @@ TEST(AsuClientImplTest, QueryAsync_CompletesThroughTransportCallback)
     ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
 
     TaskId taskId{kInvalidTaskId};
-    auto status = client->QueryAsync({MakeCacheKey("k15")}, QueryOptions{}, taskId);
+    auto status = client->QueryAsync({MakeCacheKey("k15")}, taskId);
     ASSERT_TRUE(status.ok()) << status.message;
     ASSERT_NE(taskId, kInvalidTaskId);
 
@@ -726,8 +724,7 @@ TEST(AsuClientImplTest, Query_PerKeyDispatchFailureCancelsOtherTransports)
     ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
 
     QueryResult result;
-    auto status =
-        QueryAndWait(*client, {MakeCacheKey("k05"), MakeCacheKey("k15")}, QueryOptions{}, result);
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05"), MakeCacheKey("k15")}, result);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     EXPECT_EQ(result.exists, std::vector<std::uint8_t>({0, 0}));
@@ -759,25 +756,24 @@ TEST(AsuClientImplTest, Query_PerKeyResultSizeMismatchReturnsPartialFailed)
     ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
 
     QueryResult result;
-    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, result);
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
 }
 
-TEST(AsuClientImplTest, Query_PrefixUsesPerKeyRouting)
+TEST(AsuClientImplTest, Query_ComputesPrefixInOriginalKeyOrder)
 {
     auto state = std::make_shared<TestState>();
     auto client = CreateAsuClient(MakeFactory(state));
     ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
 
-    QueryOptions options;
-    options.mode = QueryMode::PREFIX;
     QueryResult result;
     auto status = QueryAndWait(
-        *client, {MakeCacheKey("k05"), MakeCacheKey("k15"), MakeCacheKey("k25")}, options, result);
+        *client, {MakeCacheKey("k15"), MakeCacheKey("k25"), MakeCacheKey("k05")}, result);
 
     EXPECT_TRUE(status.ok()) << status.message;
-    EXPECT_EQ(result.exists, std::vector<std::uint8_t>({0, 1, 1}));
+    EXPECT_EQ(result.exists, std::vector<std::uint8_t>({1, 1, 0}));
+    EXPECT_EQ(result.prefixHitKeys, std::uint32_t{2});
     ExpectSameAsuSet(state->queryCalls, {10, 20});
 }
 
@@ -790,8 +786,7 @@ TEST(AsuClientImplTest, Query_CompletionFailuresDoNotSkipOtherTransports)
     ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
 
     QueryResult result;
-    auto status =
-        QueryAndWait(*client, {MakeCacheKey("k05"), MakeCacheKey("k15")}, QueryOptions{}, result);
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05"), MakeCacheKey("k15")}, result);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ExpectSameAsuSet(state->queryCalls, {10, 20});
@@ -807,11 +802,11 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryReturnsErrorWithoutRetry)
     EXPECT_EQ(state->createdTransports, std::uint32_t{2});
 
     QueryResult result;
-    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, result);
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
 
-    status = QueryAndWait(*client, {MakeCacheKey("k15")}, QueryOptions{}, result);
+    status = QueryAndWait(*client, {MakeCacheKey("k15")}, result);
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(result.exists, std::vector<std::uint8_t>({1}));
@@ -835,7 +830,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryDoesNotRefreshNonRefreshableError
     ASSERT_TRUE(client->Init(config).ok());
 
     QueryResult result;
-    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, result);
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     EXPECT_EQ(viewServer->FetchCount(), std::size_t{1});
@@ -860,7 +855,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryRefreshesOnIoError)
     ASSERT_TRUE(client->Init(config).ok());
 
     QueryResult result;
-    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, result);
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(client->Shutdown().ok());
@@ -885,7 +880,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryRefreshesOnTimeout)
     ASSERT_TRUE(client->Init(config).ok());
 
     QueryResult result;
-    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, result);
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(client->Shutdown().ok());
@@ -909,7 +904,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryReturnsPartialFailedWhenViewFetch
     ASSERT_TRUE(client->Init(config).ok());
 
     QueryResult result;
-    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, result);
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(client->Shutdown().ok());
@@ -1031,7 +1026,7 @@ TEST(AsuClientImplTest, ViewEpoch_DoesNotPublishSameOrOlderViewEpoch)
     ASSERT_TRUE(client->Init(config).ok());
 
     QueryResult result;
-    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, result);
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(client->Shutdown().ok());
     EXPECT_EQ(state->createdTransports, std::uint32_t{1});
@@ -1049,11 +1044,11 @@ TEST(AsuClientImplTest, SnapshotRefresh_BuildFailureKeepsOldSnapshot)
     ASSERT_TRUE(client->Init(config).ok());
 
     QueryResult result;
-    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, result);
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(WaitForFetchCount(viewServer, 2));
 
-    status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, result);
+    status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(state->createdTransports, std::uint32_t{1});
@@ -1284,7 +1279,7 @@ TEST(AsuClientImplTest, MemoryRegister_BindFailureDoesNotCacheResource)
 
     state->failFirstQuery = true;
     QueryResult queryResult;
-    status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, queryResult);
+    status = QueryAndWait(*client, {MakeCacheKey("k05")}, queryResult);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(client->Shutdown().ok());
@@ -1345,7 +1340,7 @@ TEST(AsuClientImplTest, MemoryRegister_UnregisterRemovesCachedResourceBeforeFutu
 
     state->failFirstQuery = true;
     QueryResult queryResult;
-    status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, queryResult);
+    status = QueryAndWait(*client, {MakeCacheKey("k05")}, queryResult);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(client->Shutdown().ok());
@@ -1674,9 +1669,7 @@ TEST(AsuClientImplTest, Task_DeleteKeepsEntryStatusInOriginalOrderAcrossAsus)
     state->checkEntryStatus[20] = {Status::Error(StatusCode::IO_ERROR, "delete entry on asu 20")};
     state->checkEntryStatus[30] = {Status::Error(StatusCode::NOT_FOUND, "delete entry on asu 30")};
     auto client = CreateAsuClient(MakeFactory(state));
-    auto config = MakeConfig({10, 20, 30});
-    config.timeoutMs = 321;
-    ASSERT_TRUE(client->Init(config).ok());
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20, 30})).ok());
     auto entries = BuildRoutedEntries({30, 10, 20});
     ASSERT_EQ(entries.size(), std::size_t{3});
     ASSERT_NE(entries[0].key, CacheKey{});
@@ -1698,9 +1691,6 @@ TEST(AsuClientImplTest, Task_DeleteKeepsEntryStatusInOriginalOrderAcrossAsus)
     EXPECT_EQ(result.entryStatus[0].code, StatusCode::NOT_FOUND);
     EXPECT_EQ(result.entryStatus[1].code, StatusCode::OK);
     EXPECT_EQ(result.entryStatus[2].code, StatusCode::IO_ERROR);
-    EXPECT_EQ(state->deleteTimeouts[10], std::uint64_t{321});
-    EXPECT_EQ(state->deleteTimeouts[20], std::uint64_t{321});
-    EXPECT_EQ(state->deleteTimeouts[30], std::uint64_t{321});
 }
 
 TEST(AsuClientImplTest, SnapshotRefresh_ReusesExistingTransportAndBindsResourcesToAddedAsu)
@@ -1721,7 +1711,7 @@ TEST(AsuClientImplTest, SnapshotRefresh_ReusesExistingTransportAndBindsResources
     state->failFirstQuery = true;
 
     QueryResult result;
-    status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, result);
+    status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
 
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(client->Shutdown().ok());
@@ -1757,7 +1747,7 @@ TEST(AsuClientImplTest,
 
     state->failFirstQuery = true;
     QueryResult queryResult;
-    status = QueryAndWait(*client, {MakeCacheKey("k05")}, QueryOptions{}, queryResult);
+    status = QueryAndWait(*client, {MakeCacheKey("k05")}, queryResult);
     ASSERT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(WaitForFetchCount(viewServer, 2));
     std::this_thread::sleep_for(std::chrono::milliseconds(10));

--- a/ucm/transport/kv/asu/common/task_context.h
+++ b/ucm/transport/kv/asu/common/task_context.h
@@ -106,8 +106,6 @@ struct TransportTask {
     std::vector<KVBuffer> entries;
     std::vector<std::size_t> originalIndices;
     std::vector<Status> entryStatus;
-    std::uint64_t timeoutMs{0};
-
     bool clientCompleted{false};
 
     std::shared_ptr<TransportSubBatchList> subBatchContexts;
@@ -140,7 +138,6 @@ struct ClientTask {
     std::vector<TransportTaskPtr> transportTasks;
     std::vector<Status> entryStatus;
     QueryResult queryResult;
-    std::uint64_t timeoutMs{0};
 
     std::atomic<std::size_t> remainingTransportTasks{0};
     std::atomic<ClientTaskState> state{ClientTaskState::PENDING};

--- a/ucm/transport/kv/asu/test/case/asu_client_e2e_metrics_test.cc
+++ b/ucm/transport/kv/asu/test/case/asu_client_e2e_metrics_test.cc
@@ -687,15 +687,15 @@ bool EntryStatusesOk(const TaskResult& result, std::size_t expectedCount)
                        [](const Status& status) { return status.ok(); });
 }
 
-Status QueryAndWait(AsuClient& client, const std::vector<CacheKey>& keys,
-                    const QueryOptions& options, QueryResult& result)
+Status QueryAndWait(AsuClient& client, const std::vector<CacheKey>& keys, QueryResult& result,
+                    std::uint64_t timeoutMs = 0)
 {
     TaskId taskId{kInvalidTaskId};
-    auto status = client.QueryAsync(keys, options, taskId);
+    auto status = client.QueryAsync(keys, taskId);
     if (!status.ok()) { return status; }
 
     TaskResult taskResult;
-    status = client.Wait(taskId, options.timeoutMs, taskResult);
+    status = client.Wait(taskId, timeoutMs, taskResult);
     if (taskResult.queryResult.has_value()) {
         result = std::move(*taskResult.queryResult);
     } else if (status.ok()) {
@@ -739,10 +739,8 @@ bool QueryAndMeasure(AsuClient& client, const std::vector<CacheKey>& keys,
                      const std::vector<std::uint8_t>& expected, MetricsRecorder& metrics)
 {
     QueryResult result;
-    QueryOptions options;
-    options.timeoutMs = 1000;
     const auto start = std::chrono::steady_clock::now();
-    auto status = QueryAndWait(client, keys, options, result);
+    auto status = QueryAndWait(client, keys, result, 1000);
     const bool correct = status.ok() && result.exists == expected;
     metrics.Record(OperationKind::QUERY, ElapsedNs(start), 0, status.ok(), correct);
     return correct;
@@ -873,8 +871,7 @@ TEST(AsuClientE2EMetricsTest, DiskMembershipChangesRefreshAndContinueWorkload)
     viewServer->Publish({1, 2, 3});
     state->ForceNextQueryFailure();
     QueryResult ignoredResult;
-    auto status = QueryAndWait(*client, {MakeCacheKey("membership-refresh-add")}, QueryOptions{},
-                               ignoredResult);
+    auto status = QueryAndWait(*client, {MakeCacheKey("membership-refresh-add")}, ignoredResult);
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(WaitUntil(
         [&] { return viewServer->FetchCount() >= 2 && state->Snapshot().createdTransports >= 3; }));
@@ -890,11 +887,11 @@ TEST(AsuClientE2EMetricsTest, DiskMembershipChangesRefreshAndContinueWorkload)
     viewServer->Publish({1, 3});
     state->ForceNextQueryFailure();
     const auto probeKeys = MakeProbeKeys(512);
-    status = QueryAndWait(*client, probeKeys, QueryOptions{}, ignoredResult);
+    status = QueryAndWait(*client, probeKeys, ignoredResult);
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(WaitUntil([&] {
         QueryResult result;
-        auto retryStatus = QueryAndWait(*client, probeKeys, QueryOptions{}, result);
+        auto retryStatus = QueryAndWait(*client, probeKeys, result);
         return retryStatus.ok();
     }));
 

--- a/ucm/transport/kv/asu/test/case/asu_smoke_test.cc
+++ b/ucm/transport/kv/asu/test/case/asu_smoke_test.cc
@@ -195,15 +195,15 @@ void ExpectCompleted(AsuClient& client, TaskId taskId, std::size_t entryCount)
     ASSERT_TRUE(client.Check(taskId));
 }
 
-Status QueryAndWait(AsuClient& client, const std::vector<CacheKey>& keys,
-                    const QueryOptions& options, QueryResult& result)
+Status QueryAndWait(AsuClient& client, const std::vector<CacheKey>& keys, QueryResult& result,
+                    std::uint64_t timeoutMs)
 {
     TaskId taskId{kInvalidTaskId};
-    auto status = client.QueryAsync(keys, options, taskId);
+    auto status = client.QueryAsync(keys, taskId);
     if (!status.ok()) { return status; }
 
     TaskResult taskResult;
-    status = client.Wait(taskId, options.timeoutMs, taskResult);
+    status = client.Wait(taskId, timeoutMs, taskResult);
     if (taskResult.queryResult.has_value()) {
         result = std::move(*taskResult.queryResult);
     } else if (status.ok()) {
@@ -239,10 +239,8 @@ TEST(AsuSmokeTest, ClientAsyncTasksCompleteEndToEnd)
 
     std::vector<CacheKey> keys{MakeCacheKey("alpha"), MakeCacheKey("beta"), MakeCacheKey("gamma"),
                                MakeCacheKey("delta")};
-    QueryOptions queryOptions;
-    queryOptions.timeoutMs = 500;
     QueryResult queryResult;
-    status = QueryAndWait(*client, keys, queryOptions, queryResult);
+    status = QueryAndWait(*client, keys, queryResult, 500);
     ASSERT_TRUE(status.ok()) << status.message;
     ASSERT_EQ(queryResult.exists.size(), keys.size());
 

--- a/ucm/transport/kv/asu/trans/include/asu_transport/types.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/types.h
@@ -121,16 +121,6 @@ enum class Protocol {
     TCP = 2,
 };
 
-enum class QueryMode {
-    PER_KEY = 0,
-    PREFIX = 1,
-};
-
-struct QueryOptions {
-    QueryMode mode{QueryMode::PER_KEY};
-    std::uint64_t timeoutMs{0};
-};
-
 struct QueryResult {
     std::vector<std::uint8_t> exists;
     std::uint32_t prefixHitKeys{0};

--- a/ucm/transport/kv/asu/trans/src/asu_response_status.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_response_status.cpp
@@ -178,10 +178,10 @@ QueryResult BuildQueryResultFromEntryStatus(const std::vector<Status>& entryStat
     QueryResult queryResult;
     queryResult.exists.assign(entryStatus.size(), 0);
     for (std::size_t index = 0; index < entryStatus.size(); ++index) {
-        if (entryStatus[index].code != StatusCode::ASU_ENTRY_KEY_EXIST) { continue; }
-
-        queryResult.exists[index] = 1;
-        ++queryResult.prefixHitKeys;
+        queryResult.exists[index] = entryStatus[index].code == StatusCode::ASU_ENTRY_KEY_EXIST;
+        if (queryResult.prefixHitKeys == index && queryResult.exists[index] != 0) {
+            ++queryResult.prefixHitKeys;
+        }
     }
     return queryResult;
 }

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -278,8 +278,7 @@ Status AsuTransportImpl::Submit(const TransportTaskPtr& task)
     if (!task) { return Status::Error(StatusCode::INVALID_ARGUMENT, "transport task is null"); }
     const auto entryCount = IsEntryBatchOp(task->opType) ? task->entries.size() : task->keys.size();
     task->entryStatus.assign(entryCount, Status::OK());
-    const auto timeoutMs = task->timeoutMs == 0 ? config_.timeoutMs : task->timeoutMs;
-    task->deadline = TaskDeadline(timeoutMs);
+    task->deadline = TaskDeadline(config_.timeoutMs);
     return SubmitTask(task);
 }
 

--- a/ucm/transport/kv/asu/trans/test/asu_response_status_test.cpp
+++ b/ucm/transport/kv/asu/trans/test/asu_response_status_test.cpp
@@ -151,7 +151,7 @@ TEST(AsuResponseStatusTest, QueryCheckResultBufferUsesExistEntryStatuses)
     EXPECT_EQ(queryResult.exists[0], std::uint8_t{1});
     EXPECT_EQ(queryResult.exists[1], std::uint8_t{0});
     EXPECT_EQ(queryResult.exists[2], std::uint8_t{1});
-    EXPECT_EQ(queryResult.prefixHitKeys, std::uint32_t{2});
+    EXPECT_EQ(queryResult.prefixHitKeys, std::uint32_t{1});
 }
 
 TEST(AsuResponseStatusTest, MissingResultBufferPropagatesSubBatchError)

--- a/ucm/transport/kv/kv-test/src/asu_client_runner.cpp
+++ b/ucm/transport/kv/kv-test/src/asu_client_runner.cpp
@@ -259,11 +259,8 @@ Status AsuClientRunner::Exist(const std::vector<UC::ASU::CacheKey>& keys, std::u
 {
     if (client_ == nullptr) { return Status::Error(kExitInvalidArgument, "asu client is null"); }
 
-    UC::ASU::QueryOptions options;
-    options.mode = UC::ASU::QueryMode::PER_KEY;
-    options.timeoutMs = timeoutMs;
     UC::ASU::TaskId taskId = UC::ASU::kInvalidTaskId;
-    auto status = client_->QueryAsync(keys, options, taskId);
+    auto status = client_->QueryAsync(keys, taskId);
     if (status.ok()) {
         UC::ASU::TaskResult taskResult;
         status = client_->Wait(taskId, timeoutMs, taskResult);


### PR DESCRIPTION
## Purpose
AsuStore no more exposes either Client or Transport as optional backends. This PR removes the class ClientBackend.

## Modifications 
Remove ClientBackend. AsuStore replaces backend_ with client_.

## Test
>Pass offline inference test.
>Pass AsuStore unit test.