### PR TITLE
[Feat] Add DramStore and TaskManager

### DIFF
--- a/ucm/store/dram/CMakeLists.txt
+++ b/ucm/store/dram/CMakeLists.txt
@@ -7,12 +7,25 @@ set(UCM_DRAM_STORE_CC_SOURCE_FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/cc/reply_service.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/cc/node_actor.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/cc/node_scheduler.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/cc/task_manager.cc
 )
 if(RUNTIME_ENVIRONMENT STREQUAL "ascend")
     list(APPEND UCM_DRAM_STORE_CC_SOURCE_FILES
         ${CMAKE_CURRENT_SOURCE_DIR}/cc/transport_manager_backend.cc)
 endif()
 add_library(dramstore SHARED ${UCM_DRAM_STORE_CC_SOURCE_FILES})
+if(RUNTIME_ENVIRONMENT STREQUAL "ascend")
+    target_compile_definitions(dramstore PRIVATE UC_DRAM_ASCEND_BACKEND)
+    # aclrtSynchronizeEvent in dram_store.cc needs acl/acl.h + libascendcl.
+    set(ASCEND_ROOT "/usr/local/Ascend/ascend-toolkit/latest" CACHE PATH
+        "Path to Ascend root directory")
+    add_library(Ascend::ascendcl UNKNOWN IMPORTED)
+    set_target_properties(Ascend::ascendcl PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${ASCEND_ROOT}/include"
+        IMPORTED_LOCATION "${ASCEND_ROOT}/lib64/libascendcl.so"
+    )
+    target_link_libraries(dramstore PRIVATE Ascend::ascendcl)
+endif()
 target_include_directories(dramstore PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/cc)
 target_include_directories(dramstore PUBLIC
     ${CMAKE_SOURCE_DIR}/ucm/transport/p2p/include)

--- a/ucm/store/dram/cc/config.cc
+++ b/ucm/store/dram/cc/config.cc
@@ -245,10 +245,10 @@ Expected<DramConfig> DramConfig::Parse(const Detail::Dictionary& dictionary)
                                             Milliseconds(loadTimeout)};
         result.nodeScheduler.reconnectInterval = Milliseconds(reconnectInterval);
 
-        std::vector<std::size_t> ioLengths;
-        status = NumberList(dictionary, "io_lengths", &ioLengths);
+        std::vector<std::size_t> tensorSizes;
+        status = NumberList(dictionary, "tensor_size_list", &tensorSizes);
         if (status.Failure()) { return status; }
-        result.ioLengths.assign(ioLengths.begin(), ioLengths.end());
+        result.tensorSizes.assign(tensorSizes.begin(), tensorSizes.end());
 
         status = result.Validate();
         if (status.Failure()) { return status; }
@@ -298,14 +298,7 @@ Status DramConfig::Validate() const
     if (nodeScheduler.reconnectInterval.count() <= 0) {
         return Status::InvalidParam("DramStore reconnect interval must be positive");
     }
-    if (ioLengths.empty() || ioLengths.size() > std::numeric_limits<std::uint32_t>::max()) {
-        return Status::InvalidParam("io_lengths must not be empty");
-    }
-    for (const auto length : ioLengths) {
-        if (length == 0 || length > std::numeric_limits<std::uint32_t>::max()) {
-            return Status::InvalidParam("io length is outside the protocol range");
-        }
-    }
+    if (tensorSizes.empty()) { return Status::InvalidParam("tensor_size_list must not be empty"); }
     return Status::OK();
 }
 

--- a/ucm/store/dram/cc/dram_store.cc
+++ b/ucm/store/dram/cc/dram_store.cc
@@ -21,7 +21,301 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  * */
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+#include "config.h"
+#include "kv_common/router.h"
+#include "logger/logger.h"
+#include "node_scheduler.h"
+#include "reply_service.h"
+#include "task_manager.h"
+#include "transport_executor.h"
+#include "transport_manager_backend.h"
+#include "ucmstore_v1.h"
+#ifdef UC_DRAM_ASCEND_BACKEND
+#include <acl/acl.h>
+#endif
 
-namespace UC::DramStore {
+namespace UC::Dram {
 
+// Synchronize an optional compute-stream event before a dump task is submitted.
+// DramStore owns no NPU stream; the real D2H is an RDMA Read executed on the
+// remote DramPool directly against this client's device memory.
+// RDMA and the compute stream are unordered, so the only safe point is to
+// block on the prerequisite event here, before the control message is sent.
+static Status WaitPrerequisiteEvent(std::uintptr_t eventHandle)
+{
+    if (eventHandle == 0) { return Status::OK(); }
+#ifdef UC_DRAM_ASCEND_BACKEND
+    const auto ret = aclrtSynchronizeEvent(reinterpret_cast<aclrtEvent>(eventHandle));
+    if (ret == ACL_SUCCESS) { return Status::OK(); }
+    return Status::Error("aclrtSynchronizeEvent failed: " + std::to_string(ret));
+#else
+    return Status::OK();
+#endif
 }
+
+class DramStore final : public StoreV1 {
+public:
+    DramStore() = default;
+    ~DramStore() override { StopGraph(); }
+
+    DramStore(const DramStore&) = delete;
+    DramStore& operator=(const DramStore&) = delete;
+
+    Status Setup(const Detail::Dictionary& config) override;
+    std::string Readme() const override;
+    Expected<std::vector<std::uint8_t>> Lookup(const Detail::BlockId* blocks,
+                                               std::size_t num) override;
+    Expected<ssize_t> LookupOnPrefix(const Detail::BlockId* blocks, std::size_t num) override;
+    void Prefetch(const Detail::BlockId* blocks, std::size_t num) override;
+    Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override;
+    Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override;
+    Expected<bool> Check(Detail::TaskHandle taskId) override;
+    Status Wait(Detail::TaskHandle taskId) override;
+    bool NeedRegisterKVCaches() const override;
+    Status RegisterKVCaches(const KVCacheRegistration* registrations, std::size_t count) override;
+
+private:
+    Expected<Detail::TaskHandle> SubmitTransfer(OpType op, Detail::TaskDesc task);
+
+    Status SetupParsed(DramConfig parsed)
+    {
+        config = std::make_unique<DramConfig>(std::move(parsed));
+        auto status = Compose();
+
+        if (status.Failure()) {
+            StopGraph();
+            return status;
+        }
+        return Status::OK();
+    }
+
+    Status Compose()
+    {
+#ifdef UC_DRAM_ASCEND_BACKEND
+        const auto transferTimeout = std::max(config->taskTimeouts.load, config->taskTimeouts.dump);
+        auto createdBackend = CreateTransportManagerBackend(TransportManagerBackendOptions{
+            config->localControlHost, config->localControlPort, config->localTransportManagerId,
+            config->localHost, config->transportDeviceId, 1000,
+            static_cast<std::int32_t>(std::min<std::int64_t>(
+                transferTimeout.count(), std::numeric_limits<std::int32_t>::max())),
+            config->nodeScheduler.nodes});
+        if (!createdBackend) { return createdBackend.Error(); }
+        transportBackend = std::move(createdBackend).Value();
+
+        auto createdReplies = ReplyService::Create(ReplyService::Options{
+            config->replySlotSize, config->replySlotCount, std::chrono::microseconds{50},
+            [this](NodeId nodeId, NodeEvent event) {
+                nodeScheduler->Publish(nodeId, std::move(event));
+            }});
+        if (!createdReplies) { return createdReplies.Error(); }
+        replyService = std::move(createdReplies).Value();
+
+        memoryHandles.reserve(1);
+        const auto replyMemory = replyService->MemoryRegion();
+        auto registeredReply = transportBackend->RegisterMemory(
+            replyMemory.address, replyMemory.length, MemoryRegionType::HOST);
+        if (!registeredReply) { return registeredReply.Error(); }
+        memoryHandles.push_back(std::move(registeredReply).Value());
+
+        std::vector<UC::KV::NodeId> nodeIds;
+        nodeIds.reserve(config->nodeScheduler.nodes.size());
+        for (const auto& node : config->nodeScheduler.nodes) { nodeIds.push_back(node.nodeId); }
+        UC::KV::RouterConfig routerConfig;
+        routerConfig.type = config->routerType;
+        router = UC::KV::CreateRouter(nodeIds, {}, routerConfig);
+        if (!router) { return Status::Error("failed to create DramStore router"); }
+
+        transport = std::make_unique<TransportExecutor>(TransportExecutor::Options{
+            config->transportRuntime.workerCount, config->nodeScheduler.nodes.size(),
+            config->nodeScheduler.limits.maxInflightRequests, transportBackend,
+            [this](NodeId nodeId, NodeEvent event) {
+                nodeScheduler->Publish(nodeId, std::move(event));
+            }});
+
+        nodeScheduler = std::make_unique<NodeScheduler>(
+            config->nodeScheduler,
+            NodeDependencies{
+                [this](std::vector<RequestCompleted>& events) { taskManager->Publish(events); },
+                [this](TransportCommand& command) {
+                    return transport ? transport->TryPost(command)
+                                     : Status::Error("TransportExecutor is unavailable");
+                },
+                [this](const RequestToken& token, OpType op,
+                       std::size_t entryCount) -> Expected<ReplySlot> {
+                    return replyService
+                               ? replyService->Acquire(token, op, entryCount)
+                               : Expected<ReplySlot>{Status::Error("ReplyService is unavailable")};
+                },
+                [this](const RequestToken& token, const ReplySlot& slot) {
+                    return replyService ? replyService->Release(token, slot)
+                                        : Status::Error("ReplyService is unavailable");
+                }});
+
+        taskManager = std::make_unique<TaskManager>(
+            TaskManagerConfig{config->tensorSizes, config->maxIoEntries,
+                              config->nodeScheduler.limits.maxBatchEntries, config->taskTimeouts},
+            TaskManagerDependencies{router, [this](Request& request) {
+                                        return nodeScheduler
+                                                   ? nodeScheduler->Post(request)
+                                                   : Status::Error("NodeScheduler is unavailable");
+                                    }});
+
+        auto status = transport->Start();
+        if (status.Failure()) { return status; }
+        status = taskManager->Start();
+        if (status.Failure()) { return status; }
+        status = replyService->Start();
+        if (status.Failure()) { return status; }
+        return nodeScheduler->Start();
+#else
+        return Status::Unsupported();
+#endif
+    }
+
+    void StopGraph()
+    {
+        if (!config) { return; }
+
+        // Shutdown is terminal application teardown. TaskManager first stops all
+        // admission and drops late completions while its callback target remains alive.
+        if (taskManager) { taskManager->Shutdown(); }
+        if (nodeScheduler) { nodeScheduler->Shutdown(); }
+        if (replyService) { replyService->Shutdown(); }
+        if (transport) { transport->Shutdown(); }
+        if (transportBackend) { transportBackend->Stop(); }
+
+        memoryHandles.clear();
+        transport.reset();
+        replyService.reset();
+        nodeScheduler.reset();
+        taskManager.reset();
+        transportBackend.reset();
+        router.reset();
+        config.reset();
+    }
+
+    std::unique_ptr<DramConfig> config;
+    std::shared_ptr<ITransportBackend> transportBackend;
+    std::vector<MemoryHandle> memoryHandles;
+    std::shared_ptr<UC::KV::Router> router;
+    std::unique_ptr<TransportExecutor> transport;
+    std::unique_ptr<ReplyService> replyService;
+    std::unique_ptr<NodeScheduler> nodeScheduler;
+    std::unique_ptr<TaskManager> taskManager;
+};
+
+Status DramStore::Setup(const Detail::Dictionary& config)
+{
+    auto parsed = DramConfig::Parse(config);
+    if (!parsed) { return parsed.Error(); }
+    return SetupParsed(std::move(parsed).Value());
+}
+
+std::string DramStore::Readme() const
+{
+    return "DramStore: serialized task coordination and per-node remote-access safety";
+}
+
+Expected<std::vector<std::uint8_t>> DramStore::Lookup(const Detail::BlockId* blocks,
+                                                      std::size_t num)
+{
+    if (num == 0) { return std::vector<std::uint8_t>{}; }
+    if (blocks == nullptr || num > config->maxIoEntries) {
+        return Status::InvalidParam("invalid lookup input");
+    }
+    auto submitted = taskManager->SubmitLookup(blocks, num);
+    if (!submitted) { return submitted.Error(); }
+    return taskManager->WaitLookup(std::move(submitted).Value());
+}
+
+Expected<ssize_t> DramStore::LookupOnPrefix(const Detail::BlockId*, std::size_t)
+{
+    return Status::Unsupported();
+}
+
+void DramStore::Prefetch(const Detail::BlockId*, std::size_t) {}
+
+Expected<Detail::TaskHandle> DramStore::Load(Detail::TaskDesc task)
+{
+    return SubmitTransfer(OpType::LOAD, std::move(task));
+}
+
+Expected<Detail::TaskHandle> DramStore::Dump(Detail::TaskDesc task)
+{
+    auto status = WaitPrerequisiteEvent(task.prerequisiteHandle);
+    if (status.Failure()) {
+        UC_ERROR("Failed({}) to wait prerequisite event for dump.", status);
+        return status;
+    }
+    task.prerequisiteHandle = 0;
+    return SubmitTransfer(OpType::DUMP, std::move(task));
+}
+
+Expected<Detail::TaskHandle> DramStore::SubmitTransfer(OpType op, Detail::TaskDesc task)
+{
+    if (task.empty()) { return Status::InvalidParam("invalid transfer task"); }
+
+    return taskManager->SubmitTransfer(op, std::move(task));
+}
+
+Expected<bool> DramStore::Check(Detail::TaskHandle taskId) { return taskManager->Check(taskId); }
+
+Status DramStore::Wait(Detail::TaskHandle taskId) { return taskManager->WaitTransfer(taskId); }
+
+bool DramStore::NeedRegisterKVCaches() const { return true; }
+
+Status DramStore::RegisterKVCaches(const KVCacheRegistration* registrations, std::size_t count)
+{
+    if (count != 0 && registrations == nullptr) {
+        return Status::InvalidParam("KV cache registrations are null");
+    }
+    for (std::size_t index = 0; index < count; ++index) {
+        if (registrations[index].addr == 0 || registrations[index].size == 0) {
+            return Status::InvalidParam("KV cache registration has an invalid memory range");
+        }
+    }
+
+    const auto firstHandle = memoryHandles.size();
+    if (count > memoryHandles.max_size() - firstHandle) {
+        return Status::InvalidParam("too many KV cache registrations");
+    }
+    try {
+        memoryHandles.reserve(firstHandle + count);
+    } catch (...) {
+        return Status::InvalidParam("too many KV cache registrations");
+    }
+
+    for (std::size_t index = 0; index < count; ++index) {
+        auto registered =
+            transportBackend->RegisterMemory(reinterpret_cast<void*>(registrations[index].addr),
+                                             registrations[index].size, MemoryRegionType::DEVICE);
+        if (registered) {
+            memoryHandles.push_back(std::move(registered).Value());
+            continue;
+        }
+
+        auto result = registered.Error();
+        while (memoryHandles.size() > firstHandle) {
+            const auto cleanup = transportBackend->UnregisterMemory(memoryHandles.back());
+            if (cleanup.Failure()) {
+                result = cleanup;
+                break;
+            }
+            memoryHandles.pop_back();
+        }
+        return result;
+    }
+    return Status::OK();
+}
+
+}  // namespace UC::Dram
+
+extern "C" UC::StoreV1* MakeDramStore() { return new UC::Dram::DramStore(); }

--- a/ucm/store/dram/cc/node_scheduler.cc
+++ b/ucm/store/dram/cc/node_scheduler.cc
@@ -58,7 +58,7 @@ NodeScheduler::NodeScheduler(NodeSchedulerConfig config, NodeDependencies depend
 {
 }
 
-NodeScheduler::~NodeScheduler() { (void)Shutdown(); }
+NodeScheduler::~NodeScheduler() { Shutdown(); }
 
 NodeScheduler::Runner& NodeScheduler::GetRunner(NodeId nodeId) const noexcept
 {
@@ -184,7 +184,7 @@ void NodeScheduler::JoinAll()
     }
 }
 
-Status NodeScheduler::Shutdown()
+void NodeScheduler::Shutdown()
 {
     acceptingMessages_.store(false, std::memory_order_release);
     for (auto& runner : runners_) {
@@ -192,7 +192,6 @@ Status NodeScheduler::Shutdown()
         runner->wake.notify_all();
     }
     JoinAll();
-    return Status::OK();
 }
 
 }  // namespace UC::Dram

--- a/ucm/store/dram/cc/node_scheduler.h
+++ b/ucm/store/dram/cc/node_scheduler.h
@@ -42,7 +42,7 @@ public:
     NodeScheduler& operator=(const NodeScheduler&) = delete;
 
     Status Start();
-    Status Shutdown();
+    void Shutdown();
 
     // Consumes on success during runtime.
     Status Post(Request& request);

--- a/ucm/store/dram/cc/reply_service.cc
+++ b/ucm/store/dram/cc/reply_service.cc
@@ -25,6 +25,7 @@
 #include <atomic>
 #include <limits>
 #include <system_error>
+#include "logger/logger.h"
 
 namespace UC::Dram {
 
@@ -105,7 +106,7 @@ Status ReplyService::DecodeReply(const Lease& lease, std::vector<EntryResult>* e
     return Status::OK();
 }
 
-ReplyService::~ReplyService() { (void)Shutdown(); }
+ReplyService::~ReplyService() { Shutdown(); }
 
 ReplyMemoryRegion ReplyService::MemoryRegion() const noexcept
 {
@@ -286,7 +287,7 @@ void ReplyService::Run() noexcept
     }
 }
 
-Status ReplyService::Shutdown()
+void ReplyService::Shutdown()
 {
     acceptingLeases_.store(false, std::memory_order_release);
     wake_.notify_all();
@@ -294,9 +295,8 @@ Status ReplyService::Shutdown()
 
     std::lock_guard lock(activeLeasesMutex_);
     if (!activeLeaseIndices_.empty()) {
-        return Status::Error("ReplyService stopped with active reply leases");
+        UC_ERROR("ReplyService stopped with {} abandoned reply leases", activeLeaseIndices_.size());
     }
-    return Status::OK();
 }
 
 }  // namespace UC::Dram

--- a/ucm/store/dram/cc/reply_service.h
+++ b/ucm/store/dram/cc/reply_service.h
@@ -65,7 +65,7 @@ public:
     ReplyService& operator=(const ReplyService&) = delete;
 
     Status Start();
-    Status Shutdown();
+    void Shutdown();
 
     Expected<ReplySlot> Acquire(const RequestToken& token, OpType op, std::size_t entryCount);
     Status Release(const RequestToken& token, const ReplySlot& slot) noexcept;

--- a/ucm/store/dram/cc/task_manager.cc
+++ b/ucm/store/dram/cc/task_manager.cc
@@ -1,0 +1,353 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "task_manager.h"
+#include <algorithm>
+#include <fmt/format.h>
+#include <string>
+#include <system_error>
+#include "kv_common/router.h"
+#include "logger/logger.h"
+
+namespace UC::Dram {
+
+TaskManager::TaskManager(TaskManagerConfig config, TaskManagerDependencies dependencies)
+    : config_(std::move(config)),
+      dependencies_(std::move(dependencies)),
+      submissions_(config_.maxIoEntries),
+      completions_(config_.maxIoEntries)
+{
+}
+
+TaskManager::~TaskManager() { Shutdown(); }
+
+TaskId TaskManager::AllocateTaskIdLocked() noexcept { return nextTaskId_++; }
+
+Status TaskManager::Start()
+{
+    std::lock_guard lock(workMutex_);
+    accepting_ = true;
+    try {
+        worker_ = std::thread([this] { Run(); });
+        return Status::OK();
+    } catch (const std::system_error& error) {
+        accepting_ = false;
+        return Status::Error(fmt::format("failed to start TaskManager: {}", error.what()));
+    }
+}
+
+void TaskManager::Shutdown()
+{
+    {
+        std::lock_guard lock(workMutex_);
+        accepting_ = false;
+    }
+    workReady_.notify_all();
+    if (worker_.joinable()) { worker_.join(); }
+}
+
+Expected<TaskId> TaskManager::SubmitLookup(const Detail::BlockId* blocks, std::size_t num)
+{
+    std::vector<Detail::BlockId> lookup(blocks, blocks + num);
+    return EnqueueTask(OpType::LOOKUP, std::move(lookup));
+}
+
+Expected<TaskId> TaskManager::SubmitTransfer(OpType op, Detail::TaskDesc task)
+{
+    return EnqueueTask(op, std::move(task));
+}
+
+Expected<TaskId> TaskManager::EnqueueTask(OpType op, TaskInput input)
+{
+    std::promise<TaskResult> promise;
+    auto future = promise.get_future();
+    const auto timeout = op == OpType::LOOKUP ? config_.timeouts.lookup
+                         : op == OpType::DUMP ? config_.timeouts.dump
+                                              : config_.timeouts.load;
+    const auto deadline = Clock::now() + timeout;
+
+    TaskId taskId = 0;
+    {
+        std::lock_guard lock(taskMutex_);
+        taskId = AllocateTaskIdLocked();
+        taskResults_.emplace(taskId, std::move(future));
+    }
+
+    Submission submission{taskId, op, deadline, std::move(input), std::move(promise)};
+    auto enqueued = Status::OK();
+    {
+        std::lock_guard lock(workMutex_);
+        if (!accepting_) {
+            enqueued = Status::Error("TaskManager is stopping");
+        } else if (!submissions_.Push(submission)) {
+            enqueued = Status::NoSpace();
+        }
+    }
+    if (enqueued.Failure()) {
+        std::lock_guard lock(taskMutex_);
+        taskResults_.erase(taskId);
+        return enqueued;
+    }
+
+    workReady_.notify_one();
+    return taskId;
+}
+
+Expected<bool> TaskManager::Check(TaskId taskId)
+{
+    std::lock_guard lock(taskMutex_);
+    const auto found = taskResults_.find(taskId);
+    if (found == taskResults_.end()) { return Status::NotFound(); }
+    return found->second.wait_for(std::chrono::seconds{0}) == std::future_status::ready;
+}
+
+Expected<TaskManager::TaskResult> TaskManager::WaitResult(TaskId taskId)
+{
+    std::future<TaskResult> future;
+    {
+        std::lock_guard lock(taskMutex_);
+        const auto found = taskResults_.find(taskId);
+        if (found == taskResults_.end()) { return Status::NotFound(); }
+        future = std::move(found->second);
+        taskResults_.erase(found);
+    }
+    try {
+        return future.get();
+    } catch (...) {
+        return Status::Error("TaskManager task result invariant violated");
+    }
+}
+
+Expected<std::vector<std::uint8_t>> TaskManager::WaitLookup(TaskId taskId)
+{
+    auto waited = WaitResult(taskId);
+    if (!waited) { return waited.Error(); }
+    auto result = std::move(waited).Value();
+    if (result.status.Failure()) { return result.status; }
+    return std::move(result.lookupResults);
+}
+
+Status TaskManager::WaitTransfer(TaskId taskId)
+{
+    auto waited = WaitResult(taskId);
+    return waited ? std::move(waited).Value().status : waited.Error();
+}
+
+void TaskManager::Publish(std::vector<RequestCompleted>& events)
+{
+    if (events.empty()) { return; }
+    {
+        std::lock_guard lock(workMutex_);
+        if (!accepting_) { return; }
+        for (auto& completion : events) { completions_.Push(completion); }
+    }
+    workReady_.notify_one();
+}
+
+std::vector<IoEntry> TaskManager::NormalizeLookup(std::vector<Detail::BlockId> blocks) const
+{
+    std::vector<IoEntry> entries;
+    entries.reserve(blocks.size());
+    for (std::size_t index = 0; index < blocks.size(); ++index) {
+        IoEntry entry;
+        entry.blockId = std::move(blocks[index]);
+        entry.originalIndex = index;
+        entries.push_back(std::move(entry));
+    }
+    return entries;
+}
+
+std::vector<IoEntry> TaskManager::NormalizeTransfer(const Detail::TaskDesc& task) const
+{
+    const auto tensorCount = config_.tensorSizes.size();
+    std::vector<IoEntry> entries;
+    entries.reserve(task.size() * tensorCount);
+    for (const auto& shard : task) {
+        for (std::size_t tensorIndex = 0; tensorIndex < tensorCount; ++tensorIndex) {
+            IoEntry entry;
+            entry.blockId = shard.owner;
+            entry.shardId = static_cast<std::uint32_t>(shard.index * tensorCount + tensorIndex);
+            entry.buffer = BufferRef{reinterpret_cast<std::uintptr_t>(shard.addrs[tensorIndex]),
+                                     config_.tensorSizes[tensorIndex]};
+            entries.push_back(std::move(entry));
+        }
+    }
+    return entries;
+}
+
+std::vector<Request> TaskManager::BuildRequests(OpType op, std::vector<IoEntry> entries,
+                                                TimePoint deadline) const
+{
+    std::vector<std::string> keys;
+    keys.reserve(entries.size());
+    for (const auto& entry : entries) {
+        keys.emplace_back(reinterpret_cast<const char*>(entry.blockId.data()),
+                          entry.blockId.size());
+    }
+
+    const auto routed = dependencies_.router->RouteKeys(keys);
+    const auto batchLimit = std::min(config_.requestBatchEntries, kMaxProtocolBatchEntries);
+    std::vector<Request> requests;
+    requests.reserve(routed.size());
+    for (const auto& [node, indexes] : routed) {
+        for (std::size_t begin = 0; begin < indexes.size(); begin += batchLimit) {
+            const auto end = std::min(indexes.size(), begin + batchLimit);
+            Request request;
+            request.nodeId = node;
+            request.op = op;
+            request.entries.reserve(end - begin);
+            for (auto offset = begin; offset < end; ++offset) {
+                request.entries.push_back(std::move(entries[indexes[offset]]));
+            }
+            request.deadline = deadline;
+            requests.push_back(std::move(request));
+        }
+    }
+    return requests;
+}
+
+void TaskManager::ProcessSubmission(Submission submission)
+{
+    if (submission.deadline <= Clock::now()) {
+        submission.promise.set_value(TaskResult{Status::Timeout(), {}});
+        return;
+    }
+
+    auto entries =
+        std::holds_alternative<Detail::TaskDesc>(submission.input)
+            ? NormalizeTransfer(std::get<Detail::TaskDesc>(submission.input))
+            : NormalizeLookup(std::get<std::vector<Detail::BlockId>>(std::move(submission.input)));
+    const auto entryCount = entries.size();
+    if (entryCount > config_.maxIoEntries - usedIoEntries_) {
+        submission.promise.set_value(TaskResult{Status::NoSpace(), {}});
+        return;
+    }
+    auto requests = BuildRequests(submission.op, std::move(entries), submission.deadline);
+    usedIoEntries_ += entryCount;
+
+    ActiveTask task;
+    task.op = submission.op;
+    task.remainingRequests = requests.size();
+    task.entryCount = entryCount;
+    task.promise = std::move(submission.promise);
+    if (task.op == OpType::LOOKUP) { task.lookupResults.resize(entryCount); }
+
+    for (auto& request : requests) {
+        request.taskId = submission.taskId;
+        request.requestId = nextRequestId_++;
+    }
+
+    const auto taskId = submission.taskId;
+    activeTasks_.emplace(taskId, std::move(task));
+
+    for (auto& request : requests) {
+        const auto status = dependencies_.submitRequest(request);
+        if (status.Failure()) { CompleteRequest(taskId, status); }
+    }
+}
+
+void TaskManager::ApplyLookupResults(ActiveTask& task,
+                                     const std::vector<EntryResult>& results) const
+{
+    for (const auto& result : results) {
+        task.lookupResults[result.originalIndex] = static_cast<std::uint8_t>(result.found);
+    }
+}
+
+void TaskManager::CompleteRequest(TaskId taskId, Status status, std::vector<EntryResult> results)
+{
+    const auto found = activeTasks_.find(taskId);
+    if (found == activeTasks_.end()) { return; }
+    auto& task = found->second;
+    --task.remainingRequests;
+
+    if (status.Failure()) {
+        if (!task.failure.has_value()) { task.failure.emplace(std::move(status)); }
+    } else if (!task.failure.has_value() && task.op == OpType::LOOKUP) {
+        ApplyLookupResults(task, results);
+    }
+    if (task.remainingRequests != 0) { return; }
+
+    auto promise = std::move(task.promise);
+    auto taskStatus = task.failure.has_value() ? std::move(*task.failure) : Status::OK();
+    auto lookupResults =
+        taskStatus.Success() ? std::move(task.lookupResults) : std::vector<std::uint8_t>{};
+    usedIoEntries_ -= task.entryCount;
+    activeTasks_.erase(found);
+    promise.set_value(TaskResult{std::move(taskStatus), std::move(lookupResults)});
+}
+
+void TaskManager::ProcessCompletion(RequestCompleted event)
+{
+    CompleteRequest(event.taskId, std::move(event.status), std::move(event.entryResults));
+}
+
+void TaskManager::Run() noexcept
+{
+    try {
+        for (;;) {
+            std::optional<Submission> submission;
+            std::optional<RequestCompleted> completion;
+
+            {
+                std::unique_lock lock(workMutex_);
+                const auto workReady = [this] {
+                    return !accepting_ || !completions_.Empty() || !submissions_.Empty();
+                };
+                workReady_.wait(lock, workReady);
+
+                if (!accepting_) { return; }
+                if (!completions_.Empty()) {
+                    completion.emplace(completions_.Pop());
+                } else {
+                    submission.emplace(submissions_.Pop());
+                }
+            }
+
+            if (completion.has_value()) {
+                ProcessCompletion(std::move(*completion));
+            } else {
+                ProcessSubmission(std::move(*submission));
+            }
+        }
+    } catch (...) {
+        UC_ERROR("TaskManager worker stopped unexpectedly");
+        {
+            std::lock_guard lock(workMutex_);
+            accepting_ = false;
+            while (!submissions_.Empty()) {
+                auto submission = submissions_.Pop();
+                submission.promise.set_value(
+                    TaskResult{Status::Error("TaskManager stopped unexpectedly"), {}});
+            }
+        }
+        for (auto& [taskId, task] : activeTasks_) {
+            task.promise.set_value(
+                TaskResult{Status::Error("TaskManager stopped unexpectedly"), {}});
+        }
+        activeTasks_.clear();
+        usedIoEntries_ = 0;
+    }
+}
+
+}  // namespace UC::Dram

--- a/ucm/store/dram/cc/task_manager.h
+++ b/ucm/store/dram/cc/task_manager.h
@@ -1,0 +1,146 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#ifndef UNIFIEDCACHE_DRAM_STORE_CC_TASK_MANAGER_H
+#define UNIFIEDCACHE_DRAM_STORE_CC_TASK_MANAGER_H
+
+#include <chrono>
+#include <condition_variable>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+#include "bounded_queue.h"
+#include "messages.h"
+#include "status/status.h"
+
+namespace UC::KV {
+class Router;
+}
+
+namespace UC::Dram {
+
+struct TaskManagerConfig {
+    std::vector<std::uint64_t> tensorSizes;
+    std::size_t maxIoEntries{0};
+    std::size_t requestBatchEntries{0};
+    TimeoutConfig timeouts;
+};
+
+struct TaskManagerDependencies {
+    std::shared_ptr<const UC::KV::Router> router;
+    RequestSubmitter submitRequest;
+};
+
+// A single-worker task actor. Submission planning and completion aggregation are
+// serialized by the worker; public methods only own admission and task observation.
+class TaskManager final {
+public:
+    TaskManager(TaskManagerConfig config, TaskManagerDependencies dependencies);
+    ~TaskManager();
+
+    TaskManager(const TaskManager&) = delete;
+    TaskManager& operator=(const TaskManager&) = delete;
+
+    Status Start();
+    void Shutdown();
+
+    Expected<TaskId> SubmitLookup(const Detail::BlockId* blocks, std::size_t num);
+    Expected<TaskId> SubmitTransfer(OpType op, Detail::TaskDesc task);
+    Expected<bool> Check(TaskId taskId);
+    Expected<std::vector<std::uint8_t>> WaitLookup(TaskId taskId);
+    Status WaitTransfer(TaskId taskId);
+
+    // Completions are reliable while running and are discarded after shutdown begins.
+    void Publish(std::vector<RequestCompleted>& events);
+
+private:
+    using Clock = std::chrono::steady_clock;
+    using TimePoint = Clock::time_point;
+    using TaskInput = std::variant<Detail::TaskDesc, std::vector<Detail::BlockId>>;
+
+    struct TaskResult {
+        Status status;
+        std::vector<std::uint8_t> lookupResults;
+    };
+
+    struct Submission {
+        TaskId taskId{0};
+        OpType op{OpType::LOOKUP};
+        TimePoint deadline;
+        TaskInput input;
+        std::promise<TaskResult> promise;
+    };
+
+    struct ActiveTask {
+        OpType op{OpType::LOOKUP};
+        std::size_t remainingRequests{0};
+        std::size_t entryCount{0};
+        std::optional<Status> failure;
+        std::vector<std::uint8_t> lookupResults;
+        std::promise<TaskResult> promise;
+    };
+
+    TaskId AllocateTaskIdLocked() noexcept;
+    Expected<TaskId> EnqueueTask(OpType op, TaskInput input);
+    Expected<TaskResult> WaitResult(TaskId taskId);
+
+    std::vector<IoEntry> NormalizeLookup(std::vector<Detail::BlockId> blocks) const;
+    std::vector<IoEntry> NormalizeTransfer(const Detail::TaskDesc& task) const;
+    std::vector<Request> BuildRequests(OpType op, std::vector<IoEntry> entries,
+                                       TimePoint deadline) const;
+
+    void Run() noexcept;
+    void ProcessSubmission(Submission submission);
+    void ProcessCompletion(RequestCompleted event);
+    void CompleteRequest(TaskId taskId, Status status, std::vector<EntryResult> results = {});
+    void ApplyLookupResults(ActiveTask& task, const std::vector<EntryResult>& results) const;
+
+    TaskManagerConfig config_;
+    TaskManagerDependencies dependencies_;
+
+    std::mutex taskMutex_;
+    std::unordered_map<TaskId, std::future<TaskResult>> taskResults_;
+    TaskId nextTaskId_{1};
+
+    std::mutex workMutex_;
+    std::condition_variable workReady_;
+    bool accepting_{false};
+    BoundedQueue<Submission> submissions_;
+    BoundedQueue<RequestCompleted> completions_;
+
+    std::thread worker_;
+
+    // Worker-only execution state.
+    std::unordered_map<TaskId, ActiveTask> activeTasks_;
+    std::size_t usedIoEntries_{0};
+    RequestId nextRequestId_{1};
+};
+
+}  // namespace UC::Dram
+
+#endif  // UNIFIEDCACHE_DRAM_STORE_CC_TASK_MANAGER_H

--- a/ucm/store/dram/cc/transport_executor.cc
+++ b/ucm/store/dram/cc/transport_executor.cc
@@ -53,7 +53,7 @@ bool IsFence(const TransportCommand& command) noexcept
 
 TransportExecutor::TransportExecutor(Options options) : options_(std::move(options)) {}
 
-TransportExecutor::~TransportExecutor() { (void)Shutdown(); }
+TransportExecutor::~TransportExecutor() { Shutdown(); }
 
 void TransportExecutor::Execute(TransportCommand command) noexcept
 {
@@ -146,9 +146,6 @@ Status TransportExecutor::Start()
             if (worker->thread.joinable()) { worker->thread.join(); }
         }
         workers_.clear();
-        auto backend = std::move(options_.backend);
-        const auto stopStatus = backend->Stop();
-        if (stopStatus.Failure()) { return stopStatus; }
         return Status::Error(fmt::format("failed to start TransportExecutor: {}", error.what()));
     }
 }
@@ -189,15 +186,13 @@ Status TransportExecutor::TryPost(TransportCommand& command)
     return Status::OK();
 }
 
-Status TransportExecutor::Shutdown()
+void TransportExecutor::Shutdown()
 {
     acceptingCommands_.store(false, std::memory_order_release);
     for (auto& worker : workers_) { worker->wake.notify_all(); }
     for (auto& worker : workers_) {
         if (worker->thread.joinable()) { worker->thread.join(); }
     }
-    auto backend = std::move(options_.backend);
-    return backend ? backend->Stop() : Status::OK();
 }
 
 }  // namespace UC::Dram

--- a/ucm/store/dram/cc/transport_executor.h
+++ b/ucm/store/dram/cc/transport_executor.h
@@ -54,7 +54,7 @@ public:
     virtual Status Connect(const ::UC::Dram::Connect& command) noexcept = 0;
     // Success synchronously proves that the old epoch can no longer access client memory.
     virtual Status Fence(const ::UC::Dram::FenceEpoch& command) noexcept = 0;
-    virtual Status Stop() noexcept = 0;
+    virtual void Stop() = 0;
 };
 
 class TransportExecutor final {
@@ -74,7 +74,7 @@ public:
     TransportExecutor& operator=(const TransportExecutor&) = delete;
 
     Status Start();
-    Status Shutdown();
+    void Shutdown();
 
     // Consumes on success.
     Status TryPost(TransportCommand& command);

--- a/ucm/store/dram/cc/transport_manager_backend.cc
+++ b/ucm/store/dram/cc/transport_manager_backend.cc
@@ -24,6 +24,7 @@
 #include "transport_manager_backend.h"
 #include <utility>
 #include "core/transport_init_attrs.h"
+#include "logger/logger.h"
 
 namespace UC::Dram {
 
@@ -129,15 +130,19 @@ Status TransportManagerBackend::Fence(const ::UC::Dram::FenceEpoch& command) noe
     }
 }
 
-Status TransportManagerBackend::Stop() noexcept
+void TransportManagerBackend::Stop()
 {
     std::lock_guard lock(stopMutex_);
-    if (stopped_) { return Status::OK(); }
+    if (stopped_) { return; }
     const auto controlStatus = control_.Shutdown();
     const auto managerStatus = manager_.Shutdown();
     stopped_ = true;
-    if (controlStatus.Failure()) { return controlStatus; }
-    return managerStatus;
+    if (controlStatus.Failure()) {
+        UC_ERROR("DramStore transport control shutdown failed: {}", controlStatus);
+    }
+    if (managerStatus.Failure()) {
+        UC_ERROR("DramStore transport manager shutdown failed: {}", managerStatus);
+    }
 }
 
 Expected<std::shared_ptr<ITransportBackend>> CreateTransportManagerBackend(

--- a/ucm/store/dram/cc/transport_manager_backend.h
+++ b/ucm/store/dram/cc/transport_manager_backend.h
@@ -64,7 +64,7 @@ public:
     TransmitCompleted Transmit(const ::UC::Dram::Transmit& command) noexcept override;
     Status Connect(const ::UC::Dram::Connect& command) noexcept override;
     Status Fence(const ::UC::Dram::FenceEpoch& command) noexcept override;
-    Status Stop() noexcept override;
+    void Stop() override;
 
 private:
     friend Expected<std::shared_ptr<ITransportBackend>> CreateTransportManagerBackend(

--- a/ucm/store/test/case/dram/dram_config_test.cc
+++ b/ucm/store/test/case/dram/dram_config_test.cc
@@ -24,7 +24,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <gtest/gtest.h>
-#include <limits>
 #include <string>
 #include <thread>
 #include <vector>
@@ -33,7 +32,7 @@
 namespace UC::Dram {
 namespace {
 
-Detail::Dictionary BaseConfig(bool includeIoLengths = true)
+Detail::Dictionary BaseConfig(bool includeTensorSizes = true)
 {
     Detail::Dictionary config;
     config.Set("local_control_endpoint", std::string{"127.0.0.1:6000"});
@@ -44,7 +43,7 @@ Detail::Dictionary BaseConfig(bool includeIoLengths = true)
                std::vector<std::string>{"127.0.0.1:7000", "127.0.0.1:9000"});
     config.Set("node_transport_manager_ids",
                std::vector<std::string>{"127.0.0.1:7100", "127.0.0.1:9100"});
-    if (includeIoLengths) { config.Set("io_lengths", std::vector<ssize_t>{4096}); }
+    if (includeTensorSizes) { config.Set("tensor_size_list", std::vector<ssize_t>{4096}); }
     return config;
 }
 
@@ -103,7 +102,7 @@ TEST(DramConfigTest, ParsesFixedReconnectInterval)
     EXPECT_EQ(parsed.Value().nodeScheduler.reconnectInterval.count(), 37);
 }
 
-TEST(DramConfigTest, RequiresIoLengths) { EXPECT_FALSE(DramConfig::Parse(BaseConfig(false))); }
+TEST(DramConfigTest, RequiresTensorSizes) { EXPECT_FALSE(DramConfig::Parse(BaseConfig(false))); }
 
 TEST(DramConfigTest, ParsesRouterTypeIntoStrongConfiguration)
 {
@@ -163,18 +162,6 @@ TEST(DramConfigTest, ParsesControlEndpointsAndStoresManagerIds)
     EXPECT_EQ(config.nodeScheduler.nodes[0].controlHost, "127.0.0.1");
     EXPECT_EQ(config.nodeScheduler.nodes[0].controlPort, std::uint16_t{7000});
     EXPECT_EQ(config.nodeScheduler.nodes[0].transportManagerId, "127.0.0.1:7100");
-}
-
-TEST(DramConfigTest, RejectsIoLengthOutsideProtocolRange)
-{
-    if (sizeof(ssize_t) <= sizeof(std::uint32_t)) {
-        GTEST_SKIP() << "ssize_t cannot represent an oversized IO length";
-    }
-    auto input = BaseConfig();
-    input.Set("io_lengths",
-              std::vector<ssize_t>{static_cast<ssize_t>(
-                  static_cast<std::uint64_t>(std::numeric_limits<std::uint32_t>::max()) + 1)});
-    EXPECT_FALSE(DramConfig::Parse(input));
 }
 
 }  // namespace

--- a/ucm/store/test/case/dram/dram_construction_dependencies_test.cc
+++ b/ucm/store/test/case/dram/dram_construction_dependencies_test.cc
@@ -21,39 +21,25 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  * */
-#ifndef UNIFIEDCACHE_DRAM_STORE_CC_CONFIG_H
-#define UNIFIEDCACHE_DRAM_STORE_CC_CONFIG_H
+#include <gtest/gtest.h>
+#include <memory>
+#include "ucmstore_v1.h"
 
-#include <cstddef>
-#include <cstdint>
-#include <string>
-#include <vector>
-#include "kv_common/router.h"
-#include "status/status.h"
-#include "type/dictionary.h"
-#include "types.h"
+extern "C" UC::StoreV1* MakeDramStore();
 
 namespace UC::Dram {
+namespace {
 
-struct DramConfig {
-    std::string localControlHost;
-    std::uint16_t localControlPort{0};
-    std::string localHost;
-    std::string localTransportManagerId;
-    std::int32_t transportDeviceId{0};
-    UC::KV::RouterType routerType{UC::KV::RouterType::RING_HASH_FULL_SPREAD};
-    std::size_t maxIoEntries{65536};
-    NodeSchedulerConfig nodeScheduler;
-    TransportRuntimeConfig transportRuntime;
-    TimeoutConfig taskTimeouts;
-    std::size_t replySlotCount{0};
-    std::uint32_t replySlotSize{0};
-    std::vector<std::uint64_t> tensorSizes;
+TEST(DramStoreConstructionTest, FactorySurvivesInvalidSetup)
+{
+    std::unique_ptr<StoreV1> store(MakeDramStore());
+    ASSERT_NE(store, nullptr);
+    EXPECT_FALSE(store->Readme().empty());
+    EXPECT_TRUE(store->NeedRegisterKVCaches());
 
-    static Expected<DramConfig> Parse(const Detail::Dictionary& dictionary);
-    Status Validate() const;
-};
+    Detail::Dictionary invalid;
+    EXPECT_TRUE(store->Setup(invalid).Failure());
+}
 
+}  // namespace
 }  // namespace UC::Dram
-
-#endif  // UNIFIEDCACHE_DRAM_STORE_CC_CONFIG_H

--- a/ucm/store/test/case/dram/dram_node_scheduler_test.cc
+++ b/ucm/store/test/case/dram/dram_node_scheduler_test.cc
@@ -435,7 +435,7 @@ TEST(NodeSchedulerTest, ShutdownStopsNewCommands)
         SchedulerConfig({Endpoint(1)}, 1, 1, 1h),
         SchedulerDependencies([](TransportCommand&) { return Status::Retry(); }));
     ASSERT_TRUE(scheduler.Start().Success());
-    ASSERT_TRUE(scheduler.Shutdown().Success());
+    scheduler.Shutdown();
 
     auto command = MakeRequest();
     EXPECT_TRUE(scheduler.Post(command).Failure());
@@ -487,7 +487,7 @@ TEST(NodeSchedulerTest, CompletionPublisherExceptionIsFatal)
                 releaseTransmit = true;
             }
             changed.notify_all();
-            (void)scheduler.Shutdown();
+            scheduler.Shutdown();
         },
         "");
 }
@@ -512,7 +512,7 @@ TEST(NodeSchedulerTest, DisconnectedNodeQueuesRequests)
 
     auto command = MakeRequest();
     EXPECT_TRUE(scheduler.Post(command).Success());
-    EXPECT_TRUE(scheduler.Shutdown().Success());
+    scheduler.Shutdown();
 }
 
 TEST(NodeSchedulerTest, RequestsWaitForInflightCapacity)
@@ -554,7 +554,7 @@ TEST(NodeSchedulerTest, RequestsWaitForInflightCapacity)
     });
     ASSERT_TRUE(WaitUntil(mutex, changed, [&] { return transmitted.size() == 2; }));
     EXPECT_EQ(transmitted, (std::vector<RequestId>{1, 2}));
-    EXPECT_TRUE(scheduler.Shutdown().Success());
+    scheduler.Shutdown();
 }
 
 TEST(NodeSchedulerTest, DifferentRunnersRunConcurrently)
@@ -592,7 +592,7 @@ TEST(NodeSchedulerTest, DifferentRunnersRunConcurrently)
     changed.notify_all();
 
     EXPECT_TRUE(bothEntered);
-    EXPECT_TRUE(scheduler.Shutdown().Success());
+    scheduler.Shutdown();
 }
 
 TEST(NodeSchedulerTest, NodesOnTheSameRunnerRunSerially)
@@ -628,7 +628,7 @@ TEST(NodeSchedulerTest, NodesOnTheSameRunnerRunSerially)
         std::unique_lock lock(mutex);
         EXPECT_TRUE(changed.wait_for(lock, 1s, [&] { return connectCount == 2; }));
     }
-    EXPECT_TRUE(scheduler.Shutdown().Success());
+    scheduler.Shutdown();
 }
 
 TEST(NodeSchedulerTest, DisconnectedActorRetriesConnectionOnSchedule)
@@ -651,7 +651,7 @@ TEST(NodeSchedulerTest, DisconnectedActorRetriesConnectionOnSchedule)
     const bool retried = WaitUntil(mutex, changed, [&] { return attempts >= 2; });
 
     EXPECT_TRUE(retried);
-    EXPECT_TRUE(scheduler.Shutdown().Success());
+    scheduler.Shutdown();
 }
 
 TEST(NodeSchedulerTest, TransportAdmissionFailureDoesNotParkActor)
@@ -719,7 +719,7 @@ TEST(NodeSchedulerTest, TransportAdmissionFailureDoesNotParkActor)
     ASSERT_TRUE(WaitUntil(mutex, changed, [&] { return completionCount == 2; }));
     EXPECT_EQ(transmitCount, std::size_t{2});
     EXPECT_EQ(releases, std::size_t{2});
-    EXPECT_TRUE(instance.Shutdown().Success());
+    instance.Shutdown();
 }
 
 TEST(NodeSchedulerTest, ShutdownAbandonsActiveRequest)
@@ -765,7 +765,7 @@ TEST(NodeSchedulerTest, ShutdownAbandonsActiveRequest)
     auto pending = MakeRequest(2, 2);
     EXPECT_TRUE(scheduler.Post(pending).Success());
 
-    EXPECT_TRUE(scheduler.Shutdown().Success());
+    scheduler.Shutdown();
     EXPECT_FALSE(completed);
     EXPECT_EQ(transmitAttempts, std::size_t{1});
     EXPECT_EQ(releases, std::size_t{0});
@@ -778,7 +778,7 @@ TEST(NodeSchedulerTest, LateEventsAfterShutdownAreDiscarded)
         SchedulerConfig({Endpoint(1)}, 1, 1, 1ms),
         SchedulerDependencies([](TransportCommand&) { return Status::Retry(); }));
     ASSERT_TRUE(scheduler.Start().Success());
-    ASSERT_TRUE(scheduler.Shutdown().Success());
+    scheduler.Shutdown();
 
     for (std::size_t index = 0; index < 16; ++index) {
         scheduler.Publish(1, NodeEvent{
@@ -812,7 +812,7 @@ TEST(NodeSchedulerTest, HundredsOfNodesShareAFewRunners)
     const bool allAttempted = WaitUntil(mutex, changed, [&] { return attempts == kNodeCount; }, 2s);
 
     EXPECT_TRUE(allAttempted);
-    EXPECT_TRUE(scheduler.Shutdown().Success());
+    scheduler.Shutdown();
 }
 
 }  // namespace

--- a/ucm/store/test/case/dram/dram_reply_service_polling_test.cc
+++ b/ucm/store/test/case/dram/dram_reply_service_polling_test.cc
@@ -33,33 +33,9 @@
 #include <stdexcept>
 #include <vector>
 #include "reply_service.h"
-#include "trans/device.h"
 
 namespace UC::Dram {
 namespace {
-
-class ReplyServicePollingTest : public ::testing::Test {
-protected:
-    static void SetUpTestSuite()
-    {
-        auto status = device_.Init();
-        deviceRuntimeOwned_ = status.Success();
-        ASSERT_TRUE(deviceRuntimeOwned_ || status == Status::DuplicateKey()) << status.ToString();
-        status = device_.Setup(0);
-        ASSERT_TRUE(status.Success()) << status.ToString();
-    }
-
-    static void TearDownTestSuite()
-    {
-        if (!deviceRuntimeOwned_) { return; }
-        EXPECT_TRUE(device_.Reset(0).Success());
-        EXPECT_TRUE(device_.Finalize().Success());
-        deviceRuntimeOwned_ = false;
-    }
-
-    inline static UC::Trans::Device device_;
-    inline static bool deviceRuntimeOwned_{false};
-};
 
 Status PackReply(const ReplySlot& slot, DramPool::KvOpcode opcode,
                  std::vector<std::uint8_t> results)
@@ -100,7 +76,7 @@ private:
     std::optional<NodeEvent> event_;
 };
 
-TEST_F(ReplyServicePollingTest, PublishesObservedReplyAndKeepsLeaseUntilActorRelease)
+TEST(ReplyServicePollingTest, PublishesObservedReplyAndKeepsLeaseUntilActorRelease)
 {
     EventCollector collector;
     auto created = ReplyService::Create(ReplyService::Options{
@@ -109,7 +85,7 @@ TEST_F(ReplyServicePollingTest, PublishesObservedReplyAndKeepsLeaseUntilActorRel
         std::chrono::microseconds{50},
         [&collector](NodeId node, NodeEvent event) { collector.Publish(node, std::move(event)); },
     });
-    ASSERT_TRUE(created) << created.Error().ToString();
+    ASSERT_TRUE(created);
     auto service = std::move(created).Value();
     ASSERT_TRUE(service->Start().Success());
 
@@ -135,10 +111,10 @@ TEST_F(ReplyServicePollingTest, PublishesObservedReplyAndKeepsLeaseUntilActorRel
     EXPECT_EQ(service->Available(), std::size_t{0});
     EXPECT_TRUE(service->Release(token, slot).Success());
     EXPECT_EQ(service->Available(), std::size_t{1});
-    EXPECT_TRUE(service->Shutdown().Success());
+    service->Shutdown();
 }
 
-TEST_F(ReplyServicePollingTest, ReusesSlotWhilePreviousReplyEventIsBeingPublished)
+TEST(ReplyServicePollingTest, ReusesSlotWhilePreviousReplyEventIsBeingPublished)
 {
     std::mutex mutex;
     std::condition_variable changed;
@@ -207,7 +183,7 @@ TEST_F(ReplyServicePollingTest, ReusesSlotWhilePreviousReplyEventIsBeingPublishe
     } else if (firstRelease.Failure()) {
         cleanup = service->Release(firstToken, first.Value());
     }
-    const auto shutdown = service->Shutdown();
+    service->Shutdown();
 
     EXPECT_TRUE(publishEntered);
     EXPECT_TRUE(firstRelease.Success());
@@ -216,10 +192,9 @@ TEST_F(ReplyServicePollingTest, ReusesSlotWhilePreviousReplyEventIsBeingPublishe
     EXPECT_TRUE(secondPack.Success());
     EXPECT_TRUE(secondPublished);
     EXPECT_TRUE(cleanup.Success());
-    EXPECT_TRUE(shutdown.Success());
 }
 
-TEST_F(ReplyServicePollingTest, RejectsShutdownWithActiveLease)
+TEST(ReplyServicePollingTest, AllowsShutdownWithAbandonedLease)
 {
     auto created = ReplyService::Create(ReplyService::Options{
         64,
@@ -232,15 +207,11 @@ TEST_F(ReplyServicePollingTest, RejectsShutdownWithActiveLease)
     ASSERT_TRUE(service->Start().Success());
     auto acquired = service->Acquire(RequestToken{1, kDefaultLaneId, 1, 1}, OpType::LOOKUP, 1);
     ASSERT_TRUE(acquired);
-    EXPECT_TRUE(service->Shutdown().Failure());
+    service->Shutdown();
 }
 
-TEST_F(ReplyServicePollingTest, EventPublisherExceptionIsFatal)
+TEST(ReplyServicePollingTest, EventPublisherExceptionIsFatal)
 {
-#if defined(UCM_TEST_RUNTIME_ASCEND)
-    GTEST_FLAG_SET(death_test_style, "threadsafe");
-#endif
-
     EXPECT_DEATH(
         {
             std::promise<void> publishAttempted;
@@ -264,7 +235,7 @@ TEST_F(ReplyServicePollingTest, EventPublisherExceptionIsFatal)
                     PackReply(acquired.Value(), DramPool::KvOpcode::Lookup, {1}).Success()) {
                     publishAttemptedFuture.wait();
                 }
-                (void)service->Shutdown();
+                service->Shutdown();
             }
         },
         "");

--- a/ucm/store/test/case/dram/dram_reply_service_test.cc
+++ b/ucm/store/test/case/dram/dram_reply_service_test.cc
@@ -117,7 +117,7 @@ TEST_F(ReplyServiceTest, SharesSlotsAcrossRequestsAndValidatesOwnership)
     EXPECT_TRUE(service->Release(Token(33, 4), reused.Value()).Success());
     EXPECT_TRUE(service->Release(first_token, first.Value()).Success());
     EXPECT_TRUE(service->Release(third_token, third.Value()).Success());
-    EXPECT_TRUE(service->Shutdown().Success());
+    service->Shutdown();
 }
 
 TEST_F(ReplyServiceTest, RejectsReplyPayloadLargerThanSlot)
@@ -127,7 +127,7 @@ TEST_F(ReplyServiceTest, RejectsReplyPayloadLargerThanSlot)
     auto service = std::move(created).Value();
     ASSERT_TRUE(service->Start().Success());
     EXPECT_FALSE(service->Acquire(Token(1, 1), OpType::LOOKUP, 1));
-    EXPECT_TRUE(service->Shutdown().Success());
+    service->Shutdown();
 }
 
 TEST_F(ReplyServiceTest, ShutdownStopsNewLeases)
@@ -136,7 +136,7 @@ TEST_F(ReplyServiceTest, ShutdownStopsNewLeases)
     ASSERT_TRUE(created);
     auto service = std::move(created).Value();
     ASSERT_TRUE(service->Start().Success());
-    ASSERT_TRUE(service->Shutdown().Success());
+    service->Shutdown();
     EXPECT_FALSE(service->Acquire(Token(1, 1), OpType::LOOKUP, 1));
 }
 
@@ -169,7 +169,7 @@ TEST_F(ReplyServiceTest, SupportsConcurrentLeases)
 
     EXPECT_FALSE(failed.load(std::memory_order_relaxed));
     EXPECT_EQ(service->Available(), kSlotCount);
-    EXPECT_TRUE(service->Shutdown().Success());
+    service->Shutdown();
 }
 
 }  // namespace

--- a/ucm/store/test/case/dram/dram_task_manager_test.cc
+++ b/ucm/store/test/case/dram/dram_task_manager_test.cc
@@ -1,0 +1,672 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <future>
+#include <gtest/gtest.h>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+#include "kv_common/router.h"
+#include "task_manager.h"
+
+namespace UC::Dram {
+namespace {
+
+void PublishCompletion(TaskManager& manager, RequestCompleted event)
+{
+    std::vector<RequestCompleted> events;
+    events.push_back(std::move(event));
+    manager.Publish(events);
+}
+
+class CountingRouter final : public UC::KV::Router {
+public:
+    CountingRouter() : Router([](const std::string&) { return std::uint64_t{0}; }) {}
+
+    std::unordered_map<UC::KV::NodeId, std::vector<EntryIndex>> RouteKeys(
+        const std::vector<UC::KV::CacheKey>& keys) const override
+    {
+        calls_.fetch_add(1, std::memory_order_relaxed);
+        std::vector<EntryIndex> indexes(keys.size());
+        for (std::size_t index = 0; index < keys.size(); ++index) { indexes[index] = index; }
+        return {
+            {NodeId{7}, std::move(indexes)}
+        };
+    }
+
+    std::size_t calls() const noexcept { return calls_.load(std::memory_order_relaxed); }
+
+private:
+    UC::KV::NodeId RouteKey(const UC::KV::CacheKey&) const override { return NodeId{7}; }
+
+    mutable std::atomic<std::size_t> calls_{0};
+};
+
+class BlockingRequests final {
+public:
+    Status Post(Request& request)
+    {
+        std::unique_lock lock(mutex_);
+        requests_.push_back(request);
+        changed_.notify_all();
+        if (requests_.size() == 1) {
+            changed_.wait(lock, [this] { return released_; });
+        }
+        return Status::OK();
+    }
+
+    Request WaitForSubmission(std::size_t index = 0)
+    {
+        std::unique_lock lock(mutex_);
+        changed_.wait(lock, [this, index] { return requests_.size() > index; });
+        return requests_[index];
+    }
+
+    void Release()
+    {
+        std::lock_guard lock(mutex_);
+        released_ = true;
+        changed_.notify_all();
+    }
+
+private:
+    std::mutex mutex_;
+    std::condition_variable changed_;
+    std::vector<Request> requests_;
+    bool released_{false};
+};
+
+class FailSecondRequest final {
+public:
+    Status Post(Request& request)
+    {
+        std::lock_guard lock(mutex_);
+        requests_.push_back(request);
+        changed_.notify_all();
+        return requests_.size() == 2 ? Status::Error("second request rejected") : Status::OK();
+    }
+
+    std::vector<Request> WaitForRequests(std::size_t count)
+    {
+        std::unique_lock lock(mutex_);
+        changed_.wait(lock, [this, count] { return requests_.size() >= count; });
+        return requests_;
+    }
+
+private:
+    std::mutex mutex_;
+    std::condition_variable changed_;
+    std::vector<Request> requests_;
+};
+
+class CompletingRequests final {
+public:
+    void Bind(TaskManager& manager) noexcept { manager_ = &manager; }
+
+    Status Post(Request& request)
+    {
+        std::vector<EntryResult> results;
+        for (std::size_t index = 0; index < request.entries.size(); ++index) {
+            results.push_back(EntryResult{index, true, 0});
+        }
+        PublishCompletion(*manager_,
+                          RequestCompleted{request.taskId, request.requestId, request.nodeId,
+                                           Status::OK(), std::move(results)});
+        return Status::OK();
+    }
+
+private:
+    TaskManager* manager_{nullptr};
+};
+
+class TaskManagerAsyncTest : public testing::Test {
+protected:
+    TaskManagerConfig Config(std::size_t batchSize = 8) const
+    {
+        return TaskManagerConfig{
+            {0x100},
+            32,
+            batchSize,
+            TimeoutConfig{std::chrono::milliseconds{100}, std::chrono::milliseconds{100},
+             std::chrono::milliseconds{100}}
+        };
+    }
+
+    TaskManagerDependencies Dependencies(RequestSubmitter submitRequest) const
+    {
+        return TaskManagerDependencies{router_, std::move(submitRequest)};
+    }
+
+    static Detail::TaskDesc ValidTask()
+    {
+        Detail::TaskDesc task;
+        Detail::Shard shard{};
+        shard.index = 0;
+        shard.addrs.push_back(reinterpret_cast<void*>(kLayerBase));
+        task.push_back(std::move(shard));
+        return task;
+    }
+
+    static Detail::TaskDesc TwoEntryTask()
+    {
+        Detail::TaskDesc task;
+        task.push_back(Detail::Shard{{}, 0, {reinterpret_cast<void*>(kLayerBase)}});
+        task.push_back(Detail::Shard{{}, 1, {reinterpret_cast<void*>(kSecondLayerBase)}});
+        return task;
+    }
+
+    static Detail::TaskDesc TwoTensorShardTask()
+    {
+        Detail::TaskDesc task;
+        task.push_back(Detail::Shard{
+            {},
+            1,
+            {reinterpret_cast<void*>(kLayerBase), reinterpret_cast<void*>(kSecondLayerBase)}
+        });
+        return task;
+    }
+
+    static constexpr std::uintptr_t kLayerBase = 0x10000;
+    static constexpr std::uintptr_t kSecondLayerBase = 0x12000;
+    std::shared_ptr<UC::KV::Router> router_{
+        UC::KV::CreateRouter({NodeId{7}}, {}, UC::KV::RouterConfig{})};
+};
+
+TEST_F(TaskManagerAsyncTest, CheckDoesNotWaitForTaskWorker)
+{
+    BlockingRequests commands;
+    TaskManager manager(
+        Config(), Dependencies([&commands](Request& request) { return commands.Post(request); }));
+    ASSERT_TRUE(manager.Start().Success());
+
+    auto submitted = manager.SubmitTransfer(OpType::LOAD, ValidTask());
+    ASSERT_TRUE(submitted);
+    const auto task_id = std::move(submitted).Value();
+    const auto request = commands.WaitForSubmission();
+    ASSERT_EQ(request.entries.size(), std::size_t{1});
+    EXPECT_EQ(request.entries[0].buffer.address, kLayerBase);
+    EXPECT_EQ(request.entries[0].buffer.length, std::uint64_t{0x100});
+
+    auto complete = manager.Check(task_id);
+    commands.Release();
+    ASSERT_TRUE(complete);
+    EXPECT_FALSE(std::move(complete).Value());
+
+    PublishCompletion(
+        manager,
+        RequestCompleted{request.taskId, request.requestId, request.nodeId, Status::OK(), {}});
+    EXPECT_TRUE(manager.WaitTransfer(task_id).Success());
+    EXPECT_FALSE(manager.Check(task_id));
+    manager.Shutdown();
+}
+
+TEST_F(TaskManagerAsyncTest, FlattensTensorIndexesWithinShard)
+{
+    BlockingRequests commands;
+    auto config = Config();
+    config.tensorSizes = {0x100, 0x200};
+    TaskManager manager(std::move(config), Dependencies([&commands](Request& request) {
+                            return commands.Post(request);
+                        }));
+    ASSERT_TRUE(manager.Start().Success());
+
+    auto submitted = manager.SubmitTransfer(OpType::LOAD, TwoTensorShardTask());
+    ASSERT_TRUE(submitted);
+    const auto taskId = std::move(submitted).Value();
+    const auto request = commands.WaitForSubmission();
+    ASSERT_EQ(request.entries.size(), std::size_t{2});
+    EXPECT_EQ(request.entries[0].shardId, std::uint32_t{2});
+    EXPECT_EQ(request.entries[0].buffer.address, kLayerBase);
+    EXPECT_EQ(request.entries[0].buffer.length, std::uint64_t{0x100});
+    EXPECT_EQ(request.entries[1].shardId, std::uint32_t{3});
+    EXPECT_EQ(request.entries[1].buffer.address, kSecondLayerBase);
+    EXPECT_EQ(request.entries[1].buffer.length, std::uint64_t{0x200});
+
+    commands.Release();
+    PublishCompletion(
+        manager,
+        RequestCompleted{request.taskId, request.requestId, request.nodeId, Status::OK(), {}});
+    EXPECT_TRUE(manager.WaitTransfer(taskId).Success());
+    manager.Shutdown();
+}
+
+TEST_F(TaskManagerAsyncTest, CompletionIsProcessedBeforeQueuedSubmission)
+{
+    std::mutex mutex;
+    std::condition_variable changed;
+    std::vector<Request> requests;
+    bool releaseFirstPost = false;
+    bool secondPosted = false;
+    bool firstCompletionObserved = false;
+    TaskId firstTaskId = 0;
+    TaskManager* manager = nullptr;
+
+    auto dependencies = Dependencies([&](Request& request) {
+        std::unique_lock lock(mutex);
+        requests.push_back(request);
+        changed.notify_all();
+        if (requests.size() == 1) {
+            changed.wait(lock, [&] { return releaseFirstPost; });
+        } else {
+            lock.unlock();
+            auto checked = manager->Check(firstTaskId);
+            const auto completed = checked && checked.Value();
+            lock.lock();
+            firstCompletionObserved = completed;
+            secondPosted = true;
+            changed.notify_all();
+        }
+        return Status::OK();
+    });
+    TaskManager instance(Config(), std::move(dependencies));
+    manager = &instance;
+    ASSERT_TRUE(instance.Start().Success());
+
+    auto first = instance.SubmitTransfer(OpType::LOAD, ValidTask());
+    ASSERT_TRUE(first);
+    firstTaskId = std::move(first).Value();
+    Request firstRequest;
+    {
+        std::unique_lock lock(mutex);
+        changed.wait(lock, [&] { return requests.size() == 1; });
+        firstRequest = requests.front();
+    }
+
+    auto second = instance.SubmitTransfer(OpType::LOAD, ValidTask());
+    ASSERT_TRUE(second);
+    const auto secondTaskId = std::move(second).Value();
+    PublishCompletion(
+        instance,
+        RequestCompleted{
+            firstRequest.taskId, firstRequest.requestId, firstRequest.nodeId, Status::OK(), {}});
+    {
+        std::lock_guard lock(mutex);
+        releaseFirstPost = true;
+    }
+    changed.notify_all();
+
+    Request secondRequest;
+    {
+        std::unique_lock lock(mutex);
+        changed.wait(lock, [&] { return secondPosted; });
+        ASSERT_EQ(requests.size(), std::size_t{2});
+        secondRequest = requests.back();
+    }
+    EXPECT_TRUE(firstCompletionObserved);
+    PublishCompletion(
+        instance,
+        RequestCompleted{
+            secondRequest.taskId, secondRequest.requestId, secondRequest.nodeId, Status::OK(), {}});
+    EXPECT_TRUE(instance.WaitTransfer(firstTaskId).Success());
+    EXPECT_TRUE(instance.WaitTransfer(secondTaskId).Success());
+    instance.Shutdown();
+}
+
+TEST_F(TaskManagerAsyncTest, TerminalCheckPreservesHandleAndReleasesIoEntryCapacity)
+{
+    CompletingRequests commands;
+    auto config = Config();
+    config.maxIoEntries = 2;
+    TaskManager manager(std::move(config), Dependencies([&commands](Request& request) {
+                            return commands.Post(request);
+                        }));
+    commands.Bind(manager);
+    ASSERT_TRUE(manager.Start().Success());
+
+    auto first = manager.SubmitTransfer(OpType::LOAD, TwoEntryTask());
+    ASSERT_TRUE(first);
+    const auto firstTaskId = std::move(first).Value();
+
+    bool terminal = false;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{1};
+    while (!terminal && std::chrono::steady_clock::now() < deadline) {
+        auto checked = manager.Check(firstTaskId);
+        ASSERT_TRUE(checked);
+        terminal = checked.Value();
+        if (!terminal) { std::this_thread::sleep_for(std::chrono::milliseconds{1}); }
+    }
+    ASSERT_TRUE(terminal);
+
+    auto checkedAgain = manager.Check(firstTaskId);
+    ASSERT_TRUE(checkedAgain);
+    EXPECT_TRUE(checkedAgain.Value());
+
+    auto second = manager.SubmitTransfer(OpType::LOAD, ValidTask());
+    ASSERT_TRUE(second);
+    EXPECT_TRUE(manager.WaitTransfer(std::move(second).Value()).Success());
+    EXPECT_TRUE(manager.WaitTransfer(firstTaskId).Success());
+    auto consumed = manager.Check(firstTaskId);
+    ASSERT_FALSE(consumed);
+    EXPECT_EQ(consumed.Error(), Status::NotFound());
+    manager.Shutdown();
+}
+
+TEST_F(TaskManagerAsyncTest, CapacityFailureIsReportedThroughAcceptedHandle)
+{
+    BlockingRequests commands;
+    auto config = Config(1);
+    config.maxIoEntries = 2;
+    TaskManager manager(std::move(config), Dependencies([&commands](Request& request) {
+                            return commands.Post(request);
+                        }));
+    ASSERT_TRUE(manager.Start().Success());
+
+    auto first = manager.SubmitTransfer(OpType::LOAD, TwoEntryTask());
+    ASSERT_TRUE(first);
+    const auto firstTaskId = std::move(first).Value();
+    const auto firstRequest = commands.WaitForSubmission();
+
+    auto accepted = manager.SubmitTransfer(OpType::LOAD, ValidTask());
+    ASSERT_TRUE(accepted);
+    const auto acceptedTaskId = std::move(accepted).Value();
+
+    commands.Release();
+    const auto secondRequest = commands.WaitForSubmission(1);
+    EXPECT_EQ(manager.WaitTransfer(acceptedTaskId), Status::NoSpace());
+
+    std::vector<RequestCompleted> completions;
+    completions.push_back(RequestCompleted{
+        firstRequest.taskId, firstRequest.requestId, firstRequest.nodeId, Status::OK(), {}});
+    completions.push_back(RequestCompleted{
+        secondRequest.taskId, secondRequest.requestId, secondRequest.nodeId, Status::OK(), {}});
+    manager.Publish(completions);
+
+    EXPECT_TRUE(manager.WaitTransfer(firstTaskId).Success());
+    manager.Shutdown();
+}
+
+TEST_F(TaskManagerAsyncTest, ShutdownStopsNewSubmissions)
+{
+    TaskManager manager(Config(), Dependencies([](Request&) { return Status::OK(); }));
+    ASSERT_TRUE(manager.Start().Success());
+    manager.Shutdown();
+    EXPECT_FALSE(manager.SubmitTransfer(OpType::LOAD, ValidTask()));
+}
+
+TEST_F(TaskManagerAsyncTest, ShutdownRejectsNewTasksAndDropsLateCompletions)
+{
+    BlockingRequests commands;
+    TaskManager manager(
+        Config(), Dependencies([&commands](Request& request) { return commands.Post(request); }));
+    ASSERT_TRUE(manager.Start().Success());
+    auto submitted = manager.SubmitTransfer(OpType::LOAD, ValidTask());
+    ASSERT_TRUE(submitted);
+    const auto request = commands.WaitForSubmission();
+
+    auto stopping = std::async(std::launch::async, [&manager] { return manager.Shutdown(); });
+    EXPECT_EQ(stopping.wait_for(std::chrono::milliseconds{10}), std::future_status::timeout);
+    commands.Release();
+    stopping.get();
+
+    EXPECT_FALSE(manager.SubmitTransfer(OpType::LOAD, ValidTask()));
+    PublishCompletion(
+        manager,
+        RequestCompleted{request.taskId, request.requestId, request.nodeId, Status::OK(), {}});
+}
+
+TEST_F(TaskManagerAsyncTest, PublishingWhileStoppedIsIgnored)
+{
+    TaskManager manager(Config(), Dependencies([](Request&) { return Status::OK(); }));
+    PublishCompletion(manager, RequestCompleted{1, 1, 7, Status::OK(), {}});
+    ASSERT_TRUE(manager.Start().Success());
+    manager.Shutdown();
+    PublishCompletion(manager, RequestCompleted{1, 1, 7, Status::OK(), {}});
+}
+
+TEST_F(TaskManagerAsyncTest, WorkerExceptionFailsAcceptedTasksAndStopsNewSubmissions)
+{
+    std::promise<void> dispatchStarted;
+    std::promise<void> failDispatch;
+    auto failureReady = failDispatch.get_future();
+    TaskManager manager(Config(), Dependencies([&](Request&) -> Status {
+                            dispatchStarted.set_value();
+                            failureReady.wait();
+                            throw std::runtime_error("node command publisher failed");
+                        }));
+    ASSERT_TRUE(manager.Start().Success());
+
+    auto active = manager.SubmitTransfer(OpType::LOAD, ValidTask());
+    ASSERT_TRUE(active);
+    dispatchStarted.get_future().wait();
+    auto queued = manager.SubmitTransfer(OpType::LOAD, ValidTask());
+    ASSERT_TRUE(queued);
+    failDispatch.set_value();
+
+    EXPECT_TRUE(manager.WaitTransfer(std::move(active).Value()).Failure());
+    EXPECT_TRUE(manager.WaitTransfer(std::move(queued).Value()).Failure());
+
+    bool stopped = false;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds{1};
+    while (!stopped && std::chrono::steady_clock::now() < deadline) {
+        auto attempt = manager.SubmitTransfer(OpType::LOAD, ValidTask());
+        stopped = !attempt && attempt.Error() != Status::NoSpace();
+        if (!stopped) { std::this_thread::sleep_for(std::chrono::milliseconds{1}); }
+    }
+    EXPECT_TRUE(stopped);
+
+    manager.Shutdown();
+}
+
+TEST_F(TaskManagerAsyncTest, PartialDispatchWaitsForPostedRequest)
+{
+    FailSecondRequest commands;
+    TaskManager manager(
+        Config(1), Dependencies([&commands](Request& request) { return commands.Post(request); }));
+    ASSERT_TRUE(manager.Start().Success());
+    auto submitted = manager.SubmitTransfer(OpType::DUMP, TwoEntryTask());
+    ASSERT_TRUE(submitted);
+    const auto task_id = std::move(submitted).Value();
+    const auto requests = commands.WaitForRequests(2);
+    ASSERT_EQ(requests.size(), std::size_t{2});
+    ASSERT_EQ(requests[0].entries.size(), std::size_t{1});
+    ASSERT_EQ(requests[1].entries.size(), std::size_t{1});
+    EXPECT_EQ(requests[0].taskId, task_id);
+    EXPECT_EQ(requests[1].taskId, task_id);
+    EXPECT_NE(requests[0].requestId, kInvalidRequestId);
+    EXPECT_NE(requests[1].requestId, kInvalidRequestId);
+    EXPECT_NE(requests[0].requestId, requests[1].requestId);
+    EXPECT_EQ(requests[0].nodeId, NodeId{7});
+    EXPECT_EQ(requests[1].nodeId, NodeId{7});
+    EXPECT_EQ(requests[0].entries[0].shardId, std::uint32_t{0});
+    EXPECT_EQ(requests[1].entries[0].shardId, std::uint32_t{1});
+    PublishCompletion(
+        manager,
+        RequestCompleted{
+            requests[0].taskId, requests[0].requestId, requests[0].nodeId, Status::OK(), {}});
+    EXPECT_TRUE(manager.WaitTransfer(task_id).Failure());
+    manager.Shutdown();
+}
+
+TEST_F(TaskManagerAsyncTest, ShutdownWaitsForInProgressNodeDispatch)
+{
+    BlockingRequests commands;
+    TaskManager manager(
+        Config(), Dependencies([&commands](Request& request) { return commands.Post(request); }));
+    ASSERT_TRUE(manager.Start().Success());
+    auto submitted = manager.SubmitTransfer(OpType::LOAD, ValidTask());
+    ASSERT_TRUE(submitted);
+    (void)commands.WaitForSubmission();
+
+    auto stopping = std::async(std::launch::async, [&manager] { return manager.Shutdown(); });
+    EXPECT_EQ(stopping.wait_for(std::chrono::milliseconds{10}), std::future_status::timeout);
+    commands.Release();
+    stopping.get();
+}
+
+TEST_F(TaskManagerAsyncTest, LookupCanCompleteBeforeNodePostReturns)
+{
+    CompletingRequests commands;
+    TaskManager manager(
+        Config(), Dependencies([&commands](Request& request) { return commands.Post(request); }));
+    commands.Bind(manager);
+    ASSERT_TRUE(manager.Start().Success());
+    Detail::BlockId block{};
+    auto submitted = manager.SubmitLookup(&block, 1);
+    ASSERT_TRUE(submitted);
+    auto result = manager.WaitLookup(std::move(submitted).Value());
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result.Value().size(), std::size_t{1});
+    EXPECT_EQ(result.Value()[0], std::uint8_t{1});
+    manager.Shutdown();
+}
+
+TEST_F(TaskManagerAsyncTest, BatchedRequestsCanCompleteSynchronouslyWithOneLiveTask)
+{
+    CompletingRequests commands;
+    auto config = Config(1);
+    config.maxIoEntries = 2;
+    TaskManager manager(std::move(config), Dependencies([&commands](Request& request) {
+                            return commands.Post(request);
+                        }));
+    commands.Bind(manager);
+    ASSERT_TRUE(manager.Start().Success());
+
+    auto submitted = manager.SubmitTransfer(OpType::LOAD, TwoEntryTask());
+    ASSERT_TRUE(submitted);
+    EXPECT_TRUE(manager.WaitTransfer(std::move(submitted).Value()).Success());
+    manager.Shutdown();
+}
+
+TEST_F(TaskManagerAsyncTest, NodeNoSpaceIsTerminal)
+{
+    std::size_t attempts = 0;
+    TaskManager manager(Config(), Dependencies([&attempts](Request&) {
+                            ++attempts;
+                            return Status::NoSpace();
+                        }));
+    ASSERT_TRUE(manager.Start().Success());
+
+    auto submitted = manager.SubmitTransfer(OpType::LOAD, ValidTask());
+    ASSERT_TRUE(submitted);
+    auto status = manager.WaitTransfer(std::move(submitted).Value());
+    EXPECT_EQ(status, Status::NoSpace());
+    EXPECT_EQ(attempts, std::size_t{1});
+    manager.Shutdown();
+}
+
+TEST_F(TaskManagerAsyncTest, LookupOwnsBlockIdsBeforeReturningHandle)
+{
+    BlockingRequests commands;
+    TaskManager manager(
+        Config(), Dependencies([&commands](Request& request) { return commands.Post(request); }));
+    ASSERT_TRUE(manager.Start().Success());
+
+    auto transfer = manager.SubmitTransfer(OpType::LOAD, ValidTask());
+    ASSERT_TRUE(transfer);
+    const auto transfer_id = std::move(transfer).Value();
+    const auto transfer_request = commands.WaitForSubmission();
+
+    Detail::BlockId block{};
+    block[0] = std::byte{1};
+    auto lookup = manager.SubmitLookup(&block, 1);
+    ASSERT_TRUE(lookup);
+    const auto lookup_id = std::move(lookup).Value();
+    block[0] = std::byte{2};
+
+    commands.Release();
+    const auto lookup_request = commands.WaitForSubmission(1);
+    ASSERT_EQ(lookup_request.entries.size(), std::size_t{1});
+    EXPECT_EQ(lookup_request.entries[0].blockId[0], std::byte{1});
+
+    PublishCompletion(manager, RequestCompleted{transfer_request.taskId,
+                                                transfer_request.requestId,
+                                                transfer_request.nodeId,
+                                                Status::OK(),
+                                                {}});
+    PublishCompletion(manager, RequestCompleted{lookup_request.taskId,
+                                                lookup_request.requestId,
+                                                lookup_request.nodeId,
+                                                Status::OK(),
+                                                {}});
+    EXPECT_TRUE(manager.WaitTransfer(transfer_id).Success());
+    EXPECT_TRUE(manager.WaitLookup(lookup_id));
+    manager.Shutdown();
+}
+
+TEST_F(TaskManagerAsyncTest, ExpiredQueuedSubmissionSkipsRouting)
+{
+    BlockingRequests commands;
+    auto router = std::make_shared<CountingRouter>();
+    auto config = Config();
+    config.timeouts = TimeoutConfig{std::chrono::milliseconds{20}, std::chrono::milliseconds{20},
+                                    std::chrono::milliseconds{20}};
+    auto dependencies =
+        Dependencies([&commands](Request& request) { return commands.Post(request); });
+    dependencies.router = router;
+    TaskManager manager(std::move(config), std::move(dependencies));
+    ASSERT_TRUE(manager.Start().Success());
+
+    auto first = manager.SubmitTransfer(OpType::LOAD, ValidTask());
+    ASSERT_TRUE(first);
+    const auto firstTaskId = std::move(first).Value();
+    const auto firstRequest = commands.WaitForSubmission();
+
+    auto expired = manager.SubmitTransfer(OpType::LOAD, ValidTask());
+    ASSERT_TRUE(expired);
+    const auto expiredTaskId = std::move(expired).Value();
+    std::this_thread::sleep_for(std::chrono::milliseconds{30});
+    commands.Release();
+
+    PublishCompletion(
+        manager,
+        RequestCompleted{
+            firstRequest.taskId, firstRequest.requestId, firstRequest.nodeId, Status::OK(), {}});
+    auto expiredStatus = manager.WaitTransfer(expiredTaskId);
+    EXPECT_EQ(expiredStatus, Status::Timeout());
+    EXPECT_EQ(router->calls(), std::size_t{1});
+    (void)manager.WaitTransfer(firstTaskId);
+    manager.Shutdown();
+}
+
+TEST_F(TaskManagerAsyncTest, DeadlineWaitsForPostedRequestCompletion)
+{
+    FailSecondRequest commands;
+    auto config = Config();
+    config.timeouts = TimeoutConfig{std::chrono::milliseconds{20}, std::chrono::milliseconds{20},
+                                    std::chrono::milliseconds{20}};
+    TaskManager manager(std::move(config), Dependencies([&commands](Request& request) {
+                            return commands.Post(request);
+                        }));
+    ASSERT_TRUE(manager.Start().Success());
+
+    auto submitted = manager.SubmitTransfer(OpType::LOAD, ValidTask());
+    ASSERT_TRUE(submitted);
+    const auto taskId = std::move(submitted).Value();
+    const auto requests = commands.WaitForRequests(1);
+    std::this_thread::sleep_for(std::chrono::milliseconds{30});
+
+    PublishCompletion(
+        manager,
+        RequestCompleted{taskId, requests[0].requestId, requests[0].nodeId, Status::Timeout(), {}});
+    auto status = manager.WaitTransfer(taskId);
+    EXPECT_EQ(status, Status::Timeout());
+    manager.Shutdown();
+}
+
+}  // namespace
+}  // namespace UC::Dram

--- a/ucm/store/test/case/dram/dram_transport_backend_test.cc
+++ b/ucm/store/test/case/dram/dram_transport_backend_test.cc
@@ -68,13 +68,16 @@ public:
                    : Status::OK();
     }
     Status Fence(const ::UC::Dram::FenceEpoch&) noexcept override { return Status::OK(); }
-    Status Stop() noexcept override { return Status::OK(); }
+    void Stop() override { stopCount_.fetch_add(1, std::memory_order_relaxed); }
+
+    std::size_t StopCount() const noexcept { return stopCount_.load(std::memory_order_relaxed); }
 
 private:
     std::atomic<MemoryHandle> nextRegistration_{1};
+    std::atomic<std::size_t> stopCount_{0};
 };
 
-std::shared_ptr<ITransportBackend> CreateMockTransportBackend()
+std::shared_ptr<MockTransportBackend> CreateMockTransportBackend()
 {
     return std::make_shared<MockTransportBackend>();
 }
@@ -109,15 +112,19 @@ TEST(TransportExecutorTest, PublisherIsConstructorDependency)
     TransportExecutor executor(TransportExecutor::Options{1, 1, 1, CreateMockTransportBackend(),
                                                           [](NodeId, NodeEvent) {}});
     ASSERT_TRUE(executor.Start().Success());
-    EXPECT_TRUE(executor.Shutdown().Success());
+    executor.Shutdown();
 }
 
 TEST(TransportExecutorTest, ShutdownStopsNewCommands)
 {
-    TransportExecutor executor(TransportExecutor::Options{1, 1, 1, CreateMockTransportBackend(),
-                                                          [](NodeId, NodeEvent) {}});
+    auto backend = CreateMockTransportBackend();
+    TransportExecutor executor(
+        TransportExecutor::Options{1, 1, 1, backend, [](NodeId, NodeEvent) {}});
     ASSERT_TRUE(executor.Start().Success());
-    ASSERT_TRUE(executor.Shutdown().Success());
+    executor.Shutdown();
+    EXPECT_EQ(backend->StopCount(), std::size_t{0});
+    backend->Stop();
+    EXPECT_EQ(backend->StopCount(), std::size_t{1});
 
     TransportCommand command{
         Connect{1, kDefaultLaneId, 1, TestManagerId(1234)}
@@ -135,7 +142,7 @@ TEST(TransportExecutorTest, EventPublisherExceptionIsFatal)
             (void)executor.Start();
             TransportCommand command(Connect{1, kDefaultLaneId, 1, TestManagerId(1234)});
             (void)executor.TryPost(command);
-            (void)executor.Shutdown();
+            executor.Shutdown();
         },
         "");
 }
@@ -198,7 +205,7 @@ TEST(TransportExecutorTest, RequestLimitsDeriveSeparateCommandAndFenceBudgets)
     EXPECT_EQ(commandOverflowStatus, Status::Error());
     EXPECT_TRUE(fenceStatus.Success());
     EXPECT_EQ(fenceOverflowStatus, Status::Error());
-    EXPECT_TRUE(executor.Shutdown().Success());
+    executor.Shutdown();
 }
 
 }  // namespace


### PR DESCRIPTION
## Purpose

Introduce `DramStore` and `TaskManager`:

- **DramStore**: Implements the `StoreV1` interface and forwards incoming requests to `TaskManager`.
- **TaskManager**: A single-worker task actor that serializes submission planning and completion aggregation. Its public methods are responsible only for request admission and task status observation.

## Modifications 

## Test
