### PR TITLE
[opt] Reorder shard access by deviceId to reduce lock contention between TPs

### DIFF
--- a/ucm/store/cache/cc/cache_store.cc
+++ b/ucm/store/cache/cc/cache_store.cc
@@ -154,6 +154,7 @@ private:
         config.Get("use_gdr", param.useGdr);
         config.Get("cache_sdma_direct", param.cacheSdmaDirect);
         config.Get("cache_sdma_direct_launch_granularity", param.sdmaDirectLaunchGranularity);
+        config.GetNumber("local_rank_size", param.localRankSize);
         return param;
     }
     Status CheckSizeConfig(const Config& config)
@@ -210,6 +211,9 @@ private:
         if (config.streamNumber < 1 || config.streamNumber > 32) {
             return Status::InvalidParam("invalid stream number({})", config.streamNumber);
         }
+        if (config.localRankSize == 0) {
+            return Status::InvalidParam("invalid local rank size({})", config.localRankSize);
+        }
         return Status::OK();
     }
     void ShowConfig(const Config& config)
@@ -246,6 +250,7 @@ private:
         UC_INFO("Set {}::LoadExclusiveBufferNumber to {}.", ns, config.loadExclusiveBufferNumber);
         UC_INFO("Set {}::GpuKvBufferNumber to {}.", ns, config.gpuKvBufferAddrs.size());
         UC_INFO("Set {}::UseGdr to {}.", ns, config.useGdr);
+        UC_INFO("Set {}::LocalRankSize to {}.", ns, config.localRankSize);
     }
 };
 

--- a/ucm/store/cache/cc/global_config.h
+++ b/ucm/store/cache/cc/global_config.h
@@ -62,6 +62,7 @@ struct Config {
     bool useGdr{false};
     bool cacheSdmaDirect{UCM_RUNTIME_ASCEND_SDMA_DIRECT};
     std::string sdmaDirectLaunchGranularity{kSdmaDirectLaunchShard};
+    size_t localRankSize{8};
 };
 
 }  // namespace UC::CacheStore

--- a/ucm/store/cache/cc/load_queue.cc
+++ b/ucm/store/cache/cc/load_queue.cc
@@ -47,6 +47,7 @@ Status LoadQueue::Setup(const Config& config, TaskIdSet* failureSet, TransBuffer
     cacheSdmaDirect_ = config.cacheSdmaDirect;
     sdmaDirectLaunchGranularity_ = config.sdmaDirectLaunchGranularity;
     cpuAffinityCores_ = config.cpuAffinityCores;
+    localRankSize_ = config.localRankSize;
     waiting_.Setup(config.waitingQueueDepth);
     running_.Setup(config.runningQueueDepth);
     holder_.reserve(1024);
@@ -81,6 +82,21 @@ void LoadQueue::DispatchStage()
     waiting_.ConsumerLoop(stop_, &LoadQueue::DispatchOneTask, this);
 }
 
+static std::vector<size_t> RearrangeIndex(size_t n, size_t iProc, size_t nProc)
+{
+    std::vector<size_t> order;
+    order.reserve(n);
+    for (size_t r = 0; r < nProc; ++r) {
+        size_t slice = (iProc + r) % nProc;
+        for (size_t j = 0;; ++j) {
+            size_t i = slice + j * nProc;
+            if (i >= n) { break; }
+            order.push_back(i);
+        }
+    }
+    return order;
+}
+
 void LoadQueue::DispatchOneTask(TaskPair&& pair)
 {
     auto& task = pair.first;
@@ -100,8 +116,9 @@ void LoadQueue::DispatchOneTask(TaskPair&& pair)
         readyTasks.reserve(nShard);
         pendingTasks.reserve(nShard);
     }
+    const auto indexes = RearrangeIndex(nShard, deviceId_, localRankSize_);
     for (size_t i = 0; i < nShard; i++) {
-        auto& shard = task->desc[i];
+        auto& shard = task->desc[indexes[i]];
         ShardTask shardTask;
         shardTask.bufferHandle = buffer_->Get(shard.owner, shard.index, true, true);
         shardTask.backendTaskHandle = 0;

--- a/ucm/store/cache/cc/load_queue.h
+++ b/ucm/store/cache/cc/load_queue.h
@@ -64,6 +64,7 @@ private:
     bool cacheSdmaDirect_{false};
     std::string sdmaDirectLaunchGranularity_{kSdmaDirectLaunchShard};
     std::vector<ssize_t> cpuAffinityCores_{};
+    size_t localRankSize_{};
     SpscRingQueue<TaskPair> waiting_;
     SpscRingQueue<ShardTask> running_;
     std::thread dispatcher_;


### PR DESCRIPTION
## What
Reorder the shard access sequence inside `LoadQueue::DispatchOneTask` based on `deviceId`, so that tensor-parallel (TP) ranks sharing a cache store on the same node no longer hit the same shard index at the same iteration.

## Why
On a multi-GPU node, multiple TP ranks share the same cache store and `LoadQueue`. Previously, every rank iterated shards in natural order `0,1,2,…,nShard-1`, which meant all ranks contested the same shard (and the underlying buffer/lock in `buffer_->Get(...)`) at each step. This serialized dispatch and degraded throughput as TP count grew.

By starting each rank at a different offset derived from `deviceId % localRankSize`, the ranks' access sequences are rotated relative to each other, spreading contention across shards and time.

## Config
New optional field `local_rank_size` (int, default `8`). Set it to the number of devices on the node. Misconfiguring it smaller than the actual local device count will cause two devices to start on the same slice, reducing (but not breaking) the benefit.