### PR TITLE
【bugfix】Fix duplicate layerwise KV cache dumps during speculative decoding

### DIFF
--- a/ucm/integration/vllm/hla_connector.py
+++ b/ucm/integration/vllm/hla_connector.py
@@ -1414,6 +1414,10 @@ class UCMHybridLinearAttentionLayerWiseConnector(UCMHybridLinearAttentionConnect
         self.request_data: list[tuple[str, list[bytes], list[bytes], list[int]]] = []
         self._failure_req_ids: set[str] = set()
         self._submitted_load_rows: set[int] = set()
+        # A hybrid KV row can be visited more than once in one model-runner
+        # batch (for example by speculative decoding). Persist its first
+        # successful submission only and reset this state for every batch.
+        self._dumped_row_ids: set[int] = set()
         self._dump_transfer_data: (
             tuple[list[bytes], list[int], set[str], dict[str, set[bytes]]] | None
         ) = None
@@ -1432,31 +1436,10 @@ class UCMHybridLinearAttentionLayerWiseConnector(UCMHybridLinearAttentionConnect
         self.need_load = False
         self._layerwise_batch_start: Optional[float] = None
         self._layerwise_prev_wait_end: Optional[float] = None
-        # MTP save_kv_layer is called N times per decode step; defer & keep last.
-        self._deferred_mtp_row_dumps: dict[
-            int, tuple[list[bytes], list[int], set[str]]
-        ] = {}
-        self._is_mtp = False
-        self._init_mtp_layerwise_dump_state()
         logger.info(
             "Init UCMHybridLinearAttentionLayerWiseConnector "
             f"with prefetch_rows={self._load_prefetch_rows}."
         )
-
-    def _init_mtp_layerwise_dump_state(self) -> None:
-        """Detect whether MTP is enabled."""
-        speculative_config = getattr(self._vllm_config, "speculative_config", None)
-        if speculative_config is None:
-            return
-
-        mtp_method = getattr(speculative_config, "method", None)
-        self._is_mtp = mtp_method == "mtp" or (
-            isinstance(mtp_method, str) and mtp_method.endswith("_mtp")
-        )
-
-    def _is_mtp_layer(self, layer_name: str) -> bool:
-        """Check whether a layer belongs to the MTP draft model."""
-        return self._is_mtp and "mtp" in layer_name
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         if has_ucm_sparse() and os.getenv("VLLM_HASH_ATTENTION") == "1":
@@ -1617,8 +1600,8 @@ class UCMHybridLinearAttentionLayerWiseConnector(UCMHybridLinearAttentionConnect
         self.request_data.clear()
         self._failure_req_ids.clear()
         self._submitted_load_rows.clear()
+        self._dumped_row_ids.clear()
         self._dump_transfer_data = None
-        self._deferred_mtp_row_dumps.clear()
         self.need_load = False
 
         for request_id, request in metadata.request_meta.items():
@@ -1706,6 +1689,12 @@ class UCMHybridLinearAttentionLayerWiseConnector(UCMHybridLinearAttentionConnect
             return
         if self.row_save_layer.get(row_id) != layer_name:
             return
+        if row_id in self._dumped_row_ids:
+            logger.debug(
+                "Skip duplicate hybrid layerwise dump in the same batch: "
+                f"layer_name={layer_name}, row_id={row_id}"
+            )
+            return
 
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, UCMConnectorMetadata)
@@ -1722,15 +1711,6 @@ class UCMHybridLinearAttentionLayerWiseConnector(UCMHybridLinearAttentionConnect
             return
 
         self.is_save = True
-
-        if self._is_mtp_layer(layer_name):
-            # Defer: last snapshot wins (MTP revisited N times per decode step).
-            self._deferred_mtp_row_dumps[row_id] = (
-                list(total_ucm_block_ids),
-                list(total_vllm_block_ids),
-                set(dump_request_ids),
-            )
-            return
 
         row_ptrs = self.kv_cache_layout.extract_block_addrs_for_row(
             total_vllm_block_ids, row_id
@@ -1754,6 +1734,7 @@ class UCMHybridLinearAttentionLayerWiseConnector(UCMHybridLinearAttentionConnect
                     event_handle=event_handle,
                 )
             )
+            self._dumped_row_ids.add(row_id)
         except Exception as e:
             logger.error(
                 f"submit hybrid layerwise row {row_id} dump task failed. "
@@ -1794,45 +1775,6 @@ class UCMHybridLinearAttentionLayerWiseConnector(UCMHybridLinearAttentionConnect
             block_ids_by_request,
         )
 
-    def _flush_deferred_mtp_dumps(self) -> None:
-        """Submit the last saved snapshot for each deferred MTP row."""
-        if not self._deferred_mtp_row_dumps:
-            return
-
-        deferred = self._deferred_mtp_row_dumps
-        self._deferred_mtp_row_dumps = {}
-        block_ids_by_request = (
-            self._dump_transfer_data[3] if self._dump_transfer_data is not None else {}
-        )
-        for row_id, (ucm_ids, vllm_ids, req_ids) in deferred.items():
-            try:
-                row_ptrs = self.kv_cache_layout.extract_block_addrs_for_row(
-                    vllm_ids, row_id
-                )
-                row_ptrs = np.ascontiguousarray(row_ptrs)
-                shard_indexs = [row_id] * len(ucm_ids)
-                event_handle = self._get_dump_event_handle()
-                task = self._rank_consistency.submit_dump(
-                    self.store,
-                    block_ids_by_request,
-                    ucm_ids,
-                    shard_indexs,
-                    row_ptrs,
-                    event_handle,
-                )
-                self.dump_tasks[row_id].append(
-                    PendingDumpTask(
-                        task=task,
-                        request_ids=set(req_ids),
-                        event_handle=event_handle,
-                    )
-                )
-            except Exception as e:
-                logger.error(
-                    f"submit deferred MTP row {row_id} dump task failed. "
-                    f"{type(e).__name__}: {e}"
-                )
-
     def wait_for_save(self) -> None:
         if not self.is_save:
             total_end = time.perf_counter()
@@ -1847,8 +1789,6 @@ class UCMHybridLinearAttentionLayerWiseConnector(UCMHybridLinearAttentionConnect
             if self._dump_transfer_data is not None
             else set()
         )
-        self._flush_deferred_mtp_dumps()
-
         total_start = time.perf_counter()
         for row_id in self.row_ids:
             for pending_dump_task in self.dump_tasks.pop(row_id, []):

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -2087,25 +2087,13 @@ class UCMLayerWiseConnector(UCMDirectConnector):
         self.dump_total_ptrs: np.ndarray | None = None
         self.request_data: list[tuple[str, list, list, np.ndarray]] = []
         self._failure_req_ids: set[str] = set()
+        # A layer can be visited more than once in one model-runner batch
+        # (for example by speculative decoding). Persist the first visit only.
+        # This state is reset at the start of every connector batch.
+        self._dumped_layer_ids: set[int] = set()
         self._layerwise_prev_wait_end: Optional[float] = None
         self._layerwise_batch_start: Optional[float] = None
         self._layerwise_batch_wait_blocking_total_ms = 0.0
-        # MTP layers can be revisited several times in one speculative decode
-        # batch. Keep only the last metadata snapshot for each MTP layer and
-        # submit its dump after the layerwise forward finishes.
-        self._deferred_mtp_dumps: dict[
-            int,
-            tuple[
-                list[bytes],
-                list[int],
-                set[str],
-            ],
-        ] = {}
-        self._is_mtp = False
-        self._num_mtp_layers = 0
-        self._mtp_layer_start: Optional[int] = None
-        self._mtp_layer_end: Optional[int] = None
-        self._init_mtp_layerwise_dump_state()
         logger.info("Init UCMLayerWiseConnector.")
 
     def _layerwise_batch_stats(
@@ -2134,73 +2122,16 @@ class UCMLayerWiseConnector(UCMDirectConnector):
         self._layerwise_batch_wait_blocking_total_ms = 0.0
         return stats
 
-    def _init_mtp_layerwise_dump_state(self) -> None:
-        """Cache whether MTP is enabled and how many MTP layers it has."""
-        speculative_config = getattr(self._vllm_config, "speculative_config", None)
-        if speculative_config is None:
-            return
-
-        mtp_method = getattr(speculative_config, "method", None)
-        self._is_mtp = mtp_method == "mtp" or (
-            isinstance(mtp_method, str) and mtp_method.endswith("_mtp")
-        )
-        if not self._is_mtp:
-            return
-
-        draft_model_config = getattr(speculative_config, "draft_model_config", None)
-        draft_hf_config = getattr(draft_model_config, "hf_config", None)
-        value = getattr(draft_hf_config, "n_predict", None)
-        if value is not None:
-            try:
-                self._num_mtp_layers = max(int(value), 0)
-            except (TypeError, ValueError) as e:
-                logger.warning(
-                    f"Failed to parse MTP n_predict from draft hf_config, "
-                    f"n_predict={value}. "
-                    f"{type(e).__name__}: {e}"
-                )
-
-    def _refresh_mtp_layer_range(self) -> None:
-        """Resolve MTP layer ids from the registered KV cache layout."""
-        self._mtp_layer_start = None
-        self._mtp_layer_end = None
-        if not self._is_mtp or self._num_mtp_layers <= 0:
-            return
-
-        num_hidden_layers = self.kv_cache_layout.num_hidden_layers
-        if num_hidden_layers <= 0:
-            logger.warning_once(
-                "Skip deferred MTP layerwise dump because num_hidden_layers is unknown."
-            )
-            return
-
-        # MTP layers are indexed after the base model layers, e.g. a 78-layer
-        # model uses layer_id 78 for its first MTP layer.
-        self._mtp_layer_start = num_hidden_layers
-        self._mtp_layer_end = num_hidden_layers + self._num_mtp_layers
-
-    def _is_mtp_layer(self, layer_id: int) -> bool:
-        """Check whether a global layer id belongs to the MTP layer range."""
-        return (
-            self._mtp_layer_start is not None
-            and self._mtp_layer_end is not None
-            and self._mtp_layer_start <= layer_id < self._mtp_layer_end
-        )
-
-    def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
-        super().register_kv_caches(kv_caches)
-        self._refresh_mtp_layer_range()
-
     def _submit_layerwise_dump_task(
         self,
         layer_id: int,
         total_ucm_block_ids: list[bytes],
         total_vllm_block_ids: list[int],
         dump_request_ids: set[str],
-    ) -> None:
+    ) -> bool:
         """Submit a layerwise dump and attach it to the existing async lifecycle."""
         if not dump_request_ids:
-            return
+            return False
 
         metadata = self._get_connector_metadata()
         block_ids_by_request = {
@@ -2233,6 +2164,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                     event_handle=event_handle,
                 )
             )
+            return True
         except Exception as e:
             logger.error(
                 f"submit dump task for layer {layer_id} failed. {type(e).__name__}: {e}"
@@ -2240,26 +2172,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             self._record_counter("connector_dump_submit_errors_total")
             if self.enable_event_sync and event_handle and self.device is not None:
                 self.device.destroy_event_handle(event_handle)
-
-    def _flush_deferred_mtp_dumps(self) -> None:
-        """Submit the last saved metadata snapshot for each deferred MTP layer."""
-        if not self._deferred_mtp_dumps:
-            return
-
-        deferred_mtp_dumps = self._deferred_mtp_dumps
-        self._deferred_mtp_dumps = {}
-        for layer_id in sorted(deferred_mtp_dumps):
-            (
-                total_ucm_block_ids,
-                total_vllm_block_ids,
-                dump_request_ids,
-            ) = deferred_mtp_dumps[layer_id]
-            self._submit_layerwise_dump_task(
-                layer_id,
-                total_ucm_block_ids,
-                total_vllm_block_ids,
-                dump_request_ids,
-            )
+            return False
 
     def _submit_request_load_tasks_for_layer(
         self,
@@ -2300,6 +2213,7 @@ class UCMLayerWiseConnector(UCMDirectConnector):
                 self._connector_worker_meta.mark_failed(request_id)
 
     def start_load_kv(self, forward_context: "ForwardContext", **kwargs) -> None:
+        self._dumped_layer_ids.clear()
         self._layerwise_batch_start = time.perf_counter()
         metadata = self._get_connector_metadata()
         self.load_tasks.clear()
@@ -2417,6 +2331,13 @@ class UCMLayerWiseConnector(UCMDirectConnector):
         total_ucm_block_ids, total_vllm_block_ids = [], []
         dump_request_ids: set[str] = set()
         layer_id = self.layer_name_to_id[layer_name]
+        if layer_id in self._dumped_layer_ids:
+            logger.debug(
+                f"Skip duplicate layerwise dump in the same batch: "
+                f"layer_name={layer_name}, layer_id={layer_id}"
+            )
+            return
+
         for request_id, request in metadata.request_meta.items():
             if len(request.dump_block_ids[0]) == 0:
                 continue
@@ -2433,23 +2354,14 @@ class UCMLayerWiseConnector(UCMDirectConnector):
             total_vllm_block_ids.extend(vllm_block_ids)
 
         if dump_request_ids:
-            if self._is_mtp_layer(layer_id):
-                self._deferred_mtp_dumps[layer_id] = (
-                    list(total_ucm_block_ids),
-                    list(total_vllm_block_ids),
-                    set(dump_request_ids),
-                )
-                logger.debug(
-                    f"Defer MTP layerwise dump: layer={layer_name}, "
-                    f"layer_id={layer_id}, blocks={len(total_ucm_block_ids)}"
-                )
-            else:
-                self._submit_layerwise_dump_task(
-                    layer_id,
-                    total_ucm_block_ids,
-                    total_vllm_block_ids,
-                    dump_request_ids,
-                )
+            submitted = self._submit_layerwise_dump_task(
+                layer_id,
+                total_ucm_block_ids,
+                total_vllm_block_ids,
+                dump_request_ids,
+            )
+            if submitted:
+                self._dumped_layer_ids.add(layer_id)
         if self.is_save:
             submit_end = time.perf_counter()
             ucmmetrics.update_stats(
@@ -2459,7 +2371,6 @@ class UCMLayerWiseConnector(UCMDirectConnector):
     def wait_for_save(self) -> None:
         save_tail_start = time.perf_counter()
         wait_for_save_start_ms = save_tail_start * 1000
-        self._flush_deferred_mtp_dumps()
         for pending_dump_task in self._pending_dump_tasks:
             if pending_dump_task.wait_for_save_start_ms <= 0:
                 pending_dump_task.wait_for_save_start_ms = wait_for_save_start_ms


### PR DESCRIPTION
## Purpose

During speculative decoding, the same target-model layer—particularly the final layer—may call `save_kv_layer()` multiple times within a single model-runner batch. Previously, each call submitted an asynchronous dump task for the same cache key and layer shard. Repeated writes to the final layer may cause `.tmp` files to be generated multiple times on disk and overwrite existing KV cache files, resulting in corrupted or repetitive outputs when subsequent requests load the affected cache.

## Modifications

- Added `_dumped_layer_ids` to `UCMLayerWiseConnector` to track layers whose dump tasks have already been submitted in the current batch.
- Reset `_dumped_layer_ids` at the beginning of every `start_load_kv()` call.
- Updated `save_kv_layer()` to skip duplicate dump submissions for the same `layer_id` within one batch.
- Record a `layer_id` only after its asynchronous dump task is submitted successfully, allowing a later invocation to retry after submission failure.
- Removed MTP-specific layer detection and deferred dump handling.
- Applied the duplicate filtering uniformly by `layer_id`, independent of the speculative decoding method.

## Test
Before the modification, the MiniMax model suffered a significant accuracy degradation under full‑cache‑hit scenarios, with repeated characters appearing in part of the output. After the modification, the accuracy remains on par and no repeated  output occurs.
