### PR TITLE
[Feat] Add LookupOnReverse interface for hybrid model mamba block lookup

### DIFF
--- a/docs/source/developer-guide/extending_store.md
+++ b/docs/source/developer-guide/extending_store.md
@@ -53,6 +53,15 @@ For rapid prototyping and algorithm validation where development speed outweighs
         """Check presence of blocks in external storage."""
         pass
     @abstractmethod
+    def lookup_on_reverse(self, block_ids: List[bytes]) -> int:
+        """Check presence of blocks in external storage (reverse scan).
+
+        Scans from the last block down to the first, stopping at the first
+        block that exists. Returns the index of the rightmost present block,
+        or -1 if none are found.
+        """
+        pass
+    @abstractmethod
     def prefetch(self, block_ids: List[bytes]) -> None:
         """Asynchronously prefetch blocks into high-speed cache."""
         pass
@@ -133,6 +142,7 @@ Best for balancing productivity with performance—implement hot paths in C++, o
        // Core operations
        Expected<std::vector<uint8_t>> Lookup(const Detail::BlockId* blocks, size_t num) override;
        Expected<ssize_t> LookupOnPrefix(const Detail::BlockId* blocks, size_t num) override;
+       Expected<ssize_t> LookupOnReverse(const Detail::BlockId* blocks, size_t num) override;
        void Prefetch(const Detail::BlockId* blocks, size_t num) override;
        Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override;
        Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override;
@@ -204,6 +214,7 @@ Production-ready implementation with maximum performance and resource control.
        // Required interfaces
        Expected<std::vector<uint8_t>> Lookup(const Detail::BlockId* blocks, size_t num) override;
        Expected<ssize_t> LookupOnPrefix(const Detail::BlockId* blocks, size_t num) override;
+       Expected<ssize_t> LookupOnReverse(const Detail::BlockId* blocks, size_t num) override;
        void Prefetch(const Detail::BlockId* blocks, size_t num) override;
        Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override;
        Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override;

--- a/ucm/integration/vllm/hla_connector.py
+++ b/ucm/integration/vllm/hla_connector.py
@@ -1,4 +1,4 @@
-﻿import copy
+import copy
 import math
 import os
 import time
@@ -266,7 +266,7 @@ class KVCacheGroupManager:
         num_computed_tokens: int,
         group_block_ids: list[list[bytes]],
         lookup_on_prefix: Callable[[list[bytes]], int],
-        lookup_all: Callable[[list[bytes]], list[bool]],
+        lookup_on_reverse: Callable[[list[bytes]], int],
     ) -> tuple[int, int, list[bytes]]:
         """Two-stage HLA lookup using precomputed per-group hashes.
 
@@ -279,12 +279,13 @@ class KVCacheGroupManager:
         external hit is consistent across all full-attn groups and aligns
         to the kv-cache page granularity expected by the scheduler.
 
-        Stage 2 — mamba-align state groups are checked via a sequential
-        backward scan: starting from the Stage 1 candidate position, each
-        LCM boundary is checked one at a time going backwards toward
-        ``num_computed_tokens``. The scan stops at the first position where
-        ALL state groups have their state present. If no position has all
-        states present, the external hit is downgraded to zero.
+        Stage 2 — mamba-align state groups are checked via
+        ``lookup_on_reverse``: for each state group, the state hashes at
+        all candidate LCM boundary positions (earliest-to-latest) are
+        collected and a single reverse scan finds the rightmost hit.
+        The min across state groups is the rightmost position where ALL
+        state groups' states are present. If any state group has no hit
+        at any candidate position, the external hit is downgraded to zero.
 
         Returns:
             Tuple of
@@ -335,7 +336,11 @@ class KVCacheGroupManager:
         if external_hit_tokens <= 0:
             return 0, 0, []
 
-        # Stage 2: backward scan for mamba state at LCM boundaries.
+        # Stage 2: reverse scan for mamba state at LCM boundaries.
+        # For each state group, collect state hashes at all candidate
+        # positions (earliest-to-latest) and use lookup_on_reverse to find
+        # the rightmost hit.  The min across state groups is the rightmost
+        # position where ALL states are present.
         total_hit_tokens = num_computed_tokens + external_hit_tokens
 
         if not self.state_groups:
@@ -345,26 +350,40 @@ class KVCacheGroupManager:
                 [],
             )
 
-        best_pos = num_computed_tokens
-        for pos in range(total_hit_tokens, num_computed_tokens, -self.lcm_block_size):
-            pos_hashes: list[bytes] = []
-            for sg in self.state_groups:
+        positions = list(
+            range(
+                num_computed_tokens + self.lcm_block_size,
+                total_hit_tokens + self.lcm_block_size,
+                self.lcm_block_size,
+            )
+        )
+
+        best_pos = total_hit_tokens
+        for sg in self.state_groups:
+            # Truncate to positions <= best_pos so earlier state groups
+            # can shrink the search window for subsequent ones.
+            sg_positions = [p for p in positions if p <= best_pos]
+            sg_hashes: list[bytes] = []
+            for pos in sg_positions:
                 state_hash = self.compute_mamba_align_state_hash(
                     sg, pos, group_block_ids
                 )
-                pos_hashes.append(state_hash if state_hash is not None else b"")
+                sg_hashes.append(state_hash if state_hash is not None else b"")
             try:
-                results = lookup_all(pos_hashes)
+                idx = lookup_on_reverse(sg_hashes)
             except Exception as e:
                 logger.error(
-                    f"mamba-align state lookup error at pos={pos}. "
-                    f"{type(e).__name__}: {e}"
+                    f"mamba-align state reverse lookup error for "
+                    f"group={sg.group_id}. {type(e).__name__}: {e}"
                 )
                 _record_counter("connector_lookup_errors_total")
                 return 0, 0, []
-            if all(results):
-                best_pos = pos
-                break
+            if idx < 0:
+                # This state group has no state at any candidate position.
+                return 0, 0, []
+            sg_pos = sg_positions[idx]
+            if sg_pos < best_pos:
+                best_pos = sg_pos
 
         external_hit_tokens = best_pos - num_computed_tokens
         if external_hit_tokens <= 0:
@@ -967,7 +986,7 @@ class UCMHybridLinearAttentionConnector(UCMDirectConnector, SupportsHMA):
                 lambda block_ids: self._rank_consistency.lookup_on_prefix(
                     self.store, block_ids
                 ),
-                lambda block_ids: self._rank_consistency.lookup_all(
+                lambda block_ids: self._rank_consistency.lookup_on_reverse(
                     self.store, block_ids
                 ),
             )

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -849,13 +849,11 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         # WA rows represent window boundary state, so they are not required to
         # form a prefix. Search only inside the FA-contiguous hit range and use
         # the latest boundary that exists.
-        for hit_blocks in range(fa_hit_blocks, -1, -1):
-            # TODO: Add Posix SpaceManager::LookupOnSuffix() for sparse WA
-            # boundary lookups, where only the latest existing key is needed.
-            key = external_keys[hit_blocks - 1]
-            if self._rank_consistency.lookup_all(self.wa_store, [key])[0]:
-                return hit_blocks
-        return 0
+        wa_keys = external_keys[:fa_hit_blocks]
+        reverse_idx = self._rank_consistency.lookup_on_reverse(self.wa_store, wa_keys)
+        if reverse_idx < 0:
+            return 0
+        return reverse_idx + 1
 
     @fawa_latency_metric(
         "fawa_scheduler_get_num_new_matched_tokens_ms",

--- a/ucm/integration/vllm/rank_consistency.py
+++ b/ucm/integration/vllm/rank_consistency.py
@@ -122,6 +122,24 @@ class RankConsistencyManager:
             return -1
         return store.lookup_on_prefix(block_ids)
 
+    def lookup_on_reverse(self, store: UcmKVStoreBaseV1, block_ids: list[bytes]) -> int:
+        """Exclude known-missing blocks before forwarding a reverse lookup.
+
+        A known-missing block is treated as a miss so the reverse scan
+        continues to the left.  At most one re-query per known-missing hit
+        is issued; in practice the inconsistent set is small.
+        """
+        if not self.enabled:
+            return store.lookup_on_reverse(block_ids)
+        if self._tracker is None or not block_ids:
+            return store.lookup_on_reverse(block_ids)
+        result = store.lookup_on_reverse(block_ids)
+        while result >= 0 and block_ids[result] in self._tracker:
+            if result == 0:
+                return -1
+            result = store.lookup_on_reverse(block_ids[:result])
+        return result
+
     def lookup_all(self, store: UcmKVStoreBaseV1, block_ids: list[bytes]) -> list[bool]:
         """Mask known-missing blocks after forwarding an exact lookup."""
         results = store.lookup(block_ids)

--- a/ucm/store/cache/cc/buffer_manager.h
+++ b/ucm/store/cache/cc/buffer_manager.h
@@ -77,6 +77,13 @@ public:
         }
         return LookupOnPrefixFast(blocks, num);
     }
+    Expected<ssize_t> LookupOnReverse(const Detail::BlockId* blocks, size_t num)
+    {
+        if (!buffer_ || loadBackendOnly_) {
+            return LookupThrough<&StoreV1::LookupOnReverse>(blocks, num);
+        }
+        return LookupOnReverseFast(blocks, num);
+    }
     void Prefetch(const Detail::BlockId* blocks, size_t num)
     {
         if (backend_) { backend_->Prefetch(blocks, num); }
@@ -150,6 +157,46 @@ private:
             return static_cast<ssize_t>(num) - 1;
         }
         return static_cast<ssize_t>(missIdx[result + 1]) - 1;
+    }
+    Expected<ssize_t> LookupOnReverseFast(const Detail::BlockId* blocks, size_t num)
+    {
+        std::vector<uint8_t> results;
+        std::vector<Detail::BlockId> missBlk;
+        std::vector<size_t> missIdx;
+        Lookup(blocks, num, results, missBlk, missIdx);
+
+        ssize_t bufferHitIdx = -1;
+        for (ssize_t i = static_cast<ssize_t>(num) - 1; i >= 0; --i) {
+            if (results[i]) {
+                bufferHitIdx = i;
+                break;
+            }
+        }
+        // If the last block is a buffer hit, it's the maximum possible index.
+        if (bufferHitIdx == static_cast<ssize_t>(num) - 1) { return bufferHitIdx; }
+        // Only query backend for miss blocks after the buffer hit index.
+        std::vector<Detail::BlockId> backendMiss;
+        std::vector<size_t> backendMissIdx;
+        for (size_t i = 0; i < missIdx.size(); ++i) {
+            if (static_cast<ssize_t>(missIdx[i]) > bufferHitIdx) {
+                backendMiss.push_back(missBlk[i]);
+                backendMissIdx.push_back(missIdx[i]);
+            }
+        }
+        if (backendMiss.empty()) { return bufferHitIdx; }
+
+        StopWatch sw;
+        auto res = backend_->LookupOnReverse(backendMiss.data(), backendMiss.size());
+        if (!res) [[unlikely]] { return res.Error(); }
+        UC_DEBUG("Cache reverse lookup({}/{}) in backend costs {:.3f}ms.", backendMiss.size(), num,
+                 sw.Elapsed().count() * 1e3);
+        UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_lookup_backend_duration_ms"),
+                                 sw.Elapsed().count() * 1e3);
+        const auto backendResult = res.Value();
+        if (backendResult < 0) { return bufferHitIdx; }
+        ssize_t backendHitIdx = static_cast<ssize_t>(backendMissIdx[backendResult]);
+        ssize_t result = backendHitIdx > bufferHitIdx ? backendHitIdx : bufferHitIdx;
+        return result;
     }
 };
 

--- a/ucm/store/cache/cc/cache_store.cc
+++ b/ucm/store/cache/cc/cache_store.cc
@@ -84,6 +84,12 @@ public:
         if (!res) [[unlikely]] { UC_ERROR("Failed({}) to lookup blocks({}).", res.Error(), num); }
         return res;
     }
+    Expected<ssize_t> LookupOnReverse(const Detail::BlockId* blocks, size_t num) override
+    {
+        auto res = bufferMgr_.LookupOnReverse(blocks, num);
+        if (!res) [[unlikely]] { UC_ERROR("Failed({}) to lookup blocks({}).", res.Error(), num); }
+        return res;
+    }
     void Prefetch(const Detail::BlockId* blocks, size_t num) override
     {
         bufferMgr_.Prefetch(blocks, num);

--- a/ucm/store/compress/cc/compressor.cc
+++ b/ucm/store/compress/cc/compressor.cc
@@ -95,6 +95,13 @@ Expected<ssize_t> Compressor::LookupOnPrefix(const Detail::BlockId* blocks, size
     return res;
 }
 
+Expected<ssize_t> Compressor::LookupOnReverse(const Detail::BlockId* blocks, size_t num)
+{
+    auto res = impl_->backend->LookupOnReverse(blocks, num);
+    if (!res) [[unlikely]] { UC_ERROR("Failed({}) to lookup blocks({}).", res.Error(), num); }
+    return res;
+}
+
 void Compressor::Prefetch(const Detail::BlockId* blocks, size_t num)
 {
     impl_->backend->Prefetch(blocks, num);

--- a/ucm/store/compress/cc/compressor.h
+++ b/ucm/store/compress/cc/compressor.h
@@ -15,6 +15,7 @@ public:
     std::string Readme() const override;
     Expected<std::vector<uint8_t>> Lookup(const Detail::BlockId* blocks, size_t num) override;
     Expected<ssize_t> LookupOnPrefix(const Detail::BlockId* blocks, size_t num) override;
+    Expected<ssize_t> LookupOnReverse(const Detail::BlockId* blocks, size_t num) override;
     void Prefetch(const Detail::BlockId* blocks, size_t num) override;
     Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override;
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override;

--- a/ucm/store/ds3fs/cc/ds3fs_store.cc
+++ b/ucm/store/ds3fs/cc/ds3fs_store.cc
@@ -135,6 +135,16 @@ Expected<ssize_t> Ds3fsStore::LookupOnPrefix(const Detail::BlockId* blocks, size
     return static_cast<ssize_t>(num) - 1;
 }
 
+Expected<ssize_t> Ds3fsStore::LookupOnReverse(const Detail::BlockId* blocks, size_t num)
+{
+    if (num == 0) { return static_cast<ssize_t>(-1); }
+    auto results = impl_->spaceMgr.Lookup(blocks, num);
+    for (ssize_t i = static_cast<ssize_t>(num) - 1; i >= 0; --i) {
+        if (results[i]) { return i; }
+    }
+    return static_cast<ssize_t>(-1);
+}
+
 void Ds3fsStore::Prefetch(const Detail::BlockId* blocks, size_t num) {}
 
 Expected<Detail::TaskHandle> Ds3fsStore::Load(Detail::TaskDesc task)

--- a/ucm/store/ds3fs/cc/ds3fs_store.h
+++ b/ucm/store/ds3fs/cc/ds3fs_store.h
@@ -37,6 +37,7 @@ public:
     std::string Readme() const override;
     Expected<std::vector<uint8_t>> Lookup(const Detail::BlockId* blocks, size_t num) override;
     Expected<ssize_t> LookupOnPrefix(const Detail::BlockId* blocks, size_t num) override;
+    Expected<ssize_t> LookupOnReverse(const Detail::BlockId* blocks, size_t num) override;
     void Prefetch(const Detail::BlockId* blocks, size_t num) override;
     Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override;
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override;

--- a/ucm/store/empty/cc/empty_store.cc
+++ b/ucm/store/empty/cc/empty_store.cc
@@ -37,6 +37,7 @@ public:
         return OnLookup(num);
     }
     Expected<ssize_t> LookupOnPrefix(const Detail::BlockId* blocks, size_t num) { return -1; }
+    Expected<ssize_t> LookupOnReverse(const Detail::BlockId* blocks, size_t num) { return -1; }
     void Prefetch(const Detail::BlockId* blocks, size_t num) {}
     Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) { return NextId(); }
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) { return NextId(); }

--- a/ucm/store/fake/cc/fake_store.cc
+++ b/ucm/store/fake/cc/fake_store.cc
@@ -70,6 +70,19 @@ public:
         UC_DEBUG("Fake Lookup({}/{}) costs {:.3f}ms.", index, num, sw.Elapsed().count() * 1e3);
         return index;
     }
+    Expected<ssize_t> LookupOnReverse(const Detail::BlockId* blocks, size_t num) override
+    {
+        StopWatch sw;
+        for (ssize_t i = static_cast<ssize_t>(num) - 1; i >= 0; --i) {
+            if (metaMgr_.Exist(blocks[i])) {
+                UC_DEBUG("Fake reverse lookup({}/{}) costs {:.3f}ms.", i, num,
+                         sw.Elapsed().count() * 1e3);
+                return i;
+            }
+        }
+        UC_DEBUG("Fake reverse lookup(-1/{}) costs {:.3f}ms.", num, sw.Elapsed().count() * 1e3);
+        return static_cast<ssize_t>(-1);
+    }
     void Prefetch(const Detail::BlockId* blocks, size_t num) override {}
     Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override { return NextId(); }
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override

--- a/ucm/store/mooncakestore/cc/mooncake_store.cc
+++ b/ucm/store/mooncakestore/cc/mooncake_store.cc
@@ -175,6 +175,44 @@ public:
         return firstMiss - 1;
     }
 
+    Expected<ssize_t> LookupOnReverse(const Detail::BlockId* blocks, size_t num) override
+    {
+        if (num == 0) { return static_cast<ssize_t>(-1); }
+
+        std::vector<std::string> keys;
+        keys.reserve(num);
+        for (size_t i = 0; i < num; ++i) { keys.push_back(BlockIdToKey(blocks[i]) + "_0"); }
+
+        auto exists = RpcBatchIsExist(keys);
+
+        ssize_t mcHitIdx = -1;
+        for (ssize_t i = static_cast<ssize_t>(num) - 1; i >= 0; --i) {
+            if (exists[i] == 1) {
+                mcHitIdx = i;
+                break;
+            }
+        }
+
+        UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("mooncake_lookup_hit_blocks_total"),
+                                 mcHitIdx >= 0 ? 1.0 : 0.0);
+
+        if (mcHitIdx == static_cast<ssize_t>(num) - 1) { return mcHitIdx; }
+
+        if (config_.storeBackend) {
+            size_t backendStart = mcHitIdx >= 0 ? static_cast<size_t>(mcHitIdx) + 1 : 0;
+            if (backendStart < num) {
+                auto backendRes = config_.storeBackend->LookupOnReverse(blocks + backendStart,
+                                                                        num - backendStart);
+                if (backendRes) {
+                    ssize_t backendHit = backendRes.Value();
+                    if (backendHit >= 0) { return static_cast<ssize_t>(backendStart) + backendHit; }
+                }
+            }
+        }
+
+        return mcHitIdx;
+    }
+
     void Prefetch(const Detail::BlockId* blocks, size_t num) override
     {
         if (config_.storeBackend) { config_.storeBackend->Prefetch(blocks, num); }

--- a/ucm/store/pcstore/pcstore_connector_v1.py
+++ b/ucm/store/pcstore/pcstore_connector_v1.py
@@ -113,6 +113,25 @@ class UcmPcStoreV1(UcmKVStoreBaseV1):
                 return i - 1
         return len(res) - 1
 
+    def lookup_on_reverse(self, block_ids: List[bytes]) -> int:
+        """Check presence of blocks in external storage (reverse scan).
+
+        Scans from the last block down to the first, stopping at the first
+        block that exists in storage.
+
+        Args:
+            block_ids: List of vLLM block hashes (raw bytes).
+
+        Returns:
+            The index of the rightmost block present in storage.
+            Returns -1 if none of the blocks are found.
+        """
+        res = self.lookup(block_ids)
+        for i in range(len(res) - 1, -1, -1):
+            if res[i]:
+                return i
+        return -1
+
     def prefetch(self, block_ids: List[bytes]) -> None:
         """Asynchronously prefetch blocks into high-speed cache.
 

--- a/ucm/store/pipeline/cc/health_breaker_store.cc
+++ b/ucm/store/pipeline/cc/health_breaker_store.cc
@@ -122,6 +122,12 @@ Expected<ssize_t> HealthBreakerStore::LookupOnPrefix(const Detail::BlockId* bloc
     return store_->LookupOnPrefix(blocks, num);
 }
 
+Expected<ssize_t> HealthBreakerStore::LookupOnReverse(const Detail::BlockId* blocks, size_t num)
+{
+    if (!Enabled()) { return static_cast<ssize_t>(-1); }
+    return store_->LookupOnReverse(blocks, num);
+}
+
 void HealthBreakerStore::Prefetch(const Detail::BlockId* blocks, size_t num)
 {
     if (Enabled()) { store_->Prefetch(blocks, num); }

--- a/ucm/store/pipeline/cc/health_breaker_store.h
+++ b/ucm/store/pipeline/cc/health_breaker_store.h
@@ -54,6 +54,7 @@ public:
     std::string Readme() const override;
     Expected<std::vector<uint8_t>> Lookup(const Detail::BlockId* blocks, size_t num) override;
     Expected<ssize_t> LookupOnPrefix(const Detail::BlockId* blocks, size_t num) override;
+    Expected<ssize_t> LookupOnReverse(const Detail::BlockId* blocks, size_t num) override;
     void Prefetch(const Detail::BlockId* blocks, size_t num) override;
     Status CheckHealth() override;
     Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override;

--- a/ucm/store/pipeline/connector.py
+++ b/ucm/store/pipeline/connector.py
@@ -109,6 +109,10 @@ class UcmPipelineStore(UcmKVStoreBaseV1):
         flat = np.frombuffer(b"".join(block_ids), dtype=np.uint8)
         return self.store_.LookupOnPrefix(flat)
 
+    def lookup_on_reverse(self, block_ids: List[bytes]) -> int:
+        flat = np.frombuffer(b"".join(block_ids), dtype=np.uint8)
+        return self.store_.LookupOnReverse(flat)
+
     def prefetch(self, block_ids: List[bytes]) -> None:
         flat = np.frombuffer(b"".join(block_ids), dtype=np.uint8)
         self.store_.Prefetch(flat)

--- a/ucm/store/pipeline/cpy/pipeline_store.py.cc
+++ b/ucm/store/pipeline/cpy/pipeline_store.py.cc
@@ -195,6 +195,13 @@ public:
         if (res) { return res.Value(); }
         ThrowError(res.Error());
     }
+    ssize_t LookupOnReverse(const pybind11::buffer& ids)
+    {
+        BufferArrayView<Detail::BlockId> idArr{ids};
+        auto res = StoreBack()->LookupOnReverse(idArr.data, idArr.num);
+        if (res) { return res.Value(); }
+        ThrowError(res.Error());
+    }
     void Prefetch(const pybind11::buffer& ids)
     {
         BufferArrayView<Detail::BlockId> idArr{ids};
@@ -259,6 +266,7 @@ PYBIND11_MODULE(ucmpipelinestore, m)
     s.def("Self", &PipelineStore::Self);
     s.def("Lookup", &PipelineStore::Lookup, py::arg("ids").noconvert());
     s.def("LookupOnPrefix", &PipelineStore::LookupOnPrefix, py::arg("ids").noconvert());
+    s.def("LookupOnReverse", &PipelineStore::LookupOnReverse, py::arg("ids").noconvert());
     s.def("Prefetch", &PipelineStore::Prefetch, py::arg("ids").noconvert());
     s.def("Load", &PipelineStore::Load, py::arg("ids").noconvert(), py::arg("indexes").noconvert(),
           py::arg("addrs").noconvert());

--- a/ucm/store/posix/cc/posix_store.cc
+++ b/ucm/store/posix/cc/posix_store.cc
@@ -110,6 +110,17 @@ public:
         RecordLookupHits(static_cast<size_t>(res.Value() + 1));
         return res;
     }
+    Expected<ssize_t> LookupOnReverse(const Detail::BlockId* blocks, size_t num) override
+    {
+        RecordLookupQueries(num);
+        auto res = spaceMgr_.LookupOnReverse(blocks, num);
+        if (!res) [[unlikely]] {
+            UC_ERROR("Failed({}) to lookup blocks({}).", res.Error(), num);
+            return res;
+        }
+        RecordLookupHits(res.Value() >= 0 ? 1 : 0);
+        return res;
+    }
     void Prefetch(const Detail::BlockId* blocks, size_t num) override
     {
         spaceMgr_.Prefetch(blocks, num);

--- a/ucm/store/posix/cc/space_manager.cc
+++ b/ucm/store/posix/cc/space_manager.cc
@@ -103,6 +103,18 @@ Expected<ssize_t> SpaceManager::LookupOnPrefix(const Detail::BlockId* blocks, si
     return firstFail->load() - 1;
 }
 
+Expected<ssize_t> SpaceManager::LookupOnReverse(const Detail::BlockId* blocks, size_t num)
+{
+    if (num == 0) { return static_cast<ssize_t>(-1); }
+    for (ssize_t i = static_cast<ssize_t>(num) - 1; i >= 0; --i) {
+        if (Lookup(blocks + i)) {
+            if (hotnessTrackerEnable_) { hotnessTracker_.Touch(*(blocks + i)); }
+            return i;
+        }
+    }
+    return static_cast<ssize_t>(-1);
+}
+
 uint8_t SpaceManager::Lookup(const Detail::BlockId* block)
 {
     const auto& path = layout_.DataFilePath(*block, false);

--- a/ucm/store/posix/cc/space_manager.h
+++ b/ucm/store/posix/cc/space_manager.h
@@ -56,6 +56,7 @@ public:
     Status Setup(const Config& config);
     Expected<std::vector<uint8_t>> Lookup(const Detail::BlockId* blocks, size_t num);
     Expected<ssize_t> LookupOnPrefix(const Detail::BlockId* blocks, size_t num);
+    Expected<ssize_t> LookupOnReverse(const Detail::BlockId* blocks, size_t num);
     void Prefetch(const Detail::BlockId* blocks, size_t num);
     const SpaceLayout* GetLayout() const { return &layout_; }
 

--- a/ucm/store/test/case/cache/cache_buffer_manager_test.cc
+++ b/ucm/store/test/case/cache/cache_buffer_manager_test.cc
@@ -71,6 +71,11 @@ TEST_F(UCCacheBufferManagerTest, Lookup)
         ASSERT_EQ(founds.size(), blocks.size());
         std::for_each(founds.begin(), founds.end(), [](auto found) { ASSERT_FALSE(found); });
     }
+    EXPECT_CALL(backend, LookupOnReverse).WillOnce(testing::Return(-1));
+    {
+        auto ReverseIdx = bufferMgr.LookupOnReverse(blocks.data(), blocks.size()).Value();
+        ASSERT_EQ(ReverseIdx, -1);
+    }
     EXPECT_CALL(backend, LookupOnPrefix).WillOnce(testing::Invoke([](auto, size_t num) {
         return static_cast<ssize_t>(num) - 1;
     }));
@@ -81,6 +86,13 @@ TEST_F(UCCacheBufferManagerTest, Lookup)
         auto founds = bufferMgr.Lookup(blocks.data(), blocks.size()).Value();
         ASSERT_EQ(founds.size(), blocks.size());
         std::for_each(founds.begin(), founds.end(), [](auto found) { ASSERT_TRUE(found); });
+    }
+    EXPECT_CALL(backend, LookupOnReverse).WillOnce(testing::Invoke([](auto, size_t num) {
+        return static_cast<ssize_t>(num) - 1;
+    }));
+    {
+        auto ReverseIdx = bufferMgr.LookupOnReverse(blocks.data(), blocks.size()).Value();
+        ASSERT_EQ(ReverseIdx, 2);
     }
 }
 
@@ -116,4 +128,7 @@ TEST_F(UCCacheBufferManagerTest, BackendOnlyLookupBypassesCache)
 
     EXPECT_CALL(backend, LookupOnPrefix).WillOnce(testing::Return(-1));
     ASSERT_EQ(bufferMgr.LookupOnPrefix(&block, 1).Value(), -1);
+
+    EXPECT_CALL(backend, LookupOnReverse).WillOnce(testing::Return(-1));
+    ASSERT_EQ(bufferMgr.LookupOnReverse(&block, 1).Value(), -1);
 }

--- a/ucm/store/test/case/detail/mock_store.h
+++ b/ucm/store/test/case/detail/mock_store.h
@@ -37,6 +37,8 @@ public:
                 (const UC::Detail::BlockId* blocks, size_t num), (override));
     MOCK_METHOD((UC::Expected<ssize_t>), LookupOnPrefix,
                 (const UC::Detail::BlockId* blocks, size_t num), (override));
+    MOCK_METHOD((UC::Expected<ssize_t>), LookupOnReverse,
+                (const UC::Detail::BlockId* blocks, size_t num), (override));
     MOCK_METHOD(void, Prefetch, (const UC::Detail::BlockId* blocks, size_t num), (override));
     MOCK_METHOD((UC::Status), CheckHealth, (), (override));
     MOCK_METHOD((UC::Expected<UC::Detail::TaskHandle>), Load, (UC::Detail::TaskDesc task),

--- a/ucm/store/test/case/fake/fake_store_impl_test.cc
+++ b/ucm/store/test/case/fake/fake_store_impl_test.cc
@@ -45,6 +45,8 @@ TEST_F(UCFakeStoreImplTest, Lookup)
     {
         auto foundIdx = store.LookupOnPrefix(blocks.data(), blocks.size()).Value();
         ASSERT_EQ(foundIdx, -1);
+        auto ReverseIdx = store.LookupOnReverse(blocks.data(), blocks.size()).Value();
+        ASSERT_EQ(ReverseIdx, -1);
         auto founds = store.Lookup(blocks.data(), blocks.size()).Value();
         ASSERT_EQ(founds.size(), blocks.size());
         std::for_each(founds.begin(), founds.end(), [](auto found) { ASSERT_FALSE(found); });
@@ -59,6 +61,8 @@ TEST_F(UCFakeStoreImplTest, Lookup)
     {
         auto foundIdx = store.LookupOnPrefix(blocks.data(), blocks.size()).Value();
         ASSERT_EQ(foundIdx, 2);
+        auto ReverseIdx = store.LookupOnReverse(blocks.data(), blocks.size()).Value();
+        ASSERT_EQ(ReverseIdx, 2);
         auto founds = store.Lookup(blocks.data(), blocks.size()).Value();
         ASSERT_EQ(founds.size(), blocks.size());
         std::for_each(founds.begin(), founds.end(), [](auto found) { ASSERT_TRUE(found); });
@@ -69,6 +73,8 @@ TEST_F(UCFakeStoreImplTest, Lookup)
     {
         auto foundIdx = store.LookupOnPrefix(blocks.data(), blocks.size()).Value();
         ASSERT_EQ(foundIdx, 1);
+        auto ReverseIdx = store.LookupOnReverse(blocks.data(), blocks.size()).Value();
+        ASSERT_EQ(ReverseIdx, 3);
         auto founds = store.Lookup(blocks.data(), blocks.size()).Value();
         ASSERT_EQ(founds.size(), blocks.size());
         std::vector<uint8_t> expected{true, true, false, true};

--- a/ucm/store/test/case/pipeline/health_breaker_store_test.cc
+++ b/ucm/store/test/case/pipeline/health_breaker_store_test.cc
@@ -357,6 +357,10 @@ TEST(UCHealthBreakerStoreTest, UnhealthyOperationMatrix)
     ASSERT_TRUE(prefix);
     EXPECT_EQ(prefix.Value(), -1);
 
+    auto Reverse = breaker.LookupOnReverse(blocks.data(), blocks.size());
+    ASSERT_TRUE(Reverse);
+    EXPECT_EQ(Reverse.Value(), -1);
+
     breaker.Prefetch(blocks.data(), blocks.size());
 
     EXPECT_EQ(breaker.Load({}).Error(), Status::StoreUnhealthy());
@@ -380,6 +384,8 @@ TEST(UCHealthBreakerStoreTest, HealthyOperationsPassThroughWithoutChangingWindow
     EXPECT_EQ(breaker.Lookup(blocks.data(), blocks.size()).Value(), std::vector<uint8_t>{1});
     EXPECT_CALL(store, LookupOnPrefix(blocks.data(), blocks.size())).WillOnce(Return(0));
     EXPECT_EQ(breaker.LookupOnPrefix(blocks.data(), blocks.size()).Value(), 0);
+    EXPECT_CALL(store, LookupOnReverse(blocks.data(), blocks.size())).WillOnce(Return(0));
+    EXPECT_EQ(breaker.LookupOnReverse(blocks.data(), blocks.size()).Value(), 0);
     EXPECT_CALL(store, Prefetch(blocks.data(), blocks.size()));
     breaker.Prefetch(blocks.data(), blocks.size());
     EXPECT_CALL(store, Load(testing::_)).WillOnce(Return(21));

--- a/ucm/store/test/case/posix/posix_space_manager_test.cc
+++ b/ucm/store/test/case/posix/posix_space_manager_test.cc
@@ -132,6 +132,8 @@ TEST_F(UCPosixSpaceManagerTest, Lookup)
     {
         auto foundIdx = spaceMgr.LookupOnPrefix(blocks.data(), blocks.size()).Value();
         ASSERT_EQ(foundIdx, -1);
+        auto ReverseIdx = spaceMgr.LookupOnReverse(blocks.data(), blocks.size()).Value();
+        ASSERT_EQ(ReverseIdx, -1);
         auto founds = spaceMgr.Lookup(blocks.data(), blocks.size()).Value();
         ASSERT_EQ(founds.size(), blocks.size());
         std::for_each(founds.begin(), founds.end(), [](auto found) { ASSERT_FALSE(found); });
@@ -143,6 +145,8 @@ TEST_F(UCPosixSpaceManagerTest, Lookup)
     {
         auto foundIdx = spaceMgr.LookupOnPrefix(blocks.data(), blocks.size()).Value();
         ASSERT_EQ(foundIdx, 2);
+        auto ReverseIdx = spaceMgr.LookupOnReverse(blocks.data(), blocks.size()).Value();
+        ASSERT_EQ(ReverseIdx, 2);
         auto founds = spaceMgr.Lookup(blocks.data(), blocks.size()).Value();
         ASSERT_EQ(founds.size(), blocks.size());
         std::for_each(founds.begin(), founds.end(), [](auto found) { ASSERT_TRUE(found); });
@@ -153,6 +157,8 @@ TEST_F(UCPosixSpaceManagerTest, Lookup)
     {
         auto foundIdx = spaceMgr.LookupOnPrefix(blocks.data(), blocks.size()).Value();
         ASSERT_EQ(foundIdx, 1);
+        auto ReverseIdx = spaceMgr.LookupOnReverse(blocks.data(), blocks.size()).Value();
+        ASSERT_EQ(ReverseIdx, 3);
         auto founds = spaceMgr.Lookup(blocks.data(), blocks.size()).Value();
         ASSERT_EQ(founds.size(), blocks.size());
         std::vector<uint8_t> expected{true, true, false, false};

--- a/ucm/store/ucmstore_v1.h
+++ b/ucm/store/ucmstore_v1.h
@@ -92,6 +92,28 @@ public:
     virtual Expected<ssize_t> LookupOnPrefix(const Detail::BlockId* blocks, size_t num) = 0;
 
     /**
+     * @brief Check whether the given blocks exist in storage (reverse scan).
+     *
+     * Scans blocks from the last index (num-1) down to 0 and stops at the
+     * first block that *exists* in storage (reverse semantics).  This is the
+     * dual of LookupOnPrefix: prefix scanning stops at the first *missing*
+     * block, whereas reverse scanning stops at the first *present* block.
+     *
+     * Typical use case: hybrid (full-attention + Mamba) models.  Full
+     * attention blocks are looked up with LookupOnPrefix (front-to-back,
+     * stop at first miss).  Mamba blocks are looked up with LookupOnReverse
+     * (back-to-front, stop at first hit) to maximise the reuse window.
+     *
+     * @param blocks Array of block identifiers to test.
+     * @param num Number of block identifiers to test.
+     * @return Expected<ssize_t>
+     *   - On success: the index of the rightmost block present in storage.
+     *     Returns -1 if none of the blocks are found.
+     *   - On failure: appropriate Status code.
+     * */
+    virtual Expected<ssize_t> LookupOnReverse(const Detail::BlockId* blocks, size_t num) = 0;
+
+    /**
      * @brief Hint the store to prefetch given blocks into high-speed cache.
      *
      * This call is **non-blocking** and **fire-and-forget**; it returns

--- a/ucm/store/ucmstore_v1.py
+++ b/ucm/store/ucmstore_v1.py
@@ -81,12 +81,40 @@ class UcmKVStoreBaseV1(ABC):
     def lookup_on_prefix(self, block_ids: List[bytes]) -> int:
         """Check presence of blocks in external storage.
 
+        Scans blocks from index 0 up to len-1 and stops at the first block
+        that is *absent* (prefix semantics).  Returns the index of the last
+        contiguous block present, or -1 if none are found.
+
         Args:
             block_ids: List of vLLM block hashes (raw bytes).
 
         Returns:
             An index representing the maximum index of blocks found in storage,
             returns -1 if none are found.
+        """
+        pass
+
+    @abstractmethod
+    def lookup_on_reverse(self, block_ids: List[bytes]) -> int:
+        """Check presence of blocks in external storage (reverse scan).
+
+        Scans blocks from the last index down to 0 and stops at the first
+        block that *exists* in storage (reverse semantics).  This is the dual
+        of ``lookup_on_prefix``: prefix scanning stops at the first *missing*
+        block, whereas reverse scanning stops at the first *present* block.
+
+        Typical use case: hybrid (full-attention + Mamba) models.  Full
+        attention blocks are looked up with ``lookup_on_prefix`` (front-to-
+        back, stop at first miss).  Mamba blocks are looked up with
+        ``lookup_on_reverse`` (back-to-front, stop at first hit) to maximise
+        the reuse window.
+
+        Args:
+            block_ids: List of vLLM block hashes (raw bytes).
+
+        Returns:
+            The index of the rightmost block present in storage.
+            Returns -1 if none of the blocks are found.
         """
         pass
 


### PR DESCRIPTION
## Purpose
Add a reverse-order query interface (LookupOnReverse) to the UCM store layer, dual to the existing LookupOnPrefix. This enables hybrid (full-attention + Mamba) models to maximise KV cache reuse: FA blocks use prefix lookup (front-to-back, stop at first miss), while Mamba blocks use reverse lookup (back-to-front, stop at first hit). Unlike prefix, presence is not required to be contiguous — the function simply returns the index of the rightmost block found in storage.
## Modifications 
Store layer — new LookupOnReverse / lookup_on_reverse interface across the full stack:
- C++ StoreV1 interface (ucmstore_v1.h): pure virtual LookupOnReverse — scans from the last index down to 0, stops at the first present block, returns its index (or -1)
- C++ store implementations (8 stores):
- Posix SpaceManager: sequential back-to-front single-block file access scan
- Cache BufferManager: checks buffer hits for all blocks; if the last block is a buffer hit, returns immediately; otherwise only queries backend for miss blocks after the buffer hit index; returns max(bufferHit, backendHit)
- MooncakeStore: batch RPC existence check, delegates missed blocks to the right of the mooncake hit to backend reverse scan
- Ds3fsStore / Compressor / HealthBreakerStore / EmptyStore / FakeStore: straightforward implementations
- Python (ucmstore_v1.py): abstract lookup_on_reverse on UcmKVStoreBaseV1
- Python connectors: UcmPcStoreV1 and UcmPipelineStore concrete implementations
- pybind11 binding (pipeline_store.py.cc): LookupOnReverse method + module registration
- Test mock (mock_store.h): MOCK_METHOD for LookupOnReverse
Integration layer:
- RankConsistencyManager.lookup_on_reverse: masks known-missing blocks with re-query on hit, mirroring the lookup_on_prefix pattern
- hma_connector: replaces the per-key linear backward scan loop (with TODO) with a single lookup_on_reverse call
- hla_connector: replaces Stage 2 sequential backward scan (up to M lookup_all calls) with per-state-group reverse scan (N lookup_on_reverse calls); takes the min of rightmost hits across state groups; earlier state groups truncate the search window for subsequent ones
## Test
- C++ unit tests (4 test files): verified LookupOnReverse returns -1 when no blocks exist, returns num-1 when all exist, and returns the correct rightmost hit index when blocks are partially present (e.g., [hit, hit, miss, hit] → reverse returns 3, prefix returns 1)
- Cache buffer manager test: verified reverse delegates to backend only for blocks after the buffer hit index, and returns max(bufferHit, backendHit)
- Health breaker test: verified reverse returns -1 when unhealthy, passes through when healthy