### PR TITLE
[Feat] Add TransProvider API GetServerCapabilities

### DIFF
--- a/ucm/transport/kv/asu/test/transport/connection_manager_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/connection_manager_test.cpp
@@ -37,10 +37,14 @@ namespace {
 
 static std::atomic<int> g_deleteCount{0};
 static std::atomic<int> g_createCount{0};
+static std::atomic<int> g_capabilityQueryCount{0};
 
 class StubTransProvider : public TransProvider {
 public:
     Status createStatus{Status::OK()};
+    Status capabilityStatus{Status::OK()};
+    ServerKvCapabilities serverCapabilities;
+    ConnectionHandle capabilityQueryHandle{nullptr};
 
     Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t qpNum,
                             uint32_t, std::vector<ConnectionHandle>& handles) override
@@ -53,6 +57,15 @@ public:
                 static_cast<uintptr_t>(g_createCount.load() * 100 + i + 1)));
         }
         return Status::OK();
+    }
+
+    Status GetServerCapabilities(ConnectionHandle handle,
+                                 ServerKvCapabilities& capabilities) override
+    {
+        g_capabilityQueryCount.fetch_add(1);
+        capabilityQueryHandle = handle;
+        capabilities = serverCapabilities;
+        return capabilityStatus;
     }
 
     std::vector<Status> DeleteConnections(const std::vector<ConnectionHandle>& handles) override
@@ -276,6 +289,46 @@ TEST(ConnectionManagerTest, AddGroupCreatesGroupWithChannels)
     EXPECT_TRUE(status.ok()) << status.message;
 
     EXPECT_EQ(mgr.TotalInflightCount(), 0);
+}
+
+TEST(ConnectionManagerTest, AddGroupQueriesCapabilitiesOnceUsingFirstHandle)
+{
+    g_createCount = 0;
+    g_capabilityQueryCount = 0;
+    StubTransProvider provider;
+    provider.serverCapabilities.batchStoreKeys = 77;
+    ConnectionManager mgr(provider, "", 5000);
+
+    const auto status = mgr.AddGroup(MakeEndpoint(), 3);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(g_capabilityQueryCount.load(), 1);
+    EXPECT_EQ(provider.capabilityQueryHandle,
+              reinterpret_cast<ConnectionHandle>(static_cast<uintptr_t>(101)));
+    const auto capabilities = mgr.GetServerCapabilities();
+    ASSERT_EQ(capabilities.size(), std::size_t{1});
+    EXPECT_EQ(capabilities.front().batchStoreKeys, 77u);
+    auto channel = mgr.SelectConnection();
+    ASSERT_NE(channel, nullptr);
+    EXPECT_EQ(channel->GetGroup()->GetServerCapabilities().batchStoreKeys, 77u);
+}
+
+TEST(ConnectionManagerTest, AddGroupRollsBackConnectionsWhenCapabilityQueryFails)
+{
+    g_createCount = 0;
+    g_deleteCount = 0;
+    g_capabilityQueryCount = 0;
+    StubTransProvider provider;
+    provider.capabilityStatus = Status::Error(StatusCode::IO_ERROR, "capability query failure");
+    ConnectionManager mgr(provider, "", 5000);
+
+    const auto status = mgr.AddGroup(MakeEndpoint(), 3);
+
+    EXPECT_EQ(status.code, StatusCode::IO_ERROR);
+    EXPECT_EQ(status.message, "capability query failure");
+    EXPECT_EQ(g_capabilityQueryCount.load(), 1);
+    EXPECT_EQ(g_deleteCount.load(), 3);
+    EXPECT_EQ(mgr.SelectConnection(), nullptr);
 }
 
 TEST(ConnectionManagerTest, AddGroupReturnsProviderCreateError)
@@ -542,6 +595,7 @@ TEST(ConnectionManagerTest, SelectConnectionReturnsNullptrWhenAllChannelsAtMaxIn
 {
     g_createCount = 0;
     StubTransProvider provider;
+    provider.serverCapabilities.ioQueueDepth = 3;
     ConnectionManager mgr(provider, "", 5000);
     mgr.AddGroup(MakeEndpoint(), 2);
     mgr.SetRoutingPolicy(RoutingPolicy::ROUND_ROBIN);
@@ -551,8 +605,8 @@ TEST(ConnectionManagerTest, SelectConnectionReturnsNullptrWhenAllChannelsAtMaxIn
     ASSERT_NE(ch0, nullptr);
     ASSERT_NE(ch1, nullptr);
 
-    ch0->SetInflightCount(256);
-    ch1->SetInflightCount(256);
+    ch0->SetInflightCount(3);
+    ch1->SetInflightCount(3);
 
     auto ch = mgr.SelectConnection();
     EXPECT_EQ(ch, nullptr);

--- a/ucm/transport/kv/asu/trans/include/aiv_transport/aiv_transport.h
+++ b/ucm/transport/kv/asu/trans/include/aiv_transport/aiv_transport.h
@@ -74,6 +74,9 @@ public:
         const std::vector<UnregisterMemoryDesc>& memoryDescs) = 0;
 
     virtual Status GetMemTokenId(MRHandle mrHandle, uint32_t& tokenId) = 0;
+
+    virtual Status GetServerCapabilities(ConnectionHandle connectionHandle,
+                                         ServerKvCapabilities& capabilities) = 0;
 };
 
 std::unique_ptr<AIVTransport> CreateAIVTransProvider();

--- a/ucm/transport/kv/asu/trans/include/asu_transport/types.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/types.h
@@ -125,8 +125,8 @@ struct ServerKvCapabilities {
     // A zero limit means that the provider did not advertise that capability.
     std::uint32_t queueNum{0};
     std::uint32_t ioQueueDepth{0};
-    std::uint32_t ioQueueKeyConcurrency{0};
-    std::uint32_t connectionKeyConcurrency{0};
+    std::uint32_t ioQueueKeyConcurrency{0};     // Placeholder
+    std::uint32_t connectionKeyConcurrency{0};  // Placeholder
     std::uint64_t singleValueMaxBytes{0};
     std::uint64_t batchValueMaxBytes{0};
     std::uint32_t batchStoreKeys{0};
@@ -134,7 +134,7 @@ struct ServerKvCapabilities {
     std::uint32_t deleteKeys{0};
     std::uint32_t queryKeys{0};
     std::uint32_t keyLength{0};
-    std::uint32_t kvCapabilities{0};
+    std::uint32_t kvCapabilities{0};  // Placeholder
 };
 
 struct QueryResult {

--- a/ucm/transport/kv/asu/trans/include/asu_transport/types.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/types.h
@@ -121,6 +121,22 @@ enum class Protocol {
     TCP = 2,
 };
 
+struct ServerKvCapabilities {
+    // A zero limit means that the provider did not advertise that capability.
+    std::uint32_t queueNum{0};
+    std::uint32_t ioQueueDepth{0};
+    std::uint32_t ioQueueKeyConcurrency{0};
+    std::uint32_t connectionKeyConcurrency{0};
+    std::uint64_t singleValueMaxBytes{0};
+    std::uint64_t batchValueMaxBytes{0};
+    std::uint32_t batchStoreKeys{0};
+    std::uint32_t batchLoadKeys{0};
+    std::uint32_t deleteKeys{0};
+    std::uint32_t queryKeys{0};
+    std::uint32_t keyLength{0};
+    std::uint32_t kvCapabilities{0};
+};
+
 struct QueryResult {
     std::vector<std::uint8_t> exists;
     std::uint32_t prefixHitKeys{0};

--- a/ucm/transport/kv/asu/trans/src/aiv_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/aiv_trans_provider.h
@@ -48,6 +48,12 @@ public:
         return FromImpl(impl_->DeleteConnections(connectionHandles));
     }
 
+    Status GetServerCapabilities(ConnectionHandle connectionHandle,
+                                 ServerKvCapabilities& capabilities) override
+    {
+        return FromImpl(impl_->GetServerCapabilities(connectionHandle, capabilities));
+    }
+
     std::vector<Status> Send(const std::vector<SendIoBatch>& ioBatches, uint32_t kernelCount,
                              uint32_t quietCount) override
     {

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -78,7 +78,6 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
     if (config_.maxErrorCount == 0) {
         return Status::Error(StatusCode::INVALID_ARGUMENT, "maxErrorCount must be greater than 0");
     }
-    ioScheduler_ = IoScheduler(config_);
 
     if (!transProvider_) {
         switch (config_.providerType) {
@@ -152,6 +151,42 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
         }
     }
 
+    const auto serverCapabilities = connManager_->GetServerCapabilities();
+    for (std::size_t index = 0; index < serverCapabilities.size(); ++index) {
+        const auto& capabilities = serverCapabilities[index];
+        UC_INFO(
+            "AsuTransportImpl::Init ServerKvCapabilities group={} queueNum={} ioQueueDepth={} "
+            "ioQueueKeyConcurrency={} connectionKeyConcurrency={} singleValueMaxBytes={} "
+            "batchValueMaxBytes={} batchStoreKeys={} batchLoadKeys={} deleteKeys={} "
+            "queryKeys={} keyLength={} kvCapabilities={}",
+            index, capabilities.queueNum, capabilities.ioQueueDepth,
+            capabilities.ioQueueKeyConcurrency, capabilities.connectionKeyConcurrency,
+            capabilities.singleValueMaxBytes, capabilities.batchValueMaxBytes,
+            capabilities.batchStoreKeys, capabilities.batchLoadKeys, capabilities.deleteKeys,
+            capabilities.queryKeys, capabilities.keyLength, capabilities.kvCapabilities);
+
+        if (capabilities.batchStoreKeys != 0) {
+            config_.asuBatchStoreIoNum = std::min(
+                config_.asuBatchStoreIoNum, static_cast<std::size_t>(capabilities.batchStoreKeys));
+        }
+        if (capabilities.batchLoadKeys != 0) {
+            config_.asuBatchLoadIoNum = std::min(
+                config_.asuBatchLoadIoNum, static_cast<std::size_t>(capabilities.batchLoadKeys));
+        }
+        if (capabilities.deleteKeys != 0) {
+            config_.asuDeleteIoNum =
+                std::min(config_.asuDeleteIoNum, static_cast<std::size_t>(capabilities.deleteKeys));
+        }
+        if (capabilities.queryKeys != 0) {
+            config_.asuQueryIoNum =
+                std::min(config_.asuQueryIoNum, static_cast<std::size_t>(capabilities.queryKeys));
+        }
+    }
+    UC_INFO("AsuTransportImpl::Init effective batch limits: store={} load={} delete={} query={}",
+            config_.asuBatchStoreIoNum, config_.asuBatchLoadIoNum, config_.asuDeleteIoNum,
+            config_.asuQueryIoNum);
+
+    ioScheduler_ = IoScheduler(config_);
     connManager_->StartRecoverLoop();
 
     auto status = sendBufferManager_.Init("asu send buffer", MemoryType::HOST_PINNED,

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -164,23 +164,15 @@ Status AsuTransportImpl::Init(const TransportConfig& config)
             capabilities.singleValueMaxBytes, capabilities.batchValueMaxBytes,
             capabilities.batchStoreKeys, capabilities.batchLoadKeys, capabilities.deleteKeys,
             capabilities.queryKeys, capabilities.keyLength, capabilities.kvCapabilities);
-
-        if (capabilities.batchStoreKeys != 0) {
-            config_.asuBatchStoreIoNum = std::min(
-                config_.asuBatchStoreIoNum, static_cast<std::size_t>(capabilities.batchStoreKeys));
-        }
-        if (capabilities.batchLoadKeys != 0) {
-            config_.asuBatchLoadIoNum = std::min(
-                config_.asuBatchLoadIoNum, static_cast<std::size_t>(capabilities.batchLoadKeys));
-        }
-        if (capabilities.deleteKeys != 0) {
-            config_.asuDeleteIoNum =
-                std::min(config_.asuDeleteIoNum, static_cast<std::size_t>(capabilities.deleteKeys));
-        }
-        if (capabilities.queryKeys != 0) {
-            config_.asuQueryIoNum =
-                std::min(config_.asuQueryIoNum, static_cast<std::size_t>(capabilities.queryKeys));
-        }
+        auto applyCapLimit = [](auto& cfgField, auto capValue) {
+            if (capValue != 0) {
+                cfgField = std::min(cfgField, static_cast<std::size_t>(capValue));
+            }
+        };
+        applyCapLimit(config_.asuBatchStoreIoNum, capabilities.batchStoreKeys);
+        applyCapLimit(config_.asuBatchLoadIoNum, capabilities.batchLoadKeys);
+        applyCapLimit(config_.asuDeleteIoNum, capabilities.deleteKeys);
+        applyCapLimit(config_.asuQueryIoNum, capabilities.queryKeys);
     }
     UC_INFO("AsuTransportImpl::Init effective batch limits: store={} load={} delete={} query={}",
             config_.asuBatchStoreIoNum, config_.asuBatchLoadIoNum, config_.asuDeleteIoNum,

--- a/ucm/transport/kv/asu/trans/src/connection_internal.cpp
+++ b/ucm/transport/kv/asu/trans/src/connection_internal.cpp
@@ -89,8 +89,9 @@ bool ConnectionChannel::MarkForDrain()
 
 // ─── ConnectionGroup ───
 
-ConnectionGroup::ConnectionGroup(std::uint32_t id, const AsuEndpoint& ep)
-    : groupId(id), endpoint(ep)
+ConnectionGroup::ConnectionGroup(std::uint32_t id, const AsuEndpoint& ep,
+                                 const ServerKvCapabilities& capabilities)
+    : groupId(id), endpoint(ep), serverCapabilities(capabilities)
 {
 }
 

--- a/ucm/transport/kv/asu/trans/src/connection_internal.h
+++ b/ucm/transport/kv/asu/trans/src/connection_internal.h
@@ -82,10 +82,12 @@ private:
 
 class ConnectionGroup {
 public:
-    ConnectionGroup(std::uint32_t id, const AsuEndpoint& ep);
+    ConnectionGroup(std::uint32_t id, const AsuEndpoint& ep,
+                    const ServerKvCapabilities& capabilities = {});
 
     std::uint32_t GetGroupId() const { return groupId; }
     const AsuEndpoint& GetEndpoint() const { return endpoint; }
+    const ServerKvCapabilities& GetServerCapabilities() const { return serverCapabilities; }
     const std::vector<std::shared_ptr<ConnectionChannel>>& GetChannels() const { return channels; }
 
     std::shared_ptr<ConnectionChannel> AddChannel(ConnectionHandle handle, TransProvider* provider);
@@ -95,6 +97,7 @@ public:
 private:
     std::uint32_t groupId{0};
     AsuEndpoint endpoint;
+    ServerKvCapabilities serverCapabilities;
     std::vector<std::shared_ptr<ConnectionChannel>> channels;
     std::atomic<std::uint32_t> nextChannelId_{0};
 };

--- a/ucm/transport/kv/asu/trans/src/connection_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/connection_manager.cpp
@@ -73,8 +73,7 @@ Status ConnectionManager::AddGroup(const AsuEndpoint& endpoint, std::uint32_t qp
             "configurations instead");
     }
     if (capabilities.ioQueueDepth != 0) {
-        maxInflightPerChannel_ =
-            std::min(maxInflightPerChannel_, capabilities.ioQueueDepth);
+        maxInflightPerChannel_ = std::min(maxInflightPerChannel_, capabilities.ioQueueDepth);
     }
 
     {

--- a/ucm/transport/kv/asu/trans/src/connection_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/connection_manager.cpp
@@ -278,12 +278,16 @@ std::shared_ptr<ConnectionChannel> ConnectionManager::SelectByRoundRobin()
     for (std::size_t i = 0; i < total; ++i) {
         std::size_t pos = (start + i) % total;
         const auto& channel = channelCache_[pos];
-        if (channel->GetState() == ChannelState::ACTIVE &&
-            channel->GetInflightCount() < maxInflightPerChannel) {
+        if (channel->GetState() != ChannelState::ACTIVE) { continue; }
+        if (channel->GetInflightCount() < maxInflightPerChannel) {
             channel->IncrementInflight();
             return channel;
         }
     }
+    UC_DEBUG(
+        "ConnectionManager::SelectByRoundRobin no available channel: all ACTIVE channels "
+        "reached maximum inflight limit, max_inflight_per_channel={}",
+        maxInflightPerChannel);
     return nullptr;
 }
 
@@ -308,8 +312,15 @@ std::shared_ptr<ConnectionChannel> ConnectionManager::SelectByLeastLoaded()
         }
     }
 
-    if (selected) { selected->IncrementInflight(); }
-    return selected;
+    if (selected) {
+        selected->IncrementInflight();
+        return selected;
+    }
+    UC_DEBUG(
+        "ConnectionManager::SelectByLeastLoaded no available channel: all ACTIVE channels "
+        "reached maximum inflight limit, max_inflight_per_channel={}",
+        maxInflightPerChannel);
+    return nullptr;
 }
 
 std::int64_t ConnectionManager::TotalInflightCount()

--- a/ucm/transport/kv/asu/trans/src/connection_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/connection_manager.cpp
@@ -48,12 +48,40 @@ Status ConnectionManager::AddGroup(const AsuEndpoint& endpoint, std::uint32_t qp
     auto createStatus =
         provider_.CreateConnection(localIp_, endpoint.ip, endpoint.port, qp_num, timeout_, handles);
     if (!createStatus.ok()) { return createStatus; }
+    if (handles.empty()) {
+        return Status::Error(StatusCode::INTERNAL_ERROR, "provider returned no connection handles");
+    }
+
+    ServerKvCapabilities capabilities;
+    auto capabilityStatus = provider_.GetServerCapabilities(handles.front(), capabilities);
+    if (!capabilityStatus.ok() && capabilityStatus.code != StatusCode::UNSUPPORTED) {
+        const auto deleteStatuses = provider_.DeleteConnections(handles);
+        for (const auto& deleteStatus : deleteStatuses) {
+            if (!deleteStatus.ok()) {
+                UC_WARN(
+                    "ConnectionManager::AddGroup cleanup failed after capability query failure: "
+                    "code={} message={}",
+                    static_cast<int>(deleteStatus.code), deleteStatus.message);
+            }
+        }
+        return capabilityStatus;
+    }
+    if (capabilityStatus.code == StatusCode::UNSUPPORTED) {
+        capabilities = {};
+        UC_DEBUG(
+            "ConnectionManager::AddGroup server capability query is not supported. Use default "
+            "configurations instead");
+    }
+    if (capabilities.ioQueueDepth != 0) {
+        maxInflightPerChannel_ =
+            std::min(maxInflightPerChannel_, capabilities.ioQueueDepth);
+    }
 
     {
         std::lock_guard<std::mutex> cacheLock(channelCacheMu_);
         std::unique_lock<std::shared_mutex> lock(structureMu_);
         auto gid = static_cast<std::uint32_t>(groups_.size());
-        auto group = std::make_unique<ConnectionGroup>(gid, endpoint);
+        auto group = std::make_unique<ConnectionGroup>(gid, endpoint, capabilities);
         for (auto handle : handles) { group->AddChannel(handle, &provider_); }
         groups_.push_back(std::move(group));
 
@@ -245,12 +273,13 @@ std::shared_ptr<ConnectionChannel> ConnectionManager::SelectByRoundRobin()
     auto idx = rrIndex_.fetch_add(1, std::memory_order_relaxed);
     std::size_t total = channelCache_.size();
     std::size_t start = idx % total;
+    const auto maxInflightPerChannel = maxInflightPerChannel_;
 
     for (std::size_t i = 0; i < total; ++i) {
         std::size_t pos = (start + i) % total;
         const auto& channel = channelCache_[pos];
         if (channel->GetState() == ChannelState::ACTIVE &&
-            channel->GetInflightCount() < kMaxInflightPerChannel) {
+            channel->GetInflightCount() < maxInflightPerChannel) {
             channel->IncrementInflight();
             return channel;
         }
@@ -267,10 +296,11 @@ std::shared_ptr<ConnectionChannel> ConnectionManager::SelectByLeastLoaded()
 
     std::shared_ptr<ConnectionChannel> selected;
     std::uint32_t min_inflight = std::numeric_limits<std::uint32_t>::max();
+    const auto maxInflightPerChannel = maxInflightPerChannel_;
 
     for (const auto& channel : channelCache_) {
         auto inflight = channel->GetInflightCount();
-        if (channel->GetState() == ChannelState::ACTIVE && inflight < kMaxInflightPerChannel &&
+        if (channel->GetState() == ChannelState::ACTIVE && inflight < maxInflightPerChannel &&
             inflight < min_inflight) {
             min_inflight = inflight;
             selected = channel;
@@ -291,6 +321,15 @@ std::int64_t ConnectionManager::TotalInflightCount()
         for (const auto& channel : group->GetChannels()) { sum += channel->GetInflightCount(); }
     }
     return sum;
+}
+
+std::vector<ServerKvCapabilities> ConnectionManager::GetServerCapabilities()
+{
+    std::vector<ServerKvCapabilities> capabilities;
+    std::shared_lock<std::shared_mutex> lock(structureMu_);
+    capabilities.reserve(groups_.size());
+    for (const auto& group : groups_) { capabilities.push_back(group->GetServerCapabilities()); }
+    return capabilities;
 }
 
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/connection_manager.h
+++ b/ucm/transport/kv/asu/trans/src/connection_manager.h
@@ -69,6 +69,7 @@ public:
     void StopRecoverLoop();
 
     std::int64_t TotalInflightCount();
+    std::vector<ServerKvCapabilities> GetServerCapabilities();
 
 private:
     std::vector<std::unique_ptr<ConnectionGroup>> groups_;
@@ -82,7 +83,6 @@ private:
 
     std::atomic<std::uint32_t> rrIndex_{0};
     RoutingPolicy routingPolicy_{RoutingPolicy::ROUND_ROBIN};
-    static constexpr std::uint32_t kMaxInflightPerChannel = 256;
     static constexpr std::uint64_t kRecoverIntervalMs = 100;
 
     std::thread recoverWorker_;
@@ -95,6 +95,7 @@ private:
     std::string localIp_;
     std::uint32_t timeout_;
     std::uint32_t maxErrorCount_;
+    std::uint32_t maxInflightPerChannel_{256};
 
     void RecoverLoop();
     void RebuildChannelCache();

--- a/ucm/transport/kv/asu/trans/src/trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/trans_provider.h
@@ -23,6 +23,16 @@ public:
     virtual std::vector<Status> DeleteConnections(
         const std::vector<ConnectionHandle>& connectionHandles) = 0;
 
+    // Returns provider-neutral KV limits for the server behind this connection. Providers that
+    // do not support capability discovery keep the default UNSUPPORTED result.
+    virtual Status GetServerCapabilities(ConnectionHandle connectionHandle,
+                                         ServerKvCapabilities& capabilities)
+    {
+        (void)connectionHandle;
+        capabilities = {};
+        return Status::Error(StatusCode::UNSUPPORTED, "server capability query is not supported");
+    }
+
     struct SendIoBatch {
         ConnectionHandle connectionHandle;
         void* sendBuffer;


### PR DESCRIPTION
## Purpose
This PR aims to get the response message from server. 

## Modifications 
1. Add GetServerCapabilities API in Transport Provider.
2. Use ServerCapabilities to update Transport configurations.

## Tests
> Pass the offline inference with AIV TransProvider modification https://gitcode.com/dtad5/nids_aiv_ub/commit/123089f1b0ef6c53e893dc00f045a53226e43366?ref=ucm-adapt-0810.

> Pass all unit tests of AsuClient.