### PR TITLE
[Bugfix] Improve auto trace parsing diagnostics

### DIFF
--- a/benchmarks/auto_trace_analysis.py
+++ b/benchmarks/auto_trace_analysis.py
@@ -168,11 +168,14 @@ class LRUCache:
             self.items.popitem(last=False)
 
 
-def iter_log_files(log_dir: Path) -> list[Path]:
+def iter_log_files(log_path: Path) -> list[Path]:
+    if log_path.is_file():
+        return [log_path]
+
     patterns = ("*.log", "*.log.*", "*.log.gz")
     files: dict[Path, None] = {}
     for pattern in patterns:
-        for path in log_dir.rglob(pattern):
+        for path in log_path.rglob(pattern):
             if path.is_file():
                 files[path] = None
     return sorted(files)
@@ -208,16 +211,78 @@ def parse_is_mla(value: str) -> bool:
     return value.lower() == "true"
 
 
-def parse_trace_line(line: str, source: str) -> TraceRecord | None:
+def line_excerpt(line: str, column: int | None = None, limit: int = 500) -> str:
+    text = line.rstrip("\r\n")
+    if len(text) <= limit:
+        return repr(text)
+
+    center = len(text) // 2 if column is None else max(0, column - 1)
+    start = max(0, min(center - limit // 2, len(text) - limit))
+    end = start + limit
+    prefix = "..." if start > 0 else ""
+    suffix = "..." if end < len(text) else ""
+    return repr(prefix + text[start:end] + suffix)
+
+
+def line_parse_error(
+    stage: str,
+    source: str,
+    line_number: int | None,
+    line: str,
+    cause: Exception | str,
+    column: int | None = None,
+) -> ValueError:
+    location = f"{source}:{line_number}" if line_number is not None else source
+    column_text = f"\n  column: {column}" if column is not None else ""
+    return ValueError(
+        "log line parse failed"
+        f"\n  stage: {stage}"
+        f"\n  source: {location}"
+        f"{column_text}"
+        f"\n  cause: {cause}"
+        f"\n  line excerpt: {line_excerpt(line, column)}"
+    )
+
+
+def parse_trace_line(
+    line: str, source: str, line_number: int | None = None
+) -> TraceRecord | None:
     match = TRACE_RE.search(line)
     if not match:
+        if "timestamp:" in line and "ucm_block_ids:" in line:
+            column = line.find("ucm_block_ids:") + 1
+            raise line_parse_error(
+                "trace.pattern_match",
+                source,
+                line_number,
+                line,
+                "trace marker found but required fields or list terminator are invalid",
+                column,
+            )
         return None
     try:
         hash_ids = ast.literal_eval(match.group("ucm_block_ids"))
-    except (SyntaxError, ValueError):
-        raise ValueError(f"failed to parse ucm_block_ids in {source}")
+    except (SyntaxError, ValueError) as exc:
+        offset = exc.offset if isinstance(exc, SyntaxError) else None
+        column = match.start("ucm_block_ids") + (offset or 1)
+        raise line_parse_error(
+            "trace.ucm_block_ids.literal_eval",
+            source,
+            line_number,
+            line,
+            exc,
+            column,
+        ) from exc
     if not isinstance(hash_ids, list):
-        raise ValueError(f"ucm_block_ids is not a list in {source}")
+        column = match.start("ucm_block_ids") + 1
+        raise line_parse_error(
+            "trace.ucm_block_ids.validation",
+            source,
+            line_number,
+            line,
+            f"expected list, got {type(hash_ids).__name__}",
+            column,
+        )
 
     system_time_match = SYSTEM_TIME_RE.search(line)
     request_id = match.group("request_id")
@@ -234,21 +299,32 @@ def parse_trace_line(line: str, source: str) -> TraceRecord | None:
     )
 
 
-def collect_log_facts(log_dir: Path) -> LogFacts:
-    if not log_dir.exists() or not log_dir.is_dir():
-        raise ValueError(f"log directory does not exist: {log_dir}")
+def collect_log_facts(log_path: Path) -> LogFacts:
+    if not log_path.exists():
+        raise ValueError(f"log scan failed: path does not exist: {log_path}")
+    if not log_path.is_file() and not log_path.is_dir():
+        raise ValueError(
+            f"log scan failed: path is not a file or directory: {log_path}"
+        )
 
-    log_files = iter_log_files(log_dir)
+    log_files = iter_log_files(log_path)
     if not log_files:
-        raise ValueError(f"no log files found in log directory: {log_dir}")
+        raise ValueError(
+            f"log scan failed: no log files found in directory: {log_path}"
+        )
+
+    print(f"Log files to parse ({len(log_files)}):")
+    for path in log_files:
+        print(f"  {path}")
+    sys.stdout.flush()
 
     records: list[TraceRecord] = []
     available_memory: list[int] = []
     tensor_parallel_sizes: list[int] = []
     for path in log_files:
         with open_log_file(path) as handle:
-            for line in handle:
-                record = parse_trace_line(line, str(path))
+            for line_number, line in enumerate(handle, start=1):
+                record = parse_trace_line(line, str(path), line_number)
                 if record is not None:
                     records.append(record)
 
@@ -260,11 +336,16 @@ def collect_log_facts(log_dir: Path) -> LogFacts:
                     tensor_parallel_sizes.append(int(match.group("value")))
 
     if not records:
-        raise ValueError("no trace records found in log files")
+        raise ValueError("log validation failed: no trace records found in log files")
     if not available_memory:
-        raise ValueError("available kv cache memory was not found in log files")
+        raise ValueError(
+            "log validation failed: available kv cache memory was not found "
+            "in log files"
+        )
     if not tensor_parallel_sizes:
-        raise ValueError("tensor_parallel_size was not found in log files")
+        raise ValueError(
+            "log validation failed: tensor_parallel_size was not found in log files"
+        )
 
     records.sort(key=lambda item: item.timestamp)
     return LogFacts(
@@ -487,7 +568,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Analyze theoretical UCM KV cache hit-rate uplift from logs."
     )
-    parser.add_argument("--log-dir", type=Path, required=True)
+    parser.add_argument(
+        "--log-dir",
+        type=Path,
+        required=True,
+        help="Log file or directory containing log files.",
+    )
     parser.add_argument(
         "--block-kv-cache-size",
         "--block-bytes",
@@ -516,10 +602,11 @@ def validate_args(args: argparse.Namespace) -> None:
         raise ValueError("num_nodes must be >= 1")
 
 
-def build_analysis(args: argparse.Namespace) -> dict:
+def build_analysis(args: argparse.Namespace, facts: LogFacts | None = None) -> dict:
     validate_args(args)
     is_mla = parse_is_mla(args.is_mla)
-    facts = collect_log_facts(args.log_dir)
+    if facts is None:
+        facts = collect_log_facts(args.log_dir)
     tp_size = resolve_tp_size(facts)
     gpu_kv_cache_bytes = resolve_gpu_cache_bytes(facts, is_mla, tp_size)
     block_bytes = args.block_kv_cache_size
@@ -681,9 +768,10 @@ def print_summary(result: dict) -> None:
 def main(argv: list[str] | None = None) -> int:
     args = build_arg_parser().parse_args(argv)
     try:
-        result = build_analysis(args)
+        facts = collect_log_facts(args.log_dir)
+        result = build_analysis(args, facts)
         if args.trace_output:
-            write_trace(collect_log_facts(args.log_dir).records, args.trace_output)
+            write_trace(facts.records, args.trace_output)
         if args.output:
             args.output.parent.mkdir(parents=True, exist_ok=True)
             args.output.write_text(

--- a/benchmarks/auto_trace_analysis.py
+++ b/benchmarks/auto_trace_analysis.py
@@ -24,6 +24,7 @@ PREFIX_CACHE_HITS_METRICS = (
     "vllm:prefix_cache_hits_total",
     "prefix_cache_hits_total",
 )
+DRAM_POOL_MODES = ("per-node", "shared")
 
 TRACE_RE = re.compile(
     r"timestamp:\s*(?P<timestamp>\d+(?:\.\d+)?),\s*"
@@ -489,15 +490,22 @@ def simulate_cache_hit_rate(
     fs_capacity_blocks: int,
     num_nodes: int = 1,
     random_seed: int | None = 0,
+    dram_pool_mode: str = "per-node",
 ) -> dict:
     if num_nodes < 1:
         raise ValueError("num_nodes must be >= 1")
     if gpu_capacity_blocks < 0 or dram_capacity_blocks < 0 or fs_capacity_blocks < 0:
         raise ValueError("cache capacities must be >= 0")
+    if dram_pool_mode not in DRAM_POOL_MODES:
+        raise ValueError("dram_pool_mode must be one of: " + ", ".join(DRAM_POOL_MODES))
 
     rng = random.Random(random_seed)
     gpu_caches = [LRUCache(gpu_capacity_blocks) for _ in range(num_nodes)]
-    dram_caches = [LRUCache(dram_capacity_blocks) for _ in range(num_nodes)]
+    if dram_pool_mode == "shared":
+        shared_dram_cache = LRUCache(dram_capacity_blocks)
+        dram_caches = [shared_dram_cache for _ in range(num_nodes)]
+    else:
+        dram_caches = [LRUCache(dram_capacity_blocks) for _ in range(num_nodes)]
     fs_cache = LRUCache(fs_capacity_blocks)
 
     total_tokens = 0
@@ -605,6 +613,15 @@ def build_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--is-mla", choices=("true", "false"), required=True)
     parser.add_argument("--dram-pool-size-gb", type=float, required=True)
+    parser.add_argument(
+        "--dram-pool-mode",
+        choices=DRAM_POOL_MODES,
+        default="per-node",
+        help=(
+            "Interpret --dram-pool-size-gb as capacity per node or as one "
+            "shared capacity across all nodes."
+        ),
+    )
     parser.add_argument("--fs-pool-size-gb", type=float, required=True)
     parser.add_argument("--service-url")
     parser.add_argument("--metrics-timeout", type=float, default=5.0)
@@ -634,6 +651,11 @@ def build_analysis(args: argparse.Namespace, facts: LogFacts | None = None) -> d
     block_bytes = args.block_kv_cache_size
     gpu_capacity_blocks = gpu_kv_cache_bytes // block_bytes
     dram_capacity_blocks = int(args.dram_pool_size_gb * GIB) // block_bytes
+    dram_total_capacity_blocks = (
+        dram_capacity_blocks * args.num_nodes
+        if args.dram_pool_mode == "per-node"
+        else dram_capacity_blocks
+    )
     fs_capacity_blocks = int(args.fs_pool_size_gb * GIB) // block_bytes
     unique_blocks = unique_block_count(facts.records)
 
@@ -644,6 +666,7 @@ def build_analysis(args: argparse.Namespace, facts: LogFacts | None = None) -> d
         fs_capacity_blocks=unique_blocks,
         num_nodes=args.num_nodes,
         random_seed=args.random_seed,
+        dram_pool_mode=args.dram_pool_mode,
     )
     hbm = simulate_cache_hit_rate(
         records=facts.records,
@@ -652,6 +675,7 @@ def build_analysis(args: argparse.Namespace, facts: LogFacts | None = None) -> d
         fs_capacity_blocks=0,
         num_nodes=args.num_nodes,
         random_seed=args.random_seed,
+        dram_pool_mode=args.dram_pool_mode,
     )
     hbm_dram = simulate_cache_hit_rate(
         records=facts.records,
@@ -660,6 +684,7 @@ def build_analysis(args: argparse.Namespace, facts: LogFacts | None = None) -> d
         fs_capacity_blocks=0,
         num_nodes=args.num_nodes,
         random_seed=args.random_seed,
+        dram_pool_mode=args.dram_pool_mode,
     )
     hbm_dram_fs = simulate_cache_hit_rate(
         records=facts.records,
@@ -668,6 +693,7 @@ def build_analysis(args: argparse.Namespace, facts: LogFacts | None = None) -> d
         fs_capacity_blocks=fs_capacity_blocks,
         num_nodes=args.num_nodes,
         random_seed=args.random_seed,
+        dram_pool_mode=args.dram_pool_mode,
     )
     service_metrics = (
         fetch_service_hit_rate(args.service_url, args.metrics_timeout)
@@ -709,6 +735,7 @@ def build_analysis(args: argparse.Namespace, facts: LogFacts | None = None) -> d
             "block_kv_cache_size": block_bytes,
             "is_mla": is_mla,
             "dram_pool_size_gb": args.dram_pool_size_gb,
+            "dram_pool_mode": args.dram_pool_mode,
             "fs_pool_size_gb": args.fs_pool_size_gb,
             "service_url": args.service_url,
         },
@@ -721,6 +748,7 @@ def build_analysis(args: argparse.Namespace, facts: LogFacts | None = None) -> d
             "gpu_kv_cache_bytes": gpu_kv_cache_bytes,
             "gpu_capacity_blocks": gpu_capacity_blocks,
             "dram_capacity_blocks": dram_capacity_blocks,
+            "dram_total_capacity_blocks": dram_total_capacity_blocks,
             "fs_capacity_blocks": fs_capacity_blocks,
             "unique_block_count": unique_blocks,
             "num_nodes": args.num_nodes,
@@ -750,7 +778,10 @@ def print_summary(result: dict) -> None:
     )
     print("  Total HBM available KV cache size: " f"{hbm_bytes / 1024**3:.2f} GiB")
     print(f"  TP size: {derived['tp_size']}")
-    print(f"  DRAM pool size: {inputs['dram_pool_size_gb']:.2f} GiB")
+    if inputs["dram_pool_mode"] == "per-node":
+        print(f"  DRAM pool size per node: {inputs['dram_pool_size_gb']:.2f} GiB")
+    else:
+        print(f"  Shared DRAM pool size: {inputs['dram_pool_size_gb']:.2f} GiB")
     print(f"  FS pool size: {inputs['fs_pool_size_gb']:.2f} GiB")
     print(
         "  Theoretical max KV cache hit rate: "

--- a/benchmarks/auto_trace_analysis.py
+++ b/benchmarks/auto_trace_analysis.py
@@ -81,6 +81,11 @@ class LogFacts:
     records: list[TraceRecord]
     available_kv_cache_memory_bytes: list[int]
     tensor_parallel_sizes: list[int]
+    parse_errors: list[str]
+
+
+class LogLineParseError(ValueError):
+    pass
 
 
 @dataclass(frozen=True)
@@ -231,10 +236,10 @@ def line_parse_error(
     line: str,
     cause: Exception | str,
     column: int | None = None,
-) -> ValueError:
+) -> LogLineParseError:
     location = f"{source}:{line_number}" if line_number is not None else source
     column_text = f"\n  column: {column}" if column is not None else ""
-    return ValueError(
+    return LogLineParseError(
         "log line parse failed"
         f"\n  stage: {stage}"
         f"\n  source: {location}"
@@ -242,6 +247,15 @@ def line_parse_error(
         f"\n  cause: {cause}"
         f"\n  line excerpt: {line_excerpt(line, column)}"
     )
+
+
+def print_parse_error_summary(parse_errors: list[str]) -> None:
+    if not parse_errors:
+        return
+    print(f"Log line parse failures: {len(parse_errors)}", file=sys.stderr)
+    for index, error in enumerate(parse_errors, start=1):
+        print(f"\nParse failure {index}:\n{error}", file=sys.stderr)
+    sys.stderr.flush()
 
 
 def parse_trace_line(
@@ -321,10 +335,15 @@ def collect_log_facts(log_path: Path) -> LogFacts:
     records: list[TraceRecord] = []
     available_memory: list[int] = []
     tensor_parallel_sizes: list[int] = []
+    parse_errors: list[str] = []
     for path in log_files:
         with open_log_file(path) as handle:
             for line_number, line in enumerate(handle, start=1):
-                record = parse_trace_line(line, str(path), line_number)
+                try:
+                    record = parse_trace_line(line, str(path), line_number)
+                except LogLineParseError as exc:
+                    parse_errors.append(str(exc))
+                    record = None
                 if record is not None:
                     records.append(record)
 
@@ -334,6 +353,8 @@ def collect_log_facts(log_path: Path) -> LogFacts:
                     )
                 for match in TP_SIZE_RE.finditer(line):
                     tensor_parallel_sizes.append(int(match.group("value")))
+
+    print_parse_error_summary(parse_errors)
 
     if not records:
         raise ValueError("log validation failed: no trace records found in log files")
@@ -353,6 +374,7 @@ def collect_log_facts(log_path: Path) -> LogFacts:
         records=records,
         available_kv_cache_memory_bytes=available_memory,
         tensor_parallel_sizes=tensor_parallel_sizes,
+        parse_errors=parse_errors,
     )
 
 
@@ -692,6 +714,8 @@ def build_analysis(args: argparse.Namespace, facts: LogFacts | None = None) -> d
         },
         "derived": {
             "log_files": facts.log_files,
+            "parse_failure_count": len(facts.parse_errors),
+            "parse_failures": facts.parse_errors,
             "available_kv_cache_memory_bytes": facts.available_kv_cache_memory_bytes,
             "tp_size": tp_size,
             "gpu_kv_cache_bytes": gpu_kv_cache_bytes,

--- a/benchmarks/test_auto_trace_analysis.py
+++ b/benchmarks/test_auto_trace_analysis.py
@@ -1,7 +1,7 @@
 import io
 import tempfile
 import unittest
-from contextlib import redirect_stdout
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
 
 from benchmarks import auto_trace_analysis
@@ -26,10 +26,11 @@ class AutoTraceAnalysisTest(unittest.TestCase):
             self.assertEqual(facts.log_files, [str(log_file)])
             self.assertEqual(len(facts.records), 1)
             self.assertEqual(facts.records[0].hash_ids, ["block-1"])
+            self.assertEqual(facts.parse_errors, [])
             self.assertIn("Log files to parse (1):", output.getvalue())
             self.assertIn(str(log_file), output.getvalue())
 
-    def test_parse_error_reports_stage_source_line_and_excerpt(self):
+    def test_parse_error_is_reported_after_remaining_lines_are_parsed(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             log_file = Path(temp_dir) / "broken.log"
             bad_line = (
@@ -39,14 +40,21 @@ class AutoTraceAnalysisTest(unittest.TestCase):
             log_file.write_text(
                 "available kv cache memory: 1024 bytes\n"
                 f"{bad_line}\n"
+                "timestamp: 2, input_length: 16, output_length: 1, "
+                "ucm_block_ids: ['valid-block']\n"
                 "tensor_parallel_size=2\n",
                 encoding="utf-8",
             )
 
-            with self.assertRaises(ValueError) as raised:
-                auto_trace_analysis.collect_log_facts(log_file)
+            errors = io.StringIO()
+            with redirect_stderr(errors):
+                facts = auto_trace_analysis.collect_log_facts(log_file)
 
-            message = str(raised.exception)
+            self.assertEqual(len(facts.records), 1)
+            self.assertEqual(len(facts.parse_errors), 1)
+            message = errors.getvalue()
+            self.assertIn("Log line parse failures: 1", message)
+            self.assertIn("Parse failure 1:", message)
             self.assertIn("stage: trace.ucm_block_ids.literal_eval", message)
             self.assertIn(f"source: {log_file}:2", message)
             self.assertIn("column:", message)
@@ -65,6 +73,41 @@ class AutoTraceAnalysisTest(unittest.TestCase):
         self.assertIn("stage: trace.pattern_match", message)
         self.assertIn("source: server.log:42", message)
         self.assertIn(f"line excerpt: {line!r}", message)
+
+    def test_main_succeeds_when_valid_trace_follows_parse_failure(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_file = Path(temp_dir) / "mixed.log"
+            log_file.write_text(
+                "available kv cache memory: 1024 bytes\n"
+                "tensor_parallel_size=1\n"
+                "timestamp: 1, input_length: 16, output_length: 1, "
+                "ucm_block_ids: [invalid]\n"
+                "timestamp: 2, input_length: 16, output_length: 1, "
+                "ucm_block_ids: ['valid-block']\n",
+                encoding="utf-8",
+            )
+            output = io.StringIO()
+            errors = io.StringIO()
+
+            with redirect_stdout(output), redirect_stderr(errors):
+                exit_code = auto_trace_analysis.main(
+                    [
+                        "--log-dir",
+                        str(log_file),
+                        "--block-kv-cache-size",
+                        "1024",
+                        "--is-mla",
+                        "false",
+                        "--dram-pool-size-gb",
+                        "0",
+                        "--fs-pool-size-gb",
+                        "0",
+                    ]
+                )
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Trace cache hit rate analysis", output.getvalue())
+            self.assertIn("Log line parse failures: 1", errors.getvalue())
 
     def test_directory_scan_keeps_log_file_patterns(self):
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/benchmarks/test_auto_trace_analysis.py
+++ b/benchmarks/test_auto_trace_analysis.py
@@ -109,6 +109,89 @@ class AutoTraceAnalysisTest(unittest.TestCase):
             self.assertIn("Trace cache hit rate analysis", output.getvalue())
             self.assertIn("Log line parse failures: 1", errors.getvalue())
 
+    def test_shared_dram_pool_allows_hits_across_nodes(self):
+        records = [
+            auto_trace_analysis.TraceRecord(1, 1, 0, ["shared"], "trace.log"),
+            auto_trace_analysis.TraceRecord(2, 1, 0, ["shared"], "trace.log"),
+        ]
+
+        per_node = auto_trace_analysis.simulate_cache_hit_rate(
+            records,
+            gpu_capacity_blocks=0,
+            dram_capacity_blocks=1,
+            fs_capacity_blocks=0,
+            num_nodes=2,
+            random_seed=4,
+            dram_pool_mode="per-node",
+        )
+        shared = auto_trace_analysis.simulate_cache_hit_rate(
+            records,
+            gpu_capacity_blocks=0,
+            dram_capacity_blocks=1,
+            fs_capacity_blocks=0,
+            num_nodes=2,
+            random_seed=4,
+            dram_pool_mode="shared",
+        )
+
+        self.assertEqual(per_node["dram_hit_tokens"], 0)
+        self.assertEqual(shared["dram_hit_tokens"], 1)
+
+    def test_dram_pool_mode_defaults_to_per_node(self):
+        parser = auto_trace_analysis.build_arg_parser()
+        args = parser.parse_args(
+            [
+                "--log-dir",
+                "trace.log",
+                "--block-kv-cache-size",
+                "1024",
+                "--is-mla",
+                "false",
+                "--dram-pool-size-gb",
+                "1",
+                "--fs-pool-size-gb",
+                "0",
+            ]
+        )
+
+        self.assertEqual(args.dram_pool_mode, "per-node")
+
+    def test_dram_pool_total_capacity_follows_selected_mode(self):
+        parser = auto_trace_analysis.build_arg_parser()
+        common_args = [
+            "--log-dir",
+            "trace.log",
+            "--block-kv-cache-size",
+            str(auto_trace_analysis.GIB),
+            "--is-mla",
+            "false",
+            "--dram-pool-size-gb",
+            "2",
+            "--fs-pool-size-gb",
+            "0",
+            "--num-nodes",
+            "3",
+        ]
+        facts = auto_trace_analysis.LogFacts(
+            log_files=["trace.log"],
+            records=[auto_trace_analysis.TraceRecord(1, 1, 0, ["block"], "trace.log")],
+            available_kv_cache_memory_bytes=[auto_trace_analysis.GIB],
+            tensor_parallel_sizes=[1],
+            parse_errors=[],
+        )
+
+        per_node = auto_trace_analysis.build_analysis(
+            parser.parse_args(common_args), facts
+        )
+        shared = auto_trace_analysis.build_analysis(
+            parser.parse_args([*common_args, "--dram-pool-mode", "shared"]), facts
+        )
+
+        self.assertEqual(per_node["derived"]["dram_capacity_blocks"], 2)
+        self.assertEqual(per_node["derived"]["dram_total_capacity_blocks"], 6)
+        self.assertEqual(shared["derived"]["dram_capacity_blocks"], 2)
+        self.assertEqual(shared["derived"]["dram_total_capacity_blocks"], 2)
+
     def test_directory_scan_keeps_log_file_patterns(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             log_dir = Path(temp_dir)

--- a/benchmarks/test_auto_trace_analysis.py
+++ b/benchmarks/test_auto_trace_analysis.py
@@ -1,0 +1,80 @@
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+from benchmarks import auto_trace_analysis
+
+
+class AutoTraceAnalysisTest(unittest.TestCase):
+    def test_collect_log_facts_accepts_direct_file_with_any_extension(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_file = Path(temp_dir) / "trace.txt"
+            log_file.write_text(
+                "available kv cache memory: 1024 bytes\n"
+                "tensor_parallel_size=2\n"
+                "timestamp: 1.5, request_id: request-1, input_length: 16, "
+                "output_length: 1, ucm_block_ids: ['block-1']\n",
+                encoding="utf-8",
+            )
+
+            output = io.StringIO()
+            with redirect_stdout(output):
+                facts = auto_trace_analysis.collect_log_facts(log_file)
+
+            self.assertEqual(facts.log_files, [str(log_file)])
+            self.assertEqual(len(facts.records), 1)
+            self.assertEqual(facts.records[0].hash_ids, ["block-1"])
+            self.assertIn("Log files to parse (1):", output.getvalue())
+            self.assertIn(str(log_file), output.getvalue())
+
+    def test_parse_error_reports_stage_source_line_and_excerpt(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_file = Path(temp_dir) / "broken.log"
+            bad_line = (
+                "timestamp: 1, input_length: 16, output_length: 1, "
+                "ucm_block_ids: [not-a-literal]"
+            )
+            log_file.write_text(
+                "available kv cache memory: 1024 bytes\n"
+                f"{bad_line}\n"
+                "tensor_parallel_size=2\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError) as raised:
+                auto_trace_analysis.collect_log_facts(log_file)
+
+            message = str(raised.exception)
+            self.assertIn("stage: trace.ucm_block_ids.literal_eval", message)
+            self.assertIn(f"source: {log_file}:2", message)
+            self.assertIn("column:", message)
+            self.assertIn(f"line excerpt: {bad_line!r}", message)
+
+    def test_incomplete_trace_reports_pattern_match_stage(self):
+        line = (
+            "timestamp: 1, input_length: 16, output_length: 1, "
+            "ucm_block_ids: ['missing-list-terminator'"
+        )
+
+        with self.assertRaises(ValueError) as raised:
+            auto_trace_analysis.parse_trace_line(line, "server.log", 42)
+
+        message = str(raised.exception)
+        self.assertIn("stage: trace.pattern_match", message)
+        self.assertIn("source: server.log:42", message)
+        self.assertIn(f"line excerpt: {line!r}", message)
+
+    def test_directory_scan_keeps_log_file_patterns(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            log_dir = Path(temp_dir)
+            expected = [log_dir / "a.log", log_dir / "b.log.1"]
+            for path in [*expected, log_dir / "ignored.txt"]:
+                path.touch()
+
+            self.assertEqual(auto_trace_analysis.iter_log_files(log_dir), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Allow `--log-dir` to accept either a directory or a single log file, regardless of the file extension.
- Print every discovered input file before parsing starts.
- Report malformed trace lines with the parsing stage, source file, line number, column, cause, and a bounded line excerpt.
- Continue parsing after malformed trace lines and print a consolidated failure count and error details after the scan.
- Expose `parse_failure_count` and `parse_failures` in the generated analysis result.
- Avoid scanning the same logs twice when `--trace-output` is enabled.
- Add focused unit coverage for direct file input, file discovery, malformed and truncated traces, and successful CLI analysis after a bad line.

## Why

Long `ucm_block_ids` log messages can be truncated before the list terminator. The existing non-greedy list pattern may then consume a later logger metadata bracket, and `ast.literal_eval` fails without identifying the offending line or parsing stage. One malformed line also previously aborted the entire analysis.

The new diagnostics make the source of malformed records actionable while allowing valid records later in the same file or other scanned files to remain usable.

## Impact

Users can analyze a pasted or individually selected log file directly, see the exact input set, and still receive cache-hit analysis when only part of the trace is malformed. Completely unusable inputs continue to fail the existing aggregate validation.

## Verification

```text
python -m unittest benchmarks.test_auto_trace_analysis
python -m py_compile benchmarks/auto_trace_analysis.py benchmarks/test_auto_trace_analysis.py
python -m black --check benchmarks/auto_trace_analysis.py benchmarks/test_auto_trace_analysis.py
python -m isort --check-only benchmarks/auto_trace_analysis.py benchmarks/test_auto_trace_analysis.py
git diff --check origin/develop...HEAD
```

The commit-time codespell, Black, isort, and GitHub Actions workflow lint hooks also pass.
