### PR TITLE
[Bugfix] Adjust log rate limiting defaults

### DIFF
--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -74,11 +74,19 @@ def test_dump_wait_failures_use_rate_limited_error_logging(relative_path):
     assert set(matching_calls) == {"error_limit"}
 
 
-def test_default_rate_limit_window_is_ten_seconds():
+def test_default_rate_limit_window_is_sixty_seconds():
     header = (REPO_ROOT / "ucm/shared/infra/logger/cc/spdlog_logger.h").read_text(
         encoding="utf-8"
     )
     logger_doc = (REPO_ROOT / "ucm/logger.py").read_text(encoding="utf-8")
 
-    assert "kDefaultRateLimitWindowMs = 10000" in header
-    assert "default: 10000 = 10s" in logger_doc
+    assert "kDefaultRateLimitWindowMs = 60000" in header
+    assert "default: 60000 = 60s" in logger_doc
+
+
+def test_health_breaker_transition_logging_is_unlimited():
+    source = (REPO_ROOT / "ucm/store/pipeline/cc/health_breaker_store.cc").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'UC_WARN_UNLIMITED(\n            "Store health breaker' in source

--- a/ucm/logger.py
+++ b/ucm/logger.py
@@ -37,13 +37,13 @@ Environment Variables:
                           (default: true, see logger_patch)
 
     UCM_LOG_RATE_LIMIT_ENABLE: Enable/disable rate limiting (default: true)
-    UCM_LOG_RATE_LIMIT_WINDOW_MS: Time window in milliseconds (default: 10000 = 10s)
+    UCM_LOG_RATE_LIMIT_WINDOW_MS: Time window in milliseconds (default: 60000 = 60s)
     UCM_LOG_RATE_LIMIT_MAX_LOGS: Max logs per window (default: 3, max: 3)
 
 Usage:
     logger = init_logger(__name__)
 
-    # Rate-limited logging (10s window, max 3 logs per location)
+    # Rate-limited logging (60s window, max 3 logs per location)
     logger.info_limit("Processing request %s", req_id)
 
     # One-time logging (cached by lru_cache)

--- a/ucm/shared/infra/logger/cc/spdlog_logger.h
+++ b/ucm/shared/infra/logger/cc/spdlog_logger.h
@@ -46,7 +46,7 @@ struct SourceLocation {
 const char* InternSourceString(std::string&& s);
 
 class Logger {
-    static constexpr uint64_t kDefaultRateLimitWindowMs = 10000;
+    static constexpr uint64_t kDefaultRateLimitWindowMs = 60000;
     std::shared_ptr<spdlog::logger> logger_;
     std::shared_ptr<spdlog::logger> file_logger_;
     std::mutex mutex_;

--- a/ucm/store/pipeline/cc/health_breaker_store.cc
+++ b/ucm/store/pipeline/cc/health_breaker_store.cc
@@ -202,7 +202,7 @@ void HealthBreakerStore::RecordHealth(bool healthy)
         }
     }
     if (oldEnabled != newEnabled) {
-        UC_WARN(
+        UC_WARN_UNLIMITED(
             "Store health breaker({}) transitioned to {}, window=[{}], samples={}, failures={}, "
             "threshold={}.",
             storeId_, newEnabled ? "HEALTHY" : "UNHEALTHY", healthWindow, sampleCount, failureCount,


### PR DESCRIPTION
## What changed

- Increase the default UCM log rate-limit window from 10 seconds to 60 seconds while keeping the three-log limit unchanged.
- Make store health breaker state-transition warnings bypass rate limiting.
- Update logger documentation and regression coverage for both behaviors.

## Why

A longer default window reduces repeated log noise. Health breaker transitions are operationally significant state changes, so they must remain visible even when multiple transitions occur within one rate-limit window.

## Impact

Rate-limited logs now allow at most three entries per call site in a 60-second window by default. `UCM_LOG_RATE_LIMIT_WINDOW_MS` can still override the default. Store health breaker transition warnings are always emitted.

## Verification

- Commit hooks: `codespell`, `black`, and `isort` passed.
- Direct invocation of all five checks in `test/test_logger.py` passed.
- `python -m pytest test/test_logger.py -q` was also attempted, but the Windows test environment stopped in the repository-wide fixture because the Unix-only `fcntl` module is unavailable.
