### PR TITLE
[Feat] Add CPU-accessible Ascend device buffers

### DIFF
--- a/ucm/shared/pool/buffer_pool.cc
+++ b/ucm/shared/pool/buffer_pool.cc
@@ -139,7 +139,8 @@ bool BufferPool::IsValidPointer(const void* ptr) const
 
 Status BufferPool::ZeroMemory(void* ptr, std::size_t size) const
 {
-    if (memory_type_ == MemoryType::ASCEND_DEVICE) {
+    if (memory_type_ == MemoryType::ASCEND_DEVICE ||
+        memory_type_ == MemoryType::ASCEND_DEVICE_CPU_ACCESSIBLE) {
         const auto status = UC::Trans::ZeroDeviceMemory(ptr, size);
         if (status.Failure()) { return Status::Error(name_ + ": failed to zero device memory"); }
     } else {

--- a/ucm/shared/pool/buffer_pool.cc
+++ b/ucm/shared/pool/buffer_pool.cc
@@ -140,7 +140,7 @@ bool BufferPool::IsValidPointer(const void* ptr) const
 Status BufferPool::ZeroMemory(void* ptr, std::size_t size) const
 {
     if (memory_type_ == MemoryType::ASCEND_DEVICE ||
-        memory_type_ == MemoryType::ASCEND_DEVICE_CPU_ACCESSIBLE) {
+        memory_type_ == MemoryType::DEVICE_MAPPED_HOST) {
         const auto status = UC::Trans::ZeroDeviceMemory(ptr, size);
         if (status.Failure()) { return Status::Error(name_ + ": failed to zero device memory"); }
     } else {

--- a/ucm/shared/pool/buffer_region.cc
+++ b/ucm/shared/pool/buffer_region.cc
@@ -60,6 +60,16 @@ Status BufferRegion::Create(BufferMemoryType type, std::size_t size, BufferRegio
             region.device_addr = region.owner.get();
             return Status::OK();
         }
+        case BufferMemoryType::ASCEND_DEVICE_CPU_ACCESSIBLE: {
+            auto owner = buffer->MakeCpuAccessibleDeviceBuffer(size);
+            if (!owner) {
+                return Status::Error("failed to allocate CPU-accessible device memory");
+            }
+            region.owner = std::move(owner);
+            region.local_addr = region.owner.get();
+            region.device_addr = region.owner.get();
+            return Status::OK();
+        }
         default: return Status::InvalidParam("unsupported memory type");
     }
 }

--- a/ucm/shared/pool/buffer_region.cc
+++ b/ucm/shared/pool/buffer_region.cc
@@ -60,11 +60,9 @@ Status BufferRegion::Create(BufferMemoryType type, std::size_t size, BufferRegio
             region.device_addr = region.owner.get();
             return Status::OK();
         }
-        case BufferMemoryType::ASCEND_DEVICE_CPU_ACCESSIBLE: {
+        case BufferMemoryType::DEVICE_MAPPED_HOST: {
             auto owner = buffer->MakeCpuAccessibleDeviceBuffer(size);
-            if (!owner) {
-                return Status::Error("failed to allocate CPU-accessible device memory");
-            }
+            if (!owner) { return Status::Error("failed to allocate CPU-accessible device memory"); }
             region.owner = std::move(owner);
             region.local_addr = region.owner.get();
             region.device_addr = region.owner.get();

--- a/ucm/shared/pool/buffer_region.h
+++ b/ucm/shared/pool/buffer_region.h
@@ -33,6 +33,7 @@ enum class BufferMemoryType {
     HOST = 0,
     HOST_PINNED = 1,
     ASCEND_DEVICE = 2,
+    ASCEND_DEVICE_CPU_ACCESSIBLE = 3,
 };
 
 struct BufferRegion {

--- a/ucm/shared/pool/buffer_region.h
+++ b/ucm/shared/pool/buffer_region.h
@@ -33,7 +33,7 @@ enum class BufferMemoryType {
     HOST = 0,
     HOST_PINNED = 1,
     ASCEND_DEVICE = 2,
-    ASCEND_DEVICE_CPU_ACCESSIBLE = 3,
+    DEVICE_MAPPED_HOST = 3,
 };
 
 struct BufferRegion {

--- a/ucm/shared/test/case/pool/buffer_pool_test.cc
+++ b/ucm/shared/test/case/pool/buffer_pool_test.cc
@@ -244,13 +244,12 @@ TEST_F(BufferPoolTest, CpuAccessibleDevicePoolAllocatesAndZeroesReleasedSlot)
     ASSERT_NE(stream, nullptr);
 
     BufferPool pool;
-    auto status = pool.Init("cpu_accessible_device_pool",
-                            MemoryType::ASCEND_DEVICE_CPU_ACCESSIBLE,
+    auto status = pool.Init("cpu_accessible_device_pool", MemoryType::DEVICE_MAPPED_HOST,
                             kSlotCapacity, 1, true);
     ASSERT_TRUE(status.Success()) << status.ToString();
     EXPECT_EQ(pool.GetLocalAddr(), pool.GetDeviceAddr());
     EXPECT_EQ(pool.GetTotalSize(), kSlotStride);
-    EXPECT_EQ(pool.GetMemoryType(), MemoryType::ASCEND_DEVICE_CPU_ACCESSIBLE);
+    EXPECT_EQ(pool.GetMemoryType(), MemoryType::DEVICE_MAPPED_HOST);
 
     BufferPool::Slot slot;
     ASSERT_TRUE(pool.Allocate(slot).Success());

--- a/ucm/shared/test/case/pool/buffer_pool_test.cc
+++ b/ucm/shared/test/case/pool/buffer_pool_test.cc
@@ -230,6 +230,41 @@ TEST_F(BufferPoolTest, DevicePoolZeroesReleasedSlot)
     for (const auto value : host) { EXPECT_EQ(value, 0); }
 }
 
+TEST_F(BufferPoolTest, CpuAccessibleDevicePoolAllocatesAndZeroesReleasedSlot)
+{
+#if !defined(UCM_TEST_RUNTIME_ASCEND)
+    GTEST_SKIP() << "CPU-accessible device memory is not supported by the simu backend";
+#endif
+
+    constexpr std::size_t kSlotCapacity = 71;
+    constexpr std::size_t kSlotStride = 128;
+
+    Trans::Device device;
+    auto stream = device.MakeStream();
+    ASSERT_NE(stream, nullptr);
+
+    BufferPool pool;
+    auto status = pool.Init("cpu_accessible_device_pool",
+                            MemoryType::ASCEND_DEVICE_CPU_ACCESSIBLE,
+                            kSlotCapacity, 1, true);
+    ASSERT_TRUE(status.Success()) << status.ToString();
+    EXPECT_EQ(pool.GetLocalAddr(), pool.GetDeviceAddr());
+    EXPECT_EQ(pool.GetTotalSize(), kSlotStride);
+    EXPECT_EQ(pool.GetMemoryType(), MemoryType::ASCEND_DEVICE_CPU_ACCESSIBLE);
+
+    BufferPool::Slot slot;
+    ASSERT_TRUE(pool.Allocate(slot).Success());
+    std::array<std::uint8_t, kSlotStride> dirty;
+    dirty.fill(0xAB);
+    ASSERT_TRUE(stream->HostToDevice(dirty.data(), slot.device_addr, kSlotStride).Success());
+    ASSERT_TRUE(pool.Free(slot.slot_index).Success());
+
+    ASSERT_TRUE(pool.Allocate(slot).Success());
+    std::array<std::uint8_t, kSlotStride> host{};
+    ASSERT_TRUE(stream->DeviceToHost(slot.device_addr, host.data(), kSlotStride).Success());
+    for (const auto value : host) { EXPECT_EQ(value, 0); }
+}
+
 TEST_F(BufferPoolTest, FreeZeroesAndReusesHostSlot)
 {
     constexpr std::size_t kSlotStride = 128;

--- a/ucm/shared/trans/ascend/ascend_buffer.cc
+++ b/ucm/shared/trans/ascend/ascend_buffer.cc
@@ -55,8 +55,7 @@ void ReleaseCpuAccessibleDeviceMemory(void* mappedAddress, aclrtDrvMemHandle han
 {
     auto ret = aclrtUnmapMem(mappedAddress);
     if (ret != ACL_SUCCESS) {
-        UC_ERROR("Failed to unmap CPU-accessible device memory addr={} ret={}", mappedAddress,
-                 ret);
+        UC_ERROR("Failed to unmap CPU-accessible device memory addr={} ret={}", mappedAddress, ret);
     }
     ret = aclrtReleaseMemAddress(mappedAddress);
     if (ret != ACL_SUCCESS) {
@@ -162,7 +161,11 @@ std::shared_ptr<void> Trans::AscendBuffer::MakeDeviceBuffer(size_t size)
 std::shared_ptr<void> Trans::AscendBuffer::MakeCpuAccessibleDeviceBuffer(size_t size)
 {
     int32_t deviceId = 0;
-    if (aclrtGetDevice(&deviceId) != ACL_SUCCESS) { return nullptr; }
+    auto ret = aclrtGetDevice(&deviceId);
+    if (ret != ACL_SUCCESS) {
+        UC_ERROR("aclrtGetDevice failed, size={} ret={}", size, ret);
+        return nullptr;
+    }
 
     aclrtPhysicalMemProp prop{};
     prop.handleType = ACL_MEM_HANDLE_TYPE_NONE;
@@ -172,32 +175,43 @@ std::shared_ptr<void> Trans::AscendBuffer::MakeCpuAccessibleDeviceBuffer(size_t 
     prop.location.id = static_cast<uint32_t>(deviceId);
 
     size_t granularity = 0;
-    auto ret = aclrtMemGetAllocationGranularity(
-        &prop, ACL_RT_MEM_ALLOC_GRANULARITY_MINIMUM, &granularity);
-    if (ret != ACL_SUCCESS || granularity == 0 ||
-        size > std::numeric_limits<size_t>::max() - (granularity - 1)) {
+    ret =
+        aclrtMemGetAllocationGranularity(&prop, ACL_RT_MEM_ALLOC_GRANULARITY_MINIMUM, &granularity);
+    constexpr auto maxSize = std::numeric_limits<size_t>::max();
+    if (ret != ACL_SUCCESS || granularity == 0 || size > maxSize - (granularity - 1)) {
+        UC_ERROR(
+            "Invalid device memory allocation granularity, deviceId={} size={} granularity={} "
+            "maxSize={} ret={}",
+            deviceId, size, granularity, maxSize, ret);
         return nullptr;
     }
     const auto allocationSize = (size + granularity - 1) / granularity * granularity;
 
     aclrtDrvMemHandle handle = nullptr;
     ret = aclrtMallocPhysical(&handle, allocationSize, &prop, 0);
-    if (ret != ACL_SUCCESS) { return nullptr; }
+    if (ret != ACL_SUCCESS) {
+        UC_ERROR("aclrtMallocPhysical failed, deviceId={} size={} ret={}", deviceId, allocationSize,
+                 ret);
+        return nullptr;
+    }
 
     void* mappedAddress = nullptr;
     ret = aclrtReserveMemAddress(&mappedAddress, allocationSize, 0, nullptr, 0);
     if (ret != ACL_SUCCESS) {
+        UC_ERROR("aclrtReserveMemAddress failed, size={} ret={}", allocationSize, ret);
         aclrtFreePhysical(handle);
         return nullptr;
     }
 
     ret = aclrtMapMem(mappedAddress, allocationSize, 0, handle, 0);
     if (ret != ACL_SUCCESS) {
+        UC_ERROR("aclrtMapMem failed, addr={} size={} ret={}", mappedAddress, allocationSize, ret);
         aclrtReleaseMemAddress(mappedAddress);
         aclrtFreePhysical(handle);
         return nullptr;
     }
 
+#if ACL_MAJOR_VERSION > 1 || (ACL_MAJOR_VERSION == 1 && ACL_MINOR_VERSION >= 16)
     aclrtMemAccessDesc accessDesc{};
     accessDesc.flags = ACL_RT_MEM_ACCESS_FLAGS_READWRITE;
     accessDesc.location.type = ACL_MEM_LOCATION_TYPE_HOST;
@@ -209,6 +223,14 @@ std::shared_ptr<void> Trans::AscendBuffer::MakeCpuAccessibleDeviceBuffer(size_t 
         ReleaseCpuAccessibleDeviceMemory(mappedAddress, handle);
         return nullptr;
     }
+#else
+    UC_ERROR(
+        "Unsupported ACL version {}.{}: CPU-accessible device memory requires "
+        "aclrtMemSetAccess, minimum supported ACL version is 1.16",
+        ACL_MAJOR_VERSION, ACL_MINOR_VERSION);
+    ReleaseCpuAccessibleDeviceMemory(mappedAddress, handle);
+    return nullptr;
+#endif
     return std::shared_ptr<void>(mappedAddress, [handle](void* address) {
         ReleaseCpuAccessibleDeviceMemory(address, handle);
     });

--- a/ucm/shared/trans/ascend/ascend_buffer.cc
+++ b/ucm/shared/trans/ascend/ascend_buffer.cc
@@ -51,6 +51,24 @@ void ReleaseHostPinnedMemory(void* registeredHost, void* allocatedHost)
     FreeHostMemory(allocatedHost);
 }
 
+void ReleaseCpuAccessibleDeviceMemory(void* mappedAddress, aclrtDrvMemHandle handle)
+{
+    auto ret = aclrtUnmapMem(mappedAddress);
+    if (ret != ACL_SUCCESS) {
+        UC_ERROR("Failed to unmap CPU-accessible device memory addr={} ret={}", mappedAddress,
+                 ret);
+    }
+    ret = aclrtReleaseMemAddress(mappedAddress);
+    if (ret != ACL_SUCCESS) {
+        UC_ERROR("Failed to release CPU-accessible device address addr={} ret={}", mappedAddress,
+                 ret);
+    }
+    ret = aclrtFreePhysical(handle);
+    if (ret != ACL_SUCCESS) {
+        UC_ERROR("Failed to free physical device memory handle={} ret={}", handle, ret);
+    }
+}
+
 }  // namespace
 
 class HostHugePages : public std::enable_shared_from_this<HostHugePages> {
@@ -139,6 +157,61 @@ std::shared_ptr<void> Trans::AscendBuffer::MakeDeviceBuffer(size_t size)
     auto ret = aclrtMalloc(&device, size, ACL_MEM_TYPE_HIGH_BAND_WIDTH);
     if (ret == ACL_SUCCESS) { return std::shared_ptr<void>(device, aclrtFree); }
     return nullptr;
+}
+
+std::shared_ptr<void> Trans::AscendBuffer::MakeCpuAccessibleDeviceBuffer(size_t size)
+{
+    int32_t deviceId = 0;
+    if (aclrtGetDevice(&deviceId) != ACL_SUCCESS) { return nullptr; }
+
+    aclrtPhysicalMemProp prop{};
+    prop.handleType = ACL_MEM_HANDLE_TYPE_NONE;
+    prop.allocationType = ACL_MEM_ALLOCATION_TYPE_PINNED;
+    prop.memAttr = ACL_HBM_MEM_NORMAL;
+    prop.location.type = ACL_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id = static_cast<uint32_t>(deviceId);
+
+    size_t granularity = 0;
+    auto ret = aclrtMemGetAllocationGranularity(
+        &prop, ACL_RT_MEM_ALLOC_GRANULARITY_MINIMUM, &granularity);
+    if (ret != ACL_SUCCESS || granularity == 0 ||
+        size > std::numeric_limits<size_t>::max() - (granularity - 1)) {
+        return nullptr;
+    }
+    const auto allocationSize = (size + granularity - 1) / granularity * granularity;
+
+    aclrtDrvMemHandle handle = nullptr;
+    ret = aclrtMallocPhysical(&handle, allocationSize, &prop, 0);
+    if (ret != ACL_SUCCESS) { return nullptr; }
+
+    void* mappedAddress = nullptr;
+    ret = aclrtReserveMemAddress(&mappedAddress, allocationSize, 0, nullptr, 0);
+    if (ret != ACL_SUCCESS) {
+        aclrtFreePhysical(handle);
+        return nullptr;
+    }
+
+    ret = aclrtMapMem(mappedAddress, allocationSize, 0, handle, 0);
+    if (ret != ACL_SUCCESS) {
+        aclrtReleaseMemAddress(mappedAddress);
+        aclrtFreePhysical(handle);
+        return nullptr;
+    }
+
+    aclrtMemAccessDesc accessDesc{};
+    accessDesc.flags = ACL_RT_MEM_ACCESS_FLAGS_READWRITE;
+    accessDesc.location.type = ACL_MEM_LOCATION_TYPE_HOST;
+    accessDesc.location.id = 0;
+    ret = aclrtMemSetAccess(mappedAddress, allocationSize, &accessDesc, 1);
+    if (ret != ACL_SUCCESS) {
+        UC_ERROR("Failed to grant host access to device memory addr={} size={} ret={}",
+                 mappedAddress, allocationSize, ret);
+        ReleaseCpuAccessibleDeviceMemory(mappedAddress, handle);
+        return nullptr;
+    }
+    return std::shared_ptr<void>(mappedAddress, [handle](void* address) {
+        ReleaseCpuAccessibleDeviceMemory(address, handle);
+    });
 }
 
 std::shared_ptr<void> Trans::AscendBuffer::MakeHostBuffer(size_t size)

--- a/ucm/shared/trans/ascend/ascend_buffer.h
+++ b/ucm/shared/trans/ascend/ascend_buffer.h
@@ -31,6 +31,7 @@ namespace UC::Trans {
 class AscendBuffer : public ReservedBuffer {
 public:
     std::shared_ptr<void> MakeDeviceBuffer(size_t size) override;
+    std::shared_ptr<void> MakeCpuAccessibleDeviceBuffer(size_t size) override;
     std::shared_ptr<void> MakeHostBuffer(size_t size) override;
     std::shared_ptr<void> MakeHostPinnedBuffer(size_t size, void** pDevice = nullptr) override;
     std::shared_ptr<void> MakeHostBuffer4DirectIo(size_t size) override;

--- a/ucm/shared/trans/buffer.h
+++ b/ucm/shared/trans/buffer.h
@@ -34,6 +34,9 @@ public:
     virtual ~Buffer() = default;
 
     virtual std::shared_ptr<void> MakeDeviceBuffer(size_t size) = 0;
+    // Allocates device memory through the VMM APIs. On platforms that support CPU access to
+    // mapped device memory, the returned mapped address can also be dereferenced by the CPU.
+    virtual std::shared_ptr<void> MakeCpuAccessibleDeviceBuffer(size_t size) = 0;
     virtual Status MakeDeviceBuffers(size_t size, size_t number) = 0;
     virtual std::shared_ptr<void> GetDeviceBuffer(size_t size) = 0;
 

--- a/ucm/shared/trans/detail/reserved_buffer.h
+++ b/ucm/shared/trans/detail/reserved_buffer.h
@@ -53,6 +53,8 @@ class ReservedBuffer : public Buffer {
     }
 
 public:
+    std::shared_ptr<void> MakeCpuAccessibleDeviceBuffer(size_t) override { return nullptr; }
+
     Status MakeDeviceBuffers(size_t size, size_t number) override
     {
         auto totalSize = size * number;


### PR DESCRIPTION
## Purpose
Enable BufferPool to allocate Ascend device memory that can also be polled by the CPU on supported platforms.

## Modifications
1. Add an Ascend VMM allocation flow using aclrtMallocPhysical, aclrtReserveMemAddress, aclrtMapMem, and host read-write access.
2. Add a dedicated CPU-accessible device memory type to BufferRegion and BufferPool without changing existing memory types.
3. Keep unsupported backends explicit through ReservedBuffer and add allocation and slot-clearing coverage.

## Tests
Run on Ascend A2 with CANN 8.5.1:
```text
./build-physical-flag-buffer-tests/ucm/shared/test/ucmshared.test --gtest_filter=BufferPoolTest.*
[==========] Running 13 tests from 1 test suite.
[==========] 13 tests from 1 test suite ran. (8377 ms total)
[  PASSED  ] 13 tests.
```