### PR TITLE
[Refactor] Refine ASU task completion and pre-send failure handling

### DIFF
--- a/ucm/transport/kv/asu/test/transport/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/asu_submit_flow_test.cpp
@@ -175,20 +175,295 @@ TEST(AsuSubmitFlowTest, SendSubBatchBuffersReadsSendCountsFromAttrs)
 
     TransProvider::SendIoBatch ioBatch{nullptr, nullptr, nullptr, 0};
     std::vector<TransProvider::SendIoBatch> ioBatches = {ioBatch};
-    std::vector<std::size_t> subBatchIndexes = {0};
 
     std::vector<TransportSubBatchContext> subBatchContexts(1);
     subBatchContexts[0].state = TransportSubBatchState::PENDING;
     subBatchContexts[0].entryStatus.assign(1, Status::OK());
 
-    const auto status =
-        transport.taskExecutor_->SendSubBatchBuffers(subBatchContexts, ioBatches, subBatchIndexes);
+    transport.taskExecutor_->SendSubBatchBuffers(subBatchContexts, ioBatches);
 
-    EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(g_kernelCount, std::uint32_t{3});
     EXPECT_EQ(g_quietCount, std::uint32_t{7});
     EXPECT_EQ(subBatchContexts[0].state, TransportSubBatchState::PENDING);
     EXPECT_TRUE(subBatchContexts[0].status.ok());
+}
+
+TEST(AsuSubmitFlowTest, AbortBeforeSendPreservesStatusesBeforeFailureAndCancelsFollowing)
+{
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::make_unique<StubTransProvider>());
+    CreateTaskExecutor(transport);
+
+    const auto failedStatus =
+        Status::Error(StatusCode::INTERNAL_ERROR, "sub-batch preparation failed");
+    std::vector<TransportSubBatchContext> subBatchContexts(3);
+    for (auto& subBatchContext : subBatchContexts) { subBatchContext.entryStatus = {Status::OK()}; }
+    subBatchContexts[1].status = failedStatus;
+    subBatchContexts[1].entryStatus = {failedStatus};
+
+    TransportTask task;
+    task.entryStatus.assign(3, Status::OK());
+    transport.taskExecutor_->AbortSubBatchesBeforeSend(task, subBatchContexts);
+
+    EXPECT_TRUE(subBatchContexts[0].status.ok());
+    EXPECT_TRUE(subBatchContexts[0].entryStatus[0].ok());
+    EXPECT_EQ(subBatchContexts[1].status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(subBatchContexts[1].entryStatus[0].code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(subBatchContexts[2].status.code, StatusCode::CANCELED);
+    EXPECT_EQ(subBatchContexts[2].entryStatus[0].code, StatusCode::CANCELED);
+    for (const auto& entryStatus : task.entryStatus) {
+        EXPECT_EQ(entryStatus.code, StatusCode::CANCELED);
+    }
+    for (const auto& subBatchContext : subBatchContexts) {
+        EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
+    }
+}
+
+TEST(AsuTransportRegisterTest, RegisterRegionsReturnsPartialFailedAndRollsBackSuccessfulRegions)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+    providerPtr->failRegisterAt = 2;
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    std::vector<MemoryRegion> regions(2);
+    regions[0].addr = 0x1000;
+    regions[0].size = 4096;
+    regions[1].addr = 0x2000;
+    regions[1].size = 4096;
+
+    std::vector<RegisteredMemory> registeredRegions;
+    auto status = transport.RegisterRegions(regions, registeredRegions);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_TRUE(registeredRegions.empty());
+    EXPECT_EQ(providerPtr->registerCallCount, std::uint32_t{1});
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
+}
+
+TEST(AsuTransportRegisterTest, RegisterDeviceRegionDoesNotRequireConnection)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    MemoryRegion region;
+    region.memoryType = MemoryType::ASCEND_DEVICE;
+    region.addr = 0x1000;
+    region.size = 4096;
+
+    std::vector<RegisteredMemory> registeredRegions;
+    const auto status = transport.RegisterRegions({region}, registeredRegions);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(registeredRegions.size(), std::size_t{1});
+    EXPECT_EQ(registeredRegions[0].region.addr, region.addr);
+    EXPECT_NE(registeredRegions[0].handle, kInvalidMRHandle);
+    EXPECT_EQ(providerPtr->registerCount, std::uint32_t{1});
+    EXPECT_TRUE(transport.ownsRegisteredRegionHandles_);
+}
+
+TEST(AsuTransportRegisterTest, BoundRegionsAreNotOwnedByTransport)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    RegisteredMemory region;
+    region.handle = MRHandle{1};
+    ASSERT_TRUE(transport.BindRegisteredRegions({region}).ok());
+
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
+    EXPECT_TRUE(transport.UnregisterRegions({region.handle}).ok());
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{0});
+    EXPECT_EQ(transport.registeredRegions_.size(), std::size_t{1});
+
+    EXPECT_TRUE(transport.Shutdown().ok());
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{0});
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
+}
+
+TEST(AsuTransportRegisterTest, RegisterRegionsReturnsNoRegionsAfterBatchFailure)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+    providerPtr->failRegisterAt = 2;
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    std::vector<MemoryRegion> regions(3);
+    regions[0].addr = 0x1000;
+    regions[0].size = 4096;
+    regions[1].addr = 0x2000;
+    regions[1].size = 4096;
+    regions[2].addr = 0x3000;
+    regions[2].size = 4096;
+
+    std::vector<RegisteredMemory> registeredRegions;
+    auto status = transport.RegisterRegions(regions, registeredRegions);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_TRUE(registeredRegions.empty());
+    EXPECT_EQ(providerPtr->registerCallCount, std::uint32_t{1});
+    EXPECT_EQ(providerPtr->registerCount, std::uint32_t{2});
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
+}
+
+TEST(AsuTransportRegisterTest, RegisterRegionsClearsBatchWhenTokenLookupFails)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+    providerPtr->failTokenLookupAt = 2;
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    std::vector<MemoryRegion> regions(3);
+    regions[0].addr = 0x1000;
+    regions[0].size = 4096;
+    regions[1].addr = 0x2000;
+    regions[1].size = 4096;
+    regions[2].addr = 0x3000;
+    regions[2].size = 4096;
+
+    std::vector<RegisteredMemory> registeredRegions;
+    const auto status = transport.RegisterRegions(regions, registeredRegions);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_TRUE(registeredRegions.empty());
+    EXPECT_EQ(providerPtr->registerCallCount, std::uint32_t{1});
+    EXPECT_EQ(providerPtr->registerCount, std::uint32_t{3});
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{3});
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
+}
+
+TEST(AsuTransportRegisterTest, RegisterRegionsDoesNotTrackHandlesWhenBatchCleanupFails)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+    providerPtr->failRegisterAt = 2;
+    providerPtr->failUnregister = true;
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    std::vector<MemoryRegion> regions(2);
+    regions[0].addr = 0x1000;
+    regions[0].size = 4096;
+    regions[1].addr = 0x2000;
+    regions[1].size = 4096;
+
+    std::vector<RegisteredMemory> registeredRegions;
+    const auto status = transport.RegisterRegions(regions, registeredRegions);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_NE(status.message.find("cleanup was incomplete"), std::string::npos);
+    EXPECT_TRUE(registeredRegions.empty());
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
+
+    providerPtr->failUnregister = false;
+    const auto cleanupStatus =
+        transport.UnregisterRegions({reinterpret_cast<MRHandle>(std::uintptr_t{1})});
+    EXPECT_TRUE(cleanupStatus.ok()) << cleanupStatus.message;
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
+}
+
+TEST(AsuTransportRegisterTest, UnregisterRegionsRetainsOnlyHandlesThatFailToUnregister)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    std::vector<MemoryRegion> regions(2);
+    regions[0].addr = 0x1000;
+    regions[0].size = 4096;
+    regions[1].addr = 0x2000;
+    regions[1].size = 4096;
+
+    std::vector<RegisteredMemory> registeredRegions;
+    ASSERT_TRUE(transport.RegisterRegions(regions, registeredRegions).ok());
+    providerPtr->failUnregisterAt = 2;
+
+    const auto status =
+        transport.UnregisterRegions({registeredRegions[0].handle, registeredRegions[1].handle});
+
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(transport.registeredRegions_.size(), std::size_t{1});
+    EXPECT_EQ(transport.registeredRegions_.count(registeredRegions[0].handle), std::size_t{0});
+    EXPECT_EQ(transport.registeredRegions_.count(registeredRegions[1].handle), std::size_t{1});
+
+    EXPECT_TRUE(transport.UnregisterRegions({registeredRegions[1].handle}).ok());
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
+}
+
+TEST(AsuTransportRegisterTest, ShutdownUnregistersRegisteredRegions)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    std::vector<MemoryRegion> regions(2);
+    regions[0].addr = 0x1000;
+    regions[0].size = 4096;
+    regions[1].addr = 0x2000;
+    regions[1].size = 4096;
+
+    std::vector<RegisteredMemory> registeredRegions;
+    auto status = transport.RegisterRegions(regions, registeredRegions);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(registeredRegions.size(), std::size_t{2});
+    ASSERT_EQ(transport.registeredRegions_.size(), std::size_t{2});
+
+    status = transport.Shutdown();
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{2});
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
+}
+
+TEST(AsuTransportRegisterTest, ShutdownIgnoresUnregisterFailureWithoutRetry)
+{
+    auto provider = std::make_unique<StubTransProvider>();
+    auto* providerPtr = provider.get();
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::move(provider));
+
+    std::vector<RegisteredMemory> registeredRegions;
+    ASSERT_TRUE(transport.RegisterRegions({MemoryRegion{}}, registeredRegions).ok());
+    providerPtr->failUnregister = true;
+
+    EXPECT_TRUE(transport.Shutdown().ok());
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
+    EXPECT_TRUE(transport.registeredRegions_.empty());
+    EXPECT_FALSE(transport.ownsRegisteredRegionHandles_);
+
+    providerPtr->failUnregister = false;
+    EXPECT_TRUE(transport.Shutdown().ok());
+    EXPECT_EQ(providerPtr->unregisterCount, std::uint32_t{1});
 }
 
 TEST(AsuSubmitFlowTest, SendSubBatchBuffersReportsSendFailures)
@@ -218,8 +493,6 @@ TEST(AsuSubmitFlowTest, SendSubBatchBuffersReportsSendFailures)
         TransProvider::SendIoBatch{channel0->GetConnection(), nullptr, nullptr, 0},
         TransProvider::SendIoBatch{channel1->GetConnection(), nullptr, nullptr, 0},
     };
-    std::vector<std::size_t> subBatchIndexes = {0, 1};
-
     std::vector<TransportSubBatchContext> subBatchContexts(2);
     subBatchContexts[0].state = TransportSubBatchState::PENDING;
     subBatchContexts[0].channel = channel0;
@@ -228,136 +501,13 @@ TEST(AsuSubmitFlowTest, SendSubBatchBuffersReportsSendFailures)
     subBatchContexts[1].channel = channel1;
     subBatchContexts[1].entryStatus.assign(1, Status::OK());
 
-    const auto status =
-        transport.taskExecutor_->SendSubBatchBuffers(subBatchContexts, ioBatches, subBatchIndexes);
+    transport.taskExecutor_->SendSubBatchBuffers(subBatchContexts, ioBatches);
 
-    EXPECT_EQ(status.code, StatusCode::CONNECTION_ERROR);
+    EXPECT_EQ(subBatchContexts[0].status.code, StatusCode::CONNECTION_ERROR);
     EXPECT_EQ(channel0->GetState(), ChannelState::DRAINING);
     EXPECT_EQ(subBatchContexts[0].state, TransportSubBatchState::COMPLETED);
     EXPECT_EQ(subBatchContexts[1].state, TransportSubBatchState::COMPLETED);
     g_sendStatuses.clear();
-}
-
-TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersReleasesPreFailedSubBatches)
-{
-    ASSERT_TRUE(
-        transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST, 4096, 1).ok());
-    ASSERT_TRUE(
-        transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST, 128, 1).ok());
-
-    std::vector<TransportSubBatchContext> subBatchContexts(1);
-    auto& subBatchContext = subBatchContexts[0];
-    subBatchContext.state = TransportSubBatchState::COMPLETED;
-    subBatchContext.status = Status::Error(StatusCode::INVALID_ARGUMENT, "pre-send failure");
-    subBatchContext.entryStatus.assign(1, subBatchContext.status);
-    ASSERT_TRUE(transport_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
-    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
-
-    std::vector<TransProvider::SendIoBatch> ioBatches;
-    std::vector<std::size_t> subBatchIndexes;
-    const auto status = transport_->taskExecutor_->BuildSubBatchSendBuffers(
-        subBatchContexts, ioBatches, subBatchIndexes);
-
-    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
-    EXPECT_TRUE(ioBatches.empty());
-    EXPECT_TRUE(subBatchIndexes.empty());
-    EXPECT_EQ(subBatchContext.sendSge.slot_index, UINT32_MAX);
-    EXPECT_EQ(subBatchContext.flagBuffer.slot_index, UINT32_MAX);
-    EXPECT_EQ(subBatchContext.sendSge.local_addr, std::uint64_t{0});
-    EXPECT_EQ(subBatchContext.flagBuffer.local_addr, std::uint64_t{0});
-}
-
-TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersMarksMissingFlagBufferFailed)
-{
-    ASSERT_TRUE(
-        transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST, 4096, 1).ok());
-    ASSERT_TRUE(
-        transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST, 128, 1).ok());
-
-    transport_->connManager_ =
-        std::make_unique<ConnectionManager>(*transport_->transProvider_, "", 5000);
-    ASSERT_TRUE(transport_->connManager_->AddGroup(AsuEndpoint{}, 1).ok());
-    auto channel = transport_->connManager_->SelectConnection();
-    ASSERT_NE(channel, nullptr);
-    EXPECT_EQ(channel->GetInflightCount(), std::uint32_t{1});
-
-    std::vector<TransportSubBatchContext> subBatchContexts(1);
-    auto& subBatchContext = subBatchContexts[0];
-    subBatchContext.state = TransportSubBatchState::PENDING;
-    subBatchContext.channel = channel;
-    subBatchContext.entryStatus.assign(2, Status::OK());
-    ASSERT_TRUE(transport_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
-
-    std::vector<TransProvider::SendIoBatch> ioBatches;
-    std::vector<std::size_t> subBatchIndexes;
-    const auto status = transport_->taskExecutor_->BuildSubBatchSendBuffers(
-        subBatchContexts, ioBatches, subBatchIndexes);
-
-    EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
-    EXPECT_TRUE(ioBatches.empty());
-    EXPECT_TRUE(subBatchIndexes.empty());
-    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
-    EXPECT_EQ(subBatchContext.status.code, StatusCode::NOT_INITIALIZED);
-    EXPECT_EQ(subBatchContext.channel.get(), nullptr);
-    EXPECT_EQ(channel->GetInflightCount(), std::uint32_t{0});
-    EXPECT_EQ(subBatchContext.sendSge.slot_index, UINT32_MAX);
-    for (const auto& entryStatus : subBatchContext.entryStatus) {
-        EXPECT_EQ(entryStatus.code, StatusCode::NOT_INITIALIZED);
-    }
-}
-
-TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersRejectsZeroSendLength)
-{
-    ASSERT_TRUE(
-        transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST, 4096, 1).ok());
-    ASSERT_TRUE(
-        transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST, 128, 1).ok());
-
-    transport_->connManager_ =
-        std::make_unique<ConnectionManager>(*transport_->transProvider_, "", 5000);
-    ASSERT_TRUE(transport_->connManager_->AddGroup(AsuEndpoint{}, 1).ok());
-
-    std::vector<TransportSubBatchContext> subBatchContexts(1);
-    auto& subBatchContext = subBatchContexts[0];
-    subBatchContext.state = TransportSubBatchState::PENDING;
-    subBatchContext.channel = transport_->connManager_->SelectConnection();
-    subBatchContext.entryStatus.assign(1, Status::OK());
-    ASSERT_TRUE(transport_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
-    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
-    subBatchContext.sendSge.length = 0;
-
-    std::vector<TransProvider::SendIoBatch> ioBatches;
-    std::vector<std::size_t> subBatchIndexes;
-    const auto status = transport_->taskExecutor_->BuildSubBatchSendBuffers(
-        subBatchContexts, ioBatches, subBatchIndexes);
-
-    EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
-    EXPECT_TRUE(ioBatches.empty());
-    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
-}
-
-TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersRejectsMissingChannel)
-{
-    ASSERT_TRUE(
-        transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST, 4096, 1).ok());
-    ASSERT_TRUE(
-        transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST, 128, 1).ok());
-
-    std::vector<TransportSubBatchContext> subBatchContexts(1);
-    auto& subBatchContext = subBatchContexts[0];
-    subBatchContext.state = TransportSubBatchState::PENDING;
-    subBatchContext.entryStatus.assign(1, Status::OK());
-    ASSERT_TRUE(transport_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
-    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
-
-    std::vector<TransProvider::SendIoBatch> ioBatches;
-    std::vector<std::size_t> subBatchIndexes;
-    const auto status = transport_->taskExecutor_->BuildSubBatchSendBuffers(
-        subBatchContexts, ioBatches, subBatchIndexes);
-
-    EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
-    EXPECT_TRUE(ioBatches.empty());
-    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
 }
 
 TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersUsesHostPinnedDeviceAddresses)
@@ -387,16 +537,15 @@ TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersUsesHostPinnedDeviceAddr
     ASSERT_NE(subBatchContext.flagBuffer.device_addr, std::uint64_t{0});
 
     std::vector<TransProvider::SendIoBatch> ioBatches;
-    std::vector<std::size_t> subBatchIndexes;
-    const auto status = transport_->taskExecutor_->BuildSubBatchSendBuffers(
-        subBatchContexts, ioBatches, subBatchIndexes);
+    transport_->taskExecutor_->BuildSubBatchSendBuffers(subBatchContexts, ioBatches);
 
-    ASSERT_TRUE(status.ok()) << status.message;
     ASSERT_EQ(ioBatches.size(), std::size_t{1});
+    EXPECT_EQ(ioBatches[0].connectionHandle, subBatchContext.channel->GetConnection());
     EXPECT_EQ(ioBatches[0].sendBuffer,
               reinterpret_cast<void*>(subBatchContext.sendSge.device_addr));
     EXPECT_EQ(ioBatches[0].flagBuffer,
               reinterpret_cast<void*>(subBatchContext.flagBuffer.device_addr));
+    EXPECT_EQ(ioBatches[0].len, subBatchContext.sendSge.length);
 }
 
 TEST(AsuSubmitFlowTest, SendSubBatchBuffersFailsAllSentSubBatchesWhenStatusCountMismatches)
@@ -415,18 +564,14 @@ TEST(AsuSubmitFlowTest, SendSubBatchBuffersFailsAllSentSubBatchesWhenStatusCount
         TransProvider::SendIoBatch{nullptr, nullptr, nullptr, 0},
         TransProvider::SendIoBatch{nullptr, nullptr, nullptr, 0},
     };
-    std::vector<std::size_t> subBatchIndexes = {0, 1};
-
     std::vector<TransportSubBatchContext> subBatchContexts(2);
     subBatchContexts[0].state = TransportSubBatchState::PENDING;
     subBatchContexts[0].entryStatus.assign(1, Status::OK());
     subBatchContexts[1].state = TransportSubBatchState::PENDING;
     subBatchContexts[1].entryStatus.assign(1, Status::OK());
 
-    const auto status =
-        transport.taskExecutor_->SendSubBatchBuffers(subBatchContexts, ioBatches, subBatchIndexes);
+    transport.taskExecutor_->SendSubBatchBuffers(subBatchContexts, ioBatches);
 
-    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_EQ(subBatchContexts[0].state, TransportSubBatchState::COMPLETED);
     EXPECT_EQ(subBatchContexts[0].status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_EQ(subBatchContexts[0].entryStatus[0].code, StatusCode::INTERNAL_ERROR);

--- a/ucm/transport/kv/asu/test/transport/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/sqe_request_test.cpp
@@ -115,8 +115,7 @@ void CreateTaskExecutor(AsuTransportImpl& transport)
     transport.taskExecutor_ = std::make_unique<TransportTaskExecutor>(
         transport.config_, transport.ioScheduler_, transport.transProvider_,
         transport.sendBufferManager_, transport.flagBufferManager_, transport.protocolManager_,
-        transport.connManager_, transport.nextRequestCid_, transport.registeredRegionsMu_,
-        transport.registeredRegions_);
+        transport.connManager_, transport.nextRequestCid_);
 }
 
 constexpr std::size_t kFlagBufferHeaderSize = 16;
@@ -150,16 +149,15 @@ std::vector<KVBuffer> MakeEntries(std::size_t count)
     return entries;
 }
 
-void BindEntries(AsuTransportImpl& transport, const std::vector<KVBuffer>& entries,
-                 std::uint32_t tokenBase)
+RegisteredMrKeyMap MakeRegisteredMrKeys(const std::vector<KVBuffer>& entries,
+                                        std::uint32_t tokenBase)
 {
+    RegisteredMrKeyMap registeredMrKeys;
     for (std::size_t index = 0; index < entries.size(); ++index) {
-        RegisteredMemory memory;
-        memory.region = entries[index].buffer.region;
-        memory.handle = entries[index].buffer.handle;
-        memory.tokenId = tokenBase + static_cast<std::uint32_t>(index);
-        transport.registeredRegions_[memory.handle] = memory;
+        registeredMrKeys.emplace(entries[index].buffer.handle,
+                                 tokenBase + static_cast<std::uint32_t>(index));
     }
+    return registeredMrKeys;
 }
 
 std::uint32_t PackedBatchEntryMrKey(const std::uint32_t* sqe, std::size_t entryIndex)
@@ -238,10 +236,10 @@ TEST_F(SqeRequestTest, SubmitBatchStoreAllocatesFlagBufferAndBuildsRequest)
     };
     TransportSubBatchContext subBatchContext;
     transport_->nextRequestCid_.store(41, std::memory_order_relaxed);
-    BindEntries(*transport_, entries, 0xABCD0000);
+    const auto registeredMrKeys = MakeRegisteredMrKeys(entries, 0xABCD0000);
 
     const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
-        TransportOpType::BATCH_STORE, subBatch, subBatchContext);
+        TransportOpType::BATCH_STORE, subBatch, registeredMrKeys, subBatchContext);
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(subBatchContext.flagBuffer.length, kFlagBufferHeaderSize + (entries.size() + 1) / 2);
@@ -289,14 +287,14 @@ TEST_F(SqeRequestTest, SubmitBatchStorePacksSqeIntoDeviceSendBuffer)
     CreateTaskExecutor(deviceTransport);
 
     auto entries = MakeEntries(3);
-    BindEntries(deviceTransport, entries, 0x12340000);
+    const auto registeredMrKeys = MakeRegisteredMrKeys(entries, 0x12340000);
     IoScheduler::ScheduledIoBatch subBatch{
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
     TransportSubBatchContext subBatchContext;
 
     const auto status = deviceTransport.taskExecutor_->BuildEntrySubBatchRequest(
-        TransportOpType::BATCH_STORE, subBatch, subBatchContext);
+        TransportOpType::BATCH_STORE, subBatch, registeredMrKeys, subBatchContext);
 
     ASSERT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(subBatchContext.sendSge.memory_type, MemoryType::ASCEND_DEVICE);
@@ -320,10 +318,10 @@ TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
     };
     TransportSubBatchContext subBatchContext;
     transport_->nextRequestCid_.store(9, std::memory_order_relaxed);
-    BindEntries(*transport_, entries, 0x76540000);
+    const auto registeredMrKeys = MakeRegisteredMrKeys(entries, 0x76540000);
 
     const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
-        TransportOpType::BATCH_LOAD, subBatch, subBatchContext);
+        TransportOpType::BATCH_LOAD, subBatch, registeredMrKeys, subBatchContext);
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(subBatchContext.opType, TransportOpType::BATCH_LOAD);
@@ -338,22 +336,25 @@ TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
     EXPECT_EQ(PackedBatchEntryMrKey(sqe, 1), std::uint32_t{0x76540001});
 }
 
-TEST_F(SqeRequestTest, SubmitBatchStoreUsesDefaultMrKeyForUnregisteredEntryBuffer)
+TEST_F(SqeRequestTest, SubmitBatchStoreRejectsUnregisteredEntryBuffer)
 {
     auto entries = MakeEntries(1);
     IoScheduler::ScheduledIoBatch subBatch{
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
     TransportSubBatchContext subBatchContext;
+    const RegisteredMrKeyMap registeredMrKeys;
 
     const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
-        TransportOpType::BATCH_STORE, subBatch, subBatchContext);
+        TransportOpType::BATCH_STORE, subBatch, registeredMrKeys, subBatchContext);
 
-    EXPECT_TRUE(status.ok()) << status.message;
-    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
-    const auto* sqe = reinterpret_cast<const std::uint32_t*>(subBatchContext.sendSge.local_addr);
-    ASSERT_NE(sqe, nullptr);
-    EXPECT_EQ(PackedBatchEntryMrKey(sqe, 0), std::uint32_t{1});
+    EXPECT_EQ(status.code, StatusCode::BUFFER_NOT_REGISTERED);
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
+    EXPECT_EQ(subBatchContext.status.code, StatusCode::BUFFER_NOT_REGISTERED);
+    ASSERT_EQ(subBatchContext.entryStatus.size(), entries.size());
+    EXPECT_EQ(subBatchContext.entryStatus[0].code, StatusCode::BUFFER_NOT_REGISTERED);
+    EXPECT_EQ(subBatchContext.flagBuffer.local_addr, std::uint64_t{0});
+    EXPECT_EQ(subBatchContext.sendSge.local_addr, std::uint64_t{0});
 }
 
 TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)
@@ -441,10 +442,10 @@ TEST_F(SqeRequestTest, AllocationFailureMarksWholeSubBatchFailed)
                     .ok());
     uninitializedFlagTransport.protocolManager_ = std::make_unique<ProtocolManager>();
     CreateTaskExecutor(uninitializedFlagTransport);
-    BindEntries(uninitializedFlagTransport, entries, 0x45670000);
+    const auto registeredMrKeys = MakeRegisteredMrKeys(entries, 0x45670000);
 
     const auto status = uninitializedFlagTransport.taskExecutor_->BuildEntrySubBatchRequest(
-        TransportOpType::BATCH_STORE, subBatch, subBatchContext);
+        TransportOpType::BATCH_STORE, subBatch, registeredMrKeys, subBatchContext);
 
     EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
     EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);

--- a/ucm/transport/kv/asu/test/transport/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/sqe_request_test.cpp
@@ -36,9 +36,9 @@
 #define private public
 #include "asu_transport_impl.h"
 #undef private
-#include "asu_transport/trans_provider.h"
 #include "buffer_manager.h"
 #include "kv_protocol.h"
+#include "trans_provider.h"
 #include "transport_config_parser.h"
 
 namespace UC::ASU {
@@ -115,7 +115,8 @@ void CreateTaskExecutor(AsuTransportImpl& transport)
     transport.taskExecutor_ = std::make_unique<TransportTaskExecutor>(
         transport.config_, transport.ioScheduler_, transport.transProvider_,
         transport.sendBufferManager_, transport.flagBufferManager_, transport.protocolManager_,
-        transport.connManager_, transport.nextRequestCid_);
+        transport.connManager_, transport.nextRequestCid_, transport.registeredRegionsMu_,
+        transport.registeredRegions_);
 }
 
 constexpr std::size_t kFlagBufferHeaderSize = 16;
@@ -149,15 +150,16 @@ std::vector<KVBuffer> MakeEntries(std::size_t count)
     return entries;
 }
 
-RegisteredMrKeyMap MakeRegisteredMrKeys(const std::vector<KVBuffer>& entries,
-                                        std::uint32_t tokenBase)
+void BindEntries(AsuTransportImpl& transport, const std::vector<KVBuffer>& entries,
+                 std::uint32_t tokenBase)
 {
-    RegisteredMrKeyMap registeredMrKeys;
     for (std::size_t index = 0; index < entries.size(); ++index) {
-        registeredMrKeys.emplace(entries[index].buffer.handle,
-                                 tokenBase + static_cast<std::uint32_t>(index));
+        RegisteredMemory memory;
+        memory.region = entries[index].buffer.region;
+        memory.handle = entries[index].buffer.handle;
+        memory.tokenId = tokenBase + static_cast<std::uint32_t>(index);
+        transport.registeredRegions_[memory.handle] = memory;
     }
-    return registeredMrKeys;
 }
 
 std::uint32_t PackedBatchEntryMrKey(const std::uint32_t* sqe, std::size_t entryIndex)
@@ -236,10 +238,10 @@ TEST_F(SqeRequestTest, SubmitBatchStoreAllocatesFlagBufferAndBuildsRequest)
     };
     TransportSubBatchContext subBatchContext;
     transport_->nextRequestCid_.store(41, std::memory_order_relaxed);
-    const auto registeredMrKeys = MakeRegisteredMrKeys(entries, 0xABCD0000);
+    BindEntries(*transport_, entries, 0xABCD0000);
 
-    const auto status = transport_->taskExecutor_->SubmitEntrySubBatchRequest(
-        TransportOpType::BATCH_STORE, subBatch, registeredMrKeys, subBatchContext);
+    const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
+        TransportOpType::BATCH_STORE, subBatch, subBatchContext);
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(subBatchContext.flagBuffer.length, kFlagBufferHeaderSize + (entries.size() + 1) / 2);
@@ -287,14 +289,14 @@ TEST_F(SqeRequestTest, SubmitBatchStorePacksSqeIntoDeviceSendBuffer)
     CreateTaskExecutor(deviceTransport);
 
     auto entries = MakeEntries(3);
-    const auto registeredMrKeys = MakeRegisteredMrKeys(entries, 0x12340000);
+    BindEntries(deviceTransport, entries, 0x12340000);
     IoScheduler::ScheduledIoBatch subBatch{
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
     TransportSubBatchContext subBatchContext;
 
-    const auto status = deviceTransport.taskExecutor_->SubmitEntrySubBatchRequest(
-        TransportOpType::BATCH_STORE, subBatch, registeredMrKeys, subBatchContext);
+    const auto status = deviceTransport.taskExecutor_->BuildEntrySubBatchRequest(
+        TransportOpType::BATCH_STORE, subBatch, subBatchContext);
 
     ASSERT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(subBatchContext.sendSge.memory_type, MemoryType::ASCEND_DEVICE);
@@ -318,10 +320,10 @@ TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
     };
     TransportSubBatchContext subBatchContext;
     transport_->nextRequestCid_.store(9, std::memory_order_relaxed);
-    const auto registeredMrKeys = MakeRegisteredMrKeys(entries, 0x76540000);
+    BindEntries(*transport_, entries, 0x76540000);
 
-    const auto status = transport_->taskExecutor_->SubmitEntrySubBatchRequest(
-        TransportOpType::BATCH_LOAD, subBatch, registeredMrKeys, subBatchContext);
+    const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
+        TransportOpType::BATCH_LOAD, subBatch, subBatchContext);
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(subBatchContext.opType, TransportOpType::BATCH_LOAD);
@@ -336,25 +338,22 @@ TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
     EXPECT_EQ(PackedBatchEntryMrKey(sqe, 1), std::uint32_t{0x76540001});
 }
 
-TEST_F(SqeRequestTest, SubmitBatchStoreRejectsUnregisteredEntryBuffer)
+TEST_F(SqeRequestTest, SubmitBatchStoreUsesDefaultMrKeyForUnregisteredEntryBuffer)
 {
     auto entries = MakeEntries(1);
     IoScheduler::ScheduledIoBatch subBatch{
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
     TransportSubBatchContext subBatchContext;
-    const RegisteredMrKeyMap registeredMrKeys;
 
-    const auto status = transport_->taskExecutor_->SubmitEntrySubBatchRequest(
-        TransportOpType::BATCH_STORE, subBatch, registeredMrKeys, subBatchContext);
+    const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
+        TransportOpType::BATCH_STORE, subBatch, subBatchContext);
 
-    EXPECT_EQ(status.code, StatusCode::BUFFER_NOT_REGISTERED);
-    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
-    EXPECT_EQ(subBatchContext.status.code, StatusCode::BUFFER_NOT_REGISTERED);
-    ASSERT_EQ(subBatchContext.entryStatus.size(), entries.size());
-    EXPECT_EQ(subBatchContext.entryStatus[0].code, StatusCode::BUFFER_NOT_REGISTERED);
-    EXPECT_EQ(subBatchContext.flagBuffer.local_addr, std::uint64_t{0});
-    EXPECT_EQ(subBatchContext.sendSge.local_addr, std::uint64_t{0});
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
+    const auto* sqe = reinterpret_cast<const std::uint32_t*>(subBatchContext.sendSge.local_addr);
+    ASSERT_NE(sqe, nullptr);
+    EXPECT_EQ(PackedBatchEntryMrKey(sqe, 0), std::uint32_t{1});
 }
 
 TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)
@@ -442,10 +441,10 @@ TEST_F(SqeRequestTest, AllocationFailureMarksWholeSubBatchFailed)
                     .ok());
     uninitializedFlagTransport.protocolManager_ = std::make_unique<ProtocolManager>();
     CreateTaskExecutor(uninitializedFlagTransport);
-    const auto registeredMrKeys = MakeRegisteredMrKeys(entries, 0x45670000);
+    BindEntries(uninitializedFlagTransport, entries, 0x45670000);
 
-    const auto status = uninitializedFlagTransport.taskExecutor_->SubmitEntrySubBatchRequest(
-        TransportOpType::BATCH_STORE, subBatch, registeredMrKeys, subBatchContext);
+    const auto status = uninitializedFlagTransport.taskExecutor_->BuildEntrySubBatchRequest(
+        TransportOpType::BATCH_STORE, subBatch, subBatchContext);
 
     EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
     EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);

--- a/ucm/transport/kv/asu/test/transport/transport_task_completion_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/transport_task_completion_test.cpp
@@ -548,14 +548,25 @@ TEST_F(TransportTaskCompletionTest, CancelMarksOnlyUnfinishedEntriesCanceled)
 {
     TaskId taskId = kInvalidTaskId;
     TaskResult callbackResult;
+    bool completedSubBatchPreserved = false;
+    bool pendingSubBatchCanceled = false;
     auto ctx = std::make_unique<TransportTask>();
+    auto* rawCtx = ctx.get();
     ctx->entryStatus.assign(2, Status::OK());
     ctx->subBatchContexts->resize(2);
     (*ctx->subBatchContexts)[0].state = TransportSubBatchState::COMPLETED;
     (*ctx->subBatchContexts)[0].entryStatus = {Status::OK()};
     (*ctx->subBatchContexts)[1].state = TransportSubBatchState::PENDING;
     (*ctx->subBatchContexts)[1].entryStatus = {Status::OK()};
-    ctx->onComplete = [&](TaskResult result) { callbackResult = std::move(result); };
+    ctx->onComplete = [&](TaskResult result) {
+        const auto& completedSubBatch = (*rawCtx->subBatchContexts)[0];
+        const auto& canceledSubBatch = (*rawCtx->subBatchContexts)[1];
+        completedSubBatchPreserved = completedSubBatch.state == TransportSubBatchState::COMPLETED &&
+                                     completedSubBatch.status.ok();
+        pendingSubBatchCanceled = canceledSubBatch.state == TransportSubBatchState::COMPLETED &&
+                                  canceledSubBatch.status.code == StatusCode::CANCELED;
+        callbackResult = std::move(result);
+    };
     ASSERT_TRUE(transport_->taskManager_.Submit(std::move(ctx), taskId).ok());
 
     ASSERT_TRUE(transport_->Cancel(taskId).ok());
@@ -564,6 +575,8 @@ TEST_F(TransportTaskCompletionTest, CancelMarksOnlyUnfinishedEntriesCanceled)
     ASSERT_EQ(callbackResult.entryStatus.size(), std::size_t{2});
     EXPECT_TRUE(callbackResult.entryStatus[0].ok());
     EXPECT_EQ(callbackResult.entryStatus[1].code, StatusCode::CANCELED);
+    EXPECT_TRUE(completedSubBatchPreserved);
+    EXPECT_TRUE(pendingSubBatchCanceled);
 }
 
 TEST_F(TransportTaskCompletionTest, FailedSubmissionDoesNotInvokeCallback)

--- a/ucm/transport/kv/asu/test/transport/transport_task_completion_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/transport_task_completion_test.cpp
@@ -160,14 +160,13 @@ TEST_F(TransportTaskCompletionTest, InitializeCountsOnlyPendingSubBatches)
     EXPECT_EQ(ctx.remainingSubBatchCount, std::uint32_t{1});
 }
 
-TEST_F(TransportTaskCompletionTest, CompleteSubBatchOnlyCountsPendingSubBatchOnce)
+TEST_F(TransportTaskCompletionTest, CompleteSubBatchCompletesPendingSubBatch)
 {
     TransportTask ctx;
     TransportSubBatchContext subBatchContext;
     const auto status = Status::Error(StatusCode::IO_ERROR, "fake error");
     ctx.remainingSubBatchCount = 1;
 
-    transport_->taskExecutor_->CompleteSubBatch(ctx, subBatchContext, status);
     transport_->taskExecutor_->CompleteSubBatch(ctx, subBatchContext, status);
 
     EXPECT_EQ(ctx.remainingSubBatchCount, std::uint32_t{0});

--- a/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
@@ -49,7 +49,7 @@ void SetSubBatchSendFailed(TransportSubBatchContext& subBatchContext, const Stat
 
 }  // namespace
 
-Status TransportTaskExecutor::SubmitTaskRequests(
+Status TransportTaskExecutor::PrepareTaskSubBatches(
     const TransportTask& ctx, std::vector<TransportSubBatchContext>& subBatchContexts)
 {
     Status status = Status::OK();
@@ -69,11 +69,10 @@ Status TransportTaskExecutor::SubmitTaskRequests(
         for (std::size_t index = 0; index < subBatches.size(); ++index) {
             const auto& subBatch = subBatches[index];
             auto& subBatchContext = subBatchContexts.emplace_back();
-            auto subBatchStatus =
-                SubmitEntrySubBatchRequest(opType, subBatch, registeredMrKeys, subBatchContext);
+            auto subBatchStatus = BuildEntrySubBatchRequest(opType, subBatch, subBatchContext);
             subBatchContext.status = subBatchStatus;
             if (!subBatchStatus.ok()) {
-                UC_ERROR("Submit entry sub-batch failed index={} batch_size={} code={} message={}",
+                UC_ERROR("Build entry sub-batch request failed index={} batch_size={} code={} message={}",
                          index, subBatch.entries.size, static_cast<int>(subBatchStatus.code),
                          subBatchStatus.message);
                 if (status.ok()) { status = subBatchStatus; }
@@ -137,26 +136,6 @@ Status TransportTaskExecutor::BuildSubBatchSendBuffers(
             continue;
         }
 
-        if (subBatchContext.channel == nullptr ||
-            !IsTransportBufferReady(subBatchContext.sendSge) ||
-            !IsTransportBufferReady(subBatchContext.flagBuffer)) {
-            const auto subBatchStatus = Status::Error(StatusCode::NOT_INITIALIZED,
-                                                      "sub-batch transport buffers are not ready");
-            UC_ERROR(
-                "Sub-batch transport buffers are not ready index={} cid={} channel={} "
-                "send_local_addr={} send_device_addr={} send_length={} send_slot={} "
-                "flag_local_addr={} flag_device_addr={} flag_length={} flag_slot={}",
-                index, subBatchContext.cid, subBatchContext.channel != nullptr,
-                subBatchContext.sendSge.local_addr, subBatchContext.sendSge.device_addr,
-                subBatchContext.sendSge.length, subBatchContext.sendSge.slot_index,
-                subBatchContext.flagBuffer.local_addr, subBatchContext.flagBuffer.device_addr,
-                subBatchContext.flagBuffer.length, subBatchContext.flagBuffer.slot_index);
-            SetSubBatchSendFailed(subBatchContext, subBatchStatus);
-            if (status.ok()) { status = subBatchStatus; }
-            ReleaseSubBatchResources(subBatchContext);
-            continue;
-        }
-
         ioBatches.push_back(TransProvider::SendIoBatch{
             subBatchContext.channel->GetConnection(),
             reinterpret_cast<void*>(subBatchContext.sendSge.device_addr),
@@ -178,7 +157,6 @@ Status TransportTaskExecutor::SendSubBatchBuffers(
 
     const auto kernelCount = GetSendCountAttr(config_.attrs, "kernel_count");
     const auto quietCount = GetSendCountAttr(config_.attrs, "quiet_count");
-
     const auto sendStatuses = transProvider_->Send(ioBatches, kernelCount, quietCount);
     if (sendStatuses.size() != ioBatches.size()) {
         status = Status::Error(StatusCode::INTERNAL_ERROR,

--- a/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
@@ -52,8 +52,6 @@ void SetSubBatchSendFailed(TransportSubBatchContext& subBatchContext, const Stat
 Status TransportTaskExecutor::PrepareTaskSubBatches(
     const TransportTask& ctx, std::vector<TransportSubBatchContext>& subBatchContexts)
 {
-    Status status = Status::OK();
-
     if (IsEntryBatchOp(ctx.opType)) {
         const auto opType = NormalizeTransportOpType(ctx.opType);
         if (ctx.entries.empty()) {
@@ -69,13 +67,15 @@ Status TransportTaskExecutor::PrepareTaskSubBatches(
         for (std::size_t index = 0; index < subBatches.size(); ++index) {
             const auto& subBatch = subBatches[index];
             auto& subBatchContext = subBatchContexts.emplace_back();
-            auto subBatchStatus = BuildEntrySubBatchRequest(opType, subBatch, subBatchContext);
-            subBatchContext.status = subBatchStatus;
+            const auto subBatchStatus =
+                BuildEntrySubBatchRequest(opType, subBatch, subBatchContext);
             if (!subBatchStatus.ok()) {
-                UC_ERROR("Build entry sub-batch request failed index={} batch_size={} code={} message={}",
-                         index, subBatch.entries.size, static_cast<int>(subBatchStatus.code),
-                         subBatchStatus.message);
-                if (status.ok()) { status = subBatchStatus; }
+                UC_ERROR(
+                    "Build entry sub-batch request failed index={} batch_size={} code={} "
+                    "message={}",
+                    index, subBatch.entries.size, static_cast<int>(subBatchStatus.code),
+                    subBatchStatus.message);
+                return subBatchStatus;
             }
         }
     } else if (IsKeyBatchOp(ctx.opType)) {
@@ -89,100 +89,78 @@ Status TransportTaskExecutor::PrepareTaskSubBatches(
         for (std::size_t index = 0; index < subBatches.size(); ++index) {
             const auto& subBatch = subBatches[index];
             auto& subBatchContext = subBatchContexts.emplace_back();
-            auto subBatchStatus = SubmitKeySubBatchRequest(ctx.opType, subBatch, subBatchContext);
-            subBatchContext.status = subBatchStatus;
+            const auto subBatchStatus =
+                SubmitKeySubBatchRequest(ctx.opType, subBatch, subBatchContext);
             if (!subBatchStatus.ok()) {
                 UC_ERROR("Submit key sub-batch failed index={} batch_size={} code={} message={}",
                          index, subBatch.keys.size, static_cast<int>(subBatchStatus.code),
                          subBatchStatus.message);
-                if (status.ok()) { status = subBatchStatus; }
+                return subBatchStatus;
             }
         }
     } else if (IsKeepAliveOp(ctx.opType)) {
         auto& subBatchContext = subBatchContexts.emplace_back();
-        auto subBatchStatus = SubmitKeepAliveRequest(subBatchContext);
-        subBatchContext.status = subBatchStatus;
+        const auto subBatchStatus = SubmitKeepAliveRequest(subBatchContext);
         if (!subBatchStatus.ok()) {
             UC_ERROR("Submit keep-alive request failed code={} message={}",
                      static_cast<int>(subBatchStatus.code), subBatchStatus.message);
-            if (status.ok()) { status = subBatchStatus; }
+            return subBatchStatus;
         }
     } else {
-        status = Status::Error(StatusCode::UNSUPPORTED, "transport operation is unsupported");
         UC_ERROR("Unsupported transport operation op_type={}", static_cast<int>(ctx.opType));
+        return Status::Error(StatusCode::UNSUPPORTED, "transport operation is unsupported");
     }
-    return status;
+    return Status::OK();
 }
 
-Status TransportTaskExecutor::BuildSubBatchSendBuffers(
+void TransportTaskExecutor::BuildSubBatchSendBuffers(
     std::vector<TransportSubBatchContext>& subBatchContexts,
-    std::vector<TransProvider::SendIoBatch>& ioBatches, std::vector<std::size_t>& subBatchIndexes)
+    std::vector<TransProvider::SendIoBatch>& ioBatches)
 {
-    Status status = Status::OK();
     ioBatches.reserve(subBatchContexts.size());
-    subBatchIndexes.reserve(subBatchContexts.size());
 
-    for (std::size_t index = 0; index < subBatchContexts.size(); ++index) {
-        auto& subBatchContext = subBatchContexts[index];
-        if (!subBatchContext.status.ok()) {
-            UC_ERROR("Skip sub-batch before send index={} cid={} code={} message={}", index,
-                     subBatchContext.cid, static_cast<int>(subBatchContext.status.code),
-                     subBatchContext.status.message);
-            if (status.ok()) {
-                status =
-                    Status::Error(StatusCode::PARTIAL_FAILED, "transport task partially failed");
-            }
-            ReleaseSubBatchResources(subBatchContext);
-            continue;
-        }
-
+    for (auto& subBatchContext : subBatchContexts) {
         ioBatches.push_back(TransProvider::SendIoBatch{
             subBatchContext.channel->GetConnection(),
             reinterpret_cast<void*>(subBatchContext.sendSge.device_addr),
             reinterpret_cast<void*>(subBatchContext.flagBuffer.device_addr),
             subBatchContext.sendSge.length});
-        subBatchIndexes.emplace_back(index);
     }
-
-    return status;
 }
 
-Status TransportTaskExecutor::SendSubBatchBuffers(
+void TransportTaskExecutor::SendSubBatchBuffers(
     std::vector<TransportSubBatchContext>& subBatchContexts,
-    const std::vector<TransProvider::SendIoBatch>& ioBatches,
-    const std::vector<std::size_t>& subBatchIndexes)
+    const std::vector<TransProvider::SendIoBatch>& ioBatches)
 {
-    Status status = Status::OK();
-    if (ioBatches.empty()) { return status; }
+    if (ioBatches.empty()) { return; }
 
     const auto kernelCount = GetSendCountAttr(config_.attrs, "kernel_count");
     const auto quietCount = GetSendCountAttr(config_.attrs, "quiet_count");
     const auto sendStatuses = transProvider_->Send(ioBatches, kernelCount, quietCount);
     if (sendStatuses.size() != ioBatches.size()) {
-        status = Status::Error(StatusCode::INTERNAL_ERROR,
-                               "transport send returned unexpected status count");
+        const auto status = Status::Error(StatusCode::INTERNAL_ERROR,
+                                          "transport send returned unexpected status count");
         UC_ERROR("Transport send returned unexpected status count expected={} actual={}",
                  ioBatches.size(), sendStatuses.size());
-        for (auto index : subBatchIndexes) {
-            auto& subBatchContext = subBatchContexts[index];
+        for (auto& subBatchContext : subBatchContexts) {
             SetSubBatchSendFailed(subBatchContext, status);
+            ReleaseSubBatchResources(subBatchContext);
         }
-        return status;
+        return;
     }
 
     for (std::size_t index = 0; index < sendStatuses.size(); ++index) {
-        auto& subBatchContext = subBatchContexts[subBatchIndexes[index]];
+        auto& subBatchContext = subBatchContexts[index];
         const auto& subBatchStatus = sendStatuses[index];
         if (subBatchStatus.ok()) { continue; }
 
-        UC_ERROR("Send sub-batch failed sub_batch_index={} cid={} code={} message={}",
-                 subBatchIndexes[index], subBatchContext.cid, static_cast<int>(subBatchStatus.code),
+        UC_ERROR("Send sub-batch failed sub_batch_index={} cid={} code={} message={}", index,
+                 subBatchContext.cid, static_cast<int>(subBatchStatus.code),
                  subBatchStatus.message);
         SetSubBatchSendFailed(subBatchContext, subBatchStatus);
         connManager_->ReportFailure(subBatchContext.channel);
-        if (status.ok()) { status = subBatchStatus; }
+        ReleaseSubBatchResources(subBatchContext);
     }
-    return status;
 }
 
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
@@ -68,7 +68,7 @@ Status TransportTaskExecutor::PrepareTaskSubBatches(
             const auto& subBatch = subBatches[index];
             auto& subBatchContext = subBatchContexts.emplace_back();
             const auto subBatchStatus =
-                BuildEntrySubBatchRequest(opType, subBatch, subBatchContext);
+                BuildEntrySubBatchRequest(opType, subBatch, registeredMrKeys, subBatchContext);
             if (!subBatchStatus.ok()) {
                 UC_ERROR(
                     "Build entry sub-batch request failed index={} batch_size={} code={} "

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -210,9 +210,7 @@ Status AsuTransportImpl::Shutdown()
 
     for (const auto& ctx : taskManager_.GetAll()) {
         if (ctx == nullptr) { continue; }
-        const auto canceledStatus =
-            Status::Error(StatusCode::CANCELED, "transport shutdown canceled task");
-        if (!taskExecutor_->Cancel(ctx, canceledStatus)) { continue; }
+        if (!taskExecutor_->Cancel(ctx)) { continue; }
         taskManager_.NotifyCompletion(ctx);
     }
     for (const auto& ctx : taskManager_.GetAll()) {
@@ -254,8 +252,7 @@ Status AsuTransportImpl::Cancel(TaskId taskId)
     auto ctx = taskManager_.Get(taskId);
     if (!ctx) { return Status::Error(StatusCode::TASK_NOT_FOUND, "transport task not found"); }
 
-    const auto canceledStatus = Status::Error(StatusCode::CANCELED, "transport task canceled");
-    if (!taskExecutor_->Cancel(ctx, canceledStatus)) { return Status::OK(); }
+    if (!taskExecutor_->Cancel(ctx)) { return Status::OK(); }
     taskManager_.NotifyCompletion(ctx);
     return Status::OK();
 }

--- a/ucm/transport/kv/asu/trans/src/buffer_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/buffer_manager.cpp
@@ -94,12 +94,6 @@ void BufferManager::BufferRegion::Reset()
     providerMemType = TransProvider::MemType::MEM_HOST;
 }
 
-bool IsTransportBufferReady(const ScatterGatherEntry& sge)
-{
-    return sge.local_addr != 0 && sge.device_addr != 0 && sge.length != 0 &&
-           sge.slot_index != UINT32_MAX;
-}
-
 BufferManager::~BufferManager() { Shutdown(); }
 
 void BufferManager::Shutdown()

--- a/ucm/transport/kv/asu/trans/src/buffer_manager.h
+++ b/ucm/transport/kv/asu/trans/src/buffer_manager.h
@@ -45,8 +45,6 @@ struct ScatterGatherEntry {
     MemoryType memory_type{MemoryType::HOST};
 };
 
-bool IsTransportBufferReady(const ScatterGatherEntry& sge);
-
 class BufferManager {
 public:
     BufferManager() = default;

--- a/ucm/transport/kv/asu/trans/src/sqe_request.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.cpp
@@ -112,12 +112,11 @@ Status AllocateSubBatchFlagBuffer(KvOpcode opcode, std::size_t batchNum,
     return Status::OK();
 }
 
-Status SetSubBatchBuildFailed(TransportSubBatchContext& subBatchContext, const Status& status)
+void SetSubBatchBuildFailed(TransportSubBatchContext& subBatchContext, const Status& status)
 {
     subBatchContext.state = TransportSubBatchState::COMPLETED;
     subBatchContext.status = status;
     std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(), status);
-    return status;
 }
 
 struct SubBatchRequestSource {
@@ -144,7 +143,10 @@ Status PrepareSubBatchRequest(TransportOpType opType, KvOpcode opcode, std::uint
     subBatchContext.opType = opType;
     subBatchContext.cid = cid;
     auto status = AllocateSubBatchFlagBuffer(opcode, batchNum, flagBufferManager, subBatchContext);
-    if (!status.ok()) { return SetSubBatchBuildFailed(subBatchContext, status); }
+    if (!status.ok()) {
+        SetSubBatchBuildFailed(subBatchContext, status);
+        return status;
+    }
     return Status::OK();
 }
 
@@ -160,7 +162,8 @@ Status PackSubBatchRequest(ProtocolManager& protocolManager, BufferManager& send
             "message={}",
             static_cast<int>(opcode), subBatchContext.cid, packedSize,
             static_cast<int>(status.code), status.message);
-        return SetSubBatchBuildFailed(subBatchContext, status);
+        SetSubBatchBuildFailed(subBatchContext, status);
+        return status;
     }
 
     if (subBatchContext.sendSge.memory_type == MemoryType::ASCEND_DEVICE) {
@@ -184,7 +187,8 @@ Status PackSubBatchRequest(ProtocolManager& protocolManager, BufferManager& send
         UC_ERROR("Pack sub-batch request failed opcode={} cid={} code={} message={}",
                  static_cast<int>(opcode), subBatchContext.cid, static_cast<int>(status.code),
                  status.message);
-        return SetSubBatchBuildFailed(subBatchContext, status);
+        SetSubBatchBuildFailed(subBatchContext, status);
+        return status;
     }
 
     subBatchContext.status = status;
@@ -332,21 +336,25 @@ std::unique_ptr<SqeRequest> BuildSqeRequest(
 
 }  // namespace
 
-Status TransportTaskExecutor::SubmitEntrySubBatchRequest(
+Status TransportTaskExecutor::BuildEntrySubBatchRequest(
     TransportOpType opType, const IoScheduler::ScheduledIoBatch& subBatch,
     const RegisteredMrKeyMap& registeredMrKeys, TransportSubBatchContext& subBatchContext)
 {
     const auto source = SubBatchRequestSource::FromEntries(subBatch.entries);
     subBatchContext.entryStatus.assign(subBatch.entries.size, Status::OK());
     const auto opcode = ToKvOpcode(opType);
-    const auto cid = AllocateRequestCid();
-    subBatchContext.opType = opType;
-    subBatchContext.cid = cid;
 
     std::vector<std::uint32_t> mrKeys;
-    auto resolveStatus = ResolveSqeMrKeys(subBatch.entries, registeredMrKeys, mrKeys);
-    if (!resolveStatus.ok()) { return SetSubBatchBuildFailed(subBatchContext, resolveStatus); }
+    {
+        std::lock_guard<std::mutex> lock(registeredRegionsMu_);
+        auto resolveStatus = ResolveSqeMrKeys(subBatch.entries, registeredRegions_, mrKeys);
+        if (!resolveStatus.ok()) {
+            SetSubBatchBuildFailed(subBatchContext, resolveStatus);
+            return resolveStatus;
+        }
+    }
 
+    const auto cid = AllocateRequestCid();
     auto status = PrepareSubBatchRequest(opType, opcode, cid, subBatch.entries.size,
                                          flagBufferManager_, subBatchContext);
     if (!status.ok()) { return status; }

--- a/ucm/transport/kv/asu/trans/src/sqe_request.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.cpp
@@ -345,13 +345,10 @@ Status TransportTaskExecutor::BuildEntrySubBatchRequest(
     const auto opcode = ToKvOpcode(opType);
 
     std::vector<std::uint32_t> mrKeys;
-    {
-        std::lock_guard<std::mutex> lock(registeredRegionsMu_);
-        auto resolveStatus = ResolveSqeMrKeys(subBatch.entries, registeredRegions_, mrKeys);
-        if (!resolveStatus.ok()) {
-            SetSubBatchBuildFailed(subBatchContext, resolveStatus);
-            return resolveStatus;
-        }
+    auto resolveStatus = ResolveSqeMrKeys(subBatch.entries, registeredMrKeys, mrKeys);
+    if (!resolveStatus.ok()) {
+        SetSubBatchBuildFailed(subBatchContext, resolveStatus);
+        return resolveStatus;
     }
 
     const auto cid = AllocateRequestCid();

--- a/ucm/transport/kv/asu/trans/src/transport_task_executor.cpp
+++ b/ucm/transport/kv/asu/trans/src/transport_task_executor.cpp
@@ -110,26 +110,25 @@ void TransportTaskExecutor::CompleteSubBatch(TransportTask& task,
                                              TransportSubBatchContext& subBatchContext,
                                              const Status& status)
 {
-    if (subBatchContext.state != TransportSubBatchState::PENDING) { return; }
-
     ReleaseSubBatchResources(subBatchContext);
     subBatchContext.state = TransportSubBatchState::COMPLETED;
     subBatchContext.status = status;
     --task.remainingSubBatchCount;
 }
 
-bool TransportTaskExecutor::Cancel(const TransportTaskPtr& task, const Status& status)
+bool TransportTaskExecutor::Cancel(const TransportTaskPtr& task)
 {
     if (!task) { return false; }
 
     std::lock_guard<std::mutex> lock(task->mutex);
     if (task->Done()) { return false; }
-    std::fill(task->entryStatus.begin(), task->entryStatus.end(), status);
+    const auto canceledStatus = Status::Error(StatusCode::CANCELED, "transport task canceled");
+    std::fill(task->entryStatus.begin(), task->entryStatus.end(), canceledStatus);
     for (auto& subBatchContext : *task->subBatchContexts) {
-        if (subBatchContext.state != TransportSubBatchState::PENDING) { continue; }
-        std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(), status);
+        if (subBatchContext.state == TransportSubBatchState::COMPLETED) { continue; }
+        std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(), canceledStatus);
     }
-    task->finalStatus = status;
+    task->finalStatus = canceledStatus;
     ReleaseAllSubBatchResources(*task->subBatchContexts);
     task->state.store(TransportTaskState::COMPLETED, std::memory_order_release);
     return true;
@@ -175,7 +174,7 @@ bool TransportTaskExecutor::Execute(const TransportTaskPtr& task)
     }
 
     std::vector<TransportSubBatchContext> subBatchContexts;
-    SubmitTaskRequests(*task, subBatchContexts);
+    PrepareTaskSubBatches(*task, subBatchContexts);
 
     const bool hasSubBatches = !subBatchContexts.empty();
     if (hasSubBatches) {
@@ -234,7 +233,7 @@ bool TransportTaskExecutor::Poll(const TransportTaskPtr& task)
                 Status::Error(StatusCode::TIMEOUT, "transport task execution timeout");
             std::fill(task->entryStatus.begin(), task->entryStatus.end(), timeoutStatus);
             for (auto& subBatchContext : *task->subBatchContexts) {
-                if (subBatchContext.state != TransportSubBatchState::PENDING) { continue; }
+                if (subBatchContext.state == TransportSubBatchState::COMPLETED) { continue; }
 
                 std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(),
                           timeoutStatus);
@@ -245,7 +244,7 @@ bool TransportTaskExecutor::Poll(const TransportTaskPtr& task)
             task->state.store(TransportTaskState::COMPLETED, std::memory_order_release);
         } else {
             for (auto& subBatchContext : *task->subBatchContexts) {
-                if (subBatchContext.state != TransportSubBatchState::PENDING) { continue; }
+                if (subBatchContext.state == TransportSubBatchState::COMPLETED) { continue; }
 
                 auto completeWithError = [this, &task, &subBatchContext](const Status& status) {
                     std::fill(subBatchContext.entryStatus.begin(),

--- a/ucm/transport/kv/asu/trans/src/transport_task_executor.cpp
+++ b/ucm/transport/kv/asu/trans/src/transport_task_executor.cpp
@@ -106,6 +106,27 @@ void TransportTaskExecutor::ReleaseAllSubBatchResources(
     for (auto& subBatchContext : subBatchContexts) { ReleaseSubBatchResources(subBatchContext); }
 }
 
+void TransportTaskExecutor::AbortSubBatchesBeforeSend(
+    TransportTask& task, std::vector<TransportSubBatchContext>& subBatchContexts)
+{
+    const auto canceledStatus =
+        Status::Error(StatusCode::CANCELED, "sub-batch canceled after pre-send failure");
+    std::fill(task.entryStatus.begin(), task.entryStatus.end(), canceledStatus);
+
+    bool hasFailedSubBatch = false;
+    for (auto& subBatchContext : subBatchContexts) {
+        ReleaseSubBatchResources(subBatchContext);
+        if (!subBatchContext.status.ok()) {
+            hasFailedSubBatch = true;
+        } else if (hasFailedSubBatch) {
+            std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(),
+                      canceledStatus);
+            subBatchContext.status = canceledStatus;
+        }
+        subBatchContext.state = TransportSubBatchState::COMPLETED;
+    }
+}
+
 void TransportTaskExecutor::CompleteSubBatch(TransportTask& task,
                                              TransportSubBatchContext& subBatchContext,
                                              const Status& status)
@@ -126,7 +147,10 @@ bool TransportTaskExecutor::Cancel(const TransportTaskPtr& task)
     std::fill(task->entryStatus.begin(), task->entryStatus.end(), canceledStatus);
     for (auto& subBatchContext : *task->subBatchContexts) {
         if (subBatchContext.state == TransportSubBatchState::COMPLETED) { continue; }
-        std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(), canceledStatus);
+        std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(),
+                  canceledStatus);
+        subBatchContext.status = canceledStatus;
+        subBatchContext.state = TransportSubBatchState::COMPLETED;
     }
     task->finalStatus = canceledStatus;
     ReleaseAllSubBatchResources(*task->subBatchContexts);
@@ -144,10 +168,7 @@ std::uint16_t TransportTaskExecutor::AllocateRequestCid()
 Status TransportTaskExecutor::AssignSubBatchConnections(
     std::vector<TransportSubBatchContext>& subBatchContexts)
 {
-    Status status = Status::OK();
     for (auto& subBatchContext : subBatchContexts) {
-        if (!subBatchContext.status.ok()) { continue; }
-
         auto channel = connManager_->SelectConnection();
         if (!channel) {
             const auto subBatchStatus =
@@ -156,13 +177,12 @@ Status TransportTaskExecutor::AssignSubBatchConnections(
                       subBatchStatus);
             subBatchContext.state = TransportSubBatchState::COMPLETED;
             subBatchContext.status = subBatchStatus;
-            if (status.ok()) { status = subBatchStatus; }
-            continue;
+            return subBatchStatus;
         }
 
         subBatchContext.channel = channel;
     }
-    return status;
+    return Status::OK();
 }
 
 bool TransportTaskExecutor::Execute(const TransportTaskPtr& task)
@@ -174,16 +194,18 @@ bool TransportTaskExecutor::Execute(const TransportTaskPtr& task)
     }
 
     std::vector<TransportSubBatchContext> subBatchContexts;
-    PrepareTaskSubBatches(*task, subBatchContexts);
+    auto status = PrepareTaskSubBatches(*task, subBatchContexts);
 
-    const bool hasSubBatches = !subBatchContexts.empty();
-    if (hasSubBatches) {
-        AssignSubBatchConnections(subBatchContexts);
+    if (status.ok()) { status = AssignSubBatchConnections(subBatchContexts); }
 
-        std::vector<TransProvider::SendIoBatch> ioBatches;
-        std::vector<std::size_t> subBatchIndexes;
-        BuildSubBatchSendBuffers(subBatchContexts, ioBatches, subBatchIndexes);
-        SendSubBatchBuffers(subBatchContexts, ioBatches, subBatchIndexes);
+    std::vector<TransProvider::SendIoBatch> ioBatches;
+    if (status.ok()) { BuildSubBatchSendBuffers(subBatchContexts, ioBatches); }
+
+    if (!status.ok()) {
+        UC_ERROR("Abort transport task before send task_id={} code={} message={}", task->taskId,
+                 static_cast<int>(status.code), status.message);
+    } else {
+        SendSubBatchBuffers(subBatchContexts, ioBatches);
     }
 
     bool done = false;
@@ -197,7 +219,8 @@ bool TransportTaskExecutor::Execute(const TransportTaskPtr& task)
             return false;
         }
 
-        if (hasSubBatches) { *task->subBatchContexts = std::move(subBatchContexts); }
+        if (!status.ok()) { AbortSubBatchesBeforeSend(*task, subBatchContexts); }
+        *task->subBatchContexts = std::move(subBatchContexts);
         task->InitializeRemainingSubBatchCount();
         task->TryFinalizeFromSubBatches();
         UC_DEBUG(
@@ -207,10 +230,6 @@ bool TransportTaskExecutor::Execute(const TransportTaskPtr& task)
             task->subBatchContexts->size(), task->Done(), static_cast<int>(task->finalStatus.code),
             task->finalStatus.message);
 
-        for (auto& subBatchContext : *task->subBatchContexts) {
-            if (subBatchContext.status.ok()) { continue; }
-            ReleaseSubBatchResources(subBatchContext);
-        }
         done = task->Done();
     }
     return done;

--- a/ucm/transport/kv/asu/trans/src/transport_task_executor.h
+++ b/ucm/transport/kv/asu/trans/src/transport_task_executor.h
@@ -80,13 +80,13 @@ private:
     Status SubmitKeepAliveRequest(TransportSubBatchContext& subBatchContext);
 
     Status AssignSubBatchConnections(std::vector<TransportSubBatchContext>& subBatchContexts);
-    Status BuildSubBatchSendBuffers(std::vector<TransportSubBatchContext>& subBatchContexts,
-                                    std::vector<TransProvider::SendIoBatch>& ioBatches,
-                                    std::vector<std::size_t>& subBatchIndexes);
-    Status SendSubBatchBuffers(std::vector<TransportSubBatchContext>& subBatchContexts,
-                               const std::vector<TransProvider::SendIoBatch>& ioBatches,
-                               const std::vector<std::size_t>& subBatchIndexes);
+    void BuildSubBatchSendBuffers(std::vector<TransportSubBatchContext>& subBatchContexts,
+                                  std::vector<TransProvider::SendIoBatch>& ioBatches);
+    void SendSubBatchBuffers(std::vector<TransportSubBatchContext>& subBatchContexts,
+                             const std::vector<TransProvider::SendIoBatch>& ioBatches);
 
+    void AbortSubBatchesBeforeSend(TransportTask& task,
+                                   std::vector<TransportSubBatchContext>& subBatchContexts);
     void CompleteSubBatch(TransportTask& task, TransportSubBatchContext& subBatchContext,
                           const Status& status);
     void ReleaseSubBatchResources(TransportSubBatchContext& subBatchContext);

--- a/ucm/transport/kv/asu/trans/src/transport_task_executor.h
+++ b/ucm/transport/kv/asu/trans/src/transport_task_executor.h
@@ -73,6 +73,7 @@ private:
                                  std::vector<TransportSubBatchContext>& subBatchContexts);
     Status BuildEntrySubBatchRequest(TransportOpType opType,
                                      const IoScheduler::ScheduledIoBatch& subBatch,
+                                     const RegisteredMrKeyMap& registeredMrKeys,
                                      TransportSubBatchContext& subBatchContext);
     Status SubmitKeySubBatchRequest(TransportOpType opType,
                                     const IoScheduler::ScheduledKeyBatch& subBatch,

--- a/ucm/transport/kv/asu/trans/src/transport_task_executor.h
+++ b/ucm/transport/kv/asu/trans/src/transport_task_executor.h
@@ -64,17 +64,16 @@ public:
 
     bool Execute(const TransportTaskPtr& task);
     bool Poll(const TransportTaskPtr& task);
-    bool Cancel(const TransportTaskPtr& task, const Status& status);
+    bool Cancel(const TransportTaskPtr& task);
 
 private:
     std::uint16_t AllocateRequestCid();
 
-    Status SubmitTaskRequests(const TransportTask& task,
-                              std::vector<TransportSubBatchContext>& subBatchContexts);
-    Status SubmitEntrySubBatchRequest(TransportOpType opType,
-                                      const IoScheduler::ScheduledIoBatch& subBatch,
-                                      const RegisteredMrKeyMap& registeredMrKeys,
-                                      TransportSubBatchContext& subBatchContext);
+    Status PrepareTaskSubBatches(const TransportTask& task,
+                                 std::vector<TransportSubBatchContext>& subBatchContexts);
+    Status BuildEntrySubBatchRequest(TransportOpType opType,
+                                     const IoScheduler::ScheduledIoBatch& subBatch,
+                                     TransportSubBatchContext& subBatchContext);
     Status SubmitKeySubBatchRequest(TransportOpType opType,
                                     const IoScheduler::ScheduledKeyBatch& subBatch,
                                     TransportSubBatchContext& subBatchContext);


### PR DESCRIPTION
## Purpose
Improve ASU transport task handling before sending sub-batches, ensuring a preparation-stage failure terminates the task consistently without sending any partial request.
## Modifications

- Stop the pre-send pipeline when sub-batch request preparation or connection assignment fails.
- Mark the failed sub-batch with its concrete error and complete the task as partially failed.
- Cancel sub-batches that were not sent after a pre-send failure, while preserving successful preparation results before the failure.
- Release allocated sub-batch resources consistently during pre-send abort, send failure, task completion, and cancellation.
- Simplify send-buffer construction and remove obsolete sub-batch index mapping.
- Clarify task completion and cancellation state/status handling.
- Add focused unit-test coverage for pre-send failures, sub-batch completion, cancellation, and send-buffer generation.

## Test
Unit tests are all passed.
A UCM offline inference is passed. (MLA/GQA+TP2+Layerwise(ture/false))