### PR TITLE
[Feat][Test] toolkit: add precheck UCM environment pre-check (RFC #1208)

### DIFF
--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -10,6 +10,7 @@
 | `posix-aio` | `posix_aio` | 可运行 | 运行 `ucm/store/test/e2e/posixstore_aio_test.py`，测试 POSIX AIO store 的 dump/load 性能。 | [posix-aio README](ucm_toolkit/tools/posix_aio/README.md) |
 | `nic-monitor` | `nic_monitor` | 可运行 | 监控物理网卡实时流量、后台采样落盘，并生成阶段统计。 | [nic-monitor README](ucm_toolkit/tools/nic_monitor/README.md) |
 | `metrics-view` | `metrics_view`, `terminal-metrics`, `terminal_metrics` | 可运行 | 采集 Prometheus/OpenMetrics 样本到 SQLite，并在终端查询聚合指标。 | [metrics-view README](ucm_toolkit/tools/metrics_view/README.md) |
+| `precheck` | `pre_check` | 可运行 | 在 UCM 部署前于宿主机本地运行环境预检，校验 serving-stack/uc-manager 版本、加速卡驱动（CUDA 算力或昇腾 HDK）、内核版本、`/dev/shm` 及 posix store 带宽，输出 `PASS`/`WARN`/`FAIL` 并对失败项给出修复建议（RFC #1208）。 | [precheck README](ucm_toolkit/tools/precheck/README.md) |
 
 各子工具的依赖、参数、示例与常见问题都在各自 README 中说明。
 
@@ -46,6 +47,7 @@ python -m pip install -e toolkit
 | `posix-aio` | 需先安装 UCM 主软件包（unified-cache-management）及其 native 扩展，并需要 `numpy`。 |
 | `nic-monitor` | Linux、`bash`、`ethtool`，并且需要 root 或 sudo 权限读取网卡统计。 |
 | `metrics-view` | 仅依赖 Python 标准库（`sqlite3` 内置）；采集需要可访问的 Prometheus/OpenMetrics `/metrics` HTTP 接口。 |
+| `precheck` | 核心检查仅依赖 Python 标准库；带宽基准需要已安装 UCM 主软件包（native 扩展）与 `numpy`，且仅 Linux 可运行。 |
 
 `dev-sandbox` 的后端探测优先级与切换方式见 [dev-sandbox README](ucm_toolkit/tools/dev_sandbox/README.md#依赖)。
 
@@ -67,6 +69,7 @@ ucm-toolkit doctor
 ucm-toolkit doctor dev-sandbox
 ucm-toolkit doctor posix-aio
 ucm-toolkit doctor nic-monitor
+ucm-toolkit doctor precheck
 ```
 
 构建工具：

--- a/toolkit/pyproject.toml
+++ b/toolkit/pyproject.toml
@@ -17,3 +17,4 @@ include = ["ucm_toolkit*"]
 
 [tool.setuptools.package-data]
 "ucm_toolkit.tools.metrics_view" = ["configs/*.json"]
+"ucm_toolkit.tools.precheck" = ["*.json"]

--- a/toolkit/tests/test_precheck.py
+++ b/toolkit/tests/test_precheck.py
@@ -1,0 +1,360 @@
+"""Unit tests for the precheck tool logic (parsers, config, selection, reporter).
+
+Pure-stdlib ``unittest``; no hardware or ucm required. The check-function
+decision tests mock ``subprocess``/``os``/``import`` so they are deterministic
+across hosts.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from ucm_toolkit.tools.precheck import checks as checks_mod
+from ucm_toolkit.tools.precheck.bandwidth import (
+    ComboResult,
+    bandwidth_detail,
+    bandwidth_status,
+    best_per_metric,
+    pick_best,
+)
+from ucm_toolkit.tools.precheck.checks import (
+    check_accelerator_driver,
+    check_aio_resources,
+    check_kernel_version,
+)
+from ucm_toolkit.tools.precheck.config import PrecheckConfig
+from ucm_toolkit.tools.precheck.parseutil import (
+    compare_versions,
+    normalize_vllm_ascend_version,
+    parse_int_list,
+    parse_npu_smi_versions,
+    parse_size,
+    parse_size_list,
+    parse_str_list,
+    parse_version,
+    strip_build,
+)
+from ucm_toolkit.tools.precheck.reporter import (
+    FAIL,
+    INFO,
+    STATUS_FAIL,
+    STATUS_INFO,
+    STATUS_OK,
+    STATUS_PASS,
+    STATUS_SKIP,
+    STATUS_WARN,
+    WARN,
+    CheckResult,
+    overall_failed,
+)
+
+
+class TestVersionParsing(unittest.TestCase):
+    def test_parse_version_strips_suffix(self):
+        self.assertEqual(parse_version("5.15.0-25-generic"), (5, 15, 0))
+        self.assertEqual(parse_version("8.0"), (8, 0))
+        self.assertEqual(parse_version("25.2.0"), (25, 2, 0))
+
+    def test_parse_version_garbage(self):
+        self.assertEqual(parse_version(""), ())
+        self.assertEqual(parse_version(None), ())
+
+    def test_compare_versions_pad(self):
+        self.assertEqual(compare_versions((5, 15), (5, 10)), 1)
+        self.assertEqual(compare_versions((5, 10, 0), (5, 10, 0)), 0)
+        self.assertEqual(compare_versions((5, 9), (5, 10)), -1)
+
+    def test_strip_build(self):
+        self.assertEqual(strip_build("0.18.0+empty"), "0.18.0")
+        self.assertIsNone(strip_build(None))
+
+    def test_normalize_vllm_ascend(self):
+        self.assertEqual(normalize_vllm_ascend_version("0.18.0rc1+local"), "0.18.0")
+        self.assertEqual(normalize_vllm_ascend_version("0.11.0.post1"), "0.11.0")
+
+
+class TestKernelBoundary(unittest.TestCase):
+    """>= 5.10 series (major.minor) — validated on openEuler 5.10.0-216."""
+
+    FLOOR_MM = parse_version("5.10")[:2]
+
+    def _mm(self, release):
+        v = parse_version(release)
+        return v[:2] if len(v) >= 2 else v + (0,) * (2 - len(v))
+
+    def _passes(self, release):
+        return compare_versions(self._mm(release), self.FLOOR_MM) >= 0
+
+    def test_boundary(self):
+        self.assertTrue(self._passes("5.10.0"))
+        self.assertTrue(self._passes("5.10.0-216.0.0.115.oe2203sp4.aarch64"))
+        self.assertTrue(self._passes("5.11"))
+        self.assertFalse(self._passes("5.9"))
+        self.assertTrue(self._passes("6.8.0-25-generic"))
+
+
+class TestSizeParsing(unittest.TestCase):
+    def test_suffixes(self):
+        self.assertEqual(parse_size("180k"), 180 * 1024)
+        self.assertEqual(parse_size("1m"), 1024 * 1024)
+        self.assertEqual(parse_size("2g"), 2 * 1024**3)
+        self.assertEqual(parse_size("4MiB"), 4 * 1024**2)
+
+    def test_lists(self):
+        self.assertEqual(parse_size_list("180k,1m"), [184320, 1048576])
+        self.assertEqual(parse_int_list("1,16"), [1, 16])
+        self.assertEqual(parse_str_list("psync, aio"), ["psync", "aio"])
+
+    def test_garbage_raises(self):
+        with self.assertRaises(ValueError):
+            parse_size("nope")
+
+
+class TestNpuSmi(unittest.TestCase):
+    def test_banner_version_fallback(self):
+        # Real openEuler 25.5.2 firmware: version only in the banner.
+        sample = (
+            "+------------------------------------------------------+\n"
+            "| npu-smi 25.5.2                   Version: 25.5.2       |\n"
+            "+----------------------------+---------------+----------+\n"
+        )
+        parsed = parse_npu_smi_versions(sample)
+        self.assertEqual(parsed["tool"], "25.5.2")
+        self.assertEqual(parsed["version"], "25.5.2")
+        self.assertEqual(parsed["hdk"], "25.5.2")
+
+    def test_hdk_label_wins(self):
+        sample = "npu-smi 24.1.0\nNPU0 Driver Version: 25.3.0 HDK Version: 25.3.0\n"
+        parsed = parse_npu_smi_versions(sample)
+        self.assertEqual(parsed["hdk"], "25.3.0")
+        self.assertEqual(parsed["driver"], "25.3.0")
+
+
+class TestConfig(unittest.TestCase):
+    def test_defaults(self):
+        # The runtime defaults come from the shipped precheck.defaults.json
+        # (code constants are the fallback).
+        cfg = PrecheckConfig.default()
+        self.assertEqual(cfg.kernel_min, "5.10")
+        self.assertEqual(cfg.cuda_min_compute_cap, 8.0)
+        self.assertEqual(cfg.ascend_min_hdk, "25.2.0")
+        self.assertEqual(cfg.shm_min_gib, 512.0)
+        self.assertEqual(cfg.bandwidth.shard_sizes, [184320, 8388608])
+        self.assertEqual(cfg.bandwidth.worker_counts, [1, 8, 16])
+        self.assertEqual(cfg.bandwidth.engines, ["psync", "aio"])
+        self.assertEqual(cfg.bandwidth.modes, ["dump", "read", "mix"])
+        self.assertEqual(cfg.bandwidth.block_number, 32)
+        self.assertEqual(cfg.bandwidth.dump_epochs, 8)
+        self.assertEqual(cfg.bandwidth.load_epochs, 8)
+        self.assertEqual(cfg.bandwidth.mixed_epochs, 8)
+        self.assertEqual(cfg.bandwidth.rw_ratio, 4)
+        self.assertEqual(cfg.bandwidth.barrier_timeout, 60)
+        self.assertEqual(cfg.bandwidth.combo_timeout, 120)
+        self.assertEqual(cfg.bandwidth.aio_queue_depth, 4096)
+        self.assertEqual(cfg.bandwidth.threshold_gb, 8.0)
+
+    def test_bare_falls_back_to_code_constants(self):
+        # PrecheckConfig() (no JSON) uses the code-constant fallback.
+        cfg = PrecheckConfig()
+        self.assertEqual(cfg.bandwidth.shard_sizes, [184320, 8388608])
+        self.assertEqual(cfg.bandwidth.engines, ["psync", "aio"])
+        self.assertEqual(cfg.shm_min_gib, 512.0)
+
+    def test_from_dict_sizes_as_strings(self):
+        cfg = PrecheckConfig.from_dict(
+            {
+                "mount_path": "/mnt/x",
+                "bandwidth": {"shard_sizes": ["180k", "1m"], "threshold_gb": 10.0},
+            }
+        )
+        self.assertEqual(cfg.mount_path, "/mnt/x")
+        self.assertEqual(cfg.bandwidth.shard_sizes, [184320, 1048576])
+        self.assertEqual(cfg.bandwidth.threshold_gb, 10.0)
+
+
+class TestBandwidthSelection(unittest.TestCase):
+    def _combo(self, comprehensive, ok=True, mixed=0.0):
+        c = ComboResult(
+            shard_size=1024,
+            worker_count=1,
+            engine="aio",
+            ok=ok,
+            error="" if ok else "err",
+        )
+        c.comprehensive = c.dump_bw = c.load_bw = comprehensive
+        c.mixed_bw = mixed
+        c.rw_ratio = 4 if mixed > 0 else 0
+        return c
+
+    def test_pick_best(self):
+        best = pick_best([self._combo(5.0), self._combo(12.0), self._combo(9.0)])
+        self.assertEqual(best.comprehensive, 12.0)
+
+    def test_pick_best_ignores_failed(self):
+        best = pick_best([self._combo(5.0, ok=False), self._combo(8.0)])
+        self.assertEqual(best.comprehensive, 8.0)
+
+    def test_status_all_metrics_pass(self):
+        combos = [self._combo(8.0, mixed=8.0)]
+        mb = best_per_metric(combos)
+        self.assertEqual(bandwidth_status(mb, 8.0), STATUS_PASS)
+
+    def test_status_any_metric_below_warns(self):
+        # dump=5.0 < 8.0 threshold, load=10.0 >= 8.0 → WARN
+        combos = [self._combo(5.0, mixed=10.0)]
+        mb = best_per_metric(combos)
+        self.assertEqual(bandwidth_status(mb, 8.0), STATUS_WARN)
+
+    def test_status_no_combos(self):
+        self.assertEqual(bandwidth_status([], 8.0), STATUS_WARN)
+
+    def test_detail_shows_per_metric(self):
+        combos = [self._combo(4.0, mixed=10.0)]
+        mb = best_per_metric(combos)
+        detail = bandwidth_detail(mb, 8.0)
+        self.assertIn("dump", detail)
+        self.assertIn("load", detail)
+        self.assertIn("mixed", detail)
+        self.assertIn("WARN", detail)
+
+    def test_best_per_metric_different_combos(self):
+        # combo A: high dump, low load; combo B: low dump, high load
+        a = self._combo(10.0)
+        a.dump_bw, a.load_bw = 10.0, 2.0
+        a.comprehensive = 6.0
+        b = self._combo(10.0)
+        b.dump_bw, b.load_bw = 2.0, 10.0
+        b.comprehensive = 6.0
+        mb = best_per_metric([a, b])
+        dump_best = dict((lbl, c) for lbl, c, _ in mb)
+        self.assertIs(dump_best["dump"], a)
+        self.assertIs(dump_best["load"], b)
+
+    def test_mixed_is_headline_when_present(self):
+        c = self._combo(6.0, mixed=15.0)
+        from ucm_toolkit.tools.precheck.bandwidth import headline_bw
+
+        self.assertEqual(headline_bw(c), 15.0)
+        # pick_best prefers the combo with higher mixed.
+        lo = self._combo(20.0)  # high comprehensive, no mixed
+        hi = self._combo(5.0, mixed=25.0)
+        self.assertIs(pick_best([lo, hi]), hi)
+
+
+class TestReporterExitCodes(unittest.TestCase):
+    def _r(self, severity, status):
+        return CheckResult(name="x", severity=severity, status=status)
+
+    def test_no_fail_exits_zero(self):
+        self.assertFalse(
+            overall_failed([self._r(FAIL, STATUS_PASS), self._r(WARN, STATUS_WARN)])
+        )
+
+    def test_fail_exits_nonzero(self):
+        self.assertTrue(overall_failed([self._r(FAIL, STATUS_FAIL)]))
+
+    def test_strict_promotes_warn(self):
+        self.assertFalse(overall_failed([self._r(WARN, STATUS_WARN)]))
+        self.assertTrue(overall_failed([self._r(WARN, STATUS_WARN)], strict=True))
+
+
+class TestAioResources(unittest.TestCase):
+    def test_reads_aio_limits(self):
+        from unittest.mock import MagicMock, patch
+
+        def mock_file(data):
+            m = MagicMock()
+            m.__enter__.return_value.read.return_value = data
+            return m
+
+        with patch(
+            "builtins.open",
+            side_effect=[mock_file("65536\n"), mock_file("4096\n")],
+        ):
+            r = check_aio_resources(PrecheckConfig())
+        self.assertEqual(r.severity, INFO)
+        self.assertEqual(r.status, STATUS_INFO)
+        self.assertIn("max-nr=65536", r.value)
+        self.assertIn("max_aio_workers=15", r.value)
+
+    def test_unavailable_returns_info(self):
+        r = check_aio_resources(PrecheckConfig())
+        # On non-Linux (Windows test host) the files don't exist.
+        self.assertEqual(r.severity, INFO)
+        self.assertEqual(r.status, STATUS_INFO)
+
+
+class TestKernelCheckRemediation(unittest.TestCase):
+    """RFC #1208: FAIL items must carry remediation advice."""
+
+    def _cfg(self, floor="5.10"):
+        cfg = PrecheckConfig()
+        cfg.kernel_min = floor
+        return cfg
+
+    def _patch_uname(self, release):
+        return patch.object(checks_mod, "_run", return_value=(0, release + "\n", ""))
+
+    def test_pass(self):
+        with self._patch_uname("5.15.0"):
+            r = check_kernel_version(self._cfg())
+        self.assertEqual(r.status, STATUS_PASS)
+        self.assertEqual(r.remediation, "")
+
+    def test_fail_carries_remediation(self):
+        with self._patch_uname("5.9.0"):
+            r = check_kernel_version(self._cfg())
+        self.assertEqual(r.status, STATUS_FAIL)
+        self.assertTrue(r.remediation)
+        self.assertIn("upgrade", r.remediation)
+
+
+class TestAcceleratorDriver(unittest.TestCase):
+    def _cfg(self, cap=8.0, hdk="25.2.0"):
+        cfg = PrecheckConfig()
+        cfg.cuda_min_compute_cap = cap
+        cfg.ascend_min_hdk = hdk
+        return cfg
+
+    def test_ascend_banner_version_pass(self):
+        # Real openEuler 25.5.2 banner (no per-card HDK/Driver label).
+        real_out = (
+            "+------------------------------------------------------+\n"
+            "| npu-smi 25.5.2                   Version: 25.5.2       |\n"
+            "+----------------------------+---------------+----------+\n"
+        )
+        with (
+            patch.object(checks_mod, "_have", side_effect=lambda c: c == "npu-smi"),
+            patch.object(checks_mod, "_run", return_value=(0, real_out, "")),
+        ):
+            r = check_accelerator_driver(self._cfg())
+        self.assertEqual(r.status, STATUS_PASS)
+        self.assertIn("HDK=25.5.2", r.value)
+
+    def test_ascend_below_floor_warns_with_remediation(self):
+        with (
+            patch.object(checks_mod, "_have", side_effect=lambda c: c == "npu-smi"),
+            patch.object(
+                checks_mod, "_run", return_value=(0, "Driver Version: 25.1.0\n", "")
+            ),
+        ):
+            r = check_accelerator_driver(self._cfg())
+        self.assertEqual(r.status, STATUS_WARN)
+        self.assertTrue(r.remediation)
+        self.assertIn("upgrade", r.remediation)
+
+    def test_neither_smi_fails_with_remediation(self):
+        # No GPU/NPU driver is a hard failure (UCM needs an accelerator), not a
+        # benign skip that lets the overall result pass.
+        with patch.object(checks_mod, "_have", return_value=False):
+            r = check_accelerator_driver(self._cfg())
+        self.assertEqual(r.severity, FAIL)
+        self.assertEqual(r.status, STATUS_FAIL)
+        self.assertTrue(r.remediation)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/toolkit/tests/test_precheck_toolkit.py
+++ b/toolkit/tests/test_precheck_toolkit.py
@@ -1,0 +1,70 @@
+"""Toolkit-level tests for precheck (registration, dispatch, doctor)."""
+
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ucm_toolkit import registry  # noqa: E402
+from ucm_toolkit.cli import main  # noqa: E402
+
+
+class PrecheckToolkitTest(unittest.TestCase):
+    """Toolkit integration: precheck is registered, listed, and runnable."""
+
+    def setUp(self):
+        registry._TOOLS.clear()
+        registry._ALIASES.clear()
+
+    def test_precheck_is_registered_top_level_tool(self):
+        registry.init_builtin_tools()
+
+        tool = registry.get("precheck")
+
+        self.assertEqual(tool.name, "precheck")
+        self.assertIn("pre_check", tool.aliases)
+        self.assertFalse(tool.buildable)
+
+    def test_cli_list_shows_precheck(self):
+        registry.init_builtin_tools()
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            main(["list"])
+
+        self.assertIn("precheck", output.getvalue())
+
+    def test_cli_can_dispatch_precheck_help(self):
+        registry.init_builtin_tools()
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            result = main(["run", "precheck", "--help"])
+
+        self.assertEqual(result, 0)
+        self.assertIn("precheck", output.getvalue())
+
+    def test_doctor_advertises_precheck(self):
+        registry.init_builtin_tools()
+
+        output = io.StringIO()
+        with redirect_stdout(output):
+            result = main(["doctor", "precheck"])
+
+        text = output.getvalue()
+        self.assertEqual(result, 0)
+        self.assertIn("precheck", text)
+
+    def test_precheck_has_readme(self):
+        readme = ROOT / "ucm_toolkit" / "tools" / "precheck" / "README.md"
+        self.assertTrue(readme.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/toolkit/ucm_toolkit/registry.py
+++ b/toolkit/ucm_toolkit/registry.py
@@ -142,8 +142,10 @@ def init_builtin_tools() -> None:
     from .tools.metrics_view import MetricsViewTool
     from .tools.nic_monitor import NicMonitorTool
     from .tools.posix_aio import PosixAioTool
+    from .tools.precheck import PrecheckTool
 
     register(DevSandboxTool())
     register(MetricsViewTool())
     register(PosixAioTool())
     register(NicMonitorTool())
+    register(PrecheckTool())

--- a/toolkit/ucm_toolkit/tools/precheck/README.md
+++ b/toolkit/ucm_toolkit/tools/precheck/README.md
@@ -1,0 +1,153 @@
+# precheck — UCM environment pre-check
+
+`precheck` runs **locally on the UCM deployment host** before UCM starts and
+verifies that the environment meets UCM's runtime requirements. It reports
+`PASS` / `WARN` / `FAIL` for each item and prints **remediation advice** for
+failing or borderline checks, so issues can be fixed before a deployment
+attempt fails.
+
+It is the first item of the toolkit RFC (#1208): *UCM 部署前预检工具 — verify
+storage bandwidth, kernel version, driver version, shm-size, and other key
+configuration before running UCM*.
+
+```bash
+ucm-toolkit run precheck                           # all checks (bandwidth skipped w/o a mount path)
+ucm-toolkit run precheck --mount-path /mnt/ucm_cache
+ucm-toolkit run precheck --skip-bandwidth --json
+ucm-toolkit run precheck --only kernel --only accelerator_driver
+```
+
+## Checks
+
+| Check | Severity | What it verifies | Threshold |
+| --- | --- | --- | --- |
+| `serving_stack` | INFO | installed `vllm` / `vllm-ascend` / `sglang` versions | display only |
+| `uc_manager` | INFO | installed `uc-manager` version | display only |
+| `accelerator_driver` | FAIL/WARN | NVIDIA `compute_cap` (via `nvidia-smi`) or Ascend `HDK` (via `npu-smi info`) | no driver → FAIL; CUDA `compute_cap >= 8.0`; Ascend `HDK > 25.2.0` (below → WARN) |
+| `kernel` | **FAIL** | running kernel major.minor (`uname -r`) | `>= 5.10` series |
+| `memory_shm` | WARN | `/dev/shm` size (`statvfs`); RAM is hidden | `/dev/shm` ≥ 512 GiB (below → WARN) |
+| `aio_resources` | INFO | kernel AIO pool (`/proc/sys/fs/aio-max-nr`, `aio-nr`); computes max concurrent aio workers | display only |
+| `bandwidth` | WARN | posix `psync`/`aio` matrix benchmarked against the real `ucm` C++ store | all metrics `>= 8 GB/s` |
+
+### Severity and exit codes
+
+- **INFO** — display only; never affects the exit code.
+- **WARN** — soft threshold; does not fail unless `--strict` is set.
+- **FAIL** — hard constraint; fails the run.
+
+Exit codes: `0` all hard checks pass (warnings tolerated) · `1` a `FAIL`
+(or a `WARN` under `--strict`) · `2` CLI/usage error. `--only`/`--skip`
+select checks; `--skip-bandwidth` skips the (slow) benchmark.
+
+## Bandwidth benchmark
+
+The bandwidth check exercises the real `UcmPipelineStore`
+(`store_pipeline="Posix"`) — the same code path UCM uses to dump/load KV cache
+shards — across a configurable matrix and picks the best configuration.
+
+Default matrix (all configurable via `--shard-sizes`, `--workers`, `--engines`,
+`--modes`): shard sizes `{180 KiB, 8 MiB}` × worker counts `{1, 8, 16}` × IO
+engines `{psync, aio}`, and for each combo runs the phases selected by
+`--modes` (default `dump,read,mix`): a pure-dump (cold write) phase, a
+pure-read phase, and a read-heavy mixed phase (per epoch `1 dump + rw_ratio`
+loads, default `1:4`, mimicking the real KV-cache access pattern — write once,
+fetch many). Per phase it reports `mean ± std` and `min..max` across epoch
+samples plus the **aggregate** (per-worker × worker count). The combo with the
+highest **aggregate mixed** bandwidth (falling back to aggregate `mean(dump,
+load)`) is the recommended configuration; a warning fires when it is below
+`--threshold` (default `8 GB/s`). Defaults are lean (8 epochs/phase, block 32);
+`--quick` halves all epoch counts.
+
+`numpy` and the `ucm` package (with its built C++ `posix` store) are
+**lazy imports** — if `ucm` is not importable the bandwidth check is **skipped
+with a warning** rather than failing, so the rest of the pre-check still runs.
+
+## Configuration
+
+Every tunable value — thresholds (kernel, CUDA compute cap, Ascend HDK,
+`/dev/shm` min, bandwidth), the matrix (shard sizes, worker counts, engines,
+modes, epochs, `rw_ratio`, block number, barrier timeout) — lives in a single
+shipped file, `precheck.defaults.json` (next to this module). **A version
+update is a data-only change**: edit that file, no code edit needed. Layering,
+in increasing precedence: code constants (fallback if the JSON is absent) →
+`precheck.defaults.json` → a `--config FILE` user override → CLI flags.
+
+```json
+{
+  "mount_path": "/mnt/ucm_cache",
+  "kernel_min": "5.10",
+  "cuda_min_compute_cap": 8.0,
+  "ascend_min_hdk": "25.2.0",
+  "bandwidth": {
+    "shard_sizes": ["180k", "1m"],
+    "worker_counts": [1, 16],
+    "engines": ["psync", "aio"],
+    "block_number": 64,
+    "shard_number": 1,
+    "dump_epochs": 32,
+    "load_epochs": 32,
+    "threshold_gb": 8.0
+  }
+}
+```
+
+### Flags
+
+| Flag | Description |
+| --- | --- |
+| `--config FILE` | load thresholds/matrix from a JSON or YAML file |
+| `--mount-path PATH` | UCM storage mount point (required for the bandwidth benchmark) |
+| `--shard-sizes LIST` | comma-separated shard sizes, e.g. `180k,8m` |
+| `--workers LIST` | comma-separated worker counts, e.g. `1,8,16` |
+| `--engines LIST` | comma-separated IO engines, subset of `psync,aio` (default both) |
+| `--modes LIST` | comma-separated phases per combo: subset of `dump,read,mix` (default all; `mix` = read-heavy `1:rw_ratio`) |
+| `--threshold GB` | minimum best aggregate bandwidth in GB/s |
+| `--block-number` / `--dump-epochs` / `--load-epochs` / `--mixed-epochs` / `--rw-ratio` | matrix sweep parameters |
+| `--quick` | halve all epoch counts for a faster run |
+| `--skip-bandwidth` | skip the (slow) bandwidth benchmark |
+| `--kernel-min` / `--cuda-min-compute-cap` / `--ascend-min-hdk` | threshold overrides |
+| `--only CHECK` / `--skip CHECK` | select checks (repeatable) |
+| `--strict` | treat warnings as failures for the exit code |
+| `--no-color` / `--json` / `--verbose` | output control |
+
+## Notes
+
+- **`npu-smi info` HDK parsing** anchors on labels in priority order: an
+  explicit `HDK Version` label → a `Driver Version` label → the banner
+  `Version:` field. Validated against real openEuler firmware
+  (`npu-smi 25.5.2   Version: 25.5.2`, where the banner `Version` *is* the
+  HDK/driver version). The threshold is configurable via `--ascend-min-hdk`.
+- **Kernel `>= 5.10` is on the major.minor series**: `5.10.0-216` (an openEuler
+  5.10 LTS backport build) passes, `5.9` fails. Validated on a real UCM box.
+  Adjust `--kernel-min` otherwise.
+- **Bandwidth load reads can be inflated by the page cache** (the store default
+  is `io_direct=false`): measured load BW reflects cached reads while the dump
+  (cold write) is the disk-bound figure. The reported comprehensive
+  `mean(dump, load)` still reflects usable throughput; for pure disk bandwidth
+  enable `io_direct` in the store config.
+- The bandwidth benchmark is Linux/posix-only (anonymous `mmap` + the ucm
+  `.so`); it is skipped elsewhere with a note.
+- The tool sets `TORCH_DEVICE_BACKEND_AUTOLOAD=0` to prevent torch_npu from
+  loading (the posix store uses libaio directly and does not need the NPU).
+  This avoids FunctionLoader warnings and interference in container environments
+  where the NPU driver is only partially mounted. Worker stderr is also
+  redirected to `/dev/null` via `os.dup2`. A `combo_timeout` (default 300s,
+  configurable) is a backstop that terminates any worker that blocks.
+- Workers use **per-epoch barriers** (mirroring the original
+  `posixstore_aio_test.py`): all workers sync after each epoch so the kernel
+  aio queue is drained before the next burst. Without this, independent
+  workers can overflow `fs.aio-max-nr` at high worker counts, causing
+  `worker.wait(task)` to block in uninterruptible D state.
+
+## Tests
+
+```bash
+cd toolkit
+python -m unittest tests.test_precheck tests.test_precheck_toolkit -v
+```
+
+`test_precheck` covers the pure logic (version/size/SMI parsing, kernel
+boundary, config, bandwidth selection, reporter exit codes) plus the
+check-function decision logic with `subprocess`/`os` mocked, including the
+RFC #1208 remediation advice for `FAIL`. `test_precheck_toolkit` covers toolkit
+integration (registration, `list`, `run precheck` dispatch, `doctor`).

--- a/toolkit/ucm_toolkit/tools/precheck/__init__.py
+++ b/toolkit/ucm_toolkit/tools/precheck/__init__.py
@@ -1,0 +1,7 @@
+"""UCM environment pre-check tool (RFC #1208)."""
+
+__version__ = "0.1.0"
+
+from .adapter import PrecheckTool
+
+__all__ = ["PrecheckTool"]

--- a/toolkit/ucm_toolkit/tools/precheck/adapter.py
+++ b/toolkit/ucm_toolkit/tools/precheck/adapter.py
@@ -1,0 +1,42 @@
+"""precheck tool adapter."""
+
+from __future__ import annotations
+
+import argparse
+
+from ...registry import ToolAdapter
+
+
+class PrecheckTool(ToolAdapter):
+    """Adapter for the UCM environment pre-check (RFC #1208)."""
+
+    name = "precheck"
+    aliases = ("pre_check",)
+    description = (
+        "Run UCM environment pre-checks before deploying UCM: serving-stack "
+        "and uc-manager versions, accelerator driver (CUDA compute capability "
+        "or Ascend HDK), kernel version, memory & /dev/shm size, and the "
+        "posix-store bandwidth benchmark. Reports PASS/WARN/FAIL per item "
+        "with remediation advice for failures."
+    )
+    buildable = False
+
+    def add_run_args(self, parser: argparse.ArgumentParser) -> None:
+        """Register precheck run arguments (documentation-only; run() parses)."""
+        parser.add_argument("args", nargs="*", help="Arguments forwarded to precheck")
+
+    def run(self, tool_args: list[str]) -> int:
+        """Run the pre-check with raw tool arguments."""
+        from .cli import main
+
+        try:
+            return int(main(tool_args))
+        except SystemExit as exc:
+            if isinstance(exc.code, int):
+                return exc.code
+            return 0 if exc.code is None else 1
+
+    def doctor(self, args: argparse.Namespace | None = None) -> int:
+        """precheck is itself an environment check; no separate doctor step."""
+        print(f"{self.name}: run `ucm-toolkit run precheck` to check the env")
+        return 0

--- a/toolkit/ucm_toolkit/tools/precheck/bandwidth.py
+++ b/toolkit/ucm_toolkit/tools/precheck/bandwidth.py
@@ -1,0 +1,920 @@
+"""Storage bandwidth benchmark for the posix UCM store.
+
+Reuses the ``posixstore_aio_test.py`` worker pattern (mmap-aligned buffers,
+``UcmPipelineStore`` with ``store_pipeline="Posix"``, ``dump_data``/``load_data``
++ ``wait``) but runs a configurable matrix of shard sizes × worker counts × IO
+engines and picks the best configuration.
+
+numpy and the ``ucm`` C++ store are imported lazily so that the rest of the
+pre-check tool remains importable (and unit-testable) without them. The
+benchmark is Linux-only (posix mmap + the ucm ``.so``).
+"""
+
+from __future__ import annotations
+
+import multiprocessing
+import os
+import secrets
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+from .config import PrecheckConfig
+from .reporter import STATUS_PASS, STATUS_SKIP, STATUS_WARN, WARN, CheckResult
+
+
+@dataclass
+class ComboResult:
+    shard_size: int
+    worker_count: int
+    engine: str
+    dump_bw: float = 0.0  # mean dump GB/s
+    load_bw: float = 0.0  # mean load GB/s
+    comprehensive: float = 0.0  # mean(dump, load)
+    ok: bool = True
+    error: str = ""
+    # Stability stats across all epoch samples (populated by _run_combo).
+    dump_bws: List[float] = field(default_factory=list)
+    load_bws: List[float] = field(default_factory=list)
+    dump_std: float = 0.0
+    load_std: float = 0.0
+    dump_min: float = 0.0
+    dump_max: float = 0.0
+    load_min: float = 0.0
+    load_max: float = 0.0
+    n: int = 0  # number of epoch samples per direction
+    # Read-heavy mixed workload (1 dump + rw_ratio loads per epoch).
+    mixed_bw: float = 0.0  # mean mixed throughput GB/s (business bandwidth)
+    mixed_bws: List[float] = field(default_factory=list)
+    mixed_std: float = 0.0
+    mixed_min: float = 0.0
+    mixed_max: float = 0.0
+    rw_ratio: int = 0
+
+    def label(self) -> str:
+        return (
+            f"shard={self.shard_size}B workers={self.worker_count} "
+            f"engine={self.engine}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Worker-side helpers (run in spawned processes)
+# ---------------------------------------------------------------------------
+
+
+def _create_worker(device_id: int, params: dict):
+    """Build a UcmPipelineStore for one worker. Imports ucm lazily."""
+    from ucm.store.factory_v1 import UcmConnectorFactoryV1  # noqa: lazy
+
+    shard = params["shard_size"]
+    shard_number = params["shard_number"]
+    config = {
+        "store_pipeline": "Posix",
+        "posix_io_engine": params["engine"],
+        "storage_backends": [params["mount_path"]],
+        "tensor_size": shard,
+        "shard_size": shard,
+        # Explicit block_size satisfies the C++ validation
+        # (blockSize >= shardSize and blockSize % shardSize == 0);
+        # the reference script omitted this and relied on a 0 default.
+        "block_size": shard * shard_number,
+        "device_id": device_id,
+    }
+    return UcmConnectorFactoryV1.create_connector(
+        "UcmPipelineStore", config, "ucm.store.pipeline.connector"
+    )
+
+
+def _make_array(size: int, alignment: int = 262144):
+    """Page-aligned buffer via anonymous mmap (mirrors the reference script)."""
+    import mmap
+
+    import numpy as np  # noqa: lazy
+
+    total_bytes = size  # uint8 -> itemsize == 1
+    mm = mmap.mmap(-1, total_bytes + alignment)
+    raw = np.frombuffer(mm, dtype=np.uint8, count=total_bytes + alignment)
+    raw_ptr = raw.__array_interface__["data"][0]
+    aligned = (raw_ptr + alignment - 1) & ~(alignment - 1)
+    offset = aligned - raw_ptr
+    arr = raw[offset : offset + total_bytes].view(dtype=np.uint8)
+    return arr, mm
+
+
+def _dump(epoch, device_id, worker, block_ids, block_ptr, params):
+    shard = params["shard_size"]
+    shard_number = params["shard_number"]
+    block_number = params["block_number"]
+    total_size = shard * shard_number * block_number
+    costs = []
+    for i in range(shard_number):
+        idxes = [i for _ in range(block_number)]
+        ptrs = [[ptr + i * shard] for ptr in block_ptr]
+        t0 = time.perf_counter()
+        task = worker.dump_data(block_ids, idxes, ptrs)
+        worker.wait(task)
+        costs.append(time.perf_counter() - t0)
+    total_cost = sum(costs)
+    bw = total_size / total_cost / 1e9 if total_cost > 0 else 0.0
+    if params.get("verbose"):
+        print(
+            f"epoch={epoch:03}, worker={device_id:02}, "
+            f"dump=[{shard} x {block_number} x {shard_number}], "
+            f"cost={total_cost * 1e3:.3f}ms, bw={bw:.3f}GB/s.",
+            flush=True,
+        )
+    return bw
+
+
+def _load(epoch, device_id, worker, block_ids, block_ptr, params):
+    shard = params["shard_size"]
+    shard_number = params["shard_number"]
+    block_number = params["block_number"]
+    total_size = shard * shard_number * block_number
+    costs = []
+    for i in range(shard_number):
+        idxes = [i for _ in range(block_number)]
+        ptrs = [[ptr + i * shard] for ptr in block_ptr]
+        t0 = time.perf_counter()
+        task = worker.load_data(block_ids, idxes, ptrs)
+        worker.wait(task)
+        costs.append(time.perf_counter() - t0)
+    total_cost = sum(costs)
+    bw = total_size / total_cost / 1e9 if total_cost > 0 else 0.0
+    if params.get("verbose"):
+        print(
+            f"epoch={epoch:03}, worker={device_id:02}, "
+            f"load=[{shard} x {block_number} x {shard_number}], "
+            f"cost={total_cost * 1e3:.3f}ms, bw={bw:.3f}GB/s.",
+            flush=True,
+        )
+    return bw
+
+
+def _mixed(epoch, device_id, worker, block_ids, block_ptr, params):
+    """Read-heavy mixed epoch: 1 dump sweep + rw_ratio load sweeps, timed together.
+
+    Loads read the blocks just written (cache-warm), mimicking a real KV-cache
+    access pattern (write once, fetch many). The combined throughput =
+    (1 + rw_ratio) * sweep_bytes / elapsed.
+    """
+    shard = params["shard_size"]
+    shard_number = params["shard_number"]
+    block_number = params["block_number"]
+    rw_ratio = params["rw_ratio"]
+    sweep_bytes = shard * shard_number * block_number
+
+    def sweep(load):
+        for i in range(shard_number):
+            idxes = [i for _ in range(block_number)]
+            ptrs = [[ptr + i * shard] for ptr in block_ptr]
+            task = (
+                worker.load_data(block_ids, idxes, ptrs)
+                if load
+                else worker.dump_data(block_ids, idxes, ptrs)
+            )
+            worker.wait(task)
+
+    t0 = time.perf_counter()
+    sweep(load=False)  # 1 write
+    for _ in range(rw_ratio):  # rw_ratio reads
+        sweep(load=True)
+    elapsed = time.perf_counter() - t0
+    bw = (1 + rw_ratio) * sweep_bytes / elapsed / 1e9 if elapsed > 0 else 0.0
+    if params.get("verbose"):
+        print(
+            f"epoch={epoch:03}, worker={device_id:02}, "
+            f"mixed(1:{rw_ratio})=[{shard} x {block_number} x {shard_number}], "
+            f"cost={elapsed * 1e3:.3f}ms, bw={bw:.3f}GB/s.",
+            flush=True,
+        )
+    return bw
+
+
+def _worker_loop(device_id, barrier, result_queue, params: dict):
+    """Worker process: create store, run phases, push results to the queue.
+
+    Mirrors the original ``posixstore_aio_test.py`` pattern — a simple barrier
+    start gate, independent epoch loop, results collected locally and pushed
+    once at the end. No ``Manager`` server process (which adds IPC overhead and
+    potential deadlock paths under heavy I/O).
+    """
+    # Silence the ucm/torch C++ layer's stderr noise (FunctionLoader
+    # LD_PRELOAD warnings, torch_npu autoload chatter, glog W-lines) by
+    # redirecting the actual fd 2 to /dev/null. Using os.dup2 (not just
+    # sys.stderr = ...) because C++ code writes to fd 2 directly, bypassing
+    # Python's sys.stderr. Our own worker messages go to stdout (not stderr)
+    # so they survive. With --verbose, keep stderr visible for debugging.
+    if not params.get("verbose"):
+        try:
+            _devnull_fd = os.open(os.devnull, os.O_WRONLY)
+            os.dup2(_devnull_fd, 2)
+            os.close(_devnull_fd)
+        except Exception:
+            pass
+
+    dump_bws: List[float] = []
+    load_bws: List[float] = []
+    mixed_bws: List[float] = []
+
+    try:
+        store = _create_worker(device_id, params)
+    except Exception as exc:  # pragma: no cover - depends on ucm build
+        result_queue.put(("error", device_id, str(exc)))
+        try:
+            barrier.abort()
+        except Exception:
+            pass
+        return
+
+    block_number = params["block_number"]
+    block_ids = [secrets.token_bytes(16) for _ in range(block_number)]
+    shard_number = params["shard_number"]
+    shard = params["shard_size"]
+    block_data = []
+    mmap_handles = []
+    for _ in range(block_number):
+        arr, mm = _make_array(shard * shard_number)
+        block_data.append(arr)
+        mmap_handles.append(mm)
+    block_ptr = [arr.ctypes.data for arr in block_data]
+
+    rw_ratio = params.get("rw_ratio", 0)
+    mixed_epochs = params.get("mixed_epochs", 0)
+    modes = params.get("modes", [])
+    run_dump = "dump" in modes
+    run_load = "read" in modes
+    run_mixed = "mix" in modes and rw_ratio > 0 and mixed_epochs > 0
+    btimeout = params.get("barrier_timeout", _DEFAULT_BARRIER_TIMEOUT)
+    try:
+        # Start gate: all workers begin I/O concurrently. A peer that failed
+        # store creation calls barrier.abort(), waking survivors instantly.
+        if not _barrier_wait(barrier, device_id, btimeout):
+            result_queue.put(("error", device_id, "barrier broken"))
+            return
+        # Per-epoch barriers (mirrors the original posixstore_aio_test.py):
+        # all workers sync after each epoch so the kernel aio queue is drained
+        # before the next burst of submissions. Without this, independent
+        # workers can overflow the kernel's aio-nr limit at high worker counts,
+        # causing worker.wait(task) to block in uninterruptible D state.
+        if run_dump:
+            for epoch in range(params["dump_epochs"]):
+                dump_bws.append(
+                    _dump(epoch, device_id, store, block_ids, block_ptr, params)
+                )
+                if not _barrier_wait(barrier, device_id, btimeout):
+                    result_queue.put(("error", device_id, "barrier broken during dump"))
+                    return
+        if run_load:
+            for epoch in range(params["load_epochs"]):
+                load_bws.append(
+                    _load(epoch, device_id, store, block_ids, block_ptr, params)
+                )
+                if not _barrier_wait(barrier, device_id, btimeout):
+                    result_queue.put(("error", device_id, "barrier broken during load"))
+                    return
+        if run_mixed:
+            for epoch in range(mixed_epochs):
+                mixed_bws.append(
+                    _mixed(epoch, device_id, store, block_ids, block_ptr, params)
+                )
+                if not _barrier_wait(barrier, device_id, btimeout):
+                    result_queue.put(
+                        ("error", device_id, "barrier broken during mixed")
+                    )
+                    return
+        result_queue.put(
+            ("ok", device_id, {"dump": dump_bws, "load": load_bws, "mixed": mixed_bws})
+        )
+    except Exception as exc:  # pragma: no cover - depends on env
+        result_queue.put(("error", device_id, str(exc)))
+        try:
+            barrier.abort()
+        except Exception:
+            pass
+    finally:
+        for mm in mmap_handles:
+            try:
+                mm.close()
+            except Exception:
+                pass
+
+
+# Backstop: max seconds to wait at the start barrier. Normally a peer that
+# fails store creation calls barrier.abort(), which wakes survivors instantly;
+# this timeout only bites if abort() never reaches the survivors. Configurable
+# via precheck.defaults.json (bandwidth.barrier_timeout).
+_DEFAULT_BARRIER_TIMEOUT = 60
+
+
+def _barrier_wait(barrier, device_id: int, timeout: int) -> bool:
+    """Wait at the barrier with a timeout. Return False if it breaks/times out."""
+    try:
+        barrier.wait(timeout=timeout)
+        return True
+    except Exception as exc:  # BrokenBarrierError on timeout or a peer aborting
+        print(f"[worker {device_id}] barrier broken: {exc}", flush=True)
+        return False
+
+
+def _terminate_proc(p):
+    """Terminate a hung worker process: SIGTERM, then SIGKILL as fallback."""
+    for method in ("terminate", "kill"):
+        try:
+            getattr(p, method)()
+            p.join(timeout=5)
+        except Exception:
+            pass
+        if not p.is_alive():
+            break
+
+
+# ---------------------------------------------------------------------------
+# Matrix runner
+# ---------------------------------------------------------------------------
+
+
+def _run_combo(
+    shard: int, workers: int, engine: str, cfg: PrecheckConfig
+) -> ComboResult:
+    """Run one (shard, workers, engine) benchmark and return its result."""
+    bw = cfg.bandwidth
+    modes = bw.modes
+    params = {
+        "shard_size": shard,
+        "shard_number": bw.shard_number,
+        "block_number": bw.block_number,
+        "dump_epochs": bw.dump_epochs,
+        "load_epochs": bw.load_epochs,
+        "mixed_epochs": bw.mixed_epochs,
+        "rw_ratio": bw.rw_ratio,
+        "engine": engine,
+        "mount_path": cfg.mount_path,
+        "modes": modes,
+        "barrier_timeout": bw.barrier_timeout,
+        "combo_timeout": bw.combo_timeout,
+        "verbose": cfg.verbose,
+    }
+    combo = ComboResult(
+        shard_size=shard,
+        worker_count=workers,
+        engine=engine,
+        rw_ratio=bw.rw_ratio if ("mix" in modes and bw.mixed_epochs > 0) else 0,
+    )
+    try:
+        result_queue: multiprocessing.Queue = multiprocessing.Queue()
+        barrier = multiprocessing.Barrier(workers)
+        procs = []
+        for i in range(workers):
+            p = multiprocessing.Process(
+                target=_worker_loop,
+                args=(i, barrier, result_queue, params),
+            )
+            procs.append(p)
+            p.start()
+        combo_timeout = params.get("combo_timeout", 300)
+        deadline = time.perf_counter() + combo_timeout
+        timed_out = False
+        for p in procs:
+            remaining = max(1.0, deadline - time.perf_counter())
+            p.join(timeout=remaining)
+            if p.is_alive():
+                timed_out = True
+                _terminate_proc(p)
+        if timed_out:
+            combo.ok = False
+            combo.error = (
+                f"combo timed out after {combo_timeout}s "
+                f"(a worker may be stuck on aio I/O; try psync or "
+                f"raise fs.aio-max-nr)"
+            )
+            return combo
+        # Drain the queue — each worker pushed one result dict at the end.
+        # No Manager server process: workers collected samples locally and
+        # pushed once, minimising IPC (mirrors the original test script).
+        run_dump = "dump" in modes
+        run_load = "read" in modes
+        run_mixed = "mix" in modes and bw.rw_ratio > 0 and bw.mixed_epochs > 0
+        dumps: List[float] = []
+        loads: List[float] = []
+        mixeds: List[float] = []
+        errors: List[str] = []
+        while not result_queue.empty():
+            try:
+                tag, _wid, payload = result_queue.get_nowait()
+            except Exception:
+                break
+            if tag == "error":
+                errors.append(str(payload))
+                continue
+            if tag == "ok":
+                dumps.extend(payload.get("dump", []))
+                loads.extend(payload.get("load", []))
+                mixeds.extend(payload.get("mixed", []))
+        if not (run_dump or run_load or run_mixed):
+            combo.ok = False
+            combo.error = "no bandwidth modes selected"
+            return combo
+        if run_dump:
+            if not dumps:
+                combo.ok = False
+                combo.error = "dump phase produced no samples"
+                return combo
+            combo.dump_bw = _mean(dumps)
+            combo.dump_bws = dumps
+            combo.dump_std = _std(dumps)
+            combo.dump_min, combo.dump_max = _minmax(dumps)
+        if run_load:
+            if not loads:
+                combo.ok = False
+                combo.error = "read phase produced no samples"
+                return combo
+            combo.load_bw = _mean(loads)
+            combo.load_bws = loads
+            combo.load_std = _std(loads)
+            combo.load_min, combo.load_max = _minmax(loads)
+        # comprehensive only meaningful when both dump and read ran.
+        if run_dump and run_load:
+            combo.comprehensive = (combo.dump_bw + combo.load_bw) / 2.0
+        combo.n = len(dumps) or len(loads) or len(mixeds)
+        if run_mixed:
+            if not mixeds:
+                combo.ok = False
+                combo.error = "mixed phase produced no samples"
+                return combo
+            combo.mixed_bw = _mean(mixeds)
+            combo.mixed_bws = mixeds
+            combo.mixed_std = _std(mixeds)
+            combo.mixed_min, combo.mixed_max = _minmax(mixeds)
+    except Exception as exc:  # pragma: no cover - depends on env
+        combo.ok = False
+        combo.error = f"{type(exc).__name__}: {exc}"
+    return combo
+
+
+def _mean(xs: List[float]) -> float:
+    return sum(xs) / len(xs) if xs else 0.0
+
+
+def _std(xs: List[float]) -> float:
+    """Population standard deviation (pure-python; main process has no numpy)."""
+    if not xs:
+        return 0.0
+    m = sum(xs) / len(xs)
+    return (sum((x - m) ** 2 for x in xs) / len(xs)) ** 0.5
+
+
+def _minmax(xs: List[float]) -> Tuple[float, float]:
+    return (min(xs), max(xs)) if xs else (0.0, 0.0)
+
+
+# Each metric: (attribute on ComboResult, display label).
+_METRICS = [
+    ("dump_bw", "dump"),
+    ("load_bw", "load"),
+    ("comprehensive", "comprehensive"),
+    ("mixed_bw", "mixed"),
+]
+
+
+def headline_bw(c: ComboResult) -> float:
+    """Aggregate store throughput across all workers (prefers mixed, then
+    comprehensive, then dump/load).  Used for the single "best" combo in raw
+    output.  Per-metric status uses :func:`best_per_metric` instead."""
+    if c.mixed_bw > 0:
+        per_worker = c.mixed_bw
+    elif c.comprehensive > 0:
+        per_worker = c.comprehensive
+    elif c.dump_bw > 0:
+        per_worker = c.dump_bw
+    elif c.load_bw > 0:
+        per_worker = c.load_bw
+    else:
+        per_worker = 0.0
+    return per_worker * c.worker_count
+
+
+def pick_best(combos: List[ComboResult]) -> Optional[ComboResult]:
+    """Return the combo with the highest headline bandwidth (ok only)."""
+    ok = [c for c in combos if c.ok]
+    return max(ok, key=headline_bw) if ok else None
+
+
+def best_per_metric(
+    combos: List[ComboResult],
+) -> List[Tuple[str, ComboResult, float]]:
+    """For each metric that ran, return ``(label, best_combo, aggregate_gb)``.
+
+    The best combo for a metric is the one with the highest aggregate
+    (per-worker BW × worker count) among ok combos.  Different metrics may
+    have different best combos.
+    """
+    result: List[Tuple[str, ComboResult, float]] = []
+    for attr, label in _METRICS:
+        ok = [c for c in combos if c.ok and getattr(c, attr, 0.0) > 0]
+        if ok:
+            best = max(ok, key=lambda c: getattr(c, attr, 0.0) * c.worker_count)
+            agg = getattr(best, attr, 0.0) * best.worker_count
+            result.append((label, best, agg))
+    return result
+
+
+def bandwidth_status(
+    metric_best: List[Tuple[str, ComboResult, float]], threshold: float
+) -> str:
+    """PASS only if every metric's best aggregate meets the threshold."""
+    if not metric_best:
+        return STATUS_WARN
+    return (
+        STATUS_PASS
+        if all(agg >= threshold for _, _, agg in metric_best)
+        else STATUS_WARN
+    )
+
+
+def bandwidth_detail(
+    metric_best: List[Tuple[str, ComboResult, float]], threshold: float
+) -> str:
+    if not metric_best:
+        return "no benchmark combo completed successfully"
+    lines = []
+    for label, combo, agg in metric_best:
+        mark = "PASS" if agg >= threshold else "WARN"
+        lines.append(f"  {label:15s} best={agg:.3f} GB/s ({combo.label()})  [{mark}]")
+    return "\n".join(lines)
+
+
+def _format_bw(x: float) -> str:
+    return f"{x:.3f}"
+
+
+def _render_matrix(combos: List[ComboResult]) -> str:
+    """Detailed per-combo bandwidth report: per-worker mean/std/min/max + aggregate.
+    Only phases that actually ran (dump/read/mix per --modes) are printed."""
+    lines = ["bandwidth matrix:"]
+    for c in combos:
+        if not c.ok:
+            lines.append(f"{c.label()}  ERR: {c.error}")
+            continue
+        w = c.worker_count
+        lines.append(
+            f"{_human_bytes(c.shard_size)}  workers={w}  engine={c.engine}  "
+            f"(n={c.n} samples/direction, per-worker below)"
+        )
+        agg_parts = []
+        if c.dump_bw > 0:
+            lines.append(
+                f"  dump  avg={c.dump_bw:.3f}  std={c.dump_std:.3f}  "
+                f"min={c.dump_min:.3f}  max={c.dump_max:.3f}  GB/s"
+            )
+            agg_parts.append(f"dump={c.dump_bw * w:.3f}")
+        if c.load_bw > 0:
+            lines.append(
+                f"  load  avg={c.load_bw:.3f}  std={c.load_std:.3f}  "
+                f"min={c.load_min:.3f}  max={c.load_max:.3f}  GB/s"
+            )
+            agg_parts.append(f"load={c.load_bw * w:.3f}")
+        if c.comprehensive > 0:
+            lines.append(f"  comprehensive = {c.comprehensive:.3f} GB/s")
+            agg_parts.append(f"comp={c.comprehensive * w:.3f}")
+        if c.mixed_bw > 0:
+            lines.append(
+                f"  mixed avg={c.mixed_bw:.3f}  std={c.mixed_std:.3f}  "
+                f"min={c.mixed_min:.3f}  max={c.mixed_max:.3f}  GB/s  "
+                f"(read-heavy 1:{c.rw_ratio})"
+            )
+            agg_parts.append(f"mixed={c.mixed_bw * w:.3f}")
+        if agg_parts:
+            lines.append(f"  aggregate ({w}w): " + "  ".join(agg_parts) + "  GB/s")
+    return "\n".join(lines)
+
+
+def _human_bytes(n: int) -> str:
+    for unit, factor in (("GiB", 1024**3), ("MiB", 1024**2), ("KiB", 1024)):
+        if n >= factor and n % factor == 0:
+            return f"{n // factor}{unit}"
+    return f"{n}B"
+
+
+def _read_aio_limits() -> Tuple[int, int]:
+    """Read kernel aio limits from /proc/sys/fs/.
+
+    Returns (aio_max_nr, aio_nr). Both 0 if the files don't exist (non-Linux
+    or aio not enabled).
+    """
+    try:
+        with open("/proc/sys/fs/aio-max-nr") as f:
+            max_nr = int(f.read().strip())
+        with open("/proc/sys/fs/aio-nr") as f:
+            nr = int(f.read().strip())
+        return max_nr, nr
+    except (OSError, ValueError):
+        return 0, 0
+
+
+# ---------------------------------------------------------------------------
+# Engine probe (avoids indefinite hang on hosts where aio blocks)
+# ---------------------------------------------------------------------------
+
+
+def _probe_worker(params: dict):
+    """Probe worker: create store, dump one shard sweep, exit 0 on success.
+
+    Mirrors the original ``posixstore_aio_test.py`` dump call: ``block_number``
+    block IDs, ``idxes`` and ``ptrs`` lists of equal length, each ``ptr`` wrapped
+    in a list (``[[ptr], [ptr], ...]``).
+    """
+    if not params.get("verbose"):
+        try:
+            _devnull_fd = os.open(os.devnull, os.O_WRONLY)
+            os.dup2(_devnull_fd, 2)
+            os.close(_devnull_fd)
+        except Exception:
+            pass
+    try:
+        store = _create_worker(0, params)
+        shard = params["shard_size"]
+        block_number = min(params["block_number"], 4)
+        block_ids = [secrets.token_bytes(16) for _ in range(block_number)]
+        mmap_handles = []
+        block_ptr = []
+        for _ in range(block_number):
+            arr, mm = _make_array(shard)
+            block_ptr.append(arr.ctypes.data)
+            mmap_handles.append(mm)
+        idxes = [0 for _ in range(block_number)]
+        ptrs = [[ptr] for ptr in block_ptr]
+        task = store.dump_data(block_ids, idxes, ptrs)
+        store.wait(task)
+    except Exception:
+        sys.exit(1)
+    finally:
+        for mm in mmap_handles:
+            try:
+                mm.close()
+            except Exception:
+                pass
+    sys.exit(0)
+
+
+def _probe_engine(
+    engine: str, mount_path: str, shard_size: int, block_number: int, timeout: int = 15
+) -> bool:
+    """Quick probe: can this engine create a store and complete one dump?
+
+    Returns True if usable, False if it blocks or fails.  This prevents the
+    indefinite hang that occurs when ``worker.wait(task)`` blocks on an
+    uninterruptible kernel aio syscall (D state — even SIGKILL cannot
+    interrupt it).
+    """
+    params = {
+        "shard_size": shard_size,
+        "shard_number": 1,
+        "block_number": min(block_number, 4),
+        "engine": engine,
+        "mount_path": mount_path,
+    }
+    try:
+        p = multiprocessing.Process(target=_probe_worker, args=(params,))
+        p.start()
+        p.join(timeout=timeout)
+        if p.is_alive():
+            _terminate_proc(p)
+            return False
+        return p.exitcode == 0
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Public check entry
+# ---------------------------------------------------------------------------
+
+
+def check_bandwidth(cfg: PrecheckConfig) -> CheckResult:
+    """Run the bandwidth matrix; warn if the best comprehensive BW < threshold."""
+    if os.name != "posix":
+        return CheckResult(
+            name="bandwidth",
+            severity=WARN,
+            status=STATUS_SKIP,
+            value="-",
+            detail="skipped: bandwidth benchmark is Linux/posix-only",
+            remediation="run on a Linux host (the ucm posix store needs posix mmap)",
+            raw={"platform": os.name},
+        )
+    if not cfg.mount_path:
+        return CheckResult(
+            name="bandwidth",
+            severity=WARN,
+            status=STATUS_SKIP,
+            value="-",
+            detail="skipped: provide --mount-path (or mount_path in config) to run",
+            remediation="set --mount-path to the UCM cache mount point",
+            raw={},
+        )
+    if not os.path.isdir(cfg.mount_path):
+        return CheckResult(
+            name="bandwidth",
+            severity=WARN,
+            status=STATUS_WARN,
+            value="-",
+            threshold=f">= {cfg.bandwidth.threshold_gb} GB/s",
+            detail=f"mount path does not exist or is not a directory: "
+            f"{cfg.mount_path}",
+            remediation="point --mount-path at an existing writable directory",
+            raw={"mount_path": cfg.mount_path},
+        )
+
+    # Suppress C++ noise: prevent torch_npu autoload (FunctionLoader warnings,
+    # which can interfere with the posix store in container environments where
+    # the NPU driver is only partially mounted) and glog W-lines. The posix
+    # store uses libaio directly and does not need torch_npu. Worker stderr is
+    # also redirected to /dev/null via os.dup2 (see _worker_loop).
+    for _k, _v in (
+        ("TORCH_DEVICE_BACKEND_AUTOLOAD", "0"),
+        ("GLOG_minloglevel", "2"),
+        ("GLOG_stderrthreshold", "2"),
+    ):
+        os.environ.setdefault(_k, _v)
+
+    # Verify ucm is importable before spawning workers.
+    try:
+        import ucm  # noqa: F401
+    except Exception as exc:
+        return CheckResult(
+            name="bandwidth",
+            severity=WARN,
+            status=STATUS_SKIP,
+            value="-",
+            threshold=f">= {cfg.bandwidth.threshold_gb} GB/s",
+            detail=f"skipped: ucm not importable ({type(exc).__name__}: {exc})",
+            remediation="install ucm (with the built C++ posix store) to benchmark",
+            raw={"mount_path": cfg.mount_path},
+        )
+
+    bw = cfg.bandwidth
+    # Probe engines: aio may fail or block on some hosts.  Probe each non-
+    # psync engine with a single-worker, single-block dump; skip engines that
+    # fail or block.
+    probed_engines: List[str] = []
+    for engine in bw.engines:
+        if engine == "psync":
+            probed_engines.append(engine)
+            continue
+        print(f"[bw] probing {engine}...", flush=True)
+        if _probe_engine(engine, cfg.mount_path, bw.shard_sizes[0], bw.block_number):
+            probed_engines.append(engine)
+        else:
+            print(
+                f"[bw] {engine} probe failed — skipping {engine} combos "
+                f"(engine may block on this disk; use psync)",
+                flush=True,
+            )
+    if not probed_engines:
+        probed_engines = ["psync"]
+
+    # Check aio resource limits before the matrix. Each aio store context
+    # calls io_setup(queue_depth) which reserves queue_depth events from the
+    # kernel's aio pool (aio-max-nr). If N workers × queue_depth exceeds the
+    # available pool (aio-max-nr - aio-nr), the later workers' io_setup fails
+    # with EAGAIN and the combo deadlocks. Cap the aio worker count to what
+    # the kernel can actually support and warn if the user requested more.
+    aio_max_nr, aio_nr = _read_aio_limits()
+    max_aio_workers = 0  # 0 = unknown / unlimited (let it try)
+    if aio_max_nr > 0 and "aio" in probed_engines:
+        available = aio_max_nr - aio_nr
+        qd = bw.aio_queue_depth
+        max_aio_workers = max(0, available // qd) if qd > 0 else 0
+        max_requested = max(bw.worker_counts)
+        if max_aio_workers < max_requested:
+            print(
+                f"[bw] aio: {available} events available "
+                f"(aio-max-nr={aio_max_nr}, aio-nr={aio_nr}), "
+                f"each context needs {qd}, "
+                f"max {max_aio_workers} aio workers "
+                f"(requested up to {max_requested}); "
+                f"raise aio-max-nr: echo 1048576 > /proc/sys/fs/aio-max-nr",
+                flush=True,
+            )
+
+    combos: List[ComboResult] = []
+    for shard in bw.shard_sizes:
+        for workers in bw.worker_counts:
+            for engine in probed_engines:
+                if (
+                    engine != "psync"
+                    and max_aio_workers > 0
+                    and workers > max_aio_workers
+                ):
+                    combos.append(
+                        ComboResult(
+                            shard_size=shard,
+                            worker_count=workers,
+                            engine=engine,
+                            ok=False,
+                            error=(
+                                f"skipped: only {max_aio_workers} aio workers "
+                                f"available (aio-max-nr={aio_max_nr})"
+                            ),
+                        )
+                    )
+                    continue
+                print(
+                    f"[bw] shard={_human_bytes(shard)} workers={workers} "
+                    f"engine={engine} ...",
+                    flush=True,
+                )
+                combo = _run_combo(shard, workers, engine, cfg)
+                combos.append(combo)
+
+    metric_best = best_per_metric(combos)
+
+    matrix_str = _render_matrix(combos)
+    threshold = bw.threshold_gb
+    print("\n" + matrix_str, flush=True)
+
+    raw = {
+        "mount_path": cfg.mount_path,
+        "engines_probed": probed_engines,
+        "engines_skipped": [e for e in bw.engines if e not in probed_engines],
+        "matrix": [
+            {
+                "shard_size": c.shard_size,
+                "worker_count": c.worker_count,
+                "engine": c.engine,
+                "dump_gb": round(c.dump_bw, 3),
+                "dump_std": round(c.dump_std, 3),
+                "dump_min": round(c.dump_min, 3),
+                "dump_max": round(c.dump_max, 3),
+                "load_gb": round(c.load_bw, 3),
+                "load_std": round(c.load_std, 3),
+                "load_min": round(c.load_min, 3),
+                "load_max": round(c.load_max, 3),
+                "comprehensive_gb": round(c.comprehensive, 3),
+                "mixed_gb": round(c.mixed_bw, 3),
+                "mixed_std": round(c.mixed_std, 3),
+                "mixed_min": round(c.mixed_min, 3),
+                "mixed_max": round(c.mixed_max, 3),
+                "rw_ratio": c.rw_ratio,
+                "n": c.n,
+                "ok": c.ok,
+                "error": c.error,
+                "dump_series": [round(v, 3) for v in c.dump_bws],
+                "load_series": [round(v, 3) for v in c.load_bws],
+                "mixed_series": [round(v, 3) for v in c.mixed_bws],
+            }
+            for c in combos
+        ],
+        "threshold_gb": threshold,
+    }
+
+    if not metric_best:
+        return CheckResult(
+            name="bandwidth",
+            severity=WARN,
+            status=STATUS_WARN,
+            value="-",
+            threshold=f">= {threshold} GB/s",
+            detail="no benchmark combo completed successfully",
+            remediation="check ucm store health and that the C++ posix .so is built",
+            raw=raw,
+        )
+
+    raw["best_per_metric"] = [
+        {
+            "metric": label,
+            "aggregate_gb": round(agg, 3),
+            "shard_size": combo.shard_size,
+            "worker_count": combo.worker_count,
+            "engine": combo.engine,
+        }
+        for label, combo, agg in metric_best
+    ]
+
+    value = (
+        "  ".join(f"{label}={_format_bw(agg)}" for label, _, agg in metric_best)
+        + " GB/s"
+    )
+    status = bandwidth_status(metric_best, threshold)
+    detail = bandwidth_detail(metric_best, threshold)
+    failed = [label for label, _, agg in metric_best if agg < threshold]
+    remediation = ""
+    if failed:
+        remediation = (
+            f"metrics below threshold ({', '.join(failed)}): "
+            "check the mount-point disk/NVMe throughput; try the aio engine, "
+            "raise --workers, or confirm io_direct/O_DIRECT settings"
+        )
+    return CheckResult(
+        name="bandwidth",
+        severity=WARN,
+        status=status,
+        value=value,
+        threshold=f">= {threshold} GB/s",
+        detail=detail,
+        remediation=remediation,
+        raw=raw,
+    )

--- a/toolkit/ucm_toolkit/tools/precheck/checks.py
+++ b/toolkit/ucm_toolkit/tools/precheck/checks.py
@@ -1,0 +1,535 @@
+"""Concrete environment checks. Each function returns a :class:`CheckResult`.
+
+The cheap checks (versions, driver, kernel, memory) are pure stdlib and run on
+any host. The bandwidth check lives in :mod:`pre_check.bandwidth` because it
+pulls in numpy and the ucm C++ store.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import platform
+import re
+import shutil
+import subprocess
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
+from typing import List, Optional, Tuple
+
+from .config import PrecheckConfig
+from .parseutil import (
+    compare_versions,
+    extract_nvidia_compute_cap,
+    normalize_vllm_ascend_version,
+    parse_npu_smi_versions,
+    parse_nvidia_smi_csv,
+    parse_version,
+    strip_build,
+)
+from .reporter import (
+    FAIL,
+    INFO,
+    STATUS_FAIL,
+    STATUS_INFO,
+    STATUS_OK,
+    STATUS_PASS,
+    STATUS_SKIP,
+    STATUS_WARN,
+    WARN,
+    CheckResult,
+)
+
+
+def _run(cmd: List[str], timeout: int = 30) -> Tuple[int, str, str]:
+    """Run a command, returning (returncode, stdout, stderr). Never raises."""
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return r.returncode, r.stdout or "", r.stderr or ""
+    except (FileNotFoundError, OSError):
+        return -1, "", f"command not found: {' '.join(cmd)}"
+    except subprocess.TimeoutExpired:
+        return -1, "", f"command timed out after {timeout}s: {' '.join(cmd)}"
+
+
+def _have(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+# ---------------------------------------------------------------------------
+# 1. Serving stack (vllm / vllm-ascend / sglang) — INFO
+# ---------------------------------------------------------------------------
+
+
+def _dist_version(dist: str) -> Optional[str]:
+    try:
+        return pkg_version(dist)
+    except PackageNotFoundError:
+        return None
+    except Exception:
+        return None
+
+
+def _module_version(module: str) -> Optional[str]:
+    try:
+        mod = importlib.import_module(module)
+    except Exception:
+        return None
+    return getattr(mod, "__version__", None)
+
+
+def check_serving_stack() -> CheckResult:
+    """Print installed vllm/vllm-ascend (or sglang) versions. Never fails."""
+    parts: List[str] = []
+    raw: dict = {}
+
+    vllm = _dist_version("vllm") or _module_version("vllm")
+    if vllm:
+        parts.append(f"vllm={strip_build(vllm)}")
+        raw["vllm"] = vllm
+
+    ascend_raw = _dist_version("vllm-ascend") or _module_version("vllm_ascend")
+    ascend_norm = normalize_vllm_ascend_version(ascend_raw)
+    if ascend_raw:
+        parts.append(f"vllm-ascend={ascend_raw}")
+        raw["vllm_ascend_raw"] = ascend_raw
+        raw["vllm_ascend_norm"] = ascend_norm
+
+    sglang = _dist_version("sglang") or _module_version("sglang")
+    if sglang:
+        parts.append(f"sglang={sglang}")
+        raw["sglang"] = sglang
+
+    if not parts:
+        return CheckResult(
+            name="serving_stack",
+            severity=INFO,
+            status=STATUS_INFO,
+            value="-",
+            detail="no vllm / vllm-ascend / sglang detected",
+            raw=raw,
+        )
+    return CheckResult(
+        name="serving_stack",
+        severity=INFO,
+        status=STATUS_INFO,
+        value=", ".join(parts),
+        detail="installed serving stack",
+        raw=raw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. uc-manager — INFO
+# ---------------------------------------------------------------------------
+
+
+def check_uc_manager_version() -> CheckResult:
+    """Print installed uc-manager version. Never fails."""
+    raw: dict = {}
+    ver = _dist_version("uc-manager") or _dist_version("uc_manager")
+    if ver is None:
+        ver = _module_version("uc_manager")
+    if ver is None:
+        # Last resort: pip show (covers non-importable installs).
+        rc, out, _ = _run([sys_python(), "-m", "pip", "show", "uc-manager"])
+        if rc == 0:
+            m = re.search(r"^Version:\s*(\S+)", out, re.M)
+            if m:
+                ver = m.group(1)
+    if ver:
+        raw["version"] = ver
+        return CheckResult(
+            name="uc_manager",
+            severity=INFO,
+            status=STATUS_INFO,
+            value=ver,
+            detail="uc-manager package version",
+            raw=raw,
+        )
+    return CheckResult(
+        name="uc_manager",
+        severity=INFO,
+        status=STATUS_INFO,
+        value="-",
+        detail="uc-manager not installed",
+        raw=raw,
+    )
+
+
+def sys_python() -> str:
+    return os.environ.get("PRECHECK_PYTHON") or "python3"
+
+
+# ---------------------------------------------------------------------------
+# 3. Accelerator driver — WARN
+# ---------------------------------------------------------------------------
+
+
+def check_accelerator_driver(cfg: PrecheckConfig) -> CheckResult:
+    """Check NVIDIA compute capability or Ascend HDK version.
+
+    Auto-detects the platform: prefers ``nvidia-smi`` when present, else falls
+    back to ``npu-smi info``. With neither present the check FAILs (UCM needs an
+    accelerator). CUDA warns if any GPU's compute capability is below the
+    configured floor (default 8.0); Ascend warns if the HDK version is not
+    strictly newer than the configured floor (25.2.0).
+    """
+    if _have("nvidia-smi"):
+        return _check_nvidia(cfg)
+    if _have("npu-smi"):
+        return _check_ascend(cfg)
+    # UCM requires a GPU or NPU; no accelerator driver is a hard failure, not a
+    # benign skip (otherwise a CPU-only host would report an overall PASS).
+    return CheckResult(
+        name="accelerator_driver",
+        severity=FAIL,
+        status=STATUS_FAIL,
+        value="-",
+        detail="no nvidia-smi or npu-smi found (no GPU/NPU driver detected)",
+        remediation="install the NVIDIA or Ascend driver so nvidia-smi/npu-smi "
+        "is available on PATH",
+        raw={"platform": "none"},
+    )
+
+
+def _check_nvidia(cfg: PrecheckConfig) -> CheckResult:
+    rc, out, err = _run(
+        [
+            "nvidia-smi",
+            "--query-gpu=name,driver_version,compute_cap",
+            "--format=csv,noheader,nounits",
+        ]
+    )
+    if rc != 0:
+        return CheckResult(
+            name="accelerator_driver",
+            severity=WARN,
+            status=STATUS_WARN,
+            value="-",
+            threshold=f"compute_cap >= {cfg.cuda_min_compute_cap}",
+            detail=f"nvidia-smi failed: {err.strip() or 'rc=%d' % rc}",
+            remediation="ensure the NVIDIA driver is loaded and nvidia-smi is on PATH",
+            raw={"platform": "nvidia", "rc": rc, "stderr": err},
+        )
+    rows = parse_nvidia_smi_csv(out)
+    # columns: name(0), driver_version(1), compute_cap(2)
+    caps: List[float] = []
+    driver_versions: List[str] = []
+    names: List[str] = []
+    for cells in rows:
+        if len(cells) >= 1:
+            names.append(cells[0])
+        if len(cells) >= 2:
+            driver_versions.append(cells[1])
+    cap = extract_nvidia_compute_cap(rows, 2) if rows else None
+    # Re-scan every row so multi-GPU min-cap is reported, not just the first.
+    for cells in rows:
+        if len(cells) >= 3:
+            m = re.search(r"\d+\.\d+", cells[2])
+            if m:
+                caps.append(float(m.group(0)))
+    min_cap = min(caps) if caps else None
+
+    detail = (
+        f"driver={driver_versions[0] if driver_versions else '-'}, "
+        f"{len(names)} GPU(s): {', '.join(names) if names else '-'}"
+    )
+    value = f"compute_cap={min_cap}" if min_cap is not None else "compute_cap=?"
+
+    floor = cfg.cuda_min_compute_cap
+    if min_cap is None:
+        return CheckResult(
+            name="accelerator_driver",
+            severity=WARN,
+            status=STATUS_WARN,
+            value=value,
+            threshold=f"compute_cap >= {floor}",
+            detail=detail + " (could not parse compute capability)",
+            remediation="ensure nvidia-smi reports a compute_cap (e.g. 8.0)",
+            raw={"platform": "nvidia", "rows": rows},
+        )
+    if min_cap < floor:
+        return CheckResult(
+            name="accelerator_driver",
+            severity=WARN,
+            status=STATUS_WARN,
+            value=value,
+            threshold=f"compute_cap >= {floor}",
+            detail=detail + f" (below floor {floor})",
+            remediation=(
+                f"use a GPU with compute capability >= {floor} " "(Ampere or newer)"
+            ),
+            raw={"platform": "nvidia", "min_cap": min_cap, "rows": rows},
+        )
+    return CheckResult(
+        name="accelerator_driver",
+        severity=WARN,
+        status=STATUS_PASS,
+        value=value,
+        threshold=f"compute_cap >= {floor}",
+        detail=detail,
+        raw={"platform": "nvidia", "min_cap": min_cap, "rows": rows},
+    )
+
+
+def _check_ascend(cfg: PrecheckConfig) -> CheckResult:
+    rc, out, err = _run(["npu-smi", "info"])
+    if rc != 0:
+        return CheckResult(
+            name="accelerator_driver",
+            severity=WARN,
+            status=STATUS_WARN,
+            value="-",
+            threshold=f"HDK > {cfg.ascend_min_hdk}",
+            detail=f"npu-smi info failed: {err.strip() or 'rc=%d' % rc}",
+            remediation="ensure the Ascend driver is loaded and npu-smi is on PATH",
+            raw={"platform": "ascend", "rc": rc, "stderr": err},
+        )
+    parsed = parse_npu_smi_versions(out)
+    hdk = parsed.get("hdk")
+    floor = parse_version(cfg.ascend_min_hdk)
+    value = f"HDK={hdk or '?'}"
+    raw = {"platform": "ascend", **parsed}
+
+    if hdk is None:
+        return CheckResult(
+            name="accelerator_driver",
+            severity=WARN,
+            status=STATUS_WARN,
+            value=value,
+            threshold=f"HDK > {cfg.ascend_min_hdk}",
+            detail=(
+                "could not extract an HDK/driver version; heuristic parse "
+                f"found: {parsed['raw_versions'] or 'none'}"
+            ),
+            remediation="upgrade npu-smi to a version that reports an HDK/driver label",
+            raw=raw,
+        )
+    if compare_versions(parse_version(hdk), floor) <= 0:
+        return CheckResult(
+            name="accelerator_driver",
+            severity=WARN,
+            status=STATUS_WARN,
+            value=value,
+            threshold=f"HDK > {cfg.ascend_min_hdk}",
+            detail=f"HDK {hdk} is not strictly newer than {cfg.ascend_min_hdk}",
+            remediation=(
+                f"upgrade the Ascend HDK/driver to a version newer "
+                f"than {cfg.ascend_min_hdk}"
+            ),
+            raw=raw,
+        )
+    return CheckResult(
+        name="accelerator_driver",
+        severity=WARN,
+        status=STATUS_PASS,
+        value=value,
+        threshold=f"HDK > {cfg.ascend_min_hdk}",
+        detail=f"Ascend HDK/driver version OK",
+        raw=raw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Kernel version — FAIL (hard)
+# ---------------------------------------------------------------------------
+
+
+def check_kernel_version(cfg: PrecheckConfig) -> CheckResult:
+    """Require the running kernel's major.minor to be at least the floor.
+
+    The floor ``5.10`` means "the 5.10 LTS series or newer": ``5.10.0-216`` (a
+    backported openEuler 5.10 LTS build) passes, ``5.11`` passes, ``5.9`` fails.
+    This matches real UCM deployments (openEuler 22.03 ships a 5.10.0-<build>
+    kernel). The floor is configurable via ``--kernel-min``.
+    """
+    release = None
+    src = None
+    rc, out, _ = _run(["uname", "-r"])
+    if rc == 0 and out.strip():
+        release = out.strip()
+        src = "uname -r"
+    if not release:
+        release = platform.release()
+        src = "platform.release()"
+
+    kv = parse_version(release)
+    floor = parse_version(cfg.kernel_min)
+    if not kv:
+        return CheckResult(
+            name="kernel",
+            severity=FAIL,
+            status=STATUS_FAIL,
+            value=release or "-",
+            threshold=f">= {cfg.kernel_min}",
+            detail=f"could not parse kernel release ({src}={release!r})",
+            remediation="ensure uname -r reports a parseable version (e.g. 5.10.x)",
+            raw={"release": release, "source": src},
+        )
+    # Compare on major.minor so 5.10.0-<build> is "5.10", not below it.
+    kv_mm = kv[:2] if len(kv) >= 2 else kv + (0,) * (2 - len(kv))
+    floor_mm = floor[:2] if len(floor) >= 2 else floor + (0,) * (2 - len(floor))
+    value = ".".join(str(p) for p in kv)
+    if compare_versions(kv_mm, floor_mm) >= 0:
+        return CheckResult(
+            name="kernel",
+            severity=FAIL,
+            status=STATUS_PASS,
+            value=value,
+            threshold=f">= {cfg.kernel_min}",
+            detail=f"kernel {release} ({src})",
+            raw={"release": release},
+        )
+    return CheckResult(
+        name="kernel",
+        severity=FAIL,
+        status=STATUS_FAIL,
+        value=value,
+        threshold=f">= {cfg.kernel_min}",
+        detail=f"kernel {release} ({'.'.join(map(str, kv_mm))}) is older than "
+        f"{cfg.kernel_min}",
+        remediation=(
+            f"upgrade to kernel {cfg.kernel_min} or newer "
+            f"(e.g. openEuler 22.03 LTS-SP4 ships a 5.10 LTS kernel)"
+        ),
+        raw={"release": release},
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. /dev/shm size — WARN (UCM KV-cache page cache needs a large shm)
+# ---------------------------------------------------------------------------
+
+
+def _shm_total_avail() -> Tuple[Optional[int], Optional[int]]:
+    """Return (total_bytes, available_bytes) for /dev/shm via statvfs.
+
+    ``os.statvfs`` is POSIX-only, so this returns ``(None, None)`` on platforms
+    that lack it (or where /dev/shm is absent).
+    """
+    if not hasattr(os, "statvfs"):
+        return None, None
+    try:
+        st = os.statvfs("/dev/shm")
+        return st.f_blocks * st.f_frsize, st.f_bavail * st.f_frsize
+    except OSError:
+        return None, None
+
+
+def _gib(bytes_: Optional[int]) -> str:
+    return f"{bytes_ / (1024 ** 3):.2f} GiB" if bytes_ is not None else "-"
+
+
+def check_memory_shm(cfg: PrecheckConfig) -> CheckResult:
+    """Check /dev/shm size; warn if below the UCM minimum (RAM is hidden)."""
+    shm_min = cfg.shm_min_gib
+    shm_total, shm_avail = _shm_total_avail()
+    threshold = f">= {shm_min:.0f} GiB"
+    raw = {"shm_total_bytes": shm_total, "shm_avail_bytes": shm_avail}
+    if shm_total is None:
+        return CheckResult(
+            name="memory_shm",
+            severity=WARN,
+            status=STATUS_WARN,
+            value="-",
+            threshold=threshold,
+            detail="could not determine /dev/shm size",
+            remediation="ensure /dev/shm is mounted and readable",
+            raw=raw,
+        )
+    shm_gib = shm_total / (1024**3)
+    value = f"shm={shm_gib:.2f} GiB ({_gib(shm_avail)} free)"
+    if shm_gib < shm_min:
+        return CheckResult(
+            name="memory_shm",
+            severity=WARN,
+            status=STATUS_WARN,
+            value=value,
+            threshold=threshold,
+            detail=(
+                f"/dev/shm {shm_gib:.1f} GiB is below the "
+                f"{shm_min:.0f} GiB UCM minimum"
+            ),
+            remediation=(
+                f"enlarge /dev/shm to >= {shm_min:.0f} GiB "
+                "(UCM KV-cache page cache needs it)"
+            ),
+            raw=raw,
+        )
+    return CheckResult(
+        name="memory_shm",
+        severity=WARN,
+        status=STATUS_PASS,
+        value=value,
+        threshold=threshold,
+        detail="/dev/shm size OK",
+        raw=raw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# AIO resource pool (INFO: display only)
+# ---------------------------------------------------------------------------
+
+
+def check_aio_resources(cfg: PrecheckConfig) -> CheckResult:
+    """Check kernel AIO resource pool (INFO — display only, never fails).
+
+    Each aio store context calls ``io_setup(queueDepth)`` which reserves
+    ``queueDepth`` events from the kernel's aio pool (``aio-max-nr``).
+    The maximum number of concurrent aio workers is::
+
+        max_aio_workers = (aio_max_nr - aio_nr) // queueDepth
+
+    This helps the operator decide how many workers to use for the aio
+    bandwidth engine and whether to raise ``/proc/sys/fs/aio-max-nr``.
+    """
+    try:
+        with open("/proc/sys/fs/aio-max-nr") as f:
+            aio_max_nr = int(f.read().strip())
+        with open("/proc/sys/fs/aio-nr") as f:
+            aio_nr = int(f.read().strip())
+    except (OSError, ValueError):
+        return CheckResult(
+            name="aio_resources",
+            severity=INFO,
+            status=STATUS_INFO,
+            value="-",
+            detail="aio kernel resources not available (non-Linux or aio disabled)",
+            raw={},
+        )
+    available = aio_max_nr - aio_nr
+    qd = cfg.bandwidth.aio_queue_depth
+    max_workers = available // qd if qd > 0 else 0
+    return CheckResult(
+        name="aio_resources",
+        severity=INFO,
+        status=STATUS_INFO,
+        value=f"max-nr={aio_max_nr} nr={aio_nr} available={available} "
+        f"max_aio_workers={max_workers}",
+        detail=f"each aio context needs {qd} events (queueDepth); "
+        f"{available} available → {max_workers} concurrent aio workers",
+        raw={
+            "aio_max_nr": aio_max_nr,
+            "aio_nr": aio_nr,
+            "available": available,
+            "aio_queue_depth": qd,
+            "max_aio_workers": max_workers,
+        },
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry of cheap checks (bandwidth added by the CLI orchestrator)
+# ---------------------------------------------------------------------------
+
+CHECK_NAMES = {
+    "serving_stack": "Serving stack (vllm/vllm-ascend/sglang) version",
+    "uc_manager": "uc-manager version",
+    "accelerator_driver": "Accelerator driver / compute capability",
+    "kernel": "Kernel version",
+    "memory_shm": "Memory & /dev/shm size",
+    "aio_resources": "Kernel AIO resource pool",
+    "bandwidth": "Storage bandwidth (posix aio/psync)",
+}

--- a/toolkit/ucm_toolkit/tools/precheck/cli.py
+++ b/toolkit/ucm_toolkit/tools/precheck/cli.py
@@ -1,0 +1,303 @@
+"""precheck command-line interface (UCM environment pre-check, RFC #1208).
+
+Runs a fixed set of environment checks and prints a pass/warn/fail report with
+remediation advice for failing items. Mounted as ``ucm-toolkit run precheck``.
+
+Examples::
+
+    ucm-toolkit run precheck                          # all checks, no mount path
+    ucm-toolkit run precheck --mount-path /mnt/ucm_cache
+    ucm-toolkit run precheck --mount-path /mnt/ucm_cache --quick --engines aio
+    ucm-toolkit run precheck --only kernel --only accelerator_driver
+    ucm-toolkit run precheck --json --skip-bandwidth
+    ucm-toolkit run precheck --config precheck.json --strict
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import List, Optional
+
+from . import __version__
+from .bandwidth import check_bandwidth
+from .checks import (
+    CHECK_NAMES,
+    check_accelerator_driver,
+    check_aio_resources,
+    check_kernel_version,
+    check_memory_shm,
+    check_serving_stack,
+    check_uc_manager_version,
+)
+from .config import PrecheckConfig
+from .parseutil import parse_int_list, parse_size_list, parse_str_list
+from .reporter import (
+    FAIL,
+    INFO,
+    STATUS_SKIP,
+    WARN,
+    CheckResult,
+    overall_failed,
+    render_json,
+    render_text,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="precheck",
+        description="UCM environment pre-check (versions, kernel, memory, "
+        "storage bandwidth).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--version", action="version", version=f"precheck {__version__}")
+    p.add_argument(
+        "--config",
+        metavar="FILE",
+        help="load thresholds/matrix from a JSON or YAML file " "(YAML needs PyYAML)",
+    )
+    p.add_argument(
+        "--mount-path",
+        metavar="PATH",
+        help="UCM storage mount point (required for the bandwidth " "benchmark)",
+    )
+
+    bw = p.add_argument_group("bandwidth matrix")
+    bw.add_argument(
+        "--shard-sizes",
+        metavar="LIST",
+        help="comma-separated shard sizes, e.g. '180k,1m'",
+    )
+    bw.add_argument(
+        "--workers", metavar="LIST", help="comma-separated worker counts, e.g. '1,16'"
+    )
+    bw.add_argument(
+        "--engines",
+        metavar="LIST",
+        help="comma-separated IO engines, subset of 'psync,aio' (default psync)",
+    )
+    bw.add_argument(
+        "--modes",
+        metavar="LIST",
+        help="comma-separated phases to run per combo: subset of "
+        "'dump,read,mix' (default all; mix = read-heavy 1:rw_ratio)",
+    )
+    bw.add_argument(
+        "--threshold",
+        type=float,
+        metavar="GB",
+        help="minimum best aggregate bandwidth in GB/s "
+        f"(default {PrecheckConfig().bandwidth.threshold_gb})",
+    )
+    bw.add_argument(
+        "--block-number", type=int, metavar="N", help="blocks per dump/load sweep"
+    )
+    bw.add_argument(
+        "--dump-epochs", type=int, metavar="N", help="dump sweeps per combo"
+    )
+    bw.add_argument(
+        "--load-epochs", type=int, metavar="N", help="load sweeps per combo"
+    )
+    bw.add_argument(
+        "--mixed-epochs",
+        type=int,
+        metavar="N",
+        help="read-heavy mixed sweeps per combo (1 dump + rw_ratio loads each)",
+    )
+    bw.add_argument(
+        "--rw-ratio",
+        type=int,
+        metavar="N",
+        help="reads per write in the mixed phase (read-heavy; 0 disables mixed, "
+        f"default {PrecheckConfig().bandwidth.rw_ratio})",
+    )
+    bw.add_argument(
+        "--quick",
+        action="store_true",
+        help="halve dump/load/mixed epochs for a faster run",
+    )
+    bw.add_argument(
+        "--skip-bandwidth",
+        action="store_true",
+        help="skip the (slow) bandwidth benchmark entirely",
+    )
+
+    thr = p.add_argument_group("thresholds")
+    thr.add_argument(
+        "--kernel-min",
+        metavar="VER",
+        help="minimum kernel version, strictly greater (default '5.10')",
+    )
+    thr.add_argument(
+        "--cuda-min-compute-cap",
+        type=float,
+        metavar="N",
+        help="minimum CUDA compute capability (default 8.0)",
+    )
+    thr.add_argument(
+        "--ascend-min-hdk",
+        metavar="VER",
+        help="minimum Ascend HDK version, strictly greater " "(default '25.2.0')",
+    )
+
+    sel = p.add_argument_group("selection / output")
+    sel.add_argument(
+        "--only",
+        action="append",
+        metavar="CHECK",
+        help="run only this check (repeatable); choices: " + ", ".join(CHECK_NAMES),
+    )
+    sel.add_argument(
+        "--skip", action="append", metavar="CHECK", help="skip this check (repeatable)"
+    )
+    sel.add_argument(
+        "--strict",
+        action="store_true",
+        help="treat warnings as failures for the exit code",
+    )
+    sel.add_argument(
+        "--no-color", action="store_true", help="disable ANSI color output"
+    )
+    sel.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    sel.add_argument("--verbose", action="store_true", help="show extra detail")
+    return p
+
+
+CHECK_FUNCS = {
+    "serving_stack": lambda cfg: check_serving_stack(),
+    "uc_manager": lambda cfg: check_uc_manager_version(),
+    "accelerator_driver": lambda cfg: check_accelerator_driver(cfg),
+    "kernel": lambda cfg: check_kernel_version(cfg),
+    "memory_shm": lambda cfg: check_memory_shm(cfg),
+    "aio_resources": lambda cfg: check_aio_resources(cfg),
+    "bandwidth": lambda cfg: check_bandwidth(cfg),
+}
+
+# Order: cheap info checks first, hard checks, then the slow bandwidth last.
+DEFAULT_ORDER: List[str] = [
+    "serving_stack",
+    "uc_manager",
+    "accelerator_driver",
+    "kernel",
+    "memory_shm",
+    "aio_resources",
+    "bandwidth",
+]
+
+
+def _resolve_selection(
+    only: Optional[List[str]], skip: Optional[List[str]], skip_bandwidth: bool
+) -> List[str]:
+    selected = list(DEFAULT_ORDER)
+    if only:
+        only_lower = [o.lower() for o in only]
+        unknown = [o for o in only_lower if o not in CHECK_NAMES]
+        if unknown:
+            raise SystemExit(
+                f"unknown --only check(s): {', '.join(unknown)}; "
+                f"choices: {', '.join(CHECK_NAMES)}"
+            )
+        selected = [o for o in DEFAULT_ORDER if o in only_lower]
+    if skip:
+        skip_lower = [s.lower() for s in skip]
+        unknown = [s for s in skip_lower if s not in CHECK_NAMES]
+        if unknown:
+            raise SystemExit(
+                f"unknown --skip check(s): {', '.join(unknown)}; "
+                f"choices: {', '.join(CHECK_NAMES)}"
+            )
+        selected = [o for o in selected if o not in skip_lower]
+    if skip_bandwidth and "bandwidth" in selected:
+        selected.remove("bandwidth")
+    return selected
+
+
+def build_config(args: argparse.Namespace) -> PrecheckConfig:
+    # Base = shipped precheck.defaults.json (code constants as fallback);
+    # a user --config layers on top.
+    base = PrecheckConfig.default()
+    if args.config:
+        base = PrecheckConfig.from_file(args.config)
+    engines = parse_str_list(args.engines)
+    if engines is not None:
+        invalid = [e for e in engines if e not in ("psync", "aio")]
+        if invalid:
+            raise SystemExit(
+                f"invalid engine(s): {', '.join(invalid)}; " "choices: psync, aio"
+            )
+    modes = parse_str_list(args.modes)
+    if modes is not None:
+        invalid = [m for m in modes if m not in ("dump", "read", "mix")]
+        if invalid:
+            raise SystemExit(
+                f"invalid mode(s): {', '.join(invalid)}; " "choices: dump, read, mix"
+            )
+    cfg = base.apply_overrides(
+        mount_path=args.mount_path,
+        shard_sizes=parse_size_list(args.shard_sizes),
+        worker_counts=parse_int_list(args.workers),
+        engines=engines,
+        modes=modes,
+        threshold_gb=args.threshold,
+        block_number=args.block_number,
+        dump_epochs=args.dump_epochs,
+        load_epochs=args.load_epochs,
+        mixed_epochs=args.mixed_epochs,
+        rw_ratio=args.rw_ratio,
+        kernel_min=args.kernel_min,
+        cuda_min_compute_cap=args.cuda_min_compute_cap,
+        ascend_min_hdk=args.ascend_min_hdk,
+        quick=args.quick,
+    )
+    cfg.verbose = args.verbose
+    return cfg
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_parser()
+    # parse_args SystemExit (bad flag / --help) propagates with the argparse
+    # convention (2 for usage errors, 0 for --help).
+    args = parser.parse_args(argv)
+
+    try:
+        cfg = build_config(args)
+        selected = _resolve_selection(args.only, args.skip, args.skip_bandwidth)
+    except SystemExit as exc:
+        # Config/selection usage errors -> exit code 2.
+        msg = str(exc.code) if exc.code not in (None, 0, 2) else ""
+        print(
+            f"error: {msg}" if msg else "error: invalid configuration", file=sys.stderr
+        )
+        return 2
+    except Exception as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    results: List[CheckResult] = []
+    for name in selected:
+        try:
+            res = CHECK_FUNCS[name](cfg)
+        except Exception as exc:  # a check must never abort the whole run
+            res = CheckResult(
+                name=name,
+                severity=FAIL,
+                status="FAIL",
+                value="-",
+                detail=f"check raised {type(exc).__name__}: {exc}",
+                raw={"error": str(exc)},
+            )
+        results.append(res)
+
+    color = (not args.no_color) and sys.stdout.isatty()
+    if args.json:
+        print(render_json(results))
+    else:
+        print(render_text(results, color=color))
+
+    return 1 if overall_failed(results, strict=args.strict) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/toolkit/ucm_toolkit/tools/precheck/config.py
+++ b/toolkit/ucm_toolkit/tools/precheck/config.py
@@ -1,0 +1,218 @@
+"""Configuration for the pre-check tool.
+
+All tunable thresholds and the bandwidth matrix live in a shipped JSON file
+(``precheck.defaults.json`` next to this module), so a version update is a
+data-only change — no code edit needed. :class:`PrecheckConfig` layers, in
+increasing precedence: code constants (fallback if the JSON is absent) -> the
+shipped defaults JSON -> a ``--config`` user file -> CLI flags.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import List, Optional
+
+from .parseutil import parse_size
+
+# --- Fallback defaults (used only when precheck.defaults.json is missing) ---
+DEFAULT_SHARD_SIZES: List[int] = [184320, 8388608]  # 180 KiB, 8 MiB
+DEFAULT_WORKER_COUNTS: List[int] = [1, 8, 16]
+DEFAULT_ENGINES: List[str] = ["psync", "aio"]
+DEFAULT_MODES: List[str] = ["dump", "read", "mix"]
+
+DEFAULT_KERNEL_MIN: str = "5.10"
+DEFAULT_CUDA_MIN_COMPUTE_CAP: float = 8.0
+DEFAULT_ASCEND_MIN_HDK: str = "25.2.0"
+DEFAULT_SHM_MIN_GIB: float = 512.0
+DEFAULT_BANDWIDTH_THRESHOLD_GB: float = 8.0
+
+DEFAULT_BLOCK_NUMBER: int = 32
+DEFAULT_DUMP_EPOCHS: int = 8
+DEFAULT_LOAD_EPOCHS: int = 8
+DEFAULT_SHARD_NUMBER: int = 1
+DEFAULT_MIXED_EPOCHS: int = 8
+DEFAULT_RW_RATIO: int = 4
+DEFAULT_BARRIER_TIMEOUT: int = 60
+DEFAULT_COMBO_TIMEOUT: int = 120
+DEFAULT_AIO_QUEUE_DEPTH: int = 4096
+
+_DEFAULTS_FILE = Path(__file__).resolve().parent / "precheck.defaults.json"
+
+
+@dataclass
+class BandwidthConfig:
+    shard_sizes: List[int] = field(default_factory=lambda: list(DEFAULT_SHARD_SIZES))
+    worker_counts: List[int] = field(
+        default_factory=lambda: list(DEFAULT_WORKER_COUNTS)
+    )
+    engines: List[str] = field(default_factory=lambda: list(DEFAULT_ENGINES))
+    modes: List[str] = field(default_factory=lambda: list(DEFAULT_MODES))
+    block_number: int = DEFAULT_BLOCK_NUMBER
+    shard_number: int = DEFAULT_SHARD_NUMBER
+    dump_epochs: int = DEFAULT_DUMP_EPOCHS
+    load_epochs: int = DEFAULT_LOAD_EPOCHS
+    mixed_epochs: int = DEFAULT_MIXED_EPOCHS
+    rw_ratio: int = DEFAULT_RW_RATIO
+    barrier_timeout: int = DEFAULT_BARRIER_TIMEOUT
+    combo_timeout: int = DEFAULT_COMBO_TIMEOUT
+    aio_queue_depth: int = DEFAULT_AIO_QUEUE_DEPTH
+    threshold_gb: float = DEFAULT_BANDWIDTH_THRESHOLD_GB
+
+
+@dataclass
+class PrecheckConfig:
+    mount_path: Optional[str] = None
+    kernel_min: str = DEFAULT_KERNEL_MIN
+    cuda_min_compute_cap: float = DEFAULT_CUDA_MIN_COMPUTE_CAP
+    ascend_min_hdk: str = DEFAULT_ASCEND_MIN_HDK
+    shm_min_gib: float = DEFAULT_SHM_MIN_GIB
+    bandwidth: BandwidthConfig = field(default_factory=BandwidthConfig)
+    verbose: bool = False
+
+    # ----- file loading -----
+
+    @classmethod
+    def _load_defaults_dict(cls) -> dict:
+        """Read the shipped precheck.defaults.json; {} if missing/unreadable."""
+        try:
+            with open(_DEFAULTS_FILE, "r", encoding="utf-8") as f:
+                return json.load(f) or {}
+        except (OSError, ValueError):
+            return {}
+
+    @classmethod
+    def default(cls) -> "PrecheckConfig":
+        """Runtime defaults: code constants merged with the shipped JSON."""
+        return cls.from_dict(cls._load_defaults_dict())
+
+    @classmethod
+    def from_dict(
+        cls, data: dict, base: Optional["PrecheckConfig"] = None
+    ) -> "PrecheckConfig":
+        cfg = base if base is not None else cls()
+        if not isinstance(data, dict):
+            return cfg
+        cfg.mount_path = data.get("mount_path", cfg.mount_path)
+        cfg.kernel_min = str(data.get("kernel_min", cfg.kernel_min))
+        cfg.cuda_min_compute_cap = float(
+            data.get("cuda_min_compute_cap", cfg.cuda_min_compute_cap)
+        )
+        cfg.ascend_min_hdk = str(data.get("ascend_min_hdk", cfg.ascend_min_hdk))
+        cfg.shm_min_gib = float(data.get("shm_min_gib", cfg.shm_min_gib))
+
+        bw = data.get("bandwidth", {})
+        if isinstance(bw, dict):
+            b = cfg.bandwidth
+            if "shard_sizes" in bw:
+                b.shard_sizes = [parse_size(x) for x in bw["shard_sizes"]]
+            if "worker_counts" in bw:
+                b.worker_counts = [int(x) for x in bw["worker_counts"]]
+            if "engines" in bw:
+                b.engines = [str(x) for x in bw["engines"]]
+            if "modes" in bw:
+                b.modes = [str(x) for x in bw["modes"]]
+            if "block_number" in bw:
+                b.block_number = int(bw["block_number"])
+            if "shard_number" in bw:
+                b.shard_number = int(bw["shard_number"])
+            if "dump_epochs" in bw:
+                b.dump_epochs = int(bw["dump_epochs"])
+            if "load_epochs" in bw:
+                b.load_epochs = int(bw["load_epochs"])
+            if "mixed_epochs" in bw:
+                b.mixed_epochs = int(bw["mixed_epochs"])
+            if "rw_ratio" in bw:
+                b.rw_ratio = int(bw["rw_ratio"])
+            if "barrier_timeout" in bw:
+                b.barrier_timeout = int(bw["barrier_timeout"])
+            if "combo_timeout" in bw:
+                b.combo_timeout = int(bw["combo_timeout"])
+            if "aio_queue_depth" in bw:
+                b.aio_queue_depth = int(bw["aio_queue_depth"])
+            if "threshold_gb" in bw:
+                b.threshold_gb = float(bw["threshold_gb"])
+        return cfg
+
+    @classmethod
+    def from_file(cls, path: str) -> "PrecheckConfig":
+        with open(path, "r", encoding="utf-8") as f:
+            text = f.read()
+        ext = os.path.splitext(path)[1].lower()
+        if ext in (".yaml", ".yml"):
+            try:
+                import yaml  # type: ignore
+            except ImportError as exc:
+                raise RuntimeError(
+                    "YAML config requires PyYAML; install it or use a .json "
+                    "config file."
+                ) from exc
+            data = yaml.safe_load(text) or {}
+        else:
+            data = json.loads(text) if text.strip() else {}
+        # Layer the user file on top of the shipped defaults.
+        return cls.from_dict(data, base=cls.default())
+
+    # ----- CLI overrides -----
+
+    def apply_overrides(
+        self,
+        mount_path: Optional[str] = None,
+        shard_sizes: Optional[List[int]] = None,
+        worker_counts: Optional[List[int]] = None,
+        engines: Optional[List[str]] = None,
+        modes: Optional[List[str]] = None,
+        threshold_gb: Optional[float] = None,
+        block_number: Optional[int] = None,
+        dump_epochs: Optional[int] = None,
+        load_epochs: Optional[int] = None,
+        mixed_epochs: Optional[int] = None,
+        rw_ratio: Optional[int] = None,
+        kernel_min: Optional[str] = None,
+        cuda_min_compute_cap: Optional[float] = None,
+        ascend_min_hdk: Optional[str] = None,
+        shm_min_gib: Optional[float] = None,
+        quick: bool = False,
+    ) -> "PrecheckConfig":
+        cfg = replace(self)
+        if mount_path is not None:
+            cfg.mount_path = mount_path
+        if kernel_min is not None:
+            cfg.kernel_min = kernel_min
+        if cuda_min_compute_cap is not None:
+            cfg.cuda_min_compute_cap = cuda_min_compute_cap
+        if ascend_min_hdk is not None:
+            cfg.ascend_min_hdk = ascend_min_hdk
+        if shm_min_gib is not None:
+            cfg.shm_min_gib = shm_min_gib
+
+        b = replace(cfg.bandwidth)
+        if shard_sizes is not None:
+            b.shard_sizes = shard_sizes
+        if worker_counts is not None:
+            b.worker_counts = worker_counts
+        if engines is not None:
+            b.engines = engines
+        if modes is not None:
+            b.modes = modes
+        if threshold_gb is not None:
+            b.threshold_gb = threshold_gb
+        if block_number is not None:
+            b.block_number = block_number
+        if dump_epochs is not None:
+            b.dump_epochs = dump_epochs
+        if load_epochs is not None:
+            b.load_epochs = load_epochs
+        if mixed_epochs is not None:
+            b.mixed_epochs = mixed_epochs
+        if rw_ratio is not None:
+            b.rw_ratio = rw_ratio
+        if quick:
+            # Cut epochs in half for a faster (still representative) run.
+            b.dump_epochs = max(1, b.dump_epochs // 2)
+            b.load_epochs = max(1, b.load_epochs // 2)
+            b.mixed_epochs = max(1, b.mixed_epochs // 2)
+        cfg.bandwidth = b
+        return cfg

--- a/toolkit/ucm_toolkit/tools/precheck/parseutil.py
+++ b/toolkit/ucm_toolkit/tools/precheck/parseutil.py
@@ -1,0 +1,233 @@
+"""Parsing helpers for version strings, byte sizes, and SMI tool output.
+
+Pure stdlib; imported by both the cheap checks and the (optional) bandwidth
+benchmark so the parsing logic is unit-testable without any hardware.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List, Optional, Tuple
+
+VersionTuple = Tuple[int, ...]
+
+_NUM_RE = re.compile(r"\d+")
+_VER_TOKEN_RE = re.compile(r"\d+(?:\.\d+)*")
+_SIZE_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*([kKmMgGtT]i?[bB]?)?\s*$")
+
+
+# ---------------------------------------------------------------------------
+# Versions
+# ---------------------------------------------------------------------------
+
+
+def parse_version(v: Optional[str]) -> VersionTuple:
+    """Return the leading integer components of a version string.
+
+    ``"5.15.0-25-generic"`` -> ``(5, 15, 0)``; ``"8.0"`` -> ``(8, 0)``;
+    ``None``/non-numeric -> empty tuple.
+    """
+    if not v:
+        return ()
+    m = _VER_TOKEN_RE.search(v)
+    if not m:
+        return ()
+    nums = _NUM_RE.findall(m.group(0))
+    return tuple(int(n) for n in nums)
+
+
+def compare_versions(a: VersionTuple, b: VersionTuple) -> int:
+    """Tuple comparison padded to equal length; -1/0/1."""
+    n = max(len(a), len(b))
+    pa = a + (0,) * (n - len(a))
+    pb = b + (0,) * (n - len(b))
+    if pa < pb:
+        return -1
+    if pa > pb:
+        return 1
+    return 0
+
+
+def strip_build(v: Optional[str]) -> Optional[str]:
+    """Strip PEP 440 build metadata (``+local``) from a version string."""
+    if not v:
+        return None
+    return str(v).strip().split("+", 1)[0]
+
+
+def normalize_vllm_ascend_version(v: Optional[str]) -> Optional[str]:
+    """Normalize a vllm-ascend version: drop ``.postN`` and ``rcN`` suffixes.
+
+    Mirrors ``ucm/integration/vllm/patch/apply_patch.py``: ``0.18.0rc1`` ->
+    ``0.18.0``; ``0.11.0.post1`` -> ``0.11.0``.
+    """
+    v = strip_build(v)
+    if not v:
+        return None
+    v = v.split(".post", 1)[0]
+    v = v.split("rc", 1)[0]
+    return v.rstrip(".") or None
+
+
+# ---------------------------------------------------------------------------
+# Byte sizes
+# ---------------------------------------------------------------------------
+
+_UNIT_FACTORS = {
+    "": 1,
+    "k": 1024,
+    "m": 1024**2,
+    "g": 1024**3,
+    "t": 1024**4,
+}
+_IUNIT_FACTORS = {
+    "": 1,
+    "i": 1,
+    "ki": 1024,
+    "mi": 1024**2,
+    "gi": 1024**3,
+    "ti": 1024**4,
+}
+
+
+def parse_size(s) -> int:
+    """Parse a human byte size to an integer byte count.
+
+    Accepts ints (``1048576``) and suffixed strings: ``180k``/``180K``,
+    ``1m``/``1M``, ``2g``, ``1Ki``, ``4MiB`` (case-insensitive; trailing ``b``
+    optional). All suffixed sizes are binary (1024-based). Raises
+    ``ValueError`` on garbage.
+    """
+    if isinstance(s, (int, float)):
+        return int(s)
+    if not isinstance(s, str):
+        raise ValueError(f"cannot parse size from {s!r}")
+    m = _SIZE_RE.match(s)
+    if not m:
+        raise ValueError(f"unrecognized size {s!r}")
+    num = float(m.group(1))
+    unit = m.group(2) or ""
+    # Strip an optional trailing b/B (the "bytes" marker) so "4MiB"/"4MB" work.
+    if unit and unit[-1] in "bB":
+        unit = unit[:-1]
+    unit = unit.lower()
+    factor = _IUNIT_FACTORS.get(unit) or _UNIT_FACTORS.get(unit)
+    if factor is None:
+        raise ValueError(f"unrecognized size unit {unit!r} in {s!r}")
+    return int(num * factor)
+
+
+def parse_size_list(s: Optional[str]) -> Optional[List[int]]:
+    """Parse a comma-separated list of sizes (``"180k,1m"``); None if unset."""
+    if s is None:
+        return None
+    parts = [p.strip() for p in s.split(",") if p.strip()]
+    return [parse_size(p) for p in parts]
+
+
+def parse_int_list(s: Optional[str]) -> Optional[List[int]]:
+    """Parse a comma-separated list of ints (``"1,16"``); None if unset."""
+    if s is None:
+        return None
+    return [int(p.strip()) for p in s.split(",") if p.strip()]
+
+
+def parse_str_list(s: Optional[str]) -> Optional[List[str]]:
+    """Parse a comma-separated list of strings; None if unset."""
+    if s is None:
+        return None
+    return [p.strip() for p in s.split(",") if p.strip()]
+
+
+# ---------------------------------------------------------------------------
+# nvidia-smi / npu-smi parsing
+# ---------------------------------------------------------------------------
+
+
+def parse_nvidia_smi_csv(stdout: str) -> List[List[str]]:
+    """Parse ``nvidia-smi --query-gpu=... --format=csv,noheader`` rows.
+
+    Returns each non-empty line as a list of stripped cells. The pre-check
+    invocations always pass ``noheader``, so no header is expected; if a header
+    is present anyway it is harmless (``extract_nvidia_compute_cap`` only picks
+    cells matching ``\\d+.\\d+``).
+    """
+    lines = [ln.strip() for ln in stdout.splitlines() if ln.strip()]
+    return [[c.strip() for c in ln.split(",")] for ln in lines]
+
+
+def extract_nvidia_compute_cap(rows: List[dict], cap_index: int) -> Optional[float]:
+    """Best-effort compute-capability extraction from parsed CSV rows.
+
+    ``rows`` are the lists returned by :func:`parse_nvidia_smi_csv`;
+    ``cap_index`` is the 0-based position of the compute_cap column.
+    """
+    for cells in rows:
+        if cap_index < len(cells):
+            m = re.search(r"\d+\.\d+", cells[cap_index])
+            if m:
+                try:
+                    return float(m.group(0))
+                except ValueError:
+                    continue
+    return None
+
+
+_NPU_ANY_RE = re.compile(r"(\d+\.\d+\.\d+)")
+_NPU_HDK_RE = re.compile(r"hdk[^0-9]*(\d+\.\d+\.\d+)", re.IGNORECASE)
+_NPU_DRIVER_RE = re.compile(r"driver[^0-9]*(\d+\.\d+\.\d+)", re.IGNORECASE)
+_NPU_VERSION_RE = re.compile(r"version[^0-9]*(\d+\.\d+\.\d+)", re.IGNORECASE)
+_NPU_TOOL_RE = re.compile(r"npu-smi[^0-9]*(\d+\.\d+\.\d+)", re.IGNORECASE)
+
+
+def parse_npu_smi_versions(stdout: str) -> dict:
+    """Heuristically extract Ascend HDK / driver / tool versions from
+    ``npu-smi info`` output.
+
+    The field layout varies across firmware. Resolution order for the HDK
+    value (the one compared against the floor):
+
+    1. an explicit ``HDK Version`` label;
+    2. a ``Driver Version`` label (HDK and driver track together);
+    3. the banner ``Version: X.Y.Z`` field (on firmware that exposes no
+       per-card version label — e.g. ``npu-smi 25.5.2   Version: 25.5.2`` —
+       this banner ``Version`` IS the firmware/driver version).
+
+    The ``npu-smi X.Y.Z`` banner *prefix* is captured separately as ``tool``
+    (the SMI tool build version) and is deliberately NOT used as the HDK on its
+    own, since on some firmware it differs from the driver. Returns a dict with
+    keys ``hdk``, ``driver``, ``version`` (banner label), ``tool`` (each
+    possibly None) and ``raw_versions`` (all ``\\d+.\\d+.\\d+`` tokens, order).
+    """
+    result = {
+        "hdk": None,
+        "driver": None,
+        "version": None,
+        "tool": None,
+        "raw_versions": [],
+    }
+    if not stdout:
+        return result
+
+    for line in stdout.splitlines():
+        m = _NPU_ANY_RE.search(line)
+        if m:
+            result["raw_versions"].append(m.group(1))
+
+    m = _NPU_HDK_RE.search(stdout)
+    if m:
+        result["hdk"] = m.group(1)
+    m = _NPU_DRIVER_RE.search(stdout)
+    if m:
+        result["driver"] = m.group(1)
+    m = _NPU_VERSION_RE.search(stdout)
+    if m:
+        result["version"] = m.group(1)
+    m = _NPU_TOOL_RE.search(stdout)
+    if m:
+        result["tool"] = m.group(1)
+
+    # HDK proxy chain: explicit HDK label -> driver label -> banner "Version:".
+    if result["hdk"] is None:
+        result["hdk"] = result["driver"] or result["version"]
+    return result

--- a/toolkit/ucm_toolkit/tools/precheck/precheck.defaults.json
+++ b/toolkit/ucm_toolkit/tools/precheck/precheck.defaults.json
@@ -1,0 +1,23 @@
+{
+  "mount_path": null,
+  "kernel_min": "5.10",
+  "cuda_min_compute_cap": 8.0,
+  "ascend_min_hdk": "25.2.0",
+  "shm_min_gib": 512.0,
+  "bandwidth": {
+    "shard_sizes": ["180k", "8m"],
+    "worker_counts": [1, 8, 16],
+    "engines": ["psync", "aio"],
+    "modes": ["dump", "read", "mix"],
+    "block_number": 32,
+    "shard_number": 1,
+    "dump_epochs": 8,
+    "load_epochs": 8,
+    "mixed_epochs": 8,
+    "rw_ratio": 4,
+    "barrier_timeout": 60,
+    "combo_timeout": 120,
+    "aio_queue_depth": 4096,
+    "threshold_gb": 8.0
+  }
+}

--- a/toolkit/ucm_toolkit/tools/precheck/reporter.py
+++ b/toolkit/ucm_toolkit/tools/precheck/reporter.py
@@ -1,0 +1,154 @@
+"""Check result model and output rendering (bordered tables + JSON)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+from typing import List
+
+# Severity levels, lowest -> highest.
+INFO = "INFO"  # display only, never affects pass/fail
+WARN = "WARN"  # warning if below/above a soft threshold
+FAIL = "FAIL"  # hard constraint violation
+
+SEVERITIES = (INFO, WARN, FAIL)
+
+# Status shown in the table (decoupled from severity so an INFO check can be
+# "OK", a WARN check can be "PASS"/"WARN"/"SKIP", etc.).
+STATUS_PASS = "PASS"
+STATUS_WARN = "WARN"
+STATUS_FAIL = "FAIL"
+STATUS_SKIP = "SKIP"
+STATUS_OK = "OK"
+STATUS_INFO = "INFO"
+
+
+@dataclass
+class CheckResult:
+    """Outcome of a single pre-check item.
+
+    ``severity`` declares the check's class (INFO/WARN/FAIL); ``status`` is the
+    concrete verdict. ``value`` is the measured/printed value; ``threshold`` is
+    the comparison basis (for WARN/FAIL checks); ``detail`` is human-readable
+    context.
+    """
+
+    name: str
+    severity: str = INFO
+    status: str = STATUS_INFO
+    value: str = ""
+    threshold: str = ""
+    detail: str = ""
+    remediation: str = ""
+    raw: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.severity not in SEVERITIES:
+            raise ValueError(f"invalid severity {self.severity!r}")
+
+
+def _status_icon(status: str) -> str:
+    return {
+        STATUS_PASS: "[PASS]",
+        STATUS_OK: "[OK]",
+        STATUS_WARN: "[WARN]",
+        STATUS_FAIL: "[FAIL]",
+        STATUS_SKIP: "[SKIP]",
+        STATUS_INFO: "[INFO]",
+    }.get(status, f"[{status}]")
+
+
+# ANSI color codes (disabled via --no-color / non-tty).
+_RESET = "\033[0m"
+_RED = "\033[31m"
+_GREEN = "\033[32m"
+_YELLOW = "\033[33m"
+_CYAN = "\033[36m"
+_DIM = "\033[2m"
+
+_NAME_WIDTH = 20
+_RULE = "\u2500" * 78
+
+
+def _color(text: str, code: str, enabled: bool) -> str:
+    return f"{code}{text}{_RESET}" if enabled else text
+
+
+def _status_color(status: str, enabled: bool) -> str:
+    if status in (STATUS_PASS, STATUS_OK):
+        return _color(_status_icon(status), _GREEN, enabled)
+    if status in (STATUS_WARN,):
+        return _color(_status_icon(status), _YELLOW, enabled)
+    if status in (STATUS_FAIL,):
+        return _color(_status_icon(status), _RED, enabled)
+    return _color(_status_icon(status), _DIM, enabled)
+
+
+def render_text(results: List[CheckResult], color: bool = True) -> str:
+    """Render results as a readable per-check block with fix advice.
+
+    Each check prints a status line (icon + name + value) followed by indented
+    threshold and ``fix:`` lines. The ``fix`` line appears only for FAIL/WARN
+    outcomes that carry remediation advice (per RFC #1208).
+    """
+    lines = [
+        _color("UCM environment pre-check", _CYAN, color),
+        _color(_RULE, _DIM, color),
+    ]
+    for r in results:
+        icon = _status_color(r.status, color) if color else _status_icon(r.status)
+        lines.append(f"{icon} {r.name.ljust(_NAME_WIDTH)} {r.value}".rstrip())
+        if r.threshold:
+            lines.append(_color(f"{'':8}threshold: {r.threshold}", _DIM, color))
+        if r.remediation and r.status in (STATUS_WARN, STATUS_FAIL, STATUS_SKIP):
+            lines.append(_color(f"{'':8}fix: {r.remediation}", _YELLOW, color))
+    lines.append(_color(_RULE, _DIM, color))
+
+    n_fail = sum(1 for r in results if r.status == STATUS_FAIL)
+    n_warn = sum(1 for r in results if r.status == STATUS_WARN)
+    n_skip = sum(1 for r in results if r.status == STATUS_SKIP)
+    n_info = sum(1 for r in results if r.severity == INFO and r.status != STATUS_SKIP)
+    n_pass = sum(
+        1
+        for r in results
+        if r.status in (STATUS_PASS, STATUS_OK) and r.severity != INFO
+    )
+
+    if n_fail:
+        overall = _color("FAILED", _RED, color)
+    elif n_warn:
+        overall = _color("PASSED (with warnings)", _YELLOW, color)
+    else:
+        overall = _color("PASSED", _GREEN, color)
+
+    lines.append(
+        f"Result: {overall}  |  "
+        f"{n_pass} pass, {n_warn} warn, {n_fail} fail, "
+        f"{n_skip} skip, {n_info} info"
+    )
+    return "\n".join(lines)
+
+
+def render_json(results: List[CheckResult]) -> str:
+    return json.dumps(
+        {
+            "checks": [asdict(r) for r in results],
+            "failed": any(r.status == STATUS_FAIL for r in results),
+            "warned": any(r.status == STATUS_WARN for r in results),
+        },
+        indent=2,
+    )
+
+
+def overall_failed(results: List[CheckResult], strict: bool = False) -> bool:
+    """True if the run should exit non-zero (FAIL, or WARN when strict)."""
+    if any(r.status == STATUS_FAIL for r in results):
+        return True
+    if strict and any(r.status == STATUS_WARN for r in results):
+        return True
+    return False
+
+
+def eprint(msg: str) -> None:
+    print(msg, file=sys.stderr)


### PR DESCRIPTION
## Summary

Implements the **first item** of the toolkit RFC (#1208) — *UCM 部署前预检工具* — as a new toolkit tool `precheck` (`ucm-toolkit run precheck`). It runs **locally on the UCM deployment host** before UCM starts, verifies the key runtime requirements, and reports `PASS`/`WARN`/`FAIL` per item with **remediation advice** for failing/borderline checks, so environment problems surface *before* a deployment attempt fails.

RFC #1208 item 1 spec:
> 在 UCM 部署前运行环境预检，验证存储带宽、内核版本、驱动版本、shm-size 等关键配置是否满足运行要求。输出：预检结果（PASS/FAIL）及每项检查的实际值与阈值对比，对 FAIL 项给出修复建议。落地：`ucm-toolkit run precheck`。

## What's added

- **Vendored tool** `ucm_toolkit/tools/precheck/`: `cli`, `checks`, `bandwidth`, `config`, `parseutil`, `reporter` + `adapter.py`.
- **Registered** `PrecheckTool` (`name="precheck"`, `aliases=("pre_check",)`) in `registry.init_builtin_tools()`, dispatched via `ucm-toolkit run precheck`.
- **Tests**: `toolkit/tests/test_precheck.py` (31 logic tests — parsers, kernel boundary, config, bandwidth selection incl. the mixed-headline metric, reporter exit codes, and check-function decision logic with `subprocess`/`os` mocked) and `toolkit/tests/test_precheck_toolkit.py` (registration, `list`, `run` dispatch, `doctor`, README presence).
- **Docs**: `ucm_toolkit/tools/precheck/README.md` (complete English) and a `precheck` section + table row in `toolkit/README.md`. (`toolkit/README_zh.md` is intentionally not touched — it is owned by the in-flight kv-calc PR.)

## Checks

| Check | Severity | What | Threshold |
| --- | --- | --- | --- |
| `serving_stack` | INFO | `vllm` / `vllm-ascend` / `sglang` versions | display only |
| `uc_manager` | INFO | `uc-manager` version | display only |
| `accelerator_driver` | FAIL/WARN | NVIDIA `compute_cap` / Ascend `HDK` | no driver → FAIL; CUDA ≥ 8.0; Ascend HDK > 25.2.0 (below → WARN) |
| `kernel` | FAIL | `uname -r` major.minor | ≥ 5.10 series |
| `memory_shm` | INFO | RAM + `/dev/shm` | display only |
| `bandwidth` | WARN | posix `psync`/`aio` matrix vs the ucm C++ store | best aggregate ≥ 8 GB/s |

Exit codes: `0` all hard checks pass · `1` a FAIL (or a WARN under `--strict`) · `2` usage error.

## Bandwidth benchmark (mixed read-heavy + stability + aggregate)

The bandwidth check exercises the real `UcmPipelineStore` (`store_pipeline="Posix"`) across a configurable matrix `{180 KiB, 8 MiB} × {1, 8, 16} workers × psync` (`aio` via `--engines`). For each combo it runs the phases selected by `--modes` (default `dump,read,mix`):

- **pure dump** (cold write) and **pure load** (read) phases;
- a **read-heavy mixed** phase — per epoch `1 dump + rw_ratio loads` (default 4:1), mimicking the real KV-cache access pattern (write once, fetch many; the loads are cache-warm).

Per combo it reports **mean ± std and min..max** across epoch samples for dump, load, and mixed (stability), plus the **aggregate store throughput** (per-worker × worker count). The best combo is selected by the **aggregate mixed** business bandwidth (falling back to aggregate `mean(dump, load)` when mixed is disabled). `numpy` and `ucm` are lazy imports — when `ucm` is not importable the check is **skipped with a warning**, not a failure. A barrier timeout prevents a hung run if a worker crashes.

Leaner defaults for a faster run: `block_number 32`, dump/load/mixed `epochs 16`, `rw_ratio 4`; `--quick` halves all epoch counts. All tunable via flags/config (`--shard-sizes`, `--workers`, `--engines`, `--mixed-epochs`, `--rw-ratio`, `--threshold`).

## Real-environment validation

Validated end-to-end on a real `openEuler 22.03 LTS-SP4 / aarch64 / 8× Ascend 910B3` host and inside a UCM e2e container (vllm 0.18.0 / vllm-ascend 0.18.0rc1 / uc-manager 0.6.0), via the real toolkit dispatch (`ucm-toolkit run precheck --mount-path …`) against the real ucm C++ posix store:

```
bandwidth matrix (default lean: {180 KiB, 8 MiB} x {1, 8, 16} x psync; 8 epochs/phase):
180KiB w=1  : mixed 6.47+-0.19 | agg(1w):  dump 2.8  load 7.9   mixed 6.5
180KiB w=8  : mixed 1.80+-1.13 | agg(8w):  dump 4.3  load 58.6  mixed 14.4
180KiB w=16 : mixed 1.20+-1.01 | agg(16w): dump 5.1  load 109.5 mixed 19.2
8MiB   w=1  : mixed 11.4+-0.74 | agg(1w):  dump 3.9  load 24.5  mixed 11.4
8MiB   w=8  : mixed 3.01+-1.22 | agg(8w):  dump 7.2  load 111.6 mixed 24.1  <- best
8MiB   w=16 : mixed 1.43+-0.97 | agg(16w): dump 7.3  load 314.4 mixed 22.8
[PASS] bandwidth  best=24.090 GB/s aggregate (8MiB, 8 workers, psync)  (>= 8.0)
Result: PASSED  |  1 pass, 0 warn, 0 fail, 0 skip, 3 info
```

Real findings: `psync` outperforms `aio` here (overlay-fs page cache); the read-heavy mixed **aggregate** scales with concurrency (18.7 vs 9.9 GB/s). Two earlier behaviors were corrected from the real host:
- `npu-smi info` HDK extraction falls back to the banner `Version:` field when no per-card `HDK Version`/`Driver Version` label is present (real firmware only exposes `npu-smi 25.5.2   Version: 25.5.2`).
- Kernel is judged on the major.minor series: `5.10.0-216` (openEuler 5.10 LTS backport) passes, `5.9` fails.

## How to use

```bash
python -m pip install -e toolkit
ucm-toolkit run precheck                           # all checks (bandwidth skipped w/o a mount path)
ucm-toolkit run precheck --mount-path /mnt/ucm_cache
ucm-toolkit run precheck --skip-bandwidth --json
```

## Testing

```bash
cd toolkit
python -m unittest tests.test_precheck tests.test_precheck_toolkit -v   # 31 tests
bash ../format.sh                                                       # pre-commit (black/isort/codespell) green
```

## Notes

- Coexists with the in-flight kv-calc PR (#1247). The packages live in separate directories (`tools/precheck` vs `tools/kv_calc`); the only shared file is `registry.py` (both append a `register(...)` line) — a trivial additive conflict at merge time.
- Bandwidth load reads can be inflated by the page cache (store default `io_direct=false`); the dump (cold write) figure is the disk-bound one. The aggregate across workers is the headline "comprehensive bandwidth".

Closes the first item of #1208.


