### PR TITLE
[Feat] Improve DramPool request diagnostics

### DIFF
--- a/ucm/store/dram/cc/drampool/buffer_manager.h
+++ b/ucm/store/dram/cc/drampool/buffer_manager.h
@@ -68,7 +68,11 @@ public:
             region.type = transport::MemoryType::Host;
             memoryRegions_.push_back(region);
             pools_.emplace(slotSize, std::move(pool));
+            UC_DEBUG(
+                "BufferManager initialized BufferPool, slot_size={}, slot_count={}, total_bytes={}",
+                slotSize, slotNum, region.length);
         }
+        UC_DEBUG("BufferManager initialized BufferPools, pool_count={}", pools_.size());
     }
 
     ~BufferManager() { Reset(); }

--- a/ucm/store/dram/cc/drampool/completion_poller.cc
+++ b/ucm/store/dram/cc/drampool/completion_poller.cc
@@ -38,8 +38,10 @@ void ReleaseResponseBuffer(BufferPool& flagBufferPool, CompletionRecord& record)
     const auto releaseStatus = flagBufferPool.Free(releasedSlot);
     record.local_resp_slot = {};
     if (releaseStatus.Failure()) {
-        UC_ERROR("CompletionPoller release response flag buffer failed, slot={}, error={}",
-                 releasedSlot, releaseStatus);
+        UC_ERROR(
+            "CompletionPoller release response flag buffer failed, request_id={}, slot={}, "
+            "error={}",
+            record.request_id, releasedSlot, releaseStatus);
     }
 }
 
@@ -107,8 +109,8 @@ void CompletionPoller::PollPendingCompletions()
                 }
                 break;
             default:
-                UC_ERROR("CompletionPoller got invalid completion stage={}",
-                         static_cast<int>(iter->stage));
+                UC_ERROR("CompletionPoller got invalid completion stage, request_id={}, stage={}",
+                         iter->request_id, static_cast<int>(iter->stage));
                 iter = pending_.erase(iter);
                 break;
         }
@@ -121,7 +123,9 @@ bool CompletionPoller::PollDataTransfer(CompletionRecord& record)
     const auto queryStatus = runtime_.transport.GetStatus(record.data_handle, transportStatus);
     if (queryStatus.Failure()) {
         // GetStatus removes failed handles, so an API failure is also terminal.
-        UC_ERROR("CompletionPoller data GetStatus failed, handle={}", record.data_handle);
+        UC_ERROR(
+            "CompletionPoller data transfer GetStatus failed, request_id={}, handle={}, error={}",
+            record.request_id, record.data_handle, queryStatus);
         SettleDataTransfer(record, transport::TransferStatus::Failed);
         record.data_handle = transport::kInvalidTransferHandle;
         record.stage = CompletionStage::SubmitResponse;
@@ -134,17 +138,22 @@ bool CompletionPoller::PollDataTransfer(CompletionRecord& record)
         if (!record.timeout_reported && OperationTimedOut(record, SteadyNowMs())) {
             record.timeout_reported = true;
             UC_ERROR(
-                "CompletionPoller data transfer timed out, peer={}, handle={}, timeout_ms={}; "
-                "waiting for Store-initiated disconnect or terminal transport status",
-                record.peer_one_sided_id, record.data_handle, g_config.opTimeoutMs);
+                "CompletionPoller data transfer timed out, request_id={}, peer={}, handle={}, "
+                "timeout_ms={}; waiting for Store-initiated disconnect or terminal transport "
+                "status",
+                record.request_id, record.peer_one_sided_id, record.data_handle,
+                g_config.opTimeoutMs);
         }
         return false;
     }
 
     // A terminal GetStatus releases the data handle before business state is settled.
+    UC_DEBUG("CompletionPoller data transfer finished, request_id={}, handle={}, status={}",
+             record.request_id, record.data_handle, static_cast<int>(transportStatus));
     SettleDataTransfer(record, transportStatus);
     record.data_handle = transport::kInvalidTransferHandle;
     record.stage = CompletionStage::SubmitResponse;
+    UC_DEBUG("CompletionPoller advances to SubmitResponse, request_id={}", record.request_id);
     return true;
 }
 
@@ -156,26 +165,33 @@ bool CompletionPoller::SubmitResponse(CompletionRecord& record)
     if (allocateStatus.Failure()) {
         if (allocateStatus.Underlying() == Status::NoSpace().Underlying()) {
             UC_WARN(
-                "CompletionPoller flag buffer pool full, opcode={}, error={}, retrying next round",
-                static_cast<int>(record.opcode), allocateStatus);
+                "CompletionPoller flag buffer pool full, request_id={}, opcode={}, error={}, "
+                "retrying next round",
+                record.request_id, static_cast<int>(record.opcode), allocateStatus);
             return false;
         }
 
-        UC_ERROR("CompletionPoller flag buffer allocation failed, opcode={}, error={}",
-                 static_cast<int>(record.opcode), allocateStatus);
+        UC_ERROR(
+            "CompletionPoller flag buffer allocation failed, request_id={}, opcode={}, error={}",
+            record.request_id, static_cast<int>(record.opcode), allocateStatus);
         return true;
     }
+    UC_DEBUG("CompletionPoller allocated response slot, request_id={}, slot={}", record.request_id,
+             record.local_resp_slot.slotIndex);
 
     const auto len = static_cast<std::uint32_t>(packedSize);
 
-    const auto protocolStatus = runtime_.protocol.PackResponse(
-        record.local_resp_slot.localAddr, record.opcode, KvResponse{record.results});
+    const auto protocolStatus =
+        runtime_.protocol.PackResponse(record.local_resp_slot.localAddr, record.opcode,
+                                       KvResponse{record.request_id, record.results});
     if (protocolStatus.Failure()) {
         ReleaseResponseBuffer(runtime_.flagBufferPool, record);
-        UC_ERROR("CompletionPoller SubmitResponse pack failed, opcode={}, error={}",
-                 static_cast<int>(record.opcode), protocolStatus);
+        UC_ERROR("CompletionPoller SubmitResponse pack failed, request_id={}, opcode={}, error={}",
+                 record.request_id, static_cast<int>(record.opcode), protocolStatus);
         return true;
     }
+    UC_DEBUG("CompletionPoller packed response, request_id={}, response_len={}", record.request_id,
+             len);
 
     transport::Operation operation;
     operation.opcode = transport::Opcode::Write;
@@ -188,8 +204,10 @@ bool CompletionPoller::SubmitResponse(CompletionRecord& record)
     const auto submitStatus = runtime_.transport.ExecuteAsync(operation, handle);
     if (submitStatus.Failure() || handle == transport::kInvalidTransferHandle) {
         ReleaseResponseBuffer(runtime_.flagBufferPool, record);
-        UC_ERROR("CompletionPoller SubmitResponse ExecuteAsync failed, opcode={}, error={}",
-                 static_cast<int>(record.opcode), submitStatus);
+        UC_ERROR(
+            "CompletionPoller SubmitResponse ExecuteAsync failed, request_id={}, opcode={}, "
+            "handle={}, error={}",
+            record.request_id, static_cast<int>(record.opcode), handle, submitStatus);
         return true;
     }
 
@@ -198,6 +216,8 @@ bool CompletionPoller::SubmitResponse(CompletionRecord& record)
     record.timeout_reported = false;
     record.results.clear();
     record.stage = CompletionStage::PollResponseTransfer;
+    UC_DEBUG("CompletionPoller submitted response transfer, request_id={}, handle={}, slot={}",
+             record.request_id, handle, record.local_resp_slot.slotIndex);
     return false;
 }
 
@@ -207,22 +227,35 @@ bool CompletionPoller::PollResponseTransfer(CompletionRecord& record)
     const auto queryStatus = runtime_.transport.GetStatus(record.response_handle, transportStatus);
     if (queryStatus.Failure()) {
         // GetStatus removes failed handles, so the response source buffer is no longer in use.
-        UC_ERROR("CompletionPoller response GetStatus failed, handle={}", record.response_handle);
-    } else if (transportStatus == transport::TransferStatus::Waiting) {
+        UC_ERROR("CompletionPoller response GetStatus failed, request_id={}, handle={}, error={}",
+                 record.request_id, record.response_handle, queryStatus);
+        ReleaseResponseBuffer(runtime_.flagBufferPool, record);
+        return true;
+    }
+    if (transportStatus == transport::TransferStatus::Waiting) {
         // Keep the response source buffer alive until transport reports a terminal state.
         if (!record.timeout_reported && OperationTimedOut(record, SteadyNowMs())) {
             record.timeout_reported = true;
             UC_ERROR(
-                "CompletionPoller response transfer timed out, peer={}, handle={}, timeout_ms={}; "
-                "waiting for Store-initiated disconnect or terminal transport status",
-                record.peer_one_sided_id, record.response_handle, g_config.opTimeoutMs);
+                "CompletionPoller response transfer timed out, request_id={}, peer={}, handle={}, "
+                "timeout_ms={}; waiting for Store-initiated disconnect or terminal transport "
+                "status",
+                record.request_id, record.peer_one_sided_id, record.response_handle,
+                g_config.opTimeoutMs);
         }
         return false;
-    } else if (transportStatus != transport::TransferStatus::Completed) {
-        UC_ERROR("CompletionPoller response transfer failed, handle={}", record.response_handle);
+    }
+    if (transportStatus != transport::TransferStatus::Completed) {
+        UC_ERROR("CompletionPoller response transfer failed, request_id={}, handle={}, status={}",
+                 record.request_id, record.response_handle, static_cast<int>(transportStatus));
+        ReleaseResponseBuffer(runtime_.flagBufferPool, record);
+        return true;
     }
 
     ReleaseResponseBuffer(runtime_.flagBufferPool, record);
+    UC_DEBUG("CompletionPoller response transfer finished, request_id={}, handle={}, status={}",
+             record.request_id, record.response_handle, static_cast<int>(transportStatus));
+
     return true;
 }
 
@@ -240,28 +273,30 @@ void CompletionPoller::SettleDataTransfer(CompletionRecord& record,
                 if (status.Success()) {
                     result = DumpLoadResult::Ok;
                 } else {
-                    UC_ERROR("CompletionPoller StoreEnd failed, handle={}, error={}",
-                             record.data_handle, status);
+                    UC_ERROR("CompletionPoller StoreEnd failed, request_id={}, handle={}, error={}",
+                             record.request_id, record.data_handle, status);
                     const auto abortStatus = runtime_.metadata.Delete(item.key);
                     if (abortStatus.Failure()) {
                         UC_ERROR(
-                            "CompletionPoller Delete failed after StoreEnd error, handle={}, "
-                            "error={}",
-                            record.data_handle, abortStatus);
+                            "CompletionPoller Delete failed after StoreEnd error, request_id={}, "
+                            "handle={}, error={}",
+                            record.request_id, record.data_handle, abortStatus);
                     }
                 }
             } else {
                 const auto abortStatus = runtime_.metadata.Delete(item.key);
                 if (abortStatus.Failure()) {
-                    UC_ERROR("CompletionPoller Delete reserved DUMP failed, handle={}, error={}",
-                             record.data_handle, abortStatus);
+                    UC_ERROR(
+                        "CompletionPoller Delete reserved DUMP failed, request_id={}, handle={}, "
+                        "error={}",
+                        record.request_id, record.data_handle, abortStatus);
                 }
             }
         } else if (record.opcode == KvOpcode::Load) {
             const auto releaseStatus = runtime_.metadata.LoadEnd(item.key);
             if (releaseStatus.Failure()) {
-                UC_ERROR("CompletionPoller LoadEnd failed, handle={}, error={}", record.data_handle,
-                         releaseStatus);
+                UC_ERROR("CompletionPoller LoadEnd failed, request_id={}, handle={}, error={}",
+                         record.request_id, record.data_handle, releaseStatus);
             } else if (terminalStatus == transport::TransferStatus::Completed) {
                 result = DumpLoadResult::Ok;
             }

--- a/ucm/store/dram/cc/drampool/drampool_server.cc
+++ b/ucm/store/dram/cc/drampool/drampool_server.cc
@@ -127,6 +127,7 @@ Status DramPoolServer::Start()
 void DramPoolServer::Stop()
 {
     if (state_ == ServerState::New || state_ == ServerState::Stopped) { return; }
+    UC_INFO("DramPool shutdown started, state={}", static_cast<int>(state_));
     // Close ingress, stop its receiver, then let TaskWorker drain accepted tasks.
     StopRequestReceiver();
     StopTaskWorker();
@@ -137,6 +138,7 @@ void DramPoolServer::Stop()
     // every active thread and transport service has stopped.
     ResetInitializedComponents();
     state_ = ServerState::Stopped;
+    UC_INFO("DramPool shutdown completed");
 }
 
 Status DramPoolServer::InitializeDeviceRuntime()
@@ -397,48 +399,66 @@ void DramPoolServer::StopTcpMessageChannel()
         tcpMessageChannelReady_ = false;
     }
     if (tcpMessageChannel_) {
+        UC_DEBUG("DramPool shutdown stopping TCP message channel");
         const auto status = tcpMessageChannel_->Shutdown();
         if (status.Failure()) {
-            UC_ERROR_UNLIMITED("DramPool TCP message channel shutdown failed");
+            UC_ERROR_UNLIMITED("DramPool TCP message channel shutdown failed, error={}", status);
         }
     }
 }
 
 void DramPoolServer::StopRequestReceiver()
 {
+    UC_DEBUG("DramPool shutdown stopping RequestReceiver and TCP ingress");
     {
         std::lock_guard<std::mutex> waitGuard(requestReceiverWaitMutex_);
         requestReceiverStop_.store(true, std::memory_order_release);
     }
     requestReceiverWaitCv_.notify_one();
     StopTcpMessageChannel();
-    if (requestReceiverThread_.joinable()) { requestReceiverThread_.join(); }
+    if (requestReceiverThread_.joinable()) {
+        UC_DEBUG("DramPool shutdown waiting for RequestReceiver thread");
+        requestReceiverThread_.join();
+    }
+    UC_DEBUG("DramPool shutdown RequestReceiver stopped");
 }
 
 void DramPoolServer::StopTaskWorker()
 {
     taskWorkerStop_.store(true, std::memory_order_release);
+    UC_DEBUG("DramPool shutdown waiting for TaskWorker to drain accepted requests");
     if (taskWorkerThread_.joinable()) { taskWorkerThread_.join(); }
+    UC_DEBUG("DramPool shutdown TaskWorker stopped");
 }
 
 void DramPoolServer::StopCompletionPoller()
 {
     completionPollerStop_.store(true, std::memory_order_release);
+    UC_DEBUG("DramPool shutdown waiting for CompletionPoller to drain pending completions");
     if (completionPollerThread_.joinable()) { completionPollerThread_.join(); }
+    UC_DEBUG("DramPool shutdown CompletionPoller stopped");
 }
 
 void DramPoolServer::StopGCThread()
 {
+    UC_DEBUG("DramPool shutdown stopping GCThread");
     gcThreadStop_.store(true, std::memory_order_release);
     stopWaitCv_.notify_one();
-    if (gcThread_.joinable()) { gcThread_.join(); }
+    if (gcThread_.joinable()) {
+        UC_DEBUG("DramPool shutdown waiting for GCThread");
+        gcThread_.join();
+    }
+    UC_DEBUG("DramPool shutdown GCThread stopped");
 }
 
 void DramPoolServer::StopTransportService()
 {
     if (transportManager_) {
+        UC_DEBUG("DramPool shutdown calling TransportManager::Shutdown");
         const auto status = transportManager_->Shutdown();
-        if (status.Failure()) { UC_ERROR_UNLIMITED("DramPool TransportManager shutdown failed"); }
+        if (status.Failure()) {
+            UC_ERROR_UNLIMITED("DramPool TransportManager shutdown failed, error={}", status);
+        }
     }
 }
 
@@ -480,20 +500,25 @@ void DramPoolServer::RequestReceiveLoop()
         const auto controlPeerId = controlPeer.ToString();
         const auto peerIt = g_config.twoSidedToOneSided.find(controlPeerId);
         if (peerIt == g_config.twoSidedToOneSided.end()) {
-            UC_WARN("RequestReceiver rejected unconfigured control peer {}", controlPeerId);
+            UC_WARN("RequestReceiver rejected unconfigured control peer, request_id={}, peer={}",
+                    request->request_id, controlPeerId);
             continue;
         }
 
         auto task = std::make_unique<RequestTask>();
         task->request = std::move(request);
         task->peer_one_sided_id = peerIt->second;
+        UC_DEBUG("RequestReceiver received request, request_id={}, opcode={}, control={}, peer={}",
+                 task->request->request_id, static_cast<int>(task->request->opcode), controlPeerId,
+                 peerIt->second);
         // This bounded handoff keeps transport I/O separate from potentially slow request handling.
         bool queueFullLogged = false;
         while (!requestReceiverStop_.load(std::memory_order_acquire)) {
             if (requestQueue_.TryPush(std::move(task))) { break; }
             if (!queueFullLogged) {
-                UC_WARN("RequestReceiver queue is full, depth={}, retry_wait_us={}",
-                        g_config.requestQueueDepth, g_config.requestReceiverIdleWaitUs);
+                UC_WARN("RequestReceiver queue is full, request_id={}, depth={}, retry_wait_us={}",
+                        task->request->request_id, g_config.requestQueueDepth,
+                        g_config.requestReceiverIdleWaitUs);
                 queueFullLogged = true;
             }
             std::this_thread::sleep_for(idleWait);
@@ -535,21 +560,27 @@ void DramPoolServer::ResetInitializedComponents()
 {
     // Dependents must be destroyed before the non-owning runtime context and
     // the components referenced by that context.
+    UC_DEBUG("DramPool cleanup releasing workers and runtime context");
     completionPoller_.reset();
     taskWorker_.reset();
     runtime_.reset();
+    UC_DEBUG("DramPool cleanup releasing protocol and metadata managers");
     protocolManager_.reset();
     metadataManager_.reset();
+    UC_DEBUG("DramPool cleanup releasing TCP channel and memory pools");
     tcpMessageChannel_.reset();
     flagBufferPool_.reset();
     bufferManager_.reset();
+    UC_DEBUG("DramPool cleanup releasing transport manager");
     transportManager_.reset();
     if (deviceRuntimeOwned_) {
+        UC_DEBUG("DramPool cleanup releasing device runtime");
         if (deviceId_) { (void)device_.Reset(*deviceId_); }
         (void)device_.Finalize();
         deviceRuntimeOwned_ = false;
     }
     deviceId_.reset();
+    UC_DEBUG("DramPool cleanup completed");
 }
 
 }  // namespace UC::DramPool

--- a/ucm/store/dram/cc/drampool/drampool_types.h
+++ b/ucm/store/dram/cc/drampool/drampool_types.h
@@ -92,6 +92,7 @@ enum class CompletionStage : std::uint8_t {
 
 struct CompletionRecord {
     CompletionStage stage{CompletionStage::PollDataTransfer};
+    std::uint64_t request_id{0};
 
     // State used while the request's data transfer is in flight.
     TransportHandle data_handle{transport::kInvalidTransferHandle};

--- a/ucm/store/dram/cc/drampool/task_worker.cc
+++ b/ucm/store/dram/cc/drampool/task_worker.cc
@@ -69,6 +69,8 @@ Status TaskWorker::ProcessOneRequest(RequestTaskPtr task)
     // must already have established the local route.
     const auto& peerOneSidedId = task->peer_one_sided_id;
     const auto& request = task->request;
+    UC_DEBUG("TaskWorker processing request, request_id={}, opcode={}, peer={}",
+             request->request_id, static_cast<int>(request->opcode), peerOneSidedId);
     switch (request->opcode) {
         case KvOpcode::Dump: {
             const auto* dump = dynamic_cast<const KvDumpRequest*>(request.get());
@@ -130,7 +132,8 @@ Status TaskWorker::ProcessDump(const KvDumpRequest& request,
             continue;
         }
         if (storeStatus.Failure()) {
-            UC_ERROR("Dump[{}] StoreBegin failed: {}", index, storeStatus);
+            UC_ERROR("Dump[{}] StoreBegin failed, request_id={}, error={}", index,
+                     request.request_id, storeStatus);
             // StoreBegin failures are typically resource-related after eviction retries.
             // Stop here to avoid costly allocation attempts for the remaining items.
             mark_remaining_failed(index);
@@ -144,22 +147,30 @@ Status TaskWorker::ProcessDump(const KvDumpRequest& request,
     }
 
     if (transfer_items.empty()) {
-        return QueueResponse(KvOpcode::Dump, request.resp_addr, peerOneSidedId, std::move(results));
+        UC_DEBUG("DUMP skips data transfer, request_id={}, batch_size={}", request.request_id,
+                 request.batch_size);
+        return QueueResponse(KvOpcode::Dump, request.resp_addr, peerOneSidedId, std::move(results),
+                             request.request_id);
     }
 
+    UC_DEBUG("DUMP submits data transfer, request_id={}, items={}, peer={}", request.request_id,
+             transfer_items.size(), peerOneSidedId);
     TransportHandle handle = transport::kInvalidTransferHandle;
     const auto submit_status = runtime_.transport.ExecuteAsync(operation, handle);
     if (submit_status.Failure() || handle == transport::kInvalidTransferHandle) {
-        UC_ERROR("Dump SubmitAsync failed, items={}", transfer_items.size());
+        UC_ERROR("Dump SubmitAsync failed, request_id={}, items={}, error={}", request.request_id,
+                 transfer_items.size(), submit_status);
         DeleteItemsMetadata(transfer_items);
         for (const auto& item : transfer_items) {
             results[item.index_in_request] = static_cast<std::uint8_t>(DumpLoadResult::Failed);
         }
-        return QueueResponse(KvOpcode::Dump, request.resp_addr, peerOneSidedId, std::move(results));
+        return QueueResponse(KvOpcode::Dump, request.resp_addr, peerOneSidedId, std::move(results),
+                             request.request_id);
     }
 
     CompletionRecord record;
     record.stage = CompletionStage::PollDataTransfer;
+    record.request_id = request.request_id;
     record.opcode = KvOpcode::Dump;
     record.data_handle = handle;
     record.remote_resp_addr = request.resp_addr;
@@ -167,6 +178,7 @@ Status TaskWorker::ProcessDump(const KvDumpRequest& request,
     record.results = std::move(results);
     record.transfer_items = std::move(transfer_items);
     record.submit_ms = SteadyNowMs();
+    UC_DEBUG("DUMP data transfer submitted, request_id={}, handle={}", request.request_id, handle);
     return SubmitCompletion(std::move(record));
 }
 
@@ -193,16 +205,18 @@ Status TaskWorker::ProcessLoad(const KvLoadRequest& request,
         const auto loadStatus = runtime_.metadata.LoadBegin(entry.key, metadataEntry);
         if (loadStatus.Failure() || !metadataEntry) {
             results[index] = static_cast<std::uint8_t>(DumpLoadResult::Failed);
-            UC_ERROR("Load[{}] LoadBegin failed: {}", index, loadStatus);
+            UC_ERROR("Load[{}] LoadBegin failed, request_id={}, error={}", index,
+                     request.request_id, loadStatus);
             continue;
         }
         if (entry.len > metadataEntry->size) {
             const auto releaseStatus = runtime_.metadata.LoadEnd(entry.key);
             if (releaseStatus.Failure()) {
-                UC_ERROR("Load[{}] LoadEnd after len mismatch failed: {}", index, releaseStatus);
+                UC_ERROR("Load[{}] LoadEnd after len mismatch failed, request_id={}, error={}",
+                         index, request.request_id, releaseStatus);
             }
-            UC_ERROR("Load[{}] invalid len, requested={}, stored={}", index, entry.len,
-                     metadataEntry->size);
+            UC_ERROR("Load[{}] invalid len, request_id={}, requested={}, stored={}", index,
+                     request.request_id, entry.len, metadataEntry->size);
             results[index] = static_cast<std::uint8_t>(DumpLoadResult::Failed);
             continue;
         }
@@ -214,22 +228,30 @@ Status TaskWorker::ProcessLoad(const KvLoadRequest& request,
     }
 
     if (transfer_items.empty()) {
-        return QueueResponse(KvOpcode::Load, request.resp_addr, peerOneSidedId, std::move(results));
+        UC_DEBUG("LOAD skips data transfer, request_id={}, batch_size={}", request.request_id,
+                 request.batch_size);
+        return QueueResponse(KvOpcode::Load, request.resp_addr, peerOneSidedId, std::move(results),
+                             request.request_id);
     }
 
+    UC_DEBUG("LOAD submits data transfer, request_id={}, items={}, peer={}", request.request_id,
+             transfer_items.size(), peerOneSidedId);
     TransportHandle handle = transport::kInvalidTransferHandle;
     const auto submit_status = runtime_.transport.ExecuteAsync(operation, handle);
     if (submit_status.Failure() || handle == transport::kInvalidTransferHandle) {
-        UC_ERROR("Load SubmitAsync failed, items={}", transfer_items.size());
+        UC_ERROR("Load SubmitAsync failed, request_id={}, items={}, error={}", request.request_id,
+                 transfer_items.size(), submit_status);
         LoadEndItems(transfer_items);
         for (const auto& item : transfer_items) {
             results[item.index_in_request] = static_cast<std::uint8_t>(DumpLoadResult::Failed);
         }
-        return QueueResponse(KvOpcode::Load, request.resp_addr, peerOneSidedId, std::move(results));
+        return QueueResponse(KvOpcode::Load, request.resp_addr, peerOneSidedId, std::move(results),
+                             request.request_id);
     }
 
     CompletionRecord record;
     record.stage = CompletionStage::PollDataTransfer;
+    record.request_id = request.request_id;
     record.opcode = KvOpcode::Load;
     record.data_handle = handle;
     record.remote_resp_addr = request.resp_addr;
@@ -237,6 +259,7 @@ Status TaskWorker::ProcessLoad(const KvLoadRequest& request,
     record.results = std::move(results);
     record.transfer_items = std::move(transfer_items);
     record.submit_ms = SteadyNowMs();
+    UC_DEBUG("LOAD data transfer submitted, request_id={}, handle={}", request.request_id, handle);
     return SubmitCompletion(std::move(record));
 }
 
@@ -255,7 +278,10 @@ Status TaskWorker::ProcessLookup(const KvLookupRequest& request,
         }
     }
 
-    return QueueResponse(KvOpcode::Lookup, request.resp_addr, peerOneSidedId, std::move(results));
+    UC_DEBUG("LOOKUP metadata scan completed, request_id={}, batch_size={}", request.request_id,
+             request.batch_size);
+    return QueueResponse(KvOpcode::Lookup, request.resp_addr, peerOneSidedId, std::move(results),
+                         request.request_id);
 }
 
 void TaskWorker::DeleteItemsMetadata(const std::vector<TransferItem>& items)
@@ -279,10 +305,11 @@ void TaskWorker::LoadEndItems(const std::vector<TransferItem>& items)
 
 Status TaskWorker::QueueResponse(KvOpcode opcode, std::uint64_t responseAddr,
                                  const transport::ManagerID& peerOneSidedId,
-                                 std::vector<std::uint8_t>&& results)
+                                 std::vector<std::uint8_t>&& results, std::uint64_t requestId)
 {
     CompletionRecord record;
     record.stage = CompletionStage::SubmitResponse;
+    record.request_id = requestId;
     record.opcode = opcode;
     record.remote_resp_addr = responseAddr;
     record.peer_one_sided_id = peerOneSidedId;
@@ -293,6 +320,9 @@ Status TaskWorker::QueueResponse(KvOpcode opcode, std::uint64_t responseAddr,
 Status TaskWorker::SubmitCompletion(CompletionRecord&& record)
 {
     // TaskWorker is the sole producer; CompletionPoller is the sole consumer.
+    UC_DEBUG("TaskWorker queues completion, request_id={}, opcode={}, stage={}, handle={}",
+             record.request_id, static_cast<int>(record.opcode), static_cast<int>(record.stage),
+             record.data_handle);
     runtime_.completionQueue.Push(std::move(record));
     return Status::OK();
 }

--- a/ucm/store/dram/cc/drampool/task_worker.h
+++ b/ucm/store/dram/cc/drampool/task_worker.h
@@ -47,7 +47,7 @@ private:
     void LoadEndItems(const std::vector<TransferItem>& items);
     Status QueueResponse(KvOpcode opcode, std::uint64_t responseAddr,
                          const transport::ManagerID& peerOneSidedId,
-                         std::vector<std::uint8_t>&& results);
+                         std::vector<std::uint8_t>&& results, std::uint64_t requestId);
     Status SubmitCompletion(CompletionRecord&& record);
 
     DramPoolRuntime& runtime_;

--- a/ucm/store/dram/cc/kv_protocol.cc
+++ b/ucm/store/dram/cc/kv_protocol.cc
@@ -142,6 +142,7 @@ template <typename Request>
 Status ValidateRequestHeader(const Request& request)
 {
     const std::string protocol = ProtocolName(request.opcode);
+    if (request.request_id == 0) { return Status::InvalidParam(protocol + ": request_id is zero"); }
     if (request.resp_addr == 0) { return Status::InvalidParam(protocol + ": resp_addr is zero"); }
     if (request.batch_size == 0 || request.batch_size != request.entries.size()) {
         return Status::InvalidParam(protocol + ": batch_size(" +
@@ -152,18 +153,20 @@ Status ValidateRequestHeader(const Request& request)
     return Status::OK();
 }
 
-void PackHeader(std::uint8_t* out, KvOpcode opcode, std::uint64_t resp_addr,
-                std::uint16_t batch_size)
+void PackHeader(std::uint8_t* out, KvOpcode opcode, std::uint64_t request_id,
+                std::uint64_t resp_addr, std::uint16_t batch_size)
 {
     out[kOpcodeOffset] = static_cast<std::uint8_t>(opcode);
+    std::memcpy(out + kRequestIdOffset, &request_id, sizeof(request_id));
     std::memcpy(out + kRespAddrOffset, &resp_addr, sizeof(resp_addr));
     std::memcpy(out + kLoadLookupBatchSizeOffset, &batch_size, sizeof(batch_size));
 }
 
-void PackDumpHeader(std::uint8_t* out, KvOpcode opcode, std::uint64_t resp_addr, std::uint32_t ttl,
-                    std::uint16_t batch_size)
+void PackDumpHeader(std::uint8_t* out, KvOpcode opcode, std::uint64_t request_id,
+                    std::uint64_t resp_addr, std::uint32_t ttl, std::uint16_t batch_size)
 {
     out[kOpcodeOffset] = static_cast<std::uint8_t>(opcode);
+    std::memcpy(out + kRequestIdOffset, &request_id, sizeof(request_id));
     std::memcpy(out + kRespAddrOffset, &resp_addr, sizeof(resp_addr));
     std::memcpy(out + kDumpTtlOffset, &ttl, sizeof(ttl));
     std::memcpy(out + kDumpBatchSizeOffset, &batch_size, sizeof(batch_size));
@@ -183,6 +186,8 @@ Status UnpackCommonRequestHeader(const void* data, std::size_t size, std::size_t
     if (request.opcode != expectedOpcode) {
         return Status::InvalidParam(protocol + ": opcode mismatch");
     }
+    std::memcpy(&request.request_id, bytes + kRequestIdOffset, sizeof(request.request_id));
+    if (request.request_id == 0) { return Status::InvalidParam(protocol + ": request_id is zero"); }
     std::memcpy(&request.resp_addr, bytes + kRespAddrOffset, sizeof(request.resp_addr));
     if (request.resp_addr == 0) { return Status::InvalidParam(protocol + ": resp_addr is zero"); }
     std::memcpy(&request.batch_size, bytes + batchSizeOffset, sizeof(request.batch_size));
@@ -226,7 +231,7 @@ Status KvDumpProtocol::PackRequest(const KvRequest& req, void* target)
     if (!status.Success()) { return status; }
 
     auto* out = static_cast<std::uint8_t*>(target);
-    PackDumpHeader(out, r.opcode, r.resp_addr, r.ttl, r.batch_size);
+    PackDumpHeader(out, r.opcode, r.request_id, r.resp_addr, r.ttl, r.batch_size);
 
     for (std::size_t i = 0; i < r.entries.size(); ++i) {
         const auto& entry = r.entries[i];
@@ -241,6 +246,7 @@ Status KvDumpProtocol::UnpackResponse(const void* data, std::uint16_t result_cou
 {
     if (!data) { return Status::InvalidParam("Dump: UnpackResponse data is null"); }
     const auto* bytes = static_cast<const std::uint8_t*>(data);
+    std::memcpy(&out.request_id, bytes + kResponseRequestIdOffset, sizeof(out.request_id));
     UnpackResults(bytes + kResponseResultsOffset, result_count, kDumpLoadResultBitWidth,
                   out.results);
     return Status::OK();
@@ -290,7 +296,9 @@ Status KvDumpProtocol::UnpackRequest(const void* data, std::size_t size,
 Status KvDumpProtocol::PackResponse(void* data, const KvResponse& resp) const
 {
     if (!data) { return Status::InvalidParam("Dump: PackResponse data is null"); }
+    if (resp.request_id == 0) { return Status::InvalidParam("Dump: request_id is zero"); }
     auto* bytes = static_cast<std::uint8_t*>(data);
+    std::memcpy(bytes + kResponseRequestIdOffset, &resp.request_id, sizeof(resp.request_id));
     const auto status =
         PackResults(bytes + kResponseResultsOffset, resp.results, kDumpLoadResultBitWidth, "Dump");
     if (status.Failure()) { return status; }
@@ -326,7 +334,7 @@ Status KvLoadProtocol::PackRequest(const KvRequest& req, void* target)
     if (!status.Success()) { return status; }
 
     auto* out = static_cast<std::uint8_t*>(target);
-    PackHeader(out, r.opcode, r.resp_addr, r.batch_size);
+    PackHeader(out, r.opcode, r.request_id, r.resp_addr, r.batch_size);
 
     for (std::size_t i = 0; i < r.entries.size(); ++i) {
         const auto& entry = r.entries[i];
@@ -341,6 +349,7 @@ Status KvLoadProtocol::UnpackResponse(const void* data, std::uint16_t result_cou
 {
     if (!data) { return Status::InvalidParam("Load: UnpackResponse data is null"); }
     const auto* bytes = static_cast<const std::uint8_t*>(data);
+    std::memcpy(&out.request_id, bytes + kResponseRequestIdOffset, sizeof(out.request_id));
     UnpackResults(bytes + kResponseResultsOffset, result_count, kDumpLoadResultBitWidth,
                   out.results);
     return Status::OK();
@@ -388,7 +397,9 @@ Status KvLoadProtocol::UnpackRequest(const void* data, std::size_t size,
 Status KvLoadProtocol::PackResponse(void* data, const KvResponse& resp) const
 {
     if (!data) { return Status::InvalidParam("Load: PackResponse data is null"); }
+    if (resp.request_id == 0) { return Status::InvalidParam("Load: request_id is zero"); }
     auto* bytes = static_cast<std::uint8_t*>(data);
+    std::memcpy(bytes + kResponseRequestIdOffset, &resp.request_id, sizeof(resp.request_id));
     const auto status =
         PackResults(bytes + kResponseResultsOffset, resp.results, kDumpLoadResultBitWidth, "Load");
     if (status.Failure()) { return status; }
@@ -424,7 +435,7 @@ Status KvLookupProtocol::PackRequest(const KvRequest& req, void* target)
     if (!status.Success()) { return status; }
 
     auto* out = static_cast<std::uint8_t*>(target);
-    PackHeader(out, r.opcode, r.resp_addr, r.batch_size);
+    PackHeader(out, r.opcode, r.request_id, r.resp_addr, r.batch_size);
 
     for (std::size_t i = 0; i < r.entries.size(); ++i) {
         const auto& entry = r.entries[i];
@@ -439,6 +450,7 @@ Status KvLookupProtocol::UnpackResponse(const void* data, std::uint16_t result_c
 {
     if (!data) { return Status::InvalidParam("Lookup: UnpackResponse data is null"); }
     const auto* bytes = static_cast<const std::uint8_t*>(data);
+    std::memcpy(&out.request_id, bytes + kResponseRequestIdOffset, sizeof(out.request_id));
     UnpackResults(bytes + kResponseResultsOffset, result_count, kLookupResultBitWidth, out.results);
     return Status::OK();
 }
@@ -488,8 +500,10 @@ Status KvLookupProtocol::UnpackRequest(const void* data, std::size_t size,
 Status KvLookupProtocol::PackResponse(void* data, const KvResponse& resp) const
 {
     if (!data) { return Status::InvalidParam("Lookup: PackResponse data is null"); }
+    if (resp.request_id == 0) { return Status::InvalidParam("Lookup: request_id is zero"); }
     if (resp.results.empty()) { return Status::InvalidParam("Lookup: results must not be empty"); }
     auto* bytes = static_cast<std::uint8_t*>(data);
+    std::memcpy(bytes + kResponseRequestIdOffset, &resp.request_id, sizeof(resp.request_id));
     const auto status =
         PackResults(bytes + kResponseResultsOffset, resp.results, kLookupResultBitWidth, "Lookup");
     if (status.Failure()) { return status; }
@@ -537,28 +551,45 @@ Status ProtocolManager::PackRequest(void* data, KvOpcode opcode, const KvRequest
     return proto->PackRequest(req, data);
 }
 
-Status ProtocolManager::IsResponseReady(const void* data, bool& ready) const
+Status ProtocolManager::IsResponseReady(const void* data, std::uint64_t expected_request_id,
+                                        bool& ready) const
 {
     ready = false;
     if (!data) { return Status::InvalidParam("IsResponseReady data is null"); }
+    if (expected_request_id == 0) {
+        return Status::InvalidParam("IsResponseReady expected_request_id is zero");
+    }
 
     // The flag can be updated by remote DMA, so each poll must reload the status byte.
     const auto* bytes = static_cast<const volatile std::uint8_t*>(data);
     const auto status = static_cast<ResponseStatus>(bytes[kResponseStatusOffset]);
     switch (status) {
         case ResponseStatus::Pending: return Status::OK();
-        case ResponseStatus::Ready: ready = true; return Status::OK();
+        case ResponseStatus::Ready: {
+            std::uint64_t observedRequestId = 0;
+            std::memcpy(&observedRequestId,
+                        static_cast<const std::uint8_t*>(data) + kResponseRequestIdOffset,
+                        sizeof(observedRequestId));
+            if (observedRequestId != expected_request_id) {
+                return Status::Error("IsResponseReady request_id mismatch: expected=" +
+                                     std::to_string(expected_request_id) +
+                                     ", observed=" + std::to_string(observedRequestId));
+            }
+            ready = true;
+            return Status::OK();
+        }
         default: return Status::InvalidParam("unknown response status");
     }
 }
 
 Status ProtocolManager::UnpackResponse(const void* data, KvOpcode opcode,
+                                       std::uint64_t expected_request_id,
                                        std::uint16_t result_count, KvResponse& out)
 {
     KvProtocol* proto = GetProtocol(opcode);
     if (!proto) { return Status::InvalidParam("unknown opcode in UnpackResponse"); }
     bool ready = false;
-    const auto status = IsResponseReady(data, ready);
+    const auto status = IsResponseReady(data, expected_request_id, ready);
     if (status.Failure()) { return status; }
     if (!ready) { return Status::Retry(); }
     return proto->UnpackResponse(data, result_count, out);

--- a/ucm/store/dram/cc/kv_protocol.h
+++ b/ucm/store/dram/cc/kv_protocol.h
@@ -51,25 +51,28 @@ enum class ResponseStatus : std::uint8_t {
 constexpr std::size_t kKvKeySize = sizeof(BlockId);
 static_assert(kKvKeySize == 16, "DramPool wire protocol requires a 16-byte BlockId");
 constexpr std::size_t kKvLoadRequestHeaderSize =
-    sizeof(std::uint8_t) + sizeof(std::uint64_t) + sizeof(std::uint16_t);
+    sizeof(std::uint8_t) + sizeof(std::uint64_t) + sizeof(std::uint64_t) + sizeof(std::uint16_t);
 constexpr std::size_t kKvLookupRequestHeaderSize =
-    sizeof(std::uint8_t) + sizeof(std::uint64_t) + sizeof(std::uint16_t);
-constexpr std::size_t kKvDumpRequestHeaderSize =
-    sizeof(std::uint8_t) + sizeof(std::uint64_t) + sizeof(std::uint32_t) + sizeof(std::uint16_t);
+    sizeof(std::uint8_t) + sizeof(std::uint64_t) + sizeof(std::uint64_t) + sizeof(std::uint16_t);
+constexpr std::size_t kKvDumpRequestHeaderSize = sizeof(std::uint8_t) + sizeof(std::uint64_t) +
+                                                 sizeof(std::uint64_t) + sizeof(std::uint32_t) +
+                                                 sizeof(std::uint16_t);
 constexpr std::size_t kKvDumpEntrySize =
     kKvKeySize + sizeof(std::uint64_t) + sizeof(std::uint32_t) + sizeof(std::uint32_t);
 constexpr std::size_t kKvLoadEntrySize =
     kKvKeySize + sizeof(std::uint64_t) + sizeof(std::uint32_t) + sizeof(std::uint32_t);
 constexpr std::size_t kKvLookupEntrySize = kKvKeySize;
-constexpr std::size_t kResponseStatusOffset = 0;
-constexpr std::size_t kResponseResultsOffset = sizeof(std::uint8_t);
+constexpr std::size_t kResponseRequestIdOffset = 0;
+constexpr std::size_t kResponseStatusOffset = sizeof(std::uint64_t);
+constexpr std::size_t kResponseResultsOffset = kResponseStatusOffset + sizeof(std::uint8_t);
 
 // Wire offsets shared by the client (pack) and server (unpack) sides.
 constexpr std::size_t kOpcodeOffset = 0;
-constexpr std::size_t kRespAddrOffset = 1;
-constexpr std::size_t kLoadLookupBatchSizeOffset = 9;
-constexpr std::size_t kDumpTtlOffset = 9;
-constexpr std::size_t kDumpBatchSizeOffset = 13;
+constexpr std::size_t kRequestIdOffset = 1;
+constexpr std::size_t kRespAddrOffset = 9;
+constexpr std::size_t kLoadLookupBatchSizeOffset = 17;
+constexpr std::size_t kDumpTtlOffset = 17;
+constexpr std::size_t kDumpBatchSizeOffset = 21;
 
 constexpr std::size_t kDumpLoadEntryKeyOffset = 0;
 constexpr std::size_t kDumpLoadEntryAddrOffset = 16;
@@ -103,6 +106,7 @@ class KvRequest {
 public:
     virtual ~KvRequest() = default;
     KvOpcode opcode{KvOpcode::None};
+    std::uint64_t request_id{0};
 };
 
 class KvDumpRequest : public KvRequest {
@@ -129,6 +133,7 @@ public:
 
 class KvResponse {
 public:
+    std::uint64_t request_id{0};
     std::vector<std::uint8_t> results;
 };
 
@@ -216,9 +221,9 @@ public:
     std::size_t GetPackedRequestSize(KvOpcode opcode, const KvRequest& req) const;
     std::size_t GetPackedResponseSize(KvOpcode opcode, std::size_t result_count) const;
     Status PackRequest(void* data, KvOpcode opcode, const KvRequest& req);
-    Status IsResponseReady(const void* data, bool& ready) const;
-    Status UnpackResponse(const void* data, KvOpcode opcode, std::uint16_t result_count,
-                          KvResponse& out);
+    Status IsResponseReady(const void* data, std::uint64_t expected_request_id, bool& ready) const;
+    Status UnpackResponse(const void* data, KvOpcode opcode, std::uint64_t expected_request_id,
+                          std::uint16_t result_count, KvResponse& out);
     // Server side
     Status UnpackRequest(const void* data, std::size_t size, std::unique_ptr<KvRequest>& out);
     Status PackResponse(void* data, KvOpcode opcode, const KvResponse& resp);

--- a/ucm/store/dram/cc/node_actor.cc
+++ b/ucm/store/dram/cc/node_actor.cc
@@ -74,7 +74,7 @@ const char* NodeActor::NodeStateName(NodeState state) noexcept
     return names[static_cast<std::uint8_t>(state)];
 }
 
-Status NodeActor::EncodeRequest(const ReplySlot& replySlot, OpType op,
+Status NodeActor::EncodeRequest(const ReplySlot& replySlot, RequestId requestId, OpType op,
                                 const std::vector<IoEntry>& entries,
                                 std::vector<std::uint8_t>& payload)
 {
@@ -92,6 +92,7 @@ Status NodeActor::EncodeRequest(const ReplySlot& replySlot, OpType op,
         case OpType::LOOKUP: {
             DramPool::KvLookupRequest request;
             request.opcode = DramPool::KvOpcode::Lookup;
+            request.request_id = requestId;
             request.resp_addr = responseAddress;
             request.batch_size = batchSize;
             request.entries.resize(entries.size());
@@ -104,6 +105,7 @@ Status NodeActor::EncodeRequest(const ReplySlot& replySlot, OpType op,
         case OpType::DUMP: {
             DramPool::KvDumpRequest request;
             request.opcode = DramPool::KvOpcode::Dump;
+            request.request_id = requestId;
             request.resp_addr = responseAddress;
             request.ttl = 0;
             request.batch_size = batchSize;
@@ -113,6 +115,7 @@ Status NodeActor::EncodeRequest(const ReplySlot& replySlot, OpType op,
         case OpType::LOAD: {
             DramPool::KvLoadRequest request;
             request.opcode = DramPool::KvOpcode::Load;
+            request.request_id = requestId;
             request.resp_addr = responseAddress;
             request.batch_size = batchSize;
             FillTransferEntries(entries, request.entries);
@@ -290,8 +293,8 @@ void NodeActor::StartRequest(Request request)
     active.replySlot = std::move(acquired).Value();
 
     std::vector<std::uint8_t> payload;
-    auto status =
-        EncodeRequest(active.replySlot, active.request.op, active.request.entries, payload);
+    auto status = EncodeRequest(active.replySlot, active.request.requestId, active.request.op,
+                                active.request.entries, payload);
     if (status.Failure()) {
         UC_ERROR(
             "DramStore request encoding failed, task_id={} request_id={} op={} "

--- a/ucm/store/dram/cc/node_actor.h
+++ b/ucm/store/dram/cc/node_actor.h
@@ -103,8 +103,8 @@ private:
 
     void TryFence(TimePoint now);
     void TryConnect(TimePoint now);
-    Status EncodeRequest(const ReplySlot& replySlot, OpType op, const std::vector<IoEntry>& entries,
-                         std::vector<std::uint8_t>& payload);
+    Status EncodeRequest(const ReplySlot& replySlot, RequestId requestId, OpType op,
+                         const std::vector<IoEntry>& entries, std::vector<std::uint8_t>& payload);
 
     Config config_;
     NodeDependencies dependencies_;

--- a/ucm/store/dram/cc/reply_service.cc
+++ b/ucm/store/dram/cc/reply_service.cc
@@ -88,7 +88,8 @@ bool ReplyService::CompletionReady(const Lease& lease) const noexcept
         return false;
     }
     bool ready = false;
-    const auto status = protocol_.IsResponseReady(lease.slot.localAddr, ready);
+    const auto status =
+        protocol_.IsResponseReady(lease.slot.localAddr, lease.token.requestId, ready);
     if (status.Failure() || !ready) { return false; }
     std::atomic_thread_fence(std::memory_order_acquire);
     return true;
@@ -100,8 +101,9 @@ Status ReplyService::DecodeReply(const Lease& lease, std::vector<EntryResult>* e
         return Status::InvalidParam("invalid DramPool reply metadata");
     }
     DramPool::KvResponse response;
-    auto status = protocol_.UnpackResponse(lease.slot.localAddr, ToOpcode(lease.op),
-                                           static_cast<std::uint16_t>(lease.entryCount), response);
+    auto status =
+        protocol_.UnpackResponse(lease.slot.localAddr, ToOpcode(lease.op), lease.token.requestId,
+                                 static_cast<std::uint16_t>(lease.entryCount), response);
     if (status.Failure()) { return status; }
     if (response.results.size() != lease.entryCount) { return Status::DeserializeFailed(); }
 

--- a/ucm/store/test/case/dram/dram_config_test.cc
+++ b/ucm/store/test/case/dram/dram_config_test.cc
@@ -63,7 +63,7 @@ TEST(DramConfigTest, DerivesNodeAndReplyCapacitiesFromGlobalEntryBudget)
     EXPECT_EQ(config.nodeScheduler.limits.maxInflightRequests, std::size_t{7});
     EXPECT_EQ(config.nodeScheduler.limits.maxBatchEntries, std::size_t{7});
     EXPECT_EQ(config.replySlotCount, std::size_t{14});
-    EXPECT_EQ(config.replySlotSize, std::uint32_t{5});
+    EXPECT_EQ(config.replySlotSize, std::uint32_t{13});
 }
 
 TEST(DramConfigTest, CapsDerivedNodeAndReplyCapacities)
@@ -75,7 +75,7 @@ TEST(DramConfigTest, CapsDerivedNodeAndReplyCapacities)
     EXPECT_EQ(config.nodeScheduler.limits.maxInflightRequests, std::size_t{128});
     EXPECT_EQ(config.nodeScheduler.limits.maxBatchEntries, std::size_t{128});
     EXPECT_EQ(config.replySlotCount, std::size_t{256});
-    EXPECT_EQ(config.replySlotSize, std::uint32_t{65});
+    EXPECT_EQ(config.replySlotSize, std::uint32_t{73});
 }
 
 TEST(DramConfigTest, OverridesWorkerCountIndependently)

--- a/ucm/store/test/case/dram/dram_node_scheduler_test.cc
+++ b/ucm/store/test/case/dram/dram_node_scheduler_test.cc
@@ -163,6 +163,7 @@ TEST(NodeActorTest, PacksLookupWithTargetDramPoolProtocol)
     ASSERT_TRUE(unpackStatus.Success());
     const auto* lookup = dynamic_cast<const DramPool::KvLookupRequest*>(unpacked.get());
     ASSERT_NE(lookup, nullptr);
+    EXPECT_EQ(lookup->request_id, 1U);
     ASSERT_EQ(lookup->entries.size(), std::size_t{1});
     EXPECT_EQ(lookup->entries[0].key[0], std::byte{7});
     EXPECT_EQ(lookup->resp_addr, reinterpret_cast<std::uintptr_t>(reply.data()));

--- a/ucm/store/test/case/dram/dram_reply_service_polling_test.cc
+++ b/ucm/store/test/case/dram/dram_reply_service_polling_test.cc
@@ -37,11 +37,12 @@
 namespace UC::Dram {
 namespace {
 
-Status PackReply(const ReplySlot& slot, DramPool::KvOpcode opcode,
+Status PackReply(const ReplySlot& slot, DramPool::KvOpcode opcode, RequestId requestId,
                  std::vector<std::uint8_t> results)
 {
     DramPool::ProtocolManager protocol;
-    return protocol.PackResponse(slot.localAddr, opcode, DramPool::KvResponse{std::move(results)});
+    return protocol.PackResponse(slot.localAddr, opcode,
+                                 DramPool::KvResponse{requestId, std::move(results)});
 }
 
 class EventCollector final {
@@ -94,7 +95,7 @@ TEST(ReplyServicePollingTest, PublishesObservedReplyAndKeepsLeaseUntilActorRelea
     auto acquired = service->Acquire(token, OpType::LOOKUP, 2);
     ASSERT_TRUE(acquired);
     auto slot = acquired.Value();
-    ASSERT_TRUE(PackReply(slot, DramPool::KvOpcode::Lookup, {1, 0}).Success());
+    ASSERT_TRUE(PackReply(slot, DramPool::KvOpcode::Lookup, token.requestId, {1, 0}).Success());
 
     auto event = collector.Wait(std::chrono::milliseconds{500});
     ASSERT_TRUE(event.has_value());
@@ -148,7 +149,8 @@ TEST(ReplyServicePollingTest, ReusesSlotWhilePreviousReplyEventIsBeingPublished)
 
     auto first = service->Acquire(firstToken, OpType::LOOKUP, 1);
     ASSERT_TRUE(first);
-    ASSERT_TRUE(PackReply(first.Value(), DramPool::KvOpcode::Lookup, {1}).Success());
+    ASSERT_TRUE(
+        PackReply(first.Value(), DramPool::KvOpcode::Lookup, firstToken.requestId, {1}).Success());
     bool publishEntered = false;
     {
         std::unique_lock lock(mutex);
@@ -162,7 +164,10 @@ TEST(ReplyServicePollingTest, ReusesSlotWhilePreviousReplyEventIsBeingPublished)
     if (publishEntered) {
         firstRelease = service->Release(firstToken, first.Value());
         second = service->Acquire(secondToken, OpType::LOOKUP, 1);
-        if (second) { secondPack = PackReply(second.Value(), DramPool::KvOpcode::Lookup, {1}); }
+        if (second) {
+            secondPack =
+                PackReply(second.Value(), DramPool::KvOpcode::Lookup, secondToken.requestId, {1});
+        }
     }
 
     {
@@ -231,12 +236,13 @@ TEST(ReplyServicePollingTest, EventPublisherExceptionIsFatal)
             });
             if (created) {
                 auto service = std::move(created).Value();
-                auto acquired =
-                    service->Start().Success()
-                        ? service->Acquire(RequestToken{3, kDefaultLaneId, 1, 9}, OpType::LOOKUP, 1)
-                        : Expected<ReplySlot>{Status::Error()};
+                const RequestToken token = (RequestToken{3, kDefaultLaneId, 1, 9});
+                auto acquired = service->Start().Success()
+                                    ? service->Acquire(token, OpType::LOOKUP, 1)
+                                    : Expected<ReplySlot>{Status::Error()};
                 if (acquired &&
-                    PackReply(acquired.Value(), DramPool::KvOpcode::Lookup, {1}).Success()) {
+                    PackReply(acquired.Value(), DramPool::KvOpcode::Lookup, token.requestId, {1})
+                        .Success()) {
                     publishAttemptedFuture.wait();
                 }
                 service->Shutdown();

--- a/ucm/store/test/case/dram/drampool/completion_poller_test.cc
+++ b/ucm/store/test/case/dram/drampool/completion_poller_test.cc
@@ -52,6 +52,7 @@ namespace {
 constexpr std::size_t kQueueCapacity = 16;
 constexpr std::size_t kValueLength = 16;
 constexpr std::size_t kFlagSlotSize = 64;
+constexpr std::uint64_t kRequestId = 42;
 constexpr char kUnavailablePeer[] = "127.0.0.1:29000";
 
 using UC::Test::Dram::Clock;
@@ -147,6 +148,7 @@ protected:
     {
         CompletionRecord record;
         record.stage = CompletionStage::SubmitResponse;
+        record.request_id = kRequestId;
         record.opcode = opcode;
         record.remote_resp_addr = 0x9000;
         record.peer_one_sided_id = kUnavailablePeer;

--- a/ucm/store/test/case/dram/drampool/drampool_startup_test.cc
+++ b/ucm/store/test/case/dram/drampool/drampool_startup_test.cc
@@ -37,6 +37,9 @@
 #include <sys/wait.h>
 #include <thread>
 #include <unistd.h>
+#include "channels/tcp/tcp_message_channel.h"
+#include "kv_protocol.h"
+#include "logger/logger.h"
 #endif
 #include "drampool_config.h"
 #include "drampool_daemon.h"
@@ -481,6 +484,87 @@ TEST(DramPoolServerTest, RejectsCallsOutsideValidState)
 
 #if defined(UCM_DRAMPOOL_RUNTIME_INTEGRATION_TESTS)
 #if !defined(_WIN32)
+TEST(DramPoolServerTest, RequestReceiverLogsReceivedRequestFields)
+{
+    constexpr std::uint64_t kRequestId = 42;
+    const auto logRoot = std::filesystem::temp_directory_path() /
+                         ("drampool_request_receiver_log_" + std::to_string(::getpid()));
+    std::filesystem::remove_all(logRoot);
+    std::filesystem::create_directories(logRoot);
+
+    const auto child = ::fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        (void)::setenv("UC_LOGGER_LEVEL", "debug", 1);
+        (void)::setenv("UCM_LOG_RATE_LIMIT_ENABLE", "false", 1);
+        UC::Logger::Setup(logRoot.string(), 1, 1);
+
+        auto config = MakeValidConfig();
+        config.poolBlockSizes = {4096};
+        config.poolBlockProportions = {1};
+        config.poolSlotCounts = {1};
+        config.gcEnabled = false;
+        const transport::Endpoint clientControl{"127.0.0.1", FindDistinctTcpPort(config.addr.port)};
+        const auto clientOneSidedPort = FindDistinctTcpPort(config.addr.port, clientControl.port);
+        config.twoSidedToOneSided.emplace(clientControl.ToString(),
+                                          "127.0.0.1:" + std::to_string(clientOneSidedPort));
+        ScopedDramPoolConfig configScope(std::move(config));
+
+        DramPoolServer server;
+        transport::TcpMessageChannel client;
+        ProtocolManager protocol;
+        if (server.Init().Failure()) { ::_exit(1); }
+        if (server.Start().Failure()) { ::_exit(2); }
+        if (client.Init(clientControl).Failure()) { ::_exit(3); }
+
+        KvLookupRequest request;
+        request.opcode = KvOpcode::Lookup;
+        request.request_id = kRequestId;
+        request.resp_addr = 0x1000;
+        request.batch_size = 1;
+        request.entries.emplace_back();
+        request.entries.back().key.back() = std::byte{1};
+        const auto packedSize = protocol.GetPackedRequestSize(request.opcode, request);
+        std::vector<std::uint8_t> packed(packedSize);
+        if (protocol.PackRequest(packed.data(), request.opcode, request).Failure()) { ::_exit(4); }
+        if (client.Send(g_config.addr, packed.data(), packed.size()).Failure()) { ::_exit(5); }
+
+        const auto expected =
+            "RequestReceiver received request, request_id=" + std::to_string(kRequestId) +
+            ", opcode=" + std::to_string(static_cast<int>(KvOpcode::Lookup));
+        const auto logPath = logRoot / std::to_string(::getpid()) / "ucm.log";
+        bool found = false;
+        for (int attempt = 0; attempt < 200 && !found; ++attempt) {
+            UC::Logger::Flush();
+            std::ifstream input(logPath);
+            const std::string content((std::istreambuf_iterator<char>(input)),
+                                      std::istreambuf_iterator<char>());
+            found = content.find(expected) != std::string::npos;
+            if (!found) { std::this_thread::sleep_for(std::chrono::milliseconds(10)); }
+        }
+
+        (void)client.Shutdown();
+        server.Stop();
+        UC::Logger::Flush();
+        ::_exit(found ? 0 : 6);
+    }
+
+    int childStatus = 0;
+    ASSERT_EQ(::waitpid(child, &childStatus, 0), child);
+    ASSERT_TRUE(WIFEXITED(childStatus));
+    ASSERT_EQ(WEXITSTATUS(childStatus), 0);
+
+    const auto logPath = logRoot / std::to_string(child) / "ucm.log";
+    std::ifstream input(logPath);
+    const std::string content((std::istreambuf_iterator<char>(input)),
+                              std::istreambuf_iterator<char>());
+    const auto messagePosition = content.find("RequestReceiver received request");
+    ASSERT_NE(messagePosition, std::string::npos);
+    const auto messageEnd = content.find('\n', messagePosition);
+    std::cout << content.substr(messagePosition, messageEnd - messagePosition) << std::endl;
+    std::filesystem::remove_all(logRoot);
+}
+
 TEST(DramPoolServerTest, StartsAndStopsService)
 {
     EXPECT_EQ(RunInIsolatedProcess([]() {

--- a/ucm/store/test/case/dram/drampool/task_worker_test.cc
+++ b/ucm/store/test/case/dram/drampool/task_worker_test.cc
@@ -63,6 +63,8 @@ std::uint8_t LookupCode(LookupResult result) { return static_cast<std::uint8_t>(
 
 class TaskWorkerTest : public ::testing::Test {
 protected:
+    static constexpr std::uint64_t kRequestId = 42;
+
     static void SetUpTestSuite()
     {
         auto status = device_.Init();
@@ -182,9 +184,12 @@ TEST_F(TaskWorkerTest, ProcessesRequestWithoutInitiatingPeerConnection)
     task->peer_one_sided_id = kTargetManager;
     task->request = std::make_unique<KvLookupRequest>();
     task->request->opcode = KvOpcode::Lookup;
+    task->request->request_id = kRequestId;
 
     EXPECT_TRUE(worker.ProcessOneRequest(std::move(task)).Success());
-    EXPECT_EQ(PopCompletion().peer_one_sided_id, kTargetManager);
+    const auto record = PopCompletion();
+    EXPECT_EQ(record.peer_one_sided_id, kTargetManager);
+    EXPECT_EQ(record.request_id, kRequestId);
 }
 
 TEST_F(TaskWorkerTest, LookupReturnsHitAndMiss)
@@ -194,6 +199,7 @@ TEST_F(TaskWorkerTest, LookupReturnsHitAndMiss)
 
     KvLookupRequest request;
     request.opcode = KvOpcode::Lookup;
+    request.request_id = kRequestId;
     request.resp_addr = kResponseAddress;
     request.entries = {{hitKey}, {KeyFromHex("a2")}};
     request.batch_size = static_cast<std::uint16_t>(request.entries.size());
@@ -213,6 +219,7 @@ TEST_F(TaskWorkerTest, DuplicateDumpIsIdempotent)
 
     KvDumpRequest request;
     request.opcode = KvOpcode::Dump;
+    request.request_id = kRequestId;
     request.resp_addr = kResponseAddress;
     request.entries = {
         {key, 0x1000, kValueLength, 0}
@@ -235,6 +242,7 @@ TEST_F(TaskWorkerTest, DumpStopsAfterFirstStoreBeginFailure)
 
     KvDumpRequest request;
     request.opcode = KvOpcode::Dump;
+    request.request_id = kRequestId;
     request.resp_addr = kResponseAddress;
     request.entries = {
         {duplicateKey, 0x1000, kValueLength,     0},
@@ -260,6 +268,7 @@ TEST_F(TaskWorkerTest, DumpSubmitFailureDeletesReservedMetadata)
 
     KvDumpRequest request;
     request.opcode = KvOpcode::Dump;
+    request.request_id = kRequestId;
     request.resp_addr = kResponseAddress;
     request.entries = {
         {key, 0x1000, kValueLength, 0}
@@ -281,6 +290,7 @@ TEST_F(TaskWorkerTest, LoadReportsMissingAndOversizedItems)
 
     KvLoadRequest request;
     request.opcode = KvOpcode::Load;
+    request.request_id = kRequestId;
     request.resp_addr = kResponseAddress;
     request.entries = {
         {missingKey,   0x1000, kValueLength,     0},
@@ -305,6 +315,7 @@ TEST_F(TaskWorkerTest, LoadSubmitFailureEndsAllPinnedItems)
 
     KvLoadRequest request;
     request.opcode = KvOpcode::Load;
+    request.request_id = kRequestId;
     request.resp_addr = kResponseAddress;
     request.entries = {
         {firstKey,  0x1000, kValueLength, 0},
@@ -329,6 +340,7 @@ TEST_F(TaskWorkerTest, RejectsResponsesLargerThanFlagBufferSlot)
 
     KvDumpRequest dump;
     dump.opcode = KvOpcode::Dump;
+    dump.request_id = kRequestId;
     dump.batch_size = 1;
     dump.entries = {
         {KeyFromHex("a1"), 0x1000, kValueLength, 0}
@@ -337,6 +349,7 @@ TEST_F(TaskWorkerTest, RejectsResponsesLargerThanFlagBufferSlot)
 
     KvLoadRequest load;
     load.opcode = KvOpcode::Load;
+    load.request_id = kRequestId;
     load.batch_size = 1;
     load.entries = {
         {KeyFromHex("a2"), 0x2000, kValueLength, 0}
@@ -345,6 +358,7 @@ TEST_F(TaskWorkerTest, RejectsResponsesLargerThanFlagBufferSlot)
 
     KvLookupRequest lookup;
     lookup.opcode = KvOpcode::Lookup;
+    lookup.request_id = kRequestId;
     lookup.batch_size = 1;
     lookup.entries = {{KeyFromHex("a3")}};
     EXPECT_TRUE(ProcessLookup(lookup).Failure());

--- a/ucm/store/test/case/dram/kv_protocol_test.cc
+++ b/ucm/store/test/case/dram/kv_protocol_test.cc
@@ -27,6 +27,7 @@
 #include <cstdint>
 #include <cstring>
 #include <gtest/gtest.h>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -36,6 +37,7 @@ namespace UC::DramPool {
 namespace {
 
 using UC::Test::Dram::KeyFromHex;
+constexpr std::uint64_t kRequestId = 0x123456789ABCDEF0ULL;
 
 void ExpectLe16(const std::vector<std::uint8_t>& buf, std::size_t offset, std::uint16_t value)
 {
@@ -72,6 +74,7 @@ TEST_F(KvProtocolTest, PackDumpRequestMatchesLayout)
 
     KvDumpRequest req;
     req.opcode = KvOpcode::Dump;
+    req.request_id = kRequestId;
     req.resp_addr = 0x0102030405060708ULL;
     req.batch_size = 1;
     req.ttl = 0x99AABBCCU;
@@ -82,9 +85,10 @@ TEST_F(KvProtocolTest, PackDumpRequestMatchesLayout)
     ASSERT_TRUE(status.Success()) << status.ToString();
 
     EXPECT_EQ(packed[0], static_cast<std::uint8_t>(KvOpcode::Dump));
-    ExpectLe64(packed, 1, req.resp_addr);
-    ExpectLe32(packed, 9, req.ttl);
-    ExpectLe16(packed, 13, req.batch_size);
+    ExpectLe64(packed, kRequestIdOffset, req.request_id);
+    ExpectLe64(packed, kRespAddrOffset, req.resp_addr);
+    ExpectLe32(packed, kDumpTtlOffset, req.ttl);
+    ExpectLe16(packed, kDumpBatchSizeOffset, req.batch_size);
     EXPECT_EQ(packed.size(), kKvDumpRequestHeaderSize + kKvDumpEntrySize);
     EXPECT_EQ(std::memcmp(packed.data() + kKvDumpRequestHeaderSize, entry.key.data(), kKvKeySize),
               0);
@@ -103,6 +107,7 @@ TEST_F(KvProtocolTest, PackLoadRequestMatchesLayout)
 
     KvLoadRequest req;
     req.opcode = KvOpcode::Load;
+    req.request_id = kRequestId;
     req.resp_addr = 0x1111222233334444ULL;
     req.batch_size = 1;
     req.entries = {entry};
@@ -112,8 +117,9 @@ TEST_F(KvProtocolTest, PackLoadRequestMatchesLayout)
     ASSERT_TRUE(status.Success()) << status.ToString();
 
     EXPECT_EQ(packed[0], static_cast<std::uint8_t>(KvOpcode::Load));
-    ExpectLe64(packed, 1, req.resp_addr);
-    ExpectLe16(packed, 9, req.batch_size);
+    ExpectLe64(packed, kRequestIdOffset, req.request_id);
+    ExpectLe64(packed, kRespAddrOffset, req.resp_addr);
+    ExpectLe16(packed, kLoadLookupBatchSizeOffset, req.batch_size);
     EXPECT_EQ(std::memcmp(packed.data() + kKvLoadRequestHeaderSize, entry.key.data(), kKvKeySize),
               0);
 }
@@ -127,6 +133,7 @@ TEST_F(KvProtocolTest, PackLookupRequestMatchesLayout)
 
     KvLookupRequest req;
     req.opcode = KvOpcode::Lookup;
+    req.request_id = kRequestId;
     req.resp_addr = 0x1234000056780000ULL;
     req.batch_size = 2;
     req.entries = {entry0, entry1};
@@ -136,8 +143,9 @@ TEST_F(KvProtocolTest, PackLookupRequestMatchesLayout)
     ASSERT_TRUE(status.Success()) << status.ToString();
 
     EXPECT_EQ(packed[0], static_cast<std::uint8_t>(KvOpcode::Lookup));
-    ExpectLe64(packed, 1, req.resp_addr);
-    ExpectLe16(packed, 9, req.batch_size);
+    ExpectLe64(packed, kRequestIdOffset, req.request_id);
+    ExpectLe64(packed, kRespAddrOffset, req.resp_addr);
+    ExpectLe16(packed, kLoadLookupBatchSizeOffset, req.batch_size);
     EXPECT_EQ(
         std::memcmp(packed.data() + kKvLookupRequestHeaderSize, entry0.key.data(), kKvKeySize), 0);
     EXPECT_EQ(std::memcmp(packed.data() + kKvLookupRequestHeaderSize + kKvLookupEntrySize,
@@ -152,6 +160,7 @@ TEST_F(KvProtocolTest, RejectsBatchSizeMismatch)
 
     KvLookupRequest req;
     req.opcode = KvOpcode::Lookup;
+    req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 2;
     req.entries = {entry};
@@ -168,6 +177,7 @@ TEST_F(KvProtocolTest, RejectsAllZeroKey)
 
     KvLookupRequest req;
     req.opcode = KvOpcode::Lookup;
+    req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 1;
     req.entries = {entry};
@@ -187,6 +197,7 @@ TEST_F(KvProtocolTest, RejectsZeroDumpLoadAddrAndLen)
 
     KvDumpRequest req;
     req.opcode = KvOpcode::Dump;
+    req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 1;
     req.entries = {entry};
@@ -210,6 +221,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsWrongSize)
 
     KvLookupRequest req;
     req.opcode = KvOpcode::Lookup;
+    req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 1;
     req.entries = {entry};
@@ -226,15 +238,21 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsWrongSize)
 
 TEST_F(KvProtocolTest, UnpackResponseReadsPackedResults)
 {
-    std::uint8_t lookupFlag[] = {static_cast<std::uint8_t>(ResponseStatus::Ready), 0x8D, 0x01};
+    std::uint8_t lookupFlag[] = {0xF0, 0xDE, 0xBC,
+                                 0x9A, 0x78, 0x56,
+                                 0x34, 0x12, static_cast<std::uint8_t>(ResponseStatus::Ready),
+                                 0x8D, 0x01};
     KvResponse resp;
-    auto status = mgr_.UnpackResponse(lookupFlag, KvOpcode::Lookup, 9, resp);
+    auto status = mgr_.UnpackResponse(lookupFlag, KvOpcode::Lookup, kRequestId, 9, resp);
     ASSERT_TRUE(status.Success()) << status.ToString();
     EXPECT_EQ(resp.results, (std::vector<std::uint8_t>{1, 0, 1, 1, 0, 0, 0, 1, 1}));
 
-    std::uint8_t dumpFlag[] = {static_cast<std::uint8_t>(ResponseStatus::Ready), 0x10, 0xF2, 0x03};
+    std::uint8_t dumpFlag[] = {0xF0, 0xDE, 0xBC,
+                               0x9A, 0x78, 0x56,
+                               0x34, 0x12, static_cast<std::uint8_t>(ResponseStatus::Ready),
+                               0x10, 0xF2, 0x03};
     resp.results.clear();
-    status = mgr_.UnpackResponse(dumpFlag, KvOpcode::Dump, 5, resp);
+    status = mgr_.UnpackResponse(dumpFlag, KvOpcode::Dump, kRequestId, 5, resp);
     ASSERT_TRUE(status.Success()) << status.ToString();
     EXPECT_EQ(resp.results, (std::vector<std::uint8_t>{0, 1, 2, 15, 3}));
 }
@@ -249,6 +267,7 @@ TEST_F(KvProtocolTest, ServerRoundTripDumpLoad)
 
     KvLoadRequest req;
     req.opcode = KvOpcode::Load;
+    req.request_id = kRequestId;
     req.resp_addr = 0x9988776655443322ULL;
     req.batch_size = 1;
     req.entries = {entry};
@@ -262,6 +281,7 @@ TEST_F(KvProtocolTest, ServerRoundTripDumpLoad)
     ASSERT_TRUE(mgr_.UnpackRequest(packed.data(), packed.size(), parsed).Success());
     auto& dl = static_cast<KvLoadRequest&>(*parsed);
     EXPECT_EQ(dl.opcode, req.opcode);
+    EXPECT_EQ(dl.request_id, req.request_id);
     EXPECT_EQ(dl.resp_addr, req.resp_addr);
     EXPECT_EQ(dl.batch_size, req.batch_size);
     EXPECT_EQ(std::memcmp(dl.entries[0].key.data(), entry.key.data(), kKvKeySize), 0);
@@ -271,12 +291,15 @@ TEST_F(KvProtocolTest, ServerRoundTripDumpLoad)
 
     // server packs response, client unpacks it
     KvResponse resp;
+    resp.request_id = req.request_id;
     resp.results = {0x0};  // batch_size == 1 errcode
     std::vector<std::uint8_t> flag(mgr_.GetPackedResponseSize(req.opcode, resp.results.size()),
                                    0xFF);
     ASSERT_TRUE(mgr_.PackResponse(flag.data(), req.opcode, resp).Success());
     KvResponse resp2;
-    ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), req.opcode, req.batch_size, resp2).Success());
+    ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), req.opcode, req.request_id, req.batch_size, resp2)
+                    .Success());
+    EXPECT_EQ(resp2.request_id, req.request_id);
     ASSERT_EQ(resp2.results.size(), 1u);
     EXPECT_EQ(resp2.results[0], 0x0U);
 }
@@ -289,6 +312,7 @@ TEST_F(KvProtocolTest, ServerRoundTripLookup)
     e1.key = KeyFromHex("a0");
     KvLookupRequest req;
     req.opcode = KvOpcode::Lookup;
+    req.request_id = kRequestId;
     req.resp_addr = 0x0E0E0E0E0E0E0E0EULL;
     req.batch_size = 2;
     req.entries = {e0, e1};
@@ -302,6 +326,7 @@ TEST_F(KvProtocolTest, ServerRoundTripLookup)
     ASSERT_TRUE(mgr_.UnpackRequest(packed.data(), packed.size(), parsed).Success());
     auto& lk = static_cast<KvLookupRequest&>(*parsed);
     EXPECT_EQ(lk.opcode, req.opcode);
+    EXPECT_EQ(lk.request_id, req.request_id);
     EXPECT_EQ(lk.resp_addr, req.resp_addr);
     EXPECT_EQ(lk.batch_size, req.batch_size);
     EXPECT_EQ(std::memcmp(lk.entries[0].key.data(), e0.key.data(), kKvKeySize), 0);
@@ -309,12 +334,14 @@ TEST_F(KvProtocolTest, ServerRoundTripLookup)
 
     // server packs one existence bit per key, client unpacks it
     KvResponse resp;
+    resp.request_id = req.request_id;
     resp.results = {1, 0};
     std::vector<std::uint8_t> flag(mgr_.GetPackedResponseSize(req.opcode, resp.results.size()),
                                    0xFF);
     ASSERT_TRUE(mgr_.PackResponse(flag.data(), req.opcode, resp).Success());
     KvResponse resp2;
-    ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), req.opcode, req.batch_size, resp2).Success());
+    ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), req.opcode, req.request_id, req.batch_size, resp2)
+                    .Success());
     EXPECT_EQ(resp2.results, resp.results);
 }
 
@@ -332,6 +359,7 @@ TEST_F(KvProtocolTest, DumpLoadMaxFieldValuesRoundTrip)
 
     KvLoadRequest req;
     req.opcode = KvOpcode::Load;
+    req.request_id = std::numeric_limits<std::uint64_t>::max();
     req.resp_addr = 0xFFFFFFFFFFFFFFFFULL;
     req.batch_size = 1;
     req.entries = {entry};
@@ -342,6 +370,7 @@ TEST_F(KvProtocolTest, DumpLoadMaxFieldValuesRoundTrip)
     std::unique_ptr<KvRequest> parsed;
     ASSERT_TRUE(mgr_.UnpackRequest(packed.data(), packed.size(), parsed).Success());
     auto& dl = static_cast<KvLoadRequest&>(*parsed);
+    EXPECT_EQ(dl.request_id, std::numeric_limits<std::uint64_t>::max());
     EXPECT_EQ(dl.resp_addr, 0xFFFFFFFFFFFFFFFFULL);
     EXPECT_EQ(dl.entries[0].addr, 0xFFFFFFFFFFFFFFFFULL);
     EXPECT_EQ(dl.entries[0].len, 0xFFFFFFFFU);
@@ -358,6 +387,7 @@ TEST_F(KvProtocolTest, DumpLoadMultiEntryRoundTrip)
     constexpr std::uint16_t kBatch = 5;
     KvDumpRequest req;
     req.opcode = KvOpcode::Dump;
+    req.request_id = kRequestId;
     req.resp_addr = 0xA5A5A5A5A5A5A5A5ULL;
     req.batch_size = kBatch;
     req.ttl = 0x10203040U;
@@ -392,6 +422,7 @@ TEST_F(KvProtocolTest, LookupMultiEntryRoundTrip)
     constexpr std::uint16_t kBatch = 4;
     KvLookupRequest req;
     req.opcode = KvOpcode::Lookup;
+    req.request_id = kRequestId;
     req.resp_addr = 0xB0B0B0B0B0B0B0B0ULL;
     req.batch_size = kBatch;
     for (std::uint16_t i = 0; i < kBatch; ++i) {
@@ -420,6 +451,7 @@ TEST_F(KvProtocolTest, LookupMultiEntryRoundTrip)
 TEST_F(KvProtocolTest, RejectsNoneOpcodeOnDumpLoad)
 {
     KvDumpRequest req;  // opcode defaults to None
+    req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 1;
     req.entries = {
@@ -436,6 +468,7 @@ TEST_F(KvProtocolTest, RejectsOpcodeMismatch)
 {
     KvDumpRequest req;
     req.opcode = KvOpcode::Lookup;  // wrong opcode for a Dump request
+    req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 1;
     req.entries = {
@@ -466,6 +499,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsExtraBytes)
 {
     KvLookupRequest req;
     req.opcode = KvOpcode::Lookup;
+    req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 1;
     req.entries = {KvLookupEntry{KeyFromHex("70")}};
@@ -513,6 +547,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsSizeMismatch)
 {
     KvDumpRequest req;
     req.opcode = KvOpcode::Dump;
+    req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 2;
     req.entries = {
@@ -536,6 +571,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsSizeMismatch)
 TEST_F(KvProtocolTest, PackResponseRejectsNullData)
 {
     KvResponse resp;
+    resp.request_id = kRequestId;
     resp.results = {0x0};
     auto status = mgr_.PackResponse(nullptr, KvOpcode::Dump, resp);
     EXPECT_FALSE(status.Success());
@@ -543,14 +579,16 @@ TEST_F(KvProtocolTest, PackResponseRejectsNullData)
 
 TEST_F(KvProtocolTest, PackResponseRejectsValuesThatDoNotFitWireWidth)
 {
-    std::uint8_t flag[2] = {0};
+    std::uint8_t flag[kResponseResultsOffset + 1] = {0};
     KvResponse lookup;
+    lookup.request_id = kRequestId;
     lookup.results = {2};
     auto status = mgr_.PackResponse(flag, KvOpcode::Lookup, lookup);
     EXPECT_FALSE(status.Success()) << status.ToString();
     EXPECT_EQ(flag[kResponseStatusOffset], static_cast<std::uint8_t>(ResponseStatus::Pending));
 
     KvResponse dump;
+    dump.request_id = kRequestId;
     dump.results = {16};
     status = mgr_.PackResponse(flag, KvOpcode::Dump, dump);
     EXPECT_FALSE(status.Success()) << status.ToString();
@@ -560,7 +598,8 @@ TEST_F(KvProtocolTest, PackResponseRejectsValuesThatDoNotFitWireWidth)
 TEST_F(KvProtocolTest, PackResponseLookupRejectsZeroCount)
 {
     KvResponse resp;  // empty results
-    std::uint8_t flag[1] = {0};
+    resp.request_id = kRequestId;
+    std::uint8_t flag[kResponseResultsOffset] = {0};
     auto status = mgr_.PackResponse(flag, KvOpcode::Lookup, resp);
     EXPECT_FALSE(status.Success());
 }
@@ -568,7 +607,8 @@ TEST_F(KvProtocolTest, PackResponseLookupRejectsZeroCount)
 TEST_F(KvProtocolTest, PackResponseDumpLoadZeroErrcodes)
 {
     KvResponse resp;  // empty, result_count=0
-    std::uint8_t flag[1] = {0xFF};
+    resp.request_id = kRequestId;
+    std::uint8_t flag[kResponseResultsOffset] = {0xFF};
     auto status = mgr_.PackResponse(flag, KvOpcode::Dump, resp);
     EXPECT_TRUE(status.Success());
     EXPECT_EQ(flag[kResponseStatusOffset], static_cast<std::uint8_t>(ResponseStatus::Ready));
@@ -581,45 +621,63 @@ TEST_F(KvProtocolTest, PackResponseDumpLoadZeroErrcodes)
 TEST_F(KvProtocolTest, UnpackResponseRejectsNullData)
 {
     KvResponse resp;
-    auto status = mgr_.UnpackResponse(nullptr, KvOpcode::Dump, 1, resp);
+    auto status = mgr_.UnpackResponse(nullptr, KvOpcode::Dump, kRequestId, 1, resp);
     EXPECT_FALSE(status.Success());
 }
 
 TEST_F(KvProtocolTest, ReportsPendingAndReadyResponseStatus)
 {
     bool ready = true;
-    const std::uint8_t pending[] = {static_cast<std::uint8_t>(ResponseStatus::Pending)};
-    auto status = mgr_.IsResponseReady(pending, ready);
+    const std::uint8_t pending[kResponseResultsOffset] = {};
+    auto status = mgr_.IsResponseReady(pending, kRequestId, ready);
     ASSERT_TRUE(status.Success()) << status.ToString();
     EXPECT_FALSE(ready);
 
-    const std::uint8_t completed[] = {static_cast<std::uint8_t>(ResponseStatus::Ready)};
-    status = mgr_.IsResponseReady(completed, ready);
+    std::uint8_t completed[kResponseResultsOffset] = {};
+    std::memcpy(completed + kResponseRequestIdOffset, &kRequestId, sizeof(kRequestId));
+    completed[kResponseStatusOffset] = static_cast<std::uint8_t>(ResponseStatus::Ready);
+    status = mgr_.IsResponseReady(completed, kRequestId, ready);
     ASSERT_TRUE(status.Success()) << status.ToString();
     EXPECT_TRUE(ready);
+}
+
+TEST_F(KvProtocolTest, ReadyResponseWithDifferentRequestIdReturnsError)
+{
+    std::uint8_t response[kResponseResultsOffset] = {};
+    const std::uint64_t staleRequestId = kRequestId - 1U;
+    std::memcpy(response + kResponseRequestIdOffset, &staleRequestId, sizeof(staleRequestId));
+    response[kResponseStatusOffset] = static_cast<std::uint8_t>(ResponseStatus::Ready);
+
+    bool ready = true;
+    const auto status = mgr_.IsResponseReady(response, kRequestId, ready);
+
+    EXPECT_TRUE(status.Failure());
+    EXPECT_FALSE(ready);
 }
 
 TEST_F(KvProtocolTest, ResponseStatusRejectsNullAndUnknownValues)
 {
     bool ready = true;
-    auto status = mgr_.IsResponseReady(nullptr, ready);
+    auto status = mgr_.IsResponseReady(nullptr, kRequestId, ready);
     EXPECT_TRUE(status.Failure());
     EXPECT_FALSE(ready);
 
-    const std::uint8_t invalid[] = {2};
+    std::uint8_t invalid[kResponseResultsOffset] = {};
+    invalid[kResponseStatusOffset] = 2;
     ready = true;
-    status = mgr_.IsResponseReady(invalid, ready);
+    status = mgr_.IsResponseReady(invalid, kRequestId, ready);
     EXPECT_TRUE(status.Failure());
     EXPECT_FALSE(ready);
 }
 
 TEST_F(KvProtocolTest, UnpackResponseReturnsRetryWithoutChangingResultsWhilePending)
 {
-    const std::uint8_t pending[] = {static_cast<std::uint8_t>(ResponseStatus::Pending), 0xFF};
+    std::uint8_t pending[kResponseResultsOffset + 1] = {};
+    pending[kResponseResultsOffset] = 0xFF;
     KvResponse response;
     response.results = {7, 8};
 
-    const auto status = mgr_.UnpackResponse(pending, KvOpcode::Dump, 2, response);
+    const auto status = mgr_.UnpackResponse(pending, KvOpcode::Dump, kRequestId, 2, response);
 
     EXPECT_EQ(status, Status::Retry());
     EXPECT_EQ(response.results, (std::vector<std::uint8_t>{7, 8}));
@@ -627,12 +685,12 @@ TEST_F(KvProtocolTest, UnpackResponseReturnsRetryWithoutChangingResultsWhilePend
 
 TEST_F(KvProtocolTest, PackedResponseSizesRoundUpAtBitBoundaries)
 {
-    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Lookup, 1), 2U);
-    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Lookup, 8), 2U);
-    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Lookup, 9), 3U);
-    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Dump, 1), 2U);
-    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Dump, 2), 2U);
-    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Load, 3), 3U);
+    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Lookup, 1), 10U);
+    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Lookup, 8), 10U);
+    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Lookup, 9), 11U);
+    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Dump, 1), 10U);
+    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Dump, 2), 10U);
+    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Load, 3), 11U);
     EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::None, 3), 0U);
 }
 
@@ -643,15 +701,18 @@ TEST_F(KvProtocolTest, PackedResponseSizesRoundUpAtBitBoundaries)
 TEST_F(KvProtocolTest, ResponseSymmetryMultipleErrcodes)
 {
     KvResponse resp;
+    resp.request_id = kRequestId;
     resp.results = {0x0, 0x1, 0x2, 0xE, 0xF};
     constexpr std::uint16_t kCount = 5;
     std::vector<std::uint8_t> flag(mgr_.GetPackedResponseSize(KvOpcode::Dump, kCount), 0xFF);
 
     ASSERT_TRUE(mgr_.PackResponse(flag.data(), KvOpcode::Dump, resp).Success());
-    EXPECT_EQ(flag, (std::vector<std::uint8_t>{static_cast<std::uint8_t>(ResponseStatus::Ready),
+    EXPECT_EQ(flag, (std::vector<std::uint8_t>{0xF0, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34, 0x12,
+                                               static_cast<std::uint8_t>(ResponseStatus::Ready),
                                                0x10, 0xE2, 0x0F}));
     KvResponse resp2;
-    ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), KvOpcode::Dump, kCount, resp2).Success());
+    ASSERT_TRUE(
+        mgr_.UnpackResponse(flag.data(), KvOpcode::Dump, kRequestId, kCount, resp2).Success());
     ASSERT_EQ(resp2.results.size(), kCount);
     for (std::uint16_t i = 0; i < kCount; ++i) {
         EXPECT_EQ(resp2.results[i], resp.results[i]) << "result " << i;
@@ -674,6 +735,7 @@ TEST_F(KvProtocolTest, MultiRoundSequentialPacks)
         if (opcode == KvOpcode::Dump) {
             KvDumpRequest req;
             req.opcode = opcode;
+            req.request_id = static_cast<std::uint64_t>(round) + 1U;
             req.resp_addr = resp_addr;
             req.batch_size = 1;
             req.ttl = 0x500U * (round + 1);
@@ -686,6 +748,7 @@ TEST_F(KvProtocolTest, MultiRoundSequentialPacks)
         } else {
             KvLoadRequest req;
             req.opcode = opcode;
+            req.request_id = static_cast<std::uint64_t>(round) + 1U;
             req.resp_addr = resp_addr;
             req.batch_size = 1;
             req.entries = {
@@ -714,11 +777,13 @@ TEST_F(KvProtocolTest, MultiRoundSequentialPacks)
 
         // response round-trip each iteration
         KvResponse resp;
+        resp.request_id = static_cast<std::uint64_t>(round) + 1U;
         resp.results = {round};
-        std::uint8_t flag[2] = {0xFF, 0xFF};
+        std::uint8_t flag[kResponseResultsOffset + 1] = {};
         ASSERT_TRUE(mgr_.PackResponse(flag, opcode, resp).Success()) << "round " << round;
         KvResponse resp2;
-        ASSERT_TRUE(mgr_.UnpackResponse(flag, opcode, 1, resp2).Success()) << "round " << round;
+        ASSERT_TRUE(mgr_.UnpackResponse(flag, opcode, resp.request_id, 1, resp2).Success())
+            << "round " << round;
         EXPECT_EQ(resp2.results[0], round) << "round " << round;
     }
 }
@@ -730,16 +795,18 @@ TEST_F(KvProtocolTest, MultiRoundSequentialPacks)
 TEST_F(KvProtocolTest, LookupPackedResponseOverwritesNonZeroBufferAndRoundTrips)
 {
     KvResponse resp;
+    resp.request_id = kRequestId;
     resp.results = {1, 0, 1, 1, 0, 0, 0, 1, 1};
     std::vector<std::uint8_t> flag(
         mgr_.GetPackedResponseSize(KvOpcode::Lookup, resp.results.size()), 0xFF);
 
     ASSERT_TRUE(mgr_.PackResponse(flag.data(), KvOpcode::Lookup, resp).Success());
-    EXPECT_EQ(flag, (std::vector<std::uint8_t>{static_cast<std::uint8_t>(ResponseStatus::Ready),
+    EXPECT_EQ(flag, (std::vector<std::uint8_t>{0xF0, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34, 0x12,
+                                               static_cast<std::uint8_t>(ResponseStatus::Ready),
                                                0x8D, 0x01}));
 
     KvResponse unpacked;
-    ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), KvOpcode::Lookup,
+    ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), KvOpcode::Lookup, kRequestId,
                                     static_cast<std::uint16_t>(resp.results.size()), unpacked)
                     .Success());
     EXPECT_EQ(unpacked.results, resp.results);
@@ -750,16 +817,18 @@ TEST_F(KvProtocolTest, FourBitResponseCoversEveryPackedByteValue)
     for (std::uint16_t low = 0; low <= 0x0FU; ++low) {
         for (std::uint16_t high = 0; high <= 0x0FU; ++high) {
             KvResponse response;
+            response.request_id = kRequestId;
             response.results = {static_cast<std::uint8_t>(low), static_cast<std::uint8_t>(high)};
             std::vector<std::uint8_t> flag(
                 mgr_.GetPackedResponseSize(KvOpcode::Dump, response.results.size()), 0xFFU);
 
             ASSERT_TRUE(mgr_.PackResponse(flag.data(), KvOpcode::Dump, response).Success());
-            ASSERT_EQ(flag.size(), 2U);
-            EXPECT_EQ(flag[1], static_cast<std::uint8_t>(low | (high << 4U)));
+            ASSERT_EQ(flag.size(), kResponseResultsOffset + 1U);
+            EXPECT_EQ(flag[kResponseResultsOffset], static_cast<std::uint8_t>(low | (high << 4U)));
 
             KvResponse unpacked;
-            ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), KvOpcode::Dump, 2U, unpacked).Success());
+            ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), KvOpcode::Dump, kRequestId, 2U, unpacked)
+                            .Success());
             EXPECT_EQ(unpacked.results, response.results);
         }
     }
@@ -769,6 +838,7 @@ TEST_F(KvProtocolTest, OneBitResponseCoversEveryPackedByteValue)
 {
     for (std::uint16_t byteValue = 0; byteValue <= 0xFFU; ++byteValue) {
         KvResponse response;
+        response.request_id = kRequestId;
         for (std::size_t bit = 0; bit < 8U; ++bit) {
             response.results.push_back(static_cast<std::uint8_t>((byteValue >> bit) & 0x01U));
         }
@@ -776,11 +846,12 @@ TEST_F(KvProtocolTest, OneBitResponseCoversEveryPackedByteValue)
             mgr_.GetPackedResponseSize(KvOpcode::Lookup, response.results.size()), 0xFFU);
 
         ASSERT_TRUE(mgr_.PackResponse(flag.data(), KvOpcode::Lookup, response).Success());
-        ASSERT_EQ(flag.size(), 2U);
-        EXPECT_EQ(flag[1], static_cast<std::uint8_t>(byteValue));
+        ASSERT_EQ(flag.size(), kResponseResultsOffset + 1U);
+        EXPECT_EQ(flag[kResponseResultsOffset], static_cast<std::uint8_t>(byteValue));
 
         KvResponse unpacked;
-        ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), KvOpcode::Lookup, 8U, unpacked).Success());
+        ASSERT_TRUE(
+            mgr_.UnpackResponse(flag.data(), KvOpcode::Lookup, kRequestId, 8U, unpacked).Success());
         EXPECT_EQ(unpacked.results, response.results);
     }
 }
@@ -792,6 +863,7 @@ TEST_F(KvProtocolTest, ResponsePackingClearsUnusedBitsAndPreservesCanary)
     for (const std::size_t count : kBoundaryCounts) {
         for (const KvOpcode opcode : {KvOpcode::Dump, KvOpcode::Load, KvOpcode::Lookup}) {
             KvResponse response;
+            response.request_id = kRequestId;
             response.results.resize(count);
             for (std::size_t index = 0; index < count; ++index) {
                 response.results[index] = static_cast<std::uint8_t>(
@@ -813,8 +885,8 @@ TEST_F(KvProtocolTest, ResponsePackingClearsUnusedBitsAndPreservesCanary)
             }
 
             KvResponse unpacked;
-            ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), opcode, static_cast<std::uint16_t>(count),
-                                            unpacked)
+            ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), opcode, kRequestId,
+                                            static_cast<std::uint16_t>(count), unpacked)
                             .Success());
             EXPECT_EQ(unpacked.results, response.results);
         }
@@ -825,6 +897,7 @@ TEST_F(KvProtocolTest, PackRequestRejectsNullTarget)
 {
     KvLookupRequest request;
     request.opcode = KvOpcode::Lookup;
+    request.request_id = kRequestId;
     request.resp_addr = 0x1000;
     request.batch_size = 1;
     request.entries = {KvLookupEntry{KeyFromHex("10")}};
@@ -839,6 +912,7 @@ TEST_F(KvProtocolTest, RejectsRequestConcreteTypeMismatch)
 {
     KvLoadRequest request;
     request.opcode = KvOpcode::Dump;
+    request.request_id = kRequestId;
     request.resp_addr = 0x1000;
     request.batch_size = 1;
     request.entries = {
@@ -858,6 +932,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsZeroHeaderFieldsForEveryOpcode)
     {
         KvDumpRequest request;
         request.opcode = KvOpcode::Dump;
+        request.request_id = kRequestId;
         request.resp_addr = 0x1000;
         request.ttl = 10;
         request.batch_size = 1;
@@ -871,6 +946,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsZeroHeaderFieldsForEveryOpcode)
     {
         KvLoadRequest request;
         request.opcode = KvOpcode::Load;
+        request.request_id = kRequestId;
         request.resp_addr = 0x1000;
         request.batch_size = 1;
         request.entries = {
@@ -883,6 +959,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsZeroHeaderFieldsForEveryOpcode)
     {
         KvLookupRequest request;
         request.opcode = KvOpcode::Lookup;
+        request.request_id = kRequestId;
         request.resp_addr = 0x1000;
         request.batch_size = 1;
         request.entries = {KvLookupEntry{KeyFromHex("30")}};
@@ -895,9 +972,15 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsZeroHeaderFieldsForEveryOpcode)
         const auto opcode = static_cast<KvOpcode>(packed[kOpcodeOffset]);
         SCOPED_TRACE(static_cast<std::uint8_t>(opcode));
         auto malformed = packed;
-        std::fill_n(malformed.begin() + kRespAddrOffset, sizeof(std::uint64_t), std::uint8_t{0});
+        std::fill_n(malformed.begin() + kRequestIdOffset, sizeof(std::uint64_t), std::uint8_t{0});
         std::unique_ptr<KvRequest> output;
         auto status = mgr_.UnpackRequest(malformed.data(), malformed.size(), output);
+        EXPECT_TRUE(status.Failure());
+        EXPECT_NE(status.ToString().find("request_id"), std::string::npos);
+
+        malformed = packed;
+        std::fill_n(malformed.begin() + kRespAddrOffset, sizeof(std::uint64_t), std::uint8_t{0});
+        status = mgr_.UnpackRequest(malformed.data(), malformed.size(), output);
         EXPECT_TRUE(status.Failure());
         EXPECT_NE(status.ToString().find("resp_addr"), std::string::npos);
 
@@ -924,6 +1007,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsInvalidDumpLoadEntryFields)
 
     KvDumpRequest dump;
     dump.opcode = KvOpcode::Dump;
+    dump.request_id = kRequestId;
     dump.resp_addr = 0x1000;
     dump.ttl = 10;
     dump.batch_size = 1;
@@ -935,6 +1019,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsInvalidDumpLoadEntryFields)
 
     KvLoadRequest load;
     load.opcode = KvOpcode::Load;
+    load.request_id = kRequestId;
     load.resp_addr = 0x1000;
     load.batch_size = 1;
     load.entries = {


### PR DESCRIPTION
  ## Purpose
  Make DramPool request processing and shutdown stalls diagnosable across RequestReceiver, TaskWorker, CompletionPoller, and memory-pool initialization.

  ## Modifications
  1. Propagate the 64-bit request_id through DramStore requests and flag-buffer responses, rejecting stale responses.
  2. Add concise request lifecycle, BufferManager initialization, shutdown, and cleanup diagnostics while preserving clear error context.
  3. Update response sizing and test coverage for request_id propagation and logging.

  ## Tests
  All related tests passed.
