### PR TITLE
[Refactor] Modify AsuClient task management

### DIFF
--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -101,13 +101,12 @@ void LogAsuStatus(const char* operation, const AsuStatus& status)
              status.message);
 }
 
-AsuStatus WaitPrerequisiteEvent(std::uintptr_t eventHandle)
+Status WaitPrerequisiteEvent(std::uintptr_t eventHandle)
 {
-    if (eventHandle == 0) { return AsuStatus::OK(); }
+    if (eventHandle == 0) { return Status::OK(); }
     auto ret = aclrtSynchronizeEvent(reinterpret_cast<aclrtEvent>(eventHandle));
-    if (ret == ACL_SUCCESS) { return AsuStatus::OK(); }
-    return AsuStatus::Error(AsuStatusCode::INTERNAL_ERROR,
-                            "aclrtSynchronizeEvent failed: " + std::to_string(ret));
+    if (ret == ACL_SUCCESS) { return Status::OK(); }
+    return Status::Error("aclrtSynchronizeEvent failed: " + std::to_string(ret));
 }
 
 const char* TransProviderBackendName(UC::ASU::TransProviderType providerType)
@@ -351,9 +350,9 @@ public:
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override
     {
         auto status = WaitPrerequisiteEvent(task.prerequisiteHandle);
-        if (!status.ok()) {
-            LogAsuStatus("wait prerequisite event", status);
-            return ConvertStatus(status);
+        if (status.Failure()) {
+            UC_ERROR("ASU wait prerequisite event failed: status={}.", status);
+            return status;
         }
         return Submit(std::move(task), &UC::ASU::AsuClient::BatchStoreAsync);
     }

--- a/ucm/transport/kv/asu/client/src/client_task_manager.cpp
+++ b/ucm/transport/kv/asu/client/src/client_task_manager.cpp
@@ -140,7 +140,7 @@ void ClientTaskManager::CompleteWithError(const ClientTaskPtr& task, const Statu
     std::fill(task->entryStatus.begin(), task->entryStatus.end(), status);
     task->finalStatus = status;
     UC_ERROR("ASU client task failed: client_task_id={} op={} code={} message={}.", task->taskId,
-             ClientOpTypeName(task->opType), static_cast<int>(status.code), status.message);
+             AsuOpTypeName(task->opType), static_cast<int>(status.code), status.message);
     task->state.store(ClientTaskState::COMPLETED, std::memory_order_release);
     task->cv.notify_all();
 }
@@ -227,8 +227,8 @@ void ClientTaskManager::Finalize(const ClientTaskPtr& task)
         UC_ERROR(
             "ASU client transport task failed: client_task_id={} op={} asuId={} "
             "transport_task_id={} item_count={} code={} message={}.",
-            task->taskId, ClientOpTypeName(task->opType), transportTask->asuId,
-            transportTask->taskId, itemCount, static_cast<int>(transportTask->finalStatus.code),
+            task->taskId, AsuOpTypeName(task->opType), transportTask->asuId, transportTask->taskId,
+            itemCount, static_cast<int>(transportTask->finalStatus.code),
             transportTask->finalStatus.message);
     }
     task->finalStatus = failedTransportTasks == 0 ? Status::OK()
@@ -236,12 +236,12 @@ void ClientTaskManager::Finalize(const ClientTaskPtr& task)
                                                                   "client task partially failed");
     if (task->finalStatus.ok()) {
         UC_DEBUG("ASU client task completed: client_task_id={} op={} transport_tasks={}.",
-                 task->taskId, ClientOpTypeName(task->opType), task->transportTasks.size());
+                 task->taskId, AsuOpTypeName(task->opType), task->transportTasks.size());
     } else {
         UC_ERROR(
             "ASU client task failed: client_task_id={} op={} transport_tasks={} "
             "failed_transport_tasks={} code={} message={}.",
-            task->taskId, ClientOpTypeName(task->opType), task->transportTasks.size(),
+            task->taskId, AsuOpTypeName(task->opType), task->transportTasks.size(),
             failedTransportTasks, static_cast<int>(task->finalStatus.code),
             task->finalStatus.message);
     }

--- a/ucm/transport/kv/asu/client/src/client_task_manager.cpp
+++ b/ucm/transport/kv/asu/client/src/client_task_manager.cpp
@@ -237,13 +237,6 @@ void ClientTaskManager::Finalize(const ClientTaskPtr& task)
     if (task->finalStatus.ok()) {
         UC_DEBUG("ASU client task completed: client_task_id={} op={} transport_tasks={}.",
                  task->taskId, AsuOpTypeName(task->opType), task->transportTasks.size());
-    } else {
-        UC_ERROR(
-            "ASU client task failed: client_task_id={} op={} transport_tasks={} "
-            "failed_transport_tasks={} code={} message={}.",
-            task->taskId, AsuOpTypeName(task->opType), task->transportTasks.size(),
-            failedTransportTasks, static_cast<int>(task->finalStatus.code),
-            task->finalStatus.message);
     }
     task->state.store(ClientTaskState::COMPLETED, std::memory_order_release);
     task->cv.notify_all();

--- a/ucm/transport/kv/asu/client/src/client_task_manager.cpp
+++ b/ucm/transport/kv/asu/client/src/client_task_manager.cpp
@@ -48,31 +48,6 @@ const char* AsuOpTypeName(AsuOpType opType)
     }
 }
 
-std::size_t TransportTaskItemCount(const TransportTask& transportTask)
-{
-    return transportTask.entries.empty() ? transportTask.keys.size() : transportTask.entries.size();
-}
-
-std::string FormatTransportTaskFailure(const ClientTask& task, const TransportTask& transportTask)
-{
-    return "client_task_id=" + std::to_string(task.taskId) + " op=" + AsuOpTypeName(task.opType) +
-           " asuId=" + std::to_string(transportTask.asuId) +
-           " trans_task_id=" + std::to_string(transportTask.taskId) +
-           " item_count=" + std::to_string(TransportTaskItemCount(transportTask));
-}
-
-std::string FirstFailedTransportTask(const ClientTask& task)
-{
-    for (const auto& transportTask : task.transportTasks) {
-        if (!transportTask || transportTask->finalStatus.ok()) { continue; }
-
-        return FormatTransportTaskFailure(task, *transportTask) +
-               " code=" + std::to_string(static_cast<int>(transportTask->finalStatus.code)) +
-               " message=" + transportTask->finalStatus.message;
-    }
-    return "client_task_id=" + std::to_string(task.taskId) + " op=" + AsuOpTypeName(task.opType);
-}
-
 std::vector<UC::KV::CacheKey> ToRouterKeys(const std::vector<CacheKey>& keys)
 {
     std::vector<UC::KV::CacheKey> routerKeys;
@@ -164,6 +139,8 @@ void ClientTaskManager::CompleteWithError(const ClientTaskPtr& task, const Statu
     std::lock_guard<std::mutex> lock{task->waitMu};
     std::fill(task->entryStatus.begin(), task->entryStatus.end(), status);
     task->finalStatus = status;
+    UC_ERROR("ASU client task failed: client_task_id={} op={} code={} message={}.", task->taskId,
+             ClientOpTypeName(task->opType), static_cast<int>(status.code), status.message);
     task->state.store(ClientTaskState::COMPLETED, std::memory_order_release);
     task->cv.notify_all();
 }
@@ -173,7 +150,7 @@ void ClientTaskManager::CompleteTransportTask(const ClientTaskPtr& task,
 {
     std::lock_guard<std::mutex> lock(task->waitMu);
     auto& transportTask = task->transportTasks[transportTaskIndex];
-    if (!transportTask || transportTask->clientCompleted) { return; }
+    if (transportTask->clientCompleted) { return; }
 
     auto completionStatus = result.status;
     bool invalidQueryResult = false;
@@ -215,7 +192,6 @@ void ClientTaskManager::CompleteUndispatchedTransportTasks(const ClientTaskPtr& 
     for (std::size_t index = firstTransportTaskIndex; index < task->transportTasks.size();
          ++index) {
         auto& failedTask = task->transportTasks[index];
-        if (!failedTask) { continue; }
         failedTask->clientCompleted = true;
         failedTask->finalStatus =
             index == firstTransportTaskIndex
@@ -241,22 +217,41 @@ void ClientTaskManager::Finalize(const ClientTaskPtr& task)
         }
     }
 
-    const bool anyFailed =
-        std::any_of(task->transportTasks.begin(), task->transportTasks.end(),
-                    [](const TransportTaskPtr& transportTask) {
-                        return transportTask != nullptr && !transportTask->finalStatus.ok();
-                    });
-    task->finalStatus =
-        anyFailed ? Status::Error(StatusCode::PARTIAL_FAILED, "client task partially failed: " +
-                                                                  FirstFailedTransportTask(*task))
-                  : Status::OK();
+    std::size_t failedTransportTasks = 0;
+    for (const auto& transportTask : task->transportTasks) {
+        if (transportTask->finalStatus.ok()) { continue; }
+
+        ++failedTransportTasks;
+        const auto itemCount = transportTask->entries.empty() ? transportTask->keys.size()
+                                                              : transportTask->entries.size();
+        UC_ERROR(
+            "ASU client transport task failed: client_task_id={} op={} asuId={} "
+            "transport_task_id={} item_count={} code={} message={}.",
+            task->taskId, ClientOpTypeName(task->opType), transportTask->asuId,
+            transportTask->taskId, itemCount, static_cast<int>(transportTask->finalStatus.code),
+            transportTask->finalStatus.message);
+    }
+    task->finalStatus = failedTransportTasks == 0 ? Status::OK()
+                                                  : Status::Error(StatusCode::PARTIAL_FAILED,
+                                                                  "client task partially failed");
+    if (task->finalStatus.ok()) {
+        UC_DEBUG("ASU client task completed: client_task_id={} op={} transport_tasks={}.",
+                 task->taskId, ClientOpTypeName(task->opType), task->transportTasks.size());
+    } else {
+        UC_ERROR(
+            "ASU client task failed: client_task_id={} op={} transport_tasks={} "
+            "failed_transport_tasks={} code={} message={}.",
+            task->taskId, ClientOpTypeName(task->opType), task->transportTasks.size(),
+            failedTransportTasks, static_cast<int>(task->finalStatus.code),
+            task->finalStatus.message);
+    }
     task->state.store(ClientTaskState::COMPLETED, std::memory_order_release);
     task->cv.notify_all();
 }
 
 Status ClientTaskManager::BuildTransportTasks(const ClientTaskPtr& task)
 {
-    auto snapshot = task == nullptr ? nullptr : task->viewSnapshot;
+    auto snapshot = task->viewSnapshot;
     if (!snapshot || !snapshot->router || snapshot->transports.empty()) {
         return Status::Error(StatusCode::NOT_INITIALIZED, "client has no ASU transports");
     }
@@ -264,30 +259,30 @@ Status ClientTaskManager::BuildTransportTasks(const ClientTaskPtr& task)
     const auto routes = task->opType == AsuOpType::QUERY || task->opType == AsuOpType::DELETE
                             ? snapshot->router->RouteKeys(ToRouterKeys(task->keys))
                             : snapshot->router->RouteKeys(ExtractEntryKeys(task->entries));
-    for (const auto& route : routes) {
-        if (snapshot->transports.find(route.first) == snapshot->transports.end()) {
+    for (const auto& [asuId, indices] : routes) {
+        if (snapshot->transports.find(asuId) == snapshot->transports.end()) {
             return AddContext(
                 Status::Error(StatusCode::NOT_FOUND, "routed asu transport not found"),
-                "asuId=" + std::to_string(route.first));
+                "asuId=" + std::to_string(asuId));
         }
     }
 
     task->transportTasks.reserve(routes.size());
-    for (const auto& route : routes) {
+    for (const auto& [asuId, indices] : routes) {
         auto transportTask = std::make_shared<TransportTask>();
-        transportTask->asuId = route.first;
-        transportTask->transport = snapshot->transports.at(route.first);
+        transportTask->asuId = asuId;
+        transportTask->transport = snapshot->transports.at(asuId);
         transportTask->registeredMrKeys = task->registeredMrKeys;
-        transportTask->originalIndices.reserve(route.second.size());
+        transportTask->originalIndices.reserve(indices.size());
         if (task->opType == AsuOpType::QUERY || task->opType == AsuOpType::DELETE) {
-            transportTask->keys.reserve(route.second.size());
-            for (auto index : route.second) {
+            transportTask->keys.reserve(indices.size());
+            for (auto index : indices) {
                 transportTask->keys.push_back(std::move(task->keys[index]));
                 transportTask->originalIndices.push_back(index);
             }
         } else {
-            transportTask->entries.reserve(route.second.size());
-            for (auto index : route.second) {
+            transportTask->entries.reserve(indices.size());
+            for (auto index : indices) {
                 transportTask->entries.push_back(std::move(task->entries[index]));
                 transportTask->originalIndices.push_back(index);
             }
@@ -302,10 +297,6 @@ Status ClientTaskManager::BuildTransportTasks(const ClientTaskPtr& task)
 
 Status ClientTaskManager::DispatchTask(const ClientTaskPtr& task)
 {
-    auto snapshot = task == nullptr ? nullptr : task->viewSnapshot;
-    if (!snapshot) {
-        return Status::Error(StatusCode::NOT_INITIALIZED, "client view is not ready");
-    }
     if (task->transportTasks.empty()) {
         std::lock_guard<std::mutex> lock(task->waitMu);
         Finalize(task);
@@ -314,13 +305,7 @@ Status ClientTaskManager::DispatchTask(const ClientTaskPtr& task)
 
     for (std::size_t taskIndex = 0; taskIndex < task->transportTasks.size(); ++taskIndex) {
         auto& transportTask = task->transportTasks[taskIndex];
-        if (!transportTask) {
-            return Status::Error(StatusCode::NOT_FOUND, "routed ASU transport not found");
-        }
         auto transport = transportTask->transport.lock();
-        if (!transport) {
-            return Status::Error(StatusCode::NOT_FOUND, "routed ASU transport not found");
-        }
 
         std::weak_ptr<ClientTask> clientTask = task;
         transportTask->onComplete = [clientTask, taskIndex](TaskResult result) {
@@ -331,22 +316,6 @@ Status ClientTaskManager::DispatchTask(const ClientTaskPtr& task)
         transportTask->opType = task->opType;
         auto status = transport->Submit(transportTask);
         if (!status.ok()) {
-            for (std::size_t index = 0; index < taskIndex; ++index) {
-                auto& dispatchedTask = task->transportTasks[index];
-                if (!dispatchedTask || dispatchedTask->taskId == kInvalidTaskId) { continue; }
-                auto dispatchedTransport = dispatchedTask->transport.lock();
-                if (dispatchedTransport) {
-                    const auto cancelStatus = dispatchedTransport->Cancel(dispatchedTask->taskId);
-                    if (!cancelStatus.ok() && cancelStatus.code != StatusCode::TASK_NOT_FOUND) {
-                        UC_WARN(
-                            "Failed to cancel dispatched transport task: asuId={} taskId={} "
-                            "code={} message={}",
-                            dispatchedTask->asuId, dispatchedTask->taskId,
-                            static_cast<int>(cancelStatus.code), cancelStatus.message);
-                    }
-                }
-            }
-
             const auto dispatchStatus =
                 AddContext(status, "asuId=" + std::to_string(transportTask->asuId));
             CompleteUndispatchedTransportTasks(task, taskIndex, dispatchStatus);

--- a/ucm/transport/kv/asu/common/task_manager_base.h
+++ b/ucm/transport/kv/asu/common/task_manager_base.h
@@ -26,6 +26,7 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -61,7 +62,7 @@ public:
         auto sharedCtx = ctx;
         sharedCtx->state.store(initialState_, std::memory_order_release);
 
-        std::lock_guard<std::mutex> lock(mutex_);
+        std::lock_guard<std::shared_mutex> lock(mutex_);
         do {
             taskId = nextTaskId_.fetch_add(1, std::memory_order_relaxed);
         } while (taskId == kInvalidTaskId || tasks_.find(taskId) != tasks_.end());
@@ -73,7 +74,7 @@ public:
 
     std::shared_ptr<Context> Get(TaskId taskId)
     {
-        std::lock_guard<std::mutex> lock(mutex_);
+        std::shared_lock<std::shared_mutex> lock(mutex_);
         auto iter = tasks_.find(taskId);
         if (iter == tasks_.end()) { return nullptr; }
         return iter->second;
@@ -81,7 +82,7 @@ public:
 
     std::vector<std::shared_ptr<Context>> GetAll()
     {
-        std::lock_guard<std::mutex> lock(mutex_);
+        std::shared_lock<std::shared_mutex> lock(mutex_);
         std::vector<std::shared_ptr<Context>> tasks;
         tasks.reserve(tasks_.size());
         for (const auto& item : tasks_) { tasks.emplace_back(item.second); }
@@ -90,7 +91,7 @@ public:
 
     Status Remove(TaskId taskId)
     {
-        std::lock_guard<std::mutex> lock(mutex_);
+        std::lock_guard<std::shared_mutex> lock(mutex_);
         auto erased = tasks_.erase(taskId);
         if (erased == 0) {
             return Status::Error(StatusCode::TASK_NOT_FOUND, taskName_ + " task not found");
@@ -103,7 +104,7 @@ private:
     std::string taskName_;
     std::atomic<TaskId> nextTaskId_{1};
     // TODO: consider using a lock-free structure !
-    std::mutex mutex_;
+    std::shared_mutex mutex_;
     std::unordered_map<TaskId, std::shared_ptr<Context>> tasks_;
 };
 

--- a/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
@@ -1712,10 +1712,11 @@ TEST(AsuClientImplTest, Task_CheckThenWaitHandlesRefreshableChildFailure)
     EXPECT_EQ(state->createdTransports, std::uint32_t{2});
 }
 
-TEST(AsuClientImplTest, Task_PartialDispatchFailureCancelsDispatchedSubtasks)
+TEST(AsuClientImplTest, Task_PartialDispatchFailureWaitsForDispatchedSubtasks)
 {
     auto state = std::make_shared<TestState>();
     state->failStoreAfterFirstDispatch = true;
+    state->deferCompletionCallbacks = true;
     auto client = CreateAsuClient(MakeFactory(state));
     const std::vector<AsuId> asuIds{10, 20, 30};
     ASSERT_TRUE(client->Init(MakeConfig(asuIds)).ok());
@@ -1727,13 +1728,27 @@ TEST(AsuClientImplTest, Task_PartialDispatchFailureCancelsDispatchedSubtasks)
 
     ASSERT_TRUE(status.ok()) << status.message;
     EXPECT_NE(taskId, kInvalidTaskId);
+    AsuId dispatchedAsuId = 0;
+    {
+        std::unique_lock<std::mutex> lock{state->completionMu};
+        ASSERT_TRUE(state->completionCv.wait_for(lock, std::chrono::milliseconds(100), [&] {
+            return !state->pendingCompletionCallbacks.empty();
+        }));
+        dispatchedAsuId = state->pendingCompletionCallbacks.begin()->first;
+    }
+    ASSERT_EQ(state->storeCalls.size(), std::size_t{1});
+    EXPECT_EQ(state->storeCalls[0], dispatchedAsuId);
+    EXPECT_FALSE(client->Check(taskId));
+    EXPECT_TRUE(state->cancelCalls.empty());
+
+    TaskResult completionResult;
+    completionResult.status = Status::OK();
+    completionResult.entryStatus = {Status::OK()};
+    ASSERT_TRUE(InvokePendingCompletion(state, dispatchedAsuId, std::move(completionResult)));
 
     TaskResult result;
     status = client->Wait(taskId, 100, result);
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
-    ASSERT_EQ(state->storeCalls.size(), std::size_t{1});
-    ASSERT_EQ(state->cancelCalls.size(), std::size_t{1});
-    EXPECT_EQ(state->cancelCalls[0], state->storeCalls[0]);
     EXPECT_EQ(state->completionCallbackCount, std::size_t{1});
     ASSERT_EQ(result.entryStatus.size(), std::size_t{3});
     EXPECT_EQ(std::count_if(result.entryStatus.begin(), result.entryStatus.end(),


### PR DESCRIPTION
## Purpose
This PR refactors task management of AsuClient.

## Modifications 
1. Remove redundant judgement in BuildTransportTasks and DispatchTask;
2. Remove defensive if-clause in DispatchTask;
3. Remove resource releasing before hand once DispatchTask fails, which will cause undefined unauthorized remote direct access;
4. Add logs at the level of AsuClient;
5. Remove TransportTaskItemCount、FormatTransportTaskFailure、FirstFailedTransportTask. Now Finalize only traverses transporTasks once;
6. Replace mutex with shared_mutex in TaskManagerBase::Get/GetAll;
7. Rewrite for-loop for better reading convenience;
8. Reuse UCM status in AsuStore.

## Test
> An offline inference test has passed with AIV mock server.
> Unit tests have all passed.