### PR TITLE
feat(dram): improve DramPool and DramStore transport configuration

### DIFF
--- a/examples/drampool.yaml
+++ b/examples/drampool.yaml
@@ -6,6 +6,9 @@
 
 transport:
   device_ids: [0, 1, 2]
+  hixl:
+    listen_port: 26666
+    enable_cs: false
   # Cluster-wide request-channel to transport-endpoint routing.
   endpoints:
     - two_sided: "127.0.0.1:9000"

--- a/examples/ucm_config_dramstore.yaml
+++ b/examples/ucm_config_dramstore.yaml
@@ -14,6 +14,9 @@ ucm_connectors:
       local_control_endpoint: "127.0.0.1:9001"
       local_host: "127.0.0.1"
       local_transport_manager_id: "127.0.0.1:4502"
+      # Workers use hixl_listen_port + 1; schedulers use the configured port.
+      hixl_listen_port: 36666
+      enable_hixl_cs: false
 
       # DramPool control endpoints and their transport IDs. The two arrays must
       # have the same length and matching indexes.

--- a/ucm/store/dram/CMakeLists.txt
+++ b/ucm/store/dram/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(dramstore SHARED ${UCM_DRAM_STORE_CC_SOURCE_FILES})
 
 set_target_properties(dramstore PROPERTIES
     BUILD_WITH_INSTALL_RPATH ON
-    INSTALL_RPATH "$ORIGIN"
+    INSTALL_RPATH "$ORIGIN;$ORIGIN/../../transport/p2p"
 )
 if(RUNTIME_ENVIRONMENT STREQUAL "ascend")
     target_compile_definitions(dramstore PRIVATE UC_DRAM_ASCEND_BACKEND)

--- a/ucm/store/dram/cc/config.cc
+++ b/ucm/store/dram/cc/config.cc
@@ -177,6 +177,19 @@ Expected<DramConfig> DramConfig::Parse(const Detail::Dictionary& dictionary)
             }
         }
 
+        std::size_t hixlListenPort = result.hixlListenPort;
+        status = OptionalSize(dictionary, "hixl_listen_port", &hixlListenPort);
+        const auto hixlPortOffset = result.role == Role::WORKER ? 1U : 0U;
+        if (status.Failure() || hixlListenPort == 0 ||
+            hixlListenPort > std::numeric_limits<std::uint16_t>::max() - hixlPortOffset) {
+            return status.Failure() ? status
+                                    : Status::InvalidParam("hixl_listen_port is out of range");
+        }
+        result.hixlListenPort = static_cast<std::uint16_t>(hixlListenPort + hixlPortOffset);
+        if (dictionary.Contains("enable_hixl_cs")) {
+            dictionary.Get("enable_hixl_cs", result.enableHixlCs);
+        }
+
         std::string managerHost;
         std::uint16_t managerPort = 0;
         status = ParseControlEndpoint(result.localTransportManagerId, "local_transport_manager_id",

--- a/ucm/store/dram/cc/config.cc
+++ b/ucm/store/dram/cc/config.cc
@@ -177,6 +177,22 @@ Expected<DramConfig> DramConfig::Parse(const Detail::Dictionary& dictionary)
             }
         }
 
+        std::string managerHost;
+        std::uint16_t managerPort = 0;
+        status = ParseControlEndpoint(result.localTransportManagerId, "local_transport_manager_id",
+                                      &managerHost, &managerPort);
+        if (status.Failure()) { return status; }
+        if (result.role == Role::WORKER) {
+            const auto offset = static_cast<std::uint32_t>(result.deviceId) + 1;
+            if (result.localControlPort > std::numeric_limits<std::uint16_t>::max() - offset ||
+                managerPort > std::numeric_limits<std::uint16_t>::max() - offset) {
+                return Status::InvalidParam("worker transport port is out of range");
+            }
+            result.localControlPort += static_cast<std::uint16_t>(offset);
+            managerPort += static_cast<std::uint16_t>(offset);
+        }
+        result.localTransportManagerId = fmt::format("{}:{}", managerHost, managerPort);
+
         std::vector<std::string> controlEndpoints;
         std::vector<std::string> transportManagerIds;
         if (!dictionary.Contains("node_control_endpoints") ||

--- a/ucm/store/dram/cc/config.h
+++ b/ucm/store/dram/cc/config.h
@@ -47,6 +47,8 @@ struct DramConfig {
     std::string localTransportManagerId;
     std::int32_t deviceId{0};
     Role role{Role::WORKER};
+    std::uint16_t hixlListenPort{36666};
+    bool enableHixlCs{false};
     UC::KV::RouterType routerType{UC::KV::RouterType::RING_HASH_FULL_SPREAD};
     std::size_t maxIoEntries{65536};
     NodeSchedulerConfig nodeScheduler;

--- a/ucm/store/dram/cc/dram_store.cc
+++ b/ucm/store/dram/cc/dram_store.cc
@@ -111,6 +111,8 @@ private:
             config_->localTransportManagerId,
             config_->localHost,
             config_->deviceId,
+            config_->hixlListenPort,
+            config_->enableHixlCs,
             1000,
             static_cast<std::int32_t>(std::min<std::int64_t>(
                 transferTimeout.count(), std::numeric_limits<std::int32_t>::max())),

--- a/ucm/store/dram/cc/drampool/drampool_config.h
+++ b/ucm/store/dram/cc/drampool/drampool_config.h
@@ -58,6 +58,8 @@ struct DramPoolConfig {
 
     // Transport internals are loaded from the runtime YAML file.
     std::vector<std::int32_t> transportDeviceIds{0};
+    std::uint16_t hixlListenPort{26666};
+    bool enableHixlCs{false};
     // Cluster-wide routing from the request channel address to the transport identity.
     std::unordered_map<std::string, transport::ManagerID> twoSidedToOneSided{};
 

--- a/ucm/store/dram/cc/drampool/drampool_server.cc
+++ b/ucm/store/dram/cc/drampool/drampool_server.cc
@@ -257,11 +257,17 @@ Status DramPoolServer::StartTransportService()
     }
     attrs.ip = managerEndpoint.host;
     attrs.role = transport::HixlRole::Client;
+    UC_DEBUG("DramPool HIXL configured: listen_port={} enable_cs={}", g_config.hixlListenPort,
+             g_config.enableHixlCs);
     attrs.instances.reserve(g_config.transportDeviceIds.size());
     for (const auto deviceId : g_config.transportDeviceIds) {
         transport::HixlInitAttrs::Instance instance;
         instance.port = -1;
         instance.device_id = deviceId;
+        instance.options["GlobalResourceConfig"] =
+            std::string{"{\"comm_resource_config.listen_port\":"} +
+            std::to_string(g_config.hixlListenPort) + "}";
+        if (g_config.enableHixlCs) { instance.options["LocalCommRes"] = R"({"version":"1.3"})"; }
         attrs.instances.push_back(std::move(instance));
     }
     attrs.connect_timeout_ms = static_cast<std::int32_t>(g_config.opTimeoutMs);

--- a/ucm/store/dram/cc/drampool/drampool_server.cc
+++ b/ucm/store/dram/cc/drampool/drampool_server.cc
@@ -510,7 +510,7 @@ void DramPoolServer::RequestReceiveLoop()
         task->peer_one_sided_id = peerIt->second;
         UC_DEBUG("RequestReceiver received request, request_id={}, opcode={}, control={}, peer={}",
                  task->request->request_id, static_cast<int>(task->request->opcode), controlPeerId,
-                 peerIt->second);
+                 task->peer_one_sided_id);
         // This bounded handoff keeps transport I/O separate from potentially slow request handling.
         bool queueFullLogged = false;
         while (!requestReceiverStop_.load(std::memory_order_acquire)) {

--- a/ucm/store/dram/cc/drampool/drampool_yaml_config.cc
+++ b/ucm/store/dram/cc/drampool/drampool_yaml_config.cc
@@ -59,6 +59,8 @@ struct EndpointEntry {
 
 constexpr const char* kRequiredRuntimeConfigKeys[] = {
     "transport.device_ids",
+    "transport.hixl.listen_port",
+    "transport.hixl.enable_cs",
     "queue.request_depth",
     "queue.completion_depth",
     "request_receiver.idle_wait_us",
@@ -252,6 +254,9 @@ const std::unordered_map<std::string_view, RuntimeConfigParser>& GetRuntimeConfi
 {
     static const std::unordered_map<std::string_view, RuntimeConfigParser> parsers = {
         {"health.port", BindConfigParser(ParseUint16, &DramPoolConfig::healthPort)},
+        {"transport.hixl.listen_port",
+         BindConfigParser(ParseUint16, &DramPoolConfig::hixlListenPort)},
+        {"transport.hixl.enable_cs", BindConfigParser(ParseBool, &DramPoolConfig::enableHixlCs)},
         {"queue.request_depth", BindConfigParser(ParseUint32, &DramPoolConfig::requestQueueDepth)},
         {"queue.completion_depth",
          BindConfigParser(ParseUint32, &DramPoolConfig::completionQueueDepth)},
@@ -315,6 +320,9 @@ Status ValidateRuntimeConfig(DramPoolConfig& config)
     }
     if (config.transportDeviceIds.empty()) {
         return Status::InvalidParam("transport.device_ids must not be empty");
+    }
+    if (config.hixlListenPort == 0) {
+        return Status::InvalidParam("transport.hixl.listen_port must be greater than zero");
     }
     std::unordered_set<std::int32_t> deviceIds;
     for (const auto deviceId : config.transportDeviceIds) {

--- a/ucm/store/dram/cc/transport_manager_backend.cc
+++ b/ucm/store/dram/cc/transport_manager_backend.cc
@@ -48,7 +48,15 @@ Status TransportManagerBackend::Init()
     // TODO: make transport backend configurable
     transport::HixlInitAttrs attrs;
     attrs.ip = options_.localHost;
-    attrs.instances.push_back(transport::HixlInitAttrs::Instance{-1, options_.deviceId, {}});
+    transport::HixlInitAttrs::Instance instance{-1, options_.deviceId, {}};
+    if (options_.hixlDeviceListenPort > 0) {
+        instance.options["GlobalResourceConfig"] =
+            std::string{"{\"comm_resource_config.listen_port\":"} +
+            std::to_string(options_.hixlDeviceListenPort) + "}";
+    }
+    if (options_.enableHixlCs) { instance.options["LocalCommRes"] = R"({"version":"1.3"})"; }
+    UC_DEBUG("DramStore HIXL LocalCommRes 1.3 configured: enabled={}", options_.enableHixlCs);
+    attrs.instances.push_back(std::move(instance));
     attrs.connect_timeout_ms = options_.connectTimeoutMs;
     attrs.transfer_timeout_ms = options_.transferTimeoutMs;
     auto transportStatus = manager_.Init();

--- a/ucm/store/dram/cc/transport_manager_backend.h
+++ b/ucm/store/dram/cc/transport_manager_backend.h
@@ -43,6 +43,8 @@ struct TransportManagerBackendOptions {
     std::string localTransportManagerId;
     std::string localHost;
     std::int32_t deviceId{0};
+    std::int32_t hixlDeviceListenPort{-1};
+    bool enableHixlCs{false};
     std::int32_t connectTimeoutMs{1000};
     std::int32_t transferTimeoutMs{5000};
     std::vector<NodeEndpoint> nodes;

--- a/ucm/store/test/case/dram/dram_config_test.cc
+++ b/ucm/store/test/case/dram/dram_config_test.cc
@@ -153,6 +153,7 @@ TEST(DramConfigTest, RejectsInvalidSchedulerBoundaries)
 TEST(DramConfigTest, ParsesControlEndpointsAndStoresManagerIds)
 {
     auto input = BaseConfig();
+    input.Set("role", std::string{"scheduler"});
     input.Set("local_control_endpoint", std::string{"127.0.0.1:06000"});
     auto parsed = DramConfig::Parse(input);
     ASSERT_TRUE(parsed);
@@ -166,6 +167,40 @@ TEST(DramConfigTest, ParsesControlEndpointsAndStoresManagerIds)
     EXPECT_EQ(config.nodeScheduler.nodes[0].controlPort, std::uint16_t{7000});
     EXPECT_EQ(config.nodeScheduler.nodes[0].transportManagerId, "127.0.0.1:7100");
     EXPECT_EQ(config.nodeScheduler.nodes[1].nodeId, NodeId{1});
+}
+
+TEST(DramConfigTest, UsesConfiguredPortsForScheduler)
+{
+    auto input = BaseConfig();
+    input.Set("role", std::string{"scheduler"});
+    input.SetNumber("device_id", 3);
+    auto parsed = DramConfig::Parse(input);
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ(parsed.Value().localControlPort, std::uint16_t{6000});
+    EXPECT_EQ(parsed.Value().localTransportManagerId, "127.0.0.1:6100");
+}
+
+TEST(DramConfigTest, OffsetsWorkerPortsByDeviceId)
+{
+    auto input = BaseConfig();
+    input.Set("role", std::string{"worker"});
+    input.SetNumber("device_id", 3);
+    auto parsed = DramConfig::Parse(input);
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ(parsed.Value().localControlPort, std::uint16_t{6004});
+    EXPECT_EQ(parsed.Value().localTransportManagerId, "127.0.0.1:6104");
+}
+
+TEST(DramConfigTest, RejectsInvalidRoleAndWorkerPortOverflow)
+{
+    auto invalidRole = BaseConfig();
+    invalidRole.Set("role", std::string{"server"});
+    EXPECT_FALSE(DramConfig::Parse(invalidRole));
+
+    auto overflow = BaseConfig();
+    overflow.Set("role", std::string{"worker"});
+    overflow.Set("local_control_endpoint", std::string{"127.0.0.1:65535"});
+    EXPECT_FALSE(DramConfig::Parse(overflow));
 }
 
 }  // namespace

--- a/ucm/store/test/case/dram/dram_config_test.cc
+++ b/ucm/store/test/case/dram/dram_config_test.cc
@@ -174,10 +174,14 @@ TEST(DramConfigTest, UsesConfiguredPortsForScheduler)
     auto input = BaseConfig();
     input.Set("role", std::string{"scheduler"});
     input.SetNumber("device_id", 3);
+    input.SetNumber("hixl_listen_port", 36666);
+    input.Set("enable_hixl_cs", true);
     auto parsed = DramConfig::Parse(input);
     ASSERT_TRUE(parsed);
     EXPECT_EQ(parsed.Value().localControlPort, std::uint16_t{6000});
     EXPECT_EQ(parsed.Value().localTransportManagerId, "127.0.0.1:6100");
+    EXPECT_EQ(parsed.Value().hixlListenPort, std::uint16_t{36666});
+    EXPECT_TRUE(parsed.Value().enableHixlCs);
 }
 
 TEST(DramConfigTest, OffsetsWorkerPortsByDeviceId)
@@ -189,6 +193,7 @@ TEST(DramConfigTest, OffsetsWorkerPortsByDeviceId)
     ASSERT_TRUE(parsed);
     EXPECT_EQ(parsed.Value().localControlPort, std::uint16_t{6004});
     EXPECT_EQ(parsed.Value().localTransportManagerId, "127.0.0.1:6104");
+    EXPECT_EQ(parsed.Value().hixlListenPort, std::uint16_t{36667});
 }
 
 TEST(DramConfigTest, RejectsInvalidRoleAndWorkerPortOverflow)
@@ -201,6 +206,10 @@ TEST(DramConfigTest, RejectsInvalidRoleAndWorkerPortOverflow)
     overflow.Set("role", std::string{"worker"});
     overflow.Set("local_control_endpoint", std::string{"127.0.0.1:65535"});
     EXPECT_FALSE(DramConfig::Parse(overflow));
+
+    auto hixlOverflow = BaseConfig();
+    hixlOverflow.SetNumber("hixl_listen_port", 65535);
+    EXPECT_FALSE(DramConfig::Parse(hixlOverflow));
 }
 
 }  // namespace

--- a/ucm/store/test/case/dram/drampool/drampool_yaml_config_test.cc
+++ b/ucm/store/test/case/dram/drampool/drampool_yaml_config_test.cc
@@ -60,6 +60,9 @@ std::string ValidRuntimeYaml()
 {
     return R"(transport:
   device_ids: [0, 2]
+  hixl:
+    listen_port: 26666
+    enable_cs: true
   endpoints:
     - two_sided: "127.0.0.1:9000"
       one_sided: "127.0.0.1:4501"
@@ -137,6 +140,8 @@ TEST(DramPoolRuntimeYamlTest, LoadsEveryRuntimeFieldAndPreservesLaunchFields)
     EXPECT_EQ(config.twoSidedToOneSided.at("127.0.0.1:9000"), "127.0.0.1:4501");
     EXPECT_EQ(config.twoSidedToOneSided.at("127.0.0.1:9001"), "127.0.0.1:4502");
     EXPECT_EQ(config.transportDeviceIds, (std::vector<std::int32_t>{0, 2}));
+    EXPECT_EQ(config.hixlListenPort, 26666U);
+    EXPECT_TRUE(config.enableHixlCs);
     EXPECT_EQ(config.healthPort, 0U);
     EXPECT_EQ(config.requestQueueDepth, 65536U);
     EXPECT_EQ(config.completionQueueDepth, 65536U);

--- a/ucm/store/test/e2e/scripts/run_drampool_e2e.sh
+++ b/ucm/store/test/e2e/scripts/run_drampool_e2e.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Exit immediately when a command fails.
+set -e
+
+# ================================================================
+# 1. Parameters and configuration
+# ================================================================
+# --- 1.1 Global environment variables ---
+# export UC_LOGGER_LEVEL=debug
+# export ASCEND_SLOG_PRINT_TO_STDOUT=1
+# export ASCEND_RT_VISIBLE_DEVICES=9,10,11,12
+
+# Preload HIXL from the standard CANN installation.
+HIXL_SO="/usr/local/Ascend/cann/lib64/libcann_hixl.so"
+export LD_PRELOAD="${HIXL_SO}"
+
+# --- 1.2 DramPool process configuration ---
+DRAMPOOL_BIN="./build/ucm/store/dram/drampool"
+DRAMPOOL_LOG="drampool_server.log"
+
+# DramPool command-line parameters.
+DRAMPOOL_CONFIG="examples/drampool.yaml"
+DRAMPOOL_ADDR="127.0.0.1:9000"
+DRAMPOOL_NICS="eth0"
+DRAMPOOL_POOL_SIZE_GB="1"
+DRAMPOOL_KVCACHE_BLOCK_SIZES=(131072 16384)
+
+# Assemble the DramPool argument array.
+DRAMPOOL_ARGS=(
+  --config "${DRAMPOOL_CONFIG}"
+  --addr "${DRAMPOOL_ADDR}"
+  --nics "${DRAMPOOL_NICS}"
+  --pool-size-gb "${DRAMPOOL_POOL_SIZE_GB}"
+  --kvcache-block-sizes "${DRAMPOOL_KVCACHE_BLOCK_SIZES[@]}"
+)
+
+# --- 1.3 Python inference process configuration ---
+PYTHON_SCRIPT="examples/offline_inference.py"
+INFERENCE_LOG="offline_inference.log"
+
+# ================================================================
+# 2. Process cleanup
+# ================================================================
+cleanup() {
+    echo ""
+    echo "[INFO] Cleaning up background processes..."
+    if [ -n "${DRAMPOOL_PID}" ] && kill -0 "${DRAMPOOL_PID}" 2>/dev/null; then
+        echo "[INFO] Stopping DramPool service (PID: ${DRAMPOOL_PID})..."
+        kill -9 "${DRAMPOOL_PID}" 2>/dev/null || true
+    fi
+    echo "[INFO] All tasks have completed or been terminated."
+    exit 0
+}
+
+# Stop the background DramPool process when the script exits.
+trap cleanup SIGINT SIGTERM EXIT
+
+# ================================================================
+# 3. Run the workload
+# ================================================================
+
+# --- Process 1: DramPool service ---
+echo "[INFO] Starting DramPool service..."
+"${DRAMPOOL_BIN}" "${DRAMPOOL_ARGS[@]}" > "${DRAMPOOL_LOG}" 2>&1 &
+
+DRAMPOOL_PID=$!
+echo "[INFO] DramPool started in the background (PID: ${DRAMPOOL_PID})"
+echo "[INFO] DramPool log: ${DRAMPOOL_LOG}"
+
+# --- Process 2: Python inference workload ---
+echo "[INFO] Starting the Python offline inference script..."
+echo "[INFO] Command: python3 ${PYTHON_SCRIPT}"
+echo "[INFO] Python inference log: ${INFERENCE_LOG}"
+
+# Run the Python workload synchronously.
+python3 "${PYTHON_SCRIPT}" > "${INFERENCE_LOG}" 2>&1
+
+echo "[INFO] Python inference workload completed."

--- a/ucm/transport/p2p/include/control/control_protocol.h
+++ b/ucm/transport/p2p/include/control/control_protocol.h
@@ -12,6 +12,16 @@ enum class ControlOperation : uint32_t {
     Disconnect = 2,
 };
 
+inline const char* ControlOperationName(ControlOperation operation) noexcept
+{
+    switch (operation) {
+        case ControlOperation::ExchangeMetadata: return "exchange-metadata";
+        case ControlOperation::Connect: return "connect";
+        case ControlOperation::Disconnect: return "disconnect";
+    }
+    return "unknown";
+}
+
 struct ControlRequest {
     ControlOperation operation;
     std::optional<TransportProtocol> protocol;

--- a/ucm/transport/p2p/src/control/control_channel.cpp
+++ b/ucm/transport/p2p/src/control/control_channel.cpp
@@ -1,6 +1,7 @@
 #include "control/control_channel.h"
 #include <algorithm>
 #include <arpa/inet.h>
+#include <cerrno>
 #include <cstring>
 #include <mutex>
 #include <netdb.h>
@@ -57,7 +58,11 @@ Status SendAll(Socket socket, const void* data, size_t length)
     while (length > 0) {
         const auto chunk = static_cast<int>(std::min<size_t>(length, 64 * 1024));
         const int sent = send(socket, cursor, chunk, 0);
-        if (sent <= 0) { return Status::Error(); }
+        if (sent <= 0) {
+            UC_ERROR("transport tcp send failed socket={} remaining={} errno={} error={}", socket,
+                     length, errno, std::strerror(errno));
+            return Status::Error();
+        }
         cursor += sent;
         length -= static_cast<size_t>(sent);
     }
@@ -70,7 +75,16 @@ Status RecvAll(Socket socket, void* data, size_t length)
     while (length > 0) {
         const auto chunk = static_cast<int>(std::min<size_t>(length, 64 * 1024));
         const int received = recv(socket, cursor, chunk, 0);
-        if (received <= 0) { return Status::Error(); }
+        if (received == 0) {
+            UC_ERROR("transport tcp peer closed connection socket={} remaining={}", socket, length);
+            return Status::Error();
+        }
+        if (received < 0) {
+            UC_ERROR(
+                "transport tcp receive failed socket={} remaining={} result={} errno={} error={}",
+                socket, length, received, errno, std::strerror(errno));
+            return Status::Error();
+        }
         cursor += received;
         length -= static_cast<size_t>(received);
     }
@@ -90,6 +104,8 @@ void CloseSocket(Socket socket)
 Status SendFrame(Socket socket, const void* data, size_t length)
 {
     if (socket == kInvalidSocket || (data == nullptr && length != 0) || length > UINT32_MAX) {
+        UC_ERROR("transport tcp send frame invalid socket={} data={} length={}", socket,
+                 static_cast<const void*>(data), length);
         return Status::InvalidParam();
     }
     const uint32_t network_length = htonl(static_cast<uint32_t>(length));
@@ -100,12 +116,19 @@ Status SendFrame(Socket socket, const void* data, size_t length)
 
 Status ReceiveFrame(Socket socket, Metadata& metadata, size_t max_length)
 {
-    if (socket == kInvalidSocket) { return Status::InvalidParam(); }
+    if (socket == kInvalidSocket) {
+        UC_ERROR("transport tcp receive frame invalid socket={}", socket);
+        return Status::InvalidParam();
+    }
     uint32_t network_length = 0;
     auto status = RecvAll(socket, &network_length, sizeof(network_length));
     if (status != Status::OK()) { return status; }
     const auto length = ntohl(network_length);
-    if (length > max_length) { return Status::InvalidParam(); }
+    if (length > max_length) {
+        UC_ERROR("transport tcp receive frame too large socket={} length={} limit={}", socket,
+                 length, max_length);
+        return Status::InvalidParam();
+    }
     metadata.assign(length, 0);
     return length == 0 ? Status::OK() : RecvAll(socket, metadata.data(), metadata.size());
 }
@@ -152,6 +175,7 @@ ControlChannel::~ControlChannel() { Close(); }
 
 Status ControlChannel::Init(const Endpoint& endpoint, RequestHandler handler)
 {
+    UC_DEBUG("transport control init begin endpoint={}:{}", endpoint.host, endpoint.port);
     Close();
     {
         std::lock_guard<std::mutex> lock(mutex_);
@@ -159,17 +183,28 @@ Status ControlChannel::Init(const Endpoint& endpoint, RequestHandler handler)
     }
     auto status = Listen(endpoint);
     if (status != Status::OK()) {
+        UC_ERROR("transport control listen initialization failed endpoint={}:{} status={}",
+                 endpoint.host, endpoint.port, status.Underlying());
         Close();
         return status;
     }
     status = StartAccepting();
-    if (status != Status::OK()) { Close(); }
+    if (status != Status::OK()) {
+        UC_ERROR("transport control accept initialization failed endpoint={}:{} status={}",
+                 endpoint.host, endpoint.port, status.Underlying());
+        Close();
+    } else {
+        UC_DEBUG("transport control init completed endpoint={}:{}", endpoint.host, endpoint.port);
+    }
     return status;
 }
 
 Status ControlChannel::Listen(const Endpoint& endpoint)
 {
-    if (endpoint.port == 0) { return Status::InvalidParam(); }
+    if (endpoint.port == 0) {
+        UC_ERROR("transport tcp listen invalid endpoint={}:{}", endpoint.host, endpoint.port);
+        return Status::InvalidParam();
+    }
     UC_DEBUG("transport tcp listen begin endpoint={}:{} backlog={}", endpoint.host, endpoint.port,
              kListenBacklog);
     addrinfo hints{};
@@ -216,7 +251,10 @@ Status ControlChannel::Listen(const Endpoint& endpoint)
 
 Status ControlChannel::AcceptSocket(SocketHandle& socket)
 {
-    if (!listen_socket_.Valid()) { return Status::InvalidParam(); }
+    if (!listen_socket_.Valid()) {
+        UC_ERROR("transport tcp accept failed: listen socket is invalid");
+        return Status::InvalidParam();
+    }
 
     const auto accepted = ::accept(listen_socket_.Get(), nullptr, nullptr);
     if (accepted == kInvalidSocket) {
@@ -235,7 +273,10 @@ Status ControlChannel::AcceptSocket(SocketHandle& socket)
 
 Status ControlChannel::Connect(const Endpoint& endpoint)
 {
-    if (endpoint.host.empty() || endpoint.port == 0) { return Status::InvalidParam(); }
+    if (endpoint.host.empty() || endpoint.port == 0) {
+        UC_ERROR("transport tcp connect invalid endpoint={}:{}", endpoint.host, endpoint.port);
+        return Status::InvalidParam();
+    }
     UC_DEBUG("transport tcp connect begin endpoint={}:{}", endpoint.host, endpoint.port);
     addrinfo hints{};
     hints.ai_family = AF_UNSPEC;
@@ -273,33 +314,69 @@ Status ControlChannel::Connect(const Endpoint& endpoint)
 Status ControlChannel::Request(const Endpoint& endpoint, const Metadata& request,
                                Metadata& response)
 {
+    UC_DEBUG("transport control request begin peer={}:{} bytes={}", endpoint.host, endpoint.port,
+             request.size());
     ControlChannel channel;
     auto status = channel.Connect(endpoint);
-    if (status != Status::OK()) { return status; }
+    if (status != Status::OK()) {
+        UC_ERROR("transport control request connect failed peer={}:{} status={}", endpoint.host,
+                 endpoint.port, status.Underlying());
+        return status;
+    }
 
     status = SendFrame(channel.socket_.Get(), request.data(), request.size());
-    if (status != Status::OK()) { return status; }
+    if (status != Status::OK()) {
+        UC_ERROR("transport control request send failed peer={}:{} socket={} status={}",
+                 endpoint.host, endpoint.port, channel.socket_.Get(), status.Underlying());
+        return status;
+    }
+    UC_DEBUG("transport control request sent peer={}:{} socket={} bytes={}", endpoint.host,
+             endpoint.port, channel.socket_.Get(), request.size());
 
     Metadata response_frame;
     status = ReceiveFrame(channel.socket_.Get(), response_frame, max_receive_frame_size_);
-    if (status != Status::OK()) { return status; }
+    if (status != Status::OK()) {
+        UC_ERROR("transport control response receive failed peer={}:{} socket={} status={}",
+                 endpoint.host, endpoint.port, channel.socket_.Get(), status.Underlying());
+        return status;
+    }
     ControlResponse decoded_response;
     status = DecodeControlResponse(response_frame, decoded_response);
-    if (status != Status::OK() || decoded_response.status != Status::OK()) {
-        return status == Status::OK() ? decoded_response.status : status;
+    if (status != Status::OK()) {
+        UC_ERROR("transport control response decode failed peer={}:{} socket={} bytes={} status={}",
+                 endpoint.host, endpoint.port, channel.socket_.Get(), response_frame.size(),
+                 status.Underlying());
+        return status;
+    }
+    if (decoded_response.status != Status::OK()) {
+        UC_ERROR("transport control peer rejected request peer={}:{} socket={} status={}",
+                 endpoint.host, endpoint.port, channel.socket_.Get(),
+                 decoded_response.status.Underlying());
+        return decoded_response.status;
     }
     response = std::move(decoded_response.payload);
+    UC_DEBUG("transport control request completed peer={}:{} socket={} response_bytes={}",
+             endpoint.host, endpoint.port, channel.socket_.Get(), response.size());
     return Status::OK();
 }
 
 Status ControlChannel::StartAccepting()
 {
-    if (!listen_socket_.Valid()) { return Status::InvalidParam(); }
+    if (!listen_socket_.Valid()) {
+        UC_ERROR("transport tcp start accepting failed: listen socket is invalid");
+        return Status::InvalidParam();
+    }
 
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        if (!request_handler_) { return Status::InvalidParam(); }
-        if (accept_thread_.joinable()) { return Status::OK(); }
+        if (!request_handler_) {
+            UC_ERROR("transport tcp start accepting failed: request handler is empty");
+            return Status::InvalidParam();
+        }
+        if (accept_thread_.joinable()) {
+            UC_DEBUG("transport tcp accept thread already running socket={}", listen_socket_.Get());
+            return Status::OK();
+        }
         stop_accept_.store(false, std::memory_order_relaxed);
     }
 
@@ -312,7 +389,13 @@ Status ControlChannel::StartAccepting()
             Metadata request_frame;
             const auto receive_status =
                 ReceiveFrame(accepted_socket.Get(), request_frame, max_receive_frame_size_);
-            if (receive_status != Status::OK()) { continue; }
+            if (receive_status != Status::OK()) {
+                UC_ERROR("transport control request receive failed socket={} status={}",
+                         accepted_socket.Get(), receive_status.Underlying());
+                continue;
+            }
+            UC_DEBUG("transport control request received socket={} bytes={}", accepted_socket.Get(),
+                     request_frame.size());
 
             RequestHandler handler;
             {
@@ -322,13 +405,30 @@ Status ControlChannel::StartAccepting()
             Metadata response;
             const auto request_status =
                 handler ? handler(request_frame, response) : Status::InvalidParam();
+            if (request_status != Status::OK()) {
+                UC_ERROR("transport control request handler failed socket={} status={}",
+                         accepted_socket.Get(), request_status.Underlying());
+            } else {
+                UC_DEBUG("transport control request handled socket={} response_bytes={}",
+                         accepted_socket.Get(), response.size());
+            }
             ControlResponse control_response{request_status, std::move(response)};
             Metadata response_payload;
-            if (EncodeControlResponse(control_response, response_payload) == Status::OK()) {
-                const auto send_status = SendFrame(accepted_socket.Get(), response_payload.data(),
-                                                   response_payload.size());
-                if (send_status != Status::OK()) { continue; }
+            const auto encode_status = EncodeControlResponse(control_response, response_payload);
+            if (encode_status != Status::OK()) {
+                UC_ERROR("transport control response encode failed socket={} status={}",
+                         accepted_socket.Get(), encode_status.Underlying());
+                continue;
             }
+            const auto send_status =
+                SendFrame(accepted_socket.Get(), response_payload.data(), response_payload.size());
+            if (send_status != Status::OK()) {
+                UC_ERROR("transport control response send failed socket={} bytes={} status={}",
+                         accepted_socket.Get(), response_payload.size(), send_status.Underlying());
+                continue;
+            }
+            UC_DEBUG("transport control response sent socket={} bytes={} status={}",
+                     accepted_socket.Get(), response_payload.size(), request_status.Underlying());
         }
     });
     return Status::OK();

--- a/ucm/transport/p2p/src/core/transport_manager.cpp
+++ b/ucm/transport/p2p/src/core/transport_manager.cpp
@@ -84,33 +84,54 @@ TransportManager::~TransportManager()
 
 Status TransportManager::Init()
 {
+    UC_DEBUG("transport manager init begin manager={}", manager_id_);
     if (ParseManagerID(manager_id_, local_endpoint_) != Status::OK()) {
+        UC_ERROR("transport manager init failed: invalid manager id={}", manager_id_);
         return Status::InvalidParam();
     }
-    if (control_) { return Status::OK(); }
+    if (control_) {
+        UC_DEBUG("transport manager init skipped: already initialized manager={}", manager_id_);
+        return Status::OK();
+    }
     control_ = std::make_shared<ControlChannel>();
     auto status =
         control_->Init(LocalEndpoint(), [this](const Metadata& request, Metadata& response) {
             return HandleControlRequest(request, response);
         });
     if (status != Status::OK()) {
+        UC_ERROR("transport manager control init failed manager={} status={}", manager_id_,
+                 status.Underlying());
         control_.reset();
         return status;
     }
+    UC_DEBUG("transport manager init completed manager={}", manager_id_);
     return Status::OK();
 }
 
 Status TransportManager::InstallTransport(TransportProtocol protocol, const InitAttrs& options)
 {
-    if (protocol_map_.find(protocol) != protocol_map_.end()) { return Status::OK(); }
+    if (protocol_map_.find(protocol) != protocol_map_.end()) {
+        UC_DEBUG("transport manager install skipped protocol={}: already installed",
+                 static_cast<uint32_t>(protocol));
+        return Status::OK();
+    }
 
     auto transport = CreateTransport(protocol);
-    if (!transport) { return Status::Unsupported(); }
+    if (!transport) {
+        UC_ERROR("transport manager install failed: unsupported protocol={}",
+                 static_cast<uint32_t>(protocol));
+        return Status::Unsupported();
+    }
     const auto status = transport->Init(options);
-    if (status != Status::OK()) { return status; }
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager install failed protocol={} status={}",
+                 static_cast<uint32_t>(protocol), status.Underlying());
+        return status;
+    }
 
     protocol_map_[protocol] = transport.get();
     transports_.push_back(InstalledTransport{protocol, std::move(transport)});
+    UC_DEBUG("transport manager installed protocol={}", static_cast<uint32_t>(protocol));
     return Status::OK();
 }
 
@@ -126,6 +147,7 @@ TransportPtr TransportManager::CreateTransport(TransportProtocol protocol) const
 
 Status TransportManager::Shutdown()
 {
+    UC_DEBUG("transport manager shutdown begin manager={}", manager_id_);
     Status result = Status::OK();
     std::vector<std::pair<TransportProtocol, ManagerID>> connections;
     {
@@ -143,7 +165,11 @@ Status TransportManager::Shutdown()
 
     for (auto& item : transports_) {
         const auto status = item.transport->Shutdown();
-        if (status != Status::OK() && result == Status::OK()) { result = status; }
+        if (status != Status::OK()) {
+            UC_ERROR("transport manager transport shutdown failed protocol={} status={}",
+                     static_cast<uint32_t>(item.protocol), status.Underlying());
+            if (result == Status::OK()) { result = status; }
+        }
     }
     memories_.clear();
     {
@@ -157,45 +183,88 @@ Status TransportManager::Shutdown()
     }
     protocol_map_.clear();
     transports_.clear();
+    UC_DEBUG("transport manager shutdown completed manager={} status={}", manager_id_,
+             result.Underlying());
     return result;
 }
 
 Status TransportManager::ExchangeMetadata(const ManagerID& manager_id)
 {
+    UC_DEBUG("transport manager metadata exchange begin local={} peer={}", manager_id_, manager_id);
     Endpoint endpoint;
     auto status = ParseManagerID(manager_id, endpoint);
-    if (status != Status::OK()) { return status; }
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager metadata exchange invalid peer={} status={}", manager_id,
+                 status.Underlying());
+        return status;
+    }
 
-    if (manager_id == LocalEndpoint().ToString()) { return Status::OK(); }
+    if (manager_id == LocalEndpoint().ToString()) {
+        UC_DEBUG("transport manager metadata exchange skipped local peer={}", manager_id);
+        return Status::OK();
+    }
 
     Metadata local;
     status = ExportLocalMetadata(manager_id, local);
-    if (status != Status::OK()) { return status; }
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager metadata export failed peer={} status={}", manager_id,
+                 status.Underlying());
+        return status;
+    }
     Metadata remote;
     Metadata request;
     status = EncodeControlRequest(ControlRequest{ControlOperation::ExchangeMetadata, std::nullopt,
                                                  manager_id_, std::move(local)},
                                   request);
-    if (status != Status::OK()) { return status; }
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager metadata request encode failed peer={} status={}", manager_id,
+                 status.Underlying());
+        return status;
+    }
     status = control_->Request(endpoint, request, remote);
-    if (status == Status::OK()) { status = ImportMetadata(remote, manager_id); }
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager metadata request failed peer={} status={}", manager_id,
+                 status.Underlying());
+        return status;
+    }
+    status = ImportMetadata(remote, manager_id);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager metadata import failed peer={} status={}", manager_id,
+                 status.Underlying());
+        return status;
+    }
+    UC_DEBUG("transport manager metadata exchange completed local={} peer={}", manager_id_,
+             manager_id);
     return status;
 }
 
 Status TransportManager::ExportLocalMetadata(const ManagerID& manager_id, Metadata& out)
 {
-    if (transports_.size() > UINT32_MAX) { return Status::InvalidParam(); }
+    if (transports_.size() > UINT32_MAX) {
+        UC_ERROR("transport manager metadata export failed peer={}: transport count={}", manager_id,
+                 transports_.size());
+        return Status::InvalidParam();
+    }
 
     PeerAdvertisement advertisement;
     advertisement.records.reserve(transports_.size());
     for (const auto& item : transports_) {
         Metadata metadata;
         const auto status = item.transport->ExportMetadata(manager_id, metadata);
-        if (status != Status::OK()) { return status; }
+        if (status != Status::OK()) {
+            UC_ERROR("transport manager metadata export failed protocol={} peer={} status={}",
+                     static_cast<uint32_t>(item.protocol), manager_id, status.Underlying());
+            return status;
+        }
         advertisement.records.push_back(
             TransportMetadataRecord{item.protocol, std::move(metadata)});
     }
-    return EncodePeerAdvertisement(advertisement, out);
+    const auto status = EncodePeerAdvertisement(advertisement, out);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager advertisement encode failed peer={} status={}", manager_id,
+                 status.Underlying());
+    }
+    return status;
 }
 
 Status TransportManager::ImportMetadata(const Metadata& metadata, const ManagerID& manager_id)
@@ -203,20 +272,34 @@ Status TransportManager::ImportMetadata(const Metadata& metadata, const ManagerI
     Endpoint endpoint;
     if (ParseManagerID(manager_id, endpoint) != Status::OK() ||
         metadata.size() < sizeof(uint32_t)) {
+        UC_ERROR("transport manager metadata import invalid peer={} bytes={}", manager_id,
+                 metadata.size());
         return Status::InvalidParam();
     }
 
     PeerAdvertisement advertisement;
     const auto decode_status = DecodePeerAdvertisement(metadata, advertisement);
-    if (decode_status != Status::OK()) { return decode_status; }
+    if (decode_status != Status::OK()) {
+        UC_ERROR("transport manager advertisement decode failed peer={} bytes={} status={}",
+                 manager_id, metadata.size(), decode_status.Underlying());
+        return decode_status;
+    }
 
     std::lock_guard<std::recursive_mutex> lock(peer_mutex_);
     for (const auto& record : advertisement.records) {
         const auto it = protocol_map_.find(record.protocol);
-        if (it == protocol_map_.end()) { continue; }
+        if (it == protocol_map_.end()) {
+            UC_DEBUG("transport manager metadata ignored unsupported protocol={} peer={}",
+                     static_cast<uint32_t>(record.protocol), manager_id);
+            continue;
+        }
 
         const auto status = it->second->ImportMetadata(manager_id, record.metadata);
-        if (status != Status::OK()) { return status; }
+        if (status != Status::OK()) {
+            UC_ERROR("transport manager metadata import failed protocol={} peer={} status={}",
+                     static_cast<uint32_t>(record.protocol), manager_id, status.Underlying());
+            return status;
+        }
     }
 
     return Status::OK();
@@ -226,39 +309,87 @@ Status TransportManager::HandleMetadataExchange(const ManagerID& manager_id,
                                                 const Metadata& remote_metadata,
                                                 Metadata& local_metadata)
 {
+    UC_DEBUG("transport manager handling metadata exchange local={} peer={} request_bytes={}",
+             manager_id_, manager_id, remote_metadata.size());
     const auto status = ImportMetadata(remote_metadata, manager_id);
-    if (status != Status::OK()) { return status; }
-    return ExportLocalMetadata(manager_id, local_metadata);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager handling metadata import failed peer={} status={}", manager_id,
+                 status.Underlying());
+        return status;
+    }
+    const auto export_status = ExportLocalMetadata(manager_id, local_metadata);
+    if (export_status != Status::OK()) {
+        UC_ERROR("transport manager handling metadata export failed peer={} status={}", manager_id,
+                 export_status.Underlying());
+        return export_status;
+    }
+    UC_DEBUG("transport manager handled metadata exchange local={} peer={} response_bytes={}",
+             manager_id_, manager_id, local_metadata.size());
+    return Status::OK();
 }
 
 Status TransportManager::HandleControlRequest(const Metadata& request, Metadata& response)
 {
     ControlRequest control_request{};
     auto status = DecodeControlRequest(request, control_request);
-    if (status != Status::OK()) { return status; }
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager control request decode failed local={} bytes={} status={}",
+                 manager_id_, request.size(), status.Underlying());
+        return status;
+    }
+
+    UC_DEBUG(
+        "transport manager control request decoded local={} operation={} protocol={} peer={}",
+        manager_id_, ControlOperationName(control_request.operation),
+        control_request.protocol.has_value() ? static_cast<int32_t>(*control_request.protocol) : -1,
+        control_request.manager_id);
 
     if (control_request.operation == ControlOperation::ExchangeMetadata) {
         return HandleMetadataExchange(control_request.manager_id, control_request.payload,
                                       response);
     }
-    if (!control_request.protocol.has_value()) { return Status::InvalidParam(); }
+    if (!control_request.protocol.has_value()) {
+        UC_ERROR("transport manager control request missing protocol local={} operation={} peer={}",
+                 manager_id_, ControlOperationName(control_request.operation),
+                 control_request.manager_id);
+        return Status::InvalidParam();
+    }
 
-    UC_INFO("transport manager received {} request protocol={} peer={}",
-            control_request.operation == ControlOperation::Connect ? "connect" : "disconnect",
-            static_cast<uint32_t>(*control_request.protocol), control_request.manager_id);
-    return ApplyConnectionLocally(control_request.operation, *control_request.protocol,
-                                  control_request.manager_id);
+    const auto apply_status = ApplyConnectionLocally(
+        control_request.operation, *control_request.protocol, control_request.manager_id);
+    if (apply_status != Status::OK()) {
+        UC_ERROR(
+            "transport manager control request apply failed operation={} protocol={} peer={} "
+            "status={}",
+            ControlOperationName(control_request.operation),
+            static_cast<uint32_t>(*control_request.protocol), control_request.manager_id,
+            apply_status.Underlying());
+        return apply_status;
+    }
+    UC_DEBUG("transport manager control request applied operation={} protocol={} peer={}",
+             ControlOperationName(control_request.operation),
+             static_cast<uint32_t>(*control_request.protocol), control_request.manager_id);
+    return Status::OK();
 }
 
 Status TransportManager::RegisterMemory(const MemoryRegion& memory, MemoryHandle& handle)
 {
     handle = kInvalidMemoryHandle;
-    if (memory.addr == nullptr || memory.length == 0) { return Status::InvalidParam(); }
-    const auto address = detail::PtrToU64(memory.addr);
-    if (memory.length > std::numeric_limits<uint64_t>::max() - address) {
+    if (memory.addr == nullptr || memory.length == 0) {
+        UC_ERROR("transport manager register memory invalid addr={} length={}", memory.addr,
+                 memory.length);
         return Status::InvalidParam();
     }
-    if (transports_.empty()) { return Status::Error(); }
+    const auto address = detail::PtrToU64(memory.addr);
+    if (memory.length > std::numeric_limits<uint64_t>::max() - address) {
+        UC_ERROR("transport manager register memory address overflow addr=0x{:x} length={}",
+                 address, memory.length);
+        return Status::InvalidParam();
+    }
+    if (transports_.empty()) {
+        UC_ERROR("transport manager register memory failed: no installed transports");
+        return Status::Error();
+    }
 
     auto record = std::make_unique<MemoryRecord>();
     record->region = memory;
@@ -288,15 +419,23 @@ Status TransportManager::RegisterMemory(const MemoryRegion& memory, MemoryHandle
 
     handle = reinterpret_cast<MemoryHandle>(record.get());
     memories_.emplace(handle, std::move(record));
+    UC_DEBUG("transport manager registered memory handle={} addr=0x{:x} length={}", handle, address,
+             memory.length);
     return Status::OK();
 }
 
 Status TransportManager::UnregisterMemory(MemoryHandle handle)
 {
-    if (handle == kInvalidMemoryHandle) { return Status::InvalidParam(); }
+    if (handle == kInvalidMemoryHandle) {
+        UC_ERROR("transport manager unregister memory invalid handle={}", handle);
+        return Status::InvalidParam();
+    }
 
     const auto it = memories_.find(handle);
-    if (it == memories_.end()) { return Status::Error(); }
+    if (it == memories_.end()) {
+        UC_ERROR("transport manager unregister memory unknown handle={}", handle);
+        return Status::Error();
+    }
 
     for (const auto& item : it->second->transport_handles) {
         const auto transport_it = protocol_map_.find(item.first);
@@ -313,21 +452,35 @@ Status TransportManager::UnregisterMemory(MemoryHandle handle)
         }
     }
     memories_.erase(it);
+    UC_DEBUG("transport manager unregistered memory handle={}", handle);
     return Status::OK();
 }
 
 Status TransportManager::FindTransport(Operation& batch, Transport*& transport)
 {
-    if (batch.target_manager.empty()) { return Status::InvalidParam(); }
+    if (batch.target_manager.empty()) {
+        UC_ERROR("transport manager select transport failed: target manager is empty");
+        return Status::InvalidParam();
+    }
     Endpoint endpoint;
     if (ParseManagerID(batch.target_manager, endpoint) != Status::OK()) {
+        UC_ERROR("transport manager select transport failed: invalid peer={}",
+                 batch.target_manager);
         return Status::InvalidParam();
     }
 
     TransportProtocol protocol = TransportProtocol::Hixl;
-    if (!TransportForDirect(batch.direct, protocol)) { return Status::Error(); }
+    if (!TransportForDirect(batch.direct, protocol)) {
+        UC_ERROR("transport manager select transport failed: unsupported direction={} peer={}",
+                 static_cast<uint32_t>(batch.direct), batch.target_manager);
+        return Status::Error();
+    }
     const auto transport_it = protocol_map_.find(protocol);
-    if (transport_it == protocol_map_.end()) { return Status::Error(); }
+    if (transport_it == protocol_map_.end()) {
+        UC_ERROR("transport manager select transport failed: protocol={} not installed peer={}",
+                 static_cast<uint32_t>(protocol), batch.target_manager);
+        return Status::Error();
+    }
     transport = transport_it->second;
     return Status::OK();
 }
@@ -346,16 +499,30 @@ Status TransportManager::ApplyConnectionLocally(ControlOperation operation,
                                                 TransportProtocol protocol,
                                                 const ManagerID& manager_id)
 {
+    UC_DEBUG("transport manager local {} begin protocol={} peer={}",
+             ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id);
     std::lock_guard<std::recursive_mutex> lock(peer_mutex_);
     if (shutting_down_ && operation == ControlOperation::Connect) { return Status::Error(); }
-
     Endpoint endpoint;
-    if (ParseManagerID(manager_id, endpoint) != Status::OK()) { return Status::InvalidParam(); }
+    if (ParseManagerID(manager_id, endpoint) != Status::OK()) {
+        UC_ERROR("transport manager local {} invalid peer={} protocol={}",
+                 ControlOperationName(operation), manager_id, static_cast<uint32_t>(protocol));
+        return Status::InvalidParam();
+    }
     const auto it = protocol_map_.find(protocol);
-    if (it == protocol_map_.end()) { return Status::InvalidParam(); }
+    if (it == protocol_map_.end()) {
+        UC_ERROR("transport manager local {} unavailable protocol={} peer={}",
+                 ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id);
+        return Status::InvalidParam();
+    }
     const auto status = operation == ControlOperation::Connect ? it->second->Connect(manager_id)
                                                                : it->second->Disconnect(manager_id);
-    if (status != Status::OK()) { return status; }
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager local {} failed protocol={} peer={} status={}",
+                 ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id,
+                 status.Underlying());
+        return status;
+    }
 
     const auto connection = std::make_pair(protocol, manager_id);
     if (operation == ControlOperation::Connect) {
@@ -363,6 +530,8 @@ Status TransportManager::ApplyConnectionLocally(ControlOperation operation,
     } else {
         connections_.erase(connection);
     }
+    UC_DEBUG("transport manager local {} completed protocol={} peer={}",
+             ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id);
     return Status::OK();
 }
 
@@ -370,16 +539,37 @@ Status TransportManager::CoordinateConnectionWithPeer(ControlOperation operation
                                                       TransportProtocol protocol,
                                                       const ManagerID& manager_id)
 {
+    UC_DEBUG("transport manager coordinate {} begin protocol={} peer={}",
+             ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id);
     Endpoint endpoint;
-    if (ParseManagerID(manager_id, endpoint) != Status::OK() || !control_) {
+    if (ParseManagerID(manager_id, endpoint) != Status::OK()) {
+        UC_ERROR("transport manager coordinate {} invalid peer={} protocol={}",
+                 ControlOperationName(operation), manager_id, static_cast<uint32_t>(protocol));
         return Status::InvalidParam();
     }
-    if (protocol_map_.find(protocol) == protocol_map_.end()) { return Status::InvalidParam(); }
+    if (!control_) {
+        UC_ERROR(
+            "transport manager coordinate {} failed: control channel is unavailable peer={} "
+            "protocol={}",
+            ControlOperationName(operation), manager_id, static_cast<uint32_t>(protocol));
+        return Status::InvalidParam();
+    }
+    if (protocol_map_.find(protocol) == protocol_map_.end()) {
+        UC_ERROR("transport manager coordinate {} unavailable protocol={} peer={}",
+                 ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id);
+        return Status::InvalidParam();
+    }
 
     Metadata request;
     auto status =
         EncodeControlRequest(ControlRequest{operation, protocol, manager_id_, {}}, request);
-    if (status != Status::OK()) { return status; }
+    if (status != Status::OK()) {
+        UC_ERROR(
+            "transport manager coordinate {} request encode failed protocol={} peer={} status={}",
+            ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id,
+            status.Underlying());
+        return status;
+    }
 
     const auto local_status = ApplyConnectionLocally(operation, protocol, manager_id);
     if (operation == ControlOperation::Connect && local_status != Status::OK()) {
@@ -389,6 +579,10 @@ Status TransportManager::CoordinateConnectionWithPeer(ControlOperation operation
     }
 
     Metadata ack;
+    UC_DEBUG(
+        "transport manager coordinate {} requesting peer ACK protocol={} peer={} local_status={}",
+        ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id,
+        local_status.Underlying());
     const auto remote_status = control_->Request(endpoint, request, ack);
     if (local_status != Status::OK() || remote_status != Status::OK()) {
         UC_ERROR("transport manager coordinated {} failed protocol={} peer={} local={} remote={}",
@@ -403,19 +597,33 @@ Status TransportManager::CoordinateConnectionWithPeer(ControlOperation operation
         }
         return local_status != Status::OK() ? local_status : remote_status;
     }
-    UC_INFO("transport manager coordinated {} success protocol={} peer={}",
-            operation == ControlOperation::Connect ? "connect" : "disconnect",
-            static_cast<uint32_t>(protocol), manager_id);
+    UC_DEBUG("transport manager coordinated {} success protocol={} peer={} ack_bytes={}",
+             ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id,
+             ack.size());
     return Status::OK();
 }
 
 Status TransportManager::ExecuteSync(const Operation& batch)
 {
+    UC_DEBUG("transport manager sync transfer begin peer={} segments={}", batch.target_manager,
+             batch.ops.size());
     Transport* transport = nullptr;
     auto request = batch;
     auto status = FindTransport(request, transport);
-    if (status != Status::OK()) { return status; }
-    return transport->ExecuteSync(request);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager sync transfer selection failed peer={} status={}",
+                 batch.target_manager, status.Underlying());
+        return status;
+    }
+    status = transport->ExecuteSync(request);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager sync transfer failed peer={} segments={} status={}",
+                 batch.target_manager, batch.ops.size(), status.Underlying());
+        return status;
+    }
+    UC_DEBUG("transport manager sync transfer completed peer={} segments={}", batch.target_manager,
+             batch.ops.size());
+    return Status::OK();
 }
 
 Status TransportManager::ExecuteAsync(const Operation& batch, TransferHandle& handle)
@@ -424,11 +632,19 @@ Status TransportManager::ExecuteAsync(const Operation& batch, TransferHandle& ha
     Transport* transport = nullptr;
     auto request = batch;
     auto status = FindTransport(request, transport);
-    if (status != Status::OK()) { return status; }
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager async transfer selection failed peer={} status={}",
+                 batch.target_manager, status.Underlying());
+        return status;
+    }
 
     TransferHandle transport_handle = kInvalidTransferHandle;
     status = transport->ExecuteAsync(request, transport_handle);
     if (status != Status::OK() || transport_handle == kInvalidTransferHandle) {
+        UC_ERROR(
+            "transport manager async transfer submit failed peer={} segments={} status={} "
+            "transport_handle={}",
+            batch.target_manager, batch.ops.size(), status.Underlying(), transport_handle);
         return status == Status::OK() ? Status::Error() : status;
     }
 
@@ -438,20 +654,39 @@ Status TransportManager::ExecuteAsync(const Operation& batch, TransferHandle& ha
         if (handle == kInvalidTransferHandle) { handle = next_transfer_handle_++; }
         transfers_.emplace(handle, TransferRecord{transport, transport_handle});
     }
+    UC_DEBUG(
+        "transport manager async transfer submitted peer={} segments={} handle={} "
+        "transport_handle={}",
+        batch.target_manager, batch.ops.size(), handle, transport_handle);
     return Status::OK();
 }
 
 Status TransportManager::GetStatus(TransferHandle handle, TransferStatus& transfer_status)
 {
-    if (handle == kInvalidTransferHandle) { return Status::InvalidParam(); }
+    if (handle == kInvalidTransferHandle) {
+        UC_ERROR("transport manager transfer status invalid handle={}", handle);
+        return Status::InvalidParam();
+    }
     TransferRecord record;
     {
         std::lock_guard<std::mutex> lock(transfers_mutex_);
         const auto it = transfers_.find(handle);
-        if (it == transfers_.end() || it->second.transport == nullptr) { return Status::Error(); }
+        if (it == transfers_.end() || it->second.transport == nullptr) {
+            UC_ERROR("transport manager transfer status unknown handle={}", handle);
+            return Status::Error();
+        }
         record = it->second;
     }
     const auto status = record.transport->GetStatus(record.transport_handle, transfer_status);
+    if (status != Status::OK()) {
+        UC_ERROR(
+            "transport manager transfer status query failed handle={} transport_handle={} "
+            "status={}",
+            handle, record.transport_handle, status.Underlying());
+    } else if (transfer_status != TransferStatus::Waiting) {
+        UC_DEBUG("transport manager transfer completed handle={} transport_handle={} status={}",
+                 handle, record.transport_handle, static_cast<uint32_t>(transfer_status));
+    }
     if (status != Status::OK() || transfer_status != TransferStatus::Waiting) {
         std::lock_guard<std::mutex> lock(transfers_mutex_);
         transfers_.erase(handle);
@@ -465,6 +700,7 @@ Status TransportManager::ParseManagerID(const ManagerID& manager_id, Endpoint& e
 {
     const auto separator = manager_id.rfind(':');
     if (separator == std::string::npos || separator == 0 || separator + 1 >= manager_id.size()) {
+        UC_ERROR("transport manager invalid manager id={}", manager_id);
         return Status::InvalidParam();
     }
 
@@ -475,11 +711,15 @@ Status TransportManager::ParseManagerID(const ManagerID& manager_id, Endpoint& e
         const auto port = std::stoul(port_text, &parsed, 10);
         if (parsed != port_text.size() || port == 0 ||
             port > std::numeric_limits<uint16_t>::max()) {
+            UC_ERROR("transport manager invalid manager port manager={} port={}", manager_id,
+                     port_text);
             return Status::InvalidParam();
         }
         endpoint = Endpoint{host, static_cast<uint16_t>(port)};
         return Status::OK();
-    } catch (const std::exception&) {
+    } catch (const std::exception& error) {
+        UC_ERROR("transport manager failed to parse manager id={} error={}", manager_id,
+                 error.what());
         return Status::InvalidParam();
     }
 }

--- a/ucm/transport/p2p/src/protocols/hixl/hixl_instance.cpp
+++ b/ucm/transport/p2p/src/protocols/hixl/hixl_instance.cpp
@@ -36,7 +36,11 @@ Status HixlInstance::Initialize(const std::map<std::string, std::string>& option
     std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        if (initialized_) { return Status::OK(); }
+        if (initialized_) {
+            UC_DEBUG("[Transport][HIXL] instance already initialized: engine={} device={}",
+                     local_endpoint_.ToString(), device_id_);
+            return Status::OK();
+        }
         stopping_ = false;
     }
     if (worker_.joinable()) { worker_.join(); }
@@ -55,7 +59,13 @@ Status HixlInstance::Run(Task task)
     auto result = queued.get_future();
     {
         std::lock_guard<std::mutex> lock(mutex_);
-        if (!initialized_ || stopping_) { return Status::Error(); }
+        if (!initialized_ || stopping_) {
+            UC_ERROR(
+                "[Transport][HIXL] reject worker task: engine={} device={} initialized={} "
+                "stopping={}",
+                local_endpoint_.ToString(), device_id_, initialized_, stopping_);
+            return Status::Error();
+        }
         tasks_.push_back(std::move(queued));
     }
     cv_.notify_one();
@@ -111,6 +121,8 @@ void HixlInstance::WorkerMain(std::map<std::string, std::string> options,
                 initialized_ = true;
             }
             initialize_result.set_value(Status::OK());
+            UC_DEBUG("[Transport][HIXL] instance initialized: engine={} device={}", local_engine,
+                     device_id_);
             ProcessTasks(engine);
             engine.Finalize();
         }
@@ -159,6 +171,11 @@ Status HixlInstance::RegisterMemory(const MemoryRegion& memory, hixl::MemHandle&
                 memory.length, static_cast<int>(native_status));
             return Status::Error();
         }
+        UC_DEBUG(
+            "[Transport][HIXL] memory registered: engine={} device={} addr=0x{:x} length={} "
+            "handle={}",
+            local_endpoint_.ToString(), device_id_, reinterpret_cast<uintptr_t>(memory.addr),
+            memory.length, native_handle);
         return Status::OK();
     });
     if (status == Status::OK()) { handle = native_handle; }
@@ -176,6 +193,8 @@ Status HixlInstance::UnregisterMemory(hixl::MemHandle handle)
                 local_endpoint_.ToString(), handle, static_cast<int>(native_status));
             return Status::Error();
         }
+        UC_DEBUG("[Transport][HIXL] memory unregistered: engine={} device={} handle={}",
+                 local_endpoint_.ToString(), device_id_, handle);
         return Status::OK();
     });
 }
@@ -191,6 +210,10 @@ Status HixlInstance::Connect(const std::string& remote_engine, int32_t timeout_m
                 local_endpoint_.ToString(), remote_engine, static_cast<int>(native_status));
             return Status::Error();
         }
+        UC_DEBUG(
+            "[Transport][HIXL] connection established: local_engine={} device={} "
+            "remote_engine={}",
+            local_endpoint_.ToString(), device_id_, remote_engine);
         return Status::OK();
     });
 }
@@ -200,10 +223,17 @@ Status HixlInstance::Disconnect(const std::string& remote_engine, int32_t timeou
     return Run([&](hixl::Hixl& engine) {
         const auto native_status = engine.Disconnect(remote_engine.c_str(), timeout_ms);
         if (native_status != hixl::SUCCESS) {
-            UC_WARN("[Transport][HIXL] disconnect returned: Disconnect(\"{}\") returned {}",
-                    remote_engine, static_cast<int>(native_status));
+            UC_ERROR(
+                "[Transport][HIXL] disconnect failed: local_engine={} device={} "
+                "remote_engine={} returned {}",
+                local_endpoint_.ToString(), device_id_, remote_engine,
+                static_cast<int>(native_status));
             return Status::Error();
         }
+        UC_DEBUG(
+            "[Transport][HIXL] connection disconnected: local_engine={} device={} "
+            "remote_engine={}",
+            local_endpoint_.ToString(), device_id_, remote_engine);
         return Status::OK();
     });
 }
@@ -223,6 +253,10 @@ Status HixlInstance::TransferSync(const std::string& remote_engine, Opcode opcod
                 remote_engine, descs.size(), timeout_ms, static_cast<int>(native_status));
             return Status::Error();
         }
+        UC_DEBUG(
+            "[Transport][HIXL] synchronous transfer completed: engine={} remote_engine={} "
+            "opcode={} segments={}",
+            local_endpoint_.ToString(), remote_engine, static_cast<int>(opcode), descs.size());
         return Status::OK();
     });
 }
@@ -244,6 +278,11 @@ Status HixlInstance::TransferAsync(const std::string& remote_engine, Opcode opco
                 remote_engine, descs.size(), static_cast<int>(native_status), native_request);
             return Status::Error();
         }
+        UC_DEBUG(
+            "[Transport][HIXL] asynchronous transfer submitted: engine={} remote_engine={} "
+            "opcode={} segments={} request={}",
+            local_endpoint_.ToString(), remote_engine, static_cast<int>(opcode), descs.size(),
+            native_request);
         return Status::OK();
     });
     if (status == Status::OK()) { request = native_request; }

--- a/ucm/transport/p2p/src/protocols/hixl/hixl_transport.cpp
+++ b/ucm/transport/p2p/src/protocols/hixl/hixl_transport.cpp
@@ -22,7 +22,10 @@ Status PickAvailablePort(const std::string& host, uint16_t& port)
     hints.ai_socktype = SOCK_STREAM;
 
     addrinfo* results = nullptr;
-    if (getaddrinfo(host.c_str(), "0", &hints, &results) != 0) { return Status::Error(); }
+    if (getaddrinfo(host.c_str(), "0", &hints, &results) != 0) {
+        UC_ERROR("[Transport][HIXL] resolve host for available port failed: host={}", host);
+        return Status::Error();
+    }
 
     Status status = Status::Error();
     for (auto* item = results; item != nullptr; item = item->ai_next) {
@@ -49,24 +52,32 @@ Status PickAvailablePort(const std::string& host, uint16_t& port)
     }
 
     freeaddrinfo(results);
+    if (status != Status::OK()) {
+        UC_ERROR("[Transport][HIXL] no available port found: host={}", host);
+    }
     return status;
 }
 
 Status EncodeMetadata(HixlRole role, const std::vector<HixlInstanceInfo>& instances, Metadata& out)
 {
     if (instances.empty() || instances.size() > std::numeric_limits<uint32_t>::max()) {
+        UC_ERROR("[Transport][HIXL] encode metadata failed: instances={}", instances.size());
         return Status::InvalidParam();
     }
 
     out.clear();
     if (!detail::AppendU8(out, static_cast<uint8_t>(role)) ||
         !detail::AppendU32(out, static_cast<uint32_t>(instances.size()))) {
+        UC_ERROR("[Transport][HIXL] encode metadata header failed: role={} instances={}",
+                 static_cast<uint32_t>(role), instances.size());
         return Status::InvalidParam();
     }
     for (const auto& instance : instances) {
         if (instance.device_id < 0 || !detail::AppendString(out, instance.endpoint.host) ||
             !detail::AppendU16(out, instance.endpoint.port) ||
             !detail::AppendU32(out, static_cast<uint32_t>(instance.device_id))) {
+            UC_ERROR("[Transport][HIXL] encode instance metadata failed: engine={} device={}",
+                     instance.endpoint.ToString(), instance.device_id);
             return Status::InvalidParam();
         }
     }
@@ -81,6 +92,7 @@ Status DecodeMetadata(const Metadata& in, HixlRole& role, std::vector<HixlInstan
     if (!detail::ReadU8(in, offset, raw_role) ||
         raw_role > static_cast<uint8_t>(HixlRole::Bidirectional) ||
         !detail::ReadU32(in, offset, count) || count == 0) {
+        UC_ERROR("[Transport][HIXL] decode metadata header failed: bytes={}", in.size());
         return Status::InvalidParam();
     }
     role = static_cast<HixlRole>(raw_role);
@@ -94,12 +106,19 @@ Status DecodeMetadata(const Metadata& in, HixlRole& role, std::vector<HixlInstan
             !detail::ReadU16(in, offset, instance.endpoint.port) ||
             !detail::ReadU32(in, offset, device_id) ||
             device_id > static_cast<uint32_t>(std::numeric_limits<int32_t>::max())) {
+            UC_ERROR("[Transport][HIXL] decode instance metadata failed: index={} bytes={}", i,
+                     in.size());
             return Status::InvalidParam();
         }
         instance.device_id = static_cast<int32_t>(device_id);
         instances.push_back(std::move(instance));
     }
-    return offset == in.size() ? Status::OK() : Status::InvalidParam();
+    if (offset != in.size()) {
+        UC_ERROR("[Transport][HIXL] decode metadata has trailing bytes: consumed={} total={}",
+                 offset, in.size());
+        return Status::InvalidParam();
+    }
+    return Status::OK();
 }
 
 }  // namespace
@@ -116,13 +135,31 @@ TransportProtocol HixlTransport::Protocol() const { return TransportProtocol::Hi
 Status HixlTransport::Init(const InitAttrs& attrs)
 {
     const auto* hixl_attrs = dynamic_cast<const HixlInitAttrs*>(&attrs);
-    return hixl_attrs == nullptr ? Status::InvalidParam() : Init(*hixl_attrs);
+    if (hixl_attrs == nullptr) {
+        UC_ERROR("[Transport][HIXL] init failed: invalid attribute type");
+        return Status::InvalidParam();
+    }
+    return Init(*hixl_attrs);
 }
 
 Status HixlTransport::Init(const HixlInitAttrs& attrs)
 {
-    if (!instances_.empty()) { return Status::OK(); }
-    if (attrs.instances.empty()) { return Status::InvalidParam(); }
+    if (!instances_.empty()) {
+        UC_DEBUG("[Transport][HIXL] transport already initialized: instances={}",
+                 instances_.size());
+        return Status::OK();
+    }
+    if (attrs.instances.empty()) {
+        UC_ERROR("[Transport][HIXL] init failed: no instances configured");
+        return Status::InvalidParam();
+    }
+    if (attrs.role != HixlRole::Client && attrs.instances.size() > 1) {
+        UC_ERROR(
+            "[Transport][HIXL] only Client role supports multiple instances: role={} "
+            "instances={}",
+            static_cast<uint32_t>(attrs.role), attrs.instances.size());
+        return Status::InvalidParam();
+    }
 
     for (size_t i = 0; i < attrs.instances.size(); ++i) {
         const auto& instance_attrs = attrs.instances[i];
@@ -160,13 +197,15 @@ Status HixlTransport::Init(const HixlInitAttrs& attrs)
     for (size_t i = 0; i < instances_.size(); ++i) {
         const auto status = instances_[i]->Initialize(attrs.instances[i].options);
         if (status != Status::OK()) {
+            UC_ERROR("[Transport][HIXL] instance init failed: instance={} device={} status={}", i,
+                     attrs.instances[i].device_id, status);
             for (auto& instance : instances_) { instance->Finalize(); }
             instances_.clear();
             return status;
         }
     }
-    UC_INFO("[Transport][HIXL] init success role={} instances={}", static_cast<uint32_t>(role_),
-            instances_.size());
+    UC_DEBUG("[Transport][HIXL] init success role={} instances={}", static_cast<uint32_t>(role_),
+             instances_.size());
     return Status::OK();
 }
 
@@ -203,7 +242,10 @@ Status HixlTransport::RegisterMemory(const MemoryRegion& memory, MemoryHandle& h
 {
     std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
     handle = kInvalidMemoryHandle;
-    if (instances_.empty()) { return Status::Error(); }
+    if (instances_.empty()) {
+        UC_ERROR("[Transport][HIXL] register memory failed: transport is not initialized");
+        return Status::Error();
+    }
 
     std::unique_lock<std::shared_mutex> memory_lock(memories_mutex_);
 
@@ -231,29 +273,47 @@ Status HixlTransport::RegisterMemory(const MemoryRegion& memory, MemoryHandle& h
         record->native_handles.emplace(i, native_handle);
     }
 
-    if (record->native_handles.empty()) { return Status::InvalidParam(); }
+    if (record->native_handles.empty()) {
+        UC_ERROR(
+            "[Transport][HIXL] register memory failed: no matching instance, type={} device={}",
+            static_cast<int>(memory.type), memory.device_id);
+        return Status::InvalidParam();
+    }
     handle = reinterpret_cast<MemoryHandle>(record.get());
     memories_.emplace(handle, std::move(record));
+    UC_DEBUG("[Transport][HIXL] memory registration completed: handle={} addr={} length={}", handle,
+             memory.addr, memory.length);
     return Status::OK();
 }
 
 Status HixlTransport::UnregisterMemory(MemoryHandle handle)
 {
     std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
-    if (handle == kInvalidMemoryHandle) { return Status::InvalidParam(); }
+    if (handle == kInvalidMemoryHandle) {
+        UC_ERROR("[Transport][HIXL] unregister memory failed: invalid handle");
+        return Status::InvalidParam();
+    }
 
     std::unique_lock<std::shared_mutex> memory_lock(memories_mutex_);
     const auto record_it = memories_.find(handle);
-    if (record_it == memories_.end()) { return Status::Error(); }
+    if (record_it == memories_.end()) {
+        UC_ERROR("[Transport][HIXL] unregister memory failed: unknown handle={}", handle);
+        return Status::Error();
+    }
     auto& record = *record_it->second;
     while (!record.native_handles.empty()) {
         const auto item = *record.native_handles.begin();
-        if (item.first >= instances_.size() || item.second == nullptr) { return Status::Error(); }
+        if (item.first >= instances_.size() || item.second == nullptr) {
+            UC_ERROR("[Transport][HIXL] unregister memory failed: handle={} instance={} native={}",
+                     handle, item.first, item.second);
+            return Status::Error();
+        }
         const auto status = instances_[item.first]->UnregisterMemory(item.second);
         if (status != Status::OK()) { return status; }
         record.native_handles.erase(item.first);
     }
     memories_.erase(record_it);
+    UC_DEBUG("[Transport][HIXL] memory unregistration completed: handle={}", handle);
     return Status::OK();
 }
 
@@ -274,7 +334,10 @@ Status HixlTransport::ImportMetadata(const ManagerID& manager_id, const Metadata
     std::vector<HixlInstanceInfo> remote_instances;
     HixlRole remote_role = HixlRole::Bidirectional;
     const auto status = DecodeMetadata(metadata, remote_role, remote_instances);
-    if (status != Status::OK()) { return status; }
+    if (status != Status::OK()) {
+        UC_ERROR("[Transport][HIXL] import metadata failed: peer={} status={}", manager_id, status);
+        return status;
+    }
 
     {
         std::unique_lock<std::shared_mutex> peer_lock(peers_mutex_);
@@ -316,18 +379,39 @@ Status HixlTransport::BuildRouteLocked(const ManagerID& manager_id, Peer& peer)
         return Status::InvalidParam();
     }
 
+    const auto& remote = peer.instances.front();
+    const bool initiates_connection = role_ != HixlRole::Server && peer.role != HixlRole::Client;
     const auto local_count = instances_.size();
+    if (local_count == 1) {
+        if (initiates_connection && peer.instances.size() == 1 &&
+            instances_.front()->LocalEndpoint().host == remote.endpoint.host &&
+            instances_.front()->DeviceId() == remote.device_id) {
+            UC_ERROR(
+                "[Transport][HIXL] build route failed: local and remote single instances use "
+                "the same device, endpoint={} device={}",
+                remote.endpoint.ToString(), remote.device_id);
+            return Status::Error();
+        }
+        peer.local_index = 0;
+        UC_DEBUG(
+            "[Transport][HIXL] build route peer={} local_instance=0 local_engine={} "
+            "local_device={} remote_engine={} remote_device={}",
+            manager_id, instances_.front()->LocalEndpoint().ToString(),
+            instances_.front()->DeviceId(), remote.endpoint.ToString(), remote.device_id);
+        return Status::OK();
+    }
+
     std::vector<size_t> load(local_count, 0);
     for (const auto& item : peers_) {
         if (item.first == manager_id) { continue; }
         if (item.second.local_index < load.size()) { ++load[item.second.local_index]; }
     }
 
-    const auto& remote = peer.instances.front();
     std::vector<size_t> candidates;
     size_t min_load = std::numeric_limits<size_t>::max();
     for (size_t local_index = 0; local_index < local_count; ++local_index) {
-        if (instances_[local_index]->LocalEndpoint().host == remote.endpoint.host &&
+        if (initiates_connection &&
+            instances_[local_index]->LocalEndpoint().host == remote.endpoint.host &&
             instances_[local_index]->DeviceId() == remote.device_id) {
             continue;
         }
@@ -357,7 +441,13 @@ Status HixlTransport::BuildRouteLocked(const ManagerID& manager_id, Peer& peer)
 
 Status HixlTransport::DisconnectRoute(const Peer& peer, bool ignore_failure)
 {
-    if (peer.local_index >= instances_.size() || peer.instances.empty()) { return Status::Error(); }
+    if (peer.local_index >= instances_.size() || peer.instances.empty()) {
+        UC_ERROR(
+            "[Transport][HIXL] disconnect route failed: local_instance={} local_count={} "
+            "remote_count={}",
+            peer.local_index, instances_.size(), peer.instances.size());
+        return Status::Error();
+    }
     if (role_ == HixlRole::Server || peer.role == HixlRole::Client) { return Status::OK(); }
 
     const auto remote_engine = peer.instances.front().endpoint.ToString();
@@ -371,11 +461,24 @@ Status HixlTransport::Connect(const ManagerID& manager_id)
     std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
     std::unique_lock<std::shared_mutex> peer_lock(peers_mutex_);
     const auto peer_it = peers_.find(manager_id);
-    if (peer_it == peers_.end()) { return Status::Error(); }
+    if (peer_it == peers_.end()) {
+        UC_ERROR("[Transport][HIXL] connect failed: unknown peer={}", manager_id);
+        return Status::Error();
+    }
     auto& peer = peer_it->second;
-    if (peer.local_index == SIZE_MAX || peer.instances.empty()) { return Status::Error(); }
-    if (peer.connected) { return Status::OK(); }
-    if (peer.local_index >= instances_.size()) { return Status::Error(); }
+    if (peer.local_index == SIZE_MAX || peer.instances.empty()) {
+        UC_ERROR("[Transport][HIXL] connect failed: peer={} has no route", manager_id);
+        return Status::Error();
+    }
+    if (peer.connected) {
+        UC_DEBUG("[Transport][HIXL] connect skipped: peer={} already connected", manager_id);
+        return Status::OK();
+    }
+    if (peer.local_index >= instances_.size()) {
+        UC_ERROR("[Transport][HIXL] connect failed: peer={} local_instance={} local_count={}",
+                 manager_id, peer.local_index, instances_.size());
+        return Status::Error();
+    }
 
     if (role_ == peer.role && role_ != HixlRole::Bidirectional) {
         UC_ERROR("[Transport][HIXL] incompatible roles: local={} remote={} peer={}",
@@ -391,6 +494,8 @@ Status HixlTransport::Connect(const ManagerID& manager_id)
     }
 
     peer.connected = true;
+    UC_DEBUG("[Transport][HIXL] connect completed: peer={} local_instance={} remote_engine={}",
+             manager_id, peer.local_index, remote_engine);
     return Status::OK();
 }
 
@@ -399,23 +504,41 @@ Status HixlTransport::Disconnect(const ManagerID& manager_id)
     std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
     std::unique_lock<std::shared_mutex> peer_lock(peers_mutex_);
     const auto peer_it = peers_.find(manager_id);
-    if (peer_it == peers_.end()) { return Status::Error(); }
+    if (peer_it == peers_.end()) {
+        UC_ERROR("[Transport][HIXL] disconnect failed: unknown peer={}", manager_id);
+        return Status::Error();
+    }
     auto& peer = peer_it->second;
-    if (!peer.connected) { return Status::OK(); }
-    if (peer.local_index >= instances_.size() || peer.instances.empty()) { return Status::Error(); }
+    if (!peer.connected) {
+        UC_DEBUG("[Transport][HIXL] disconnect skipped: peer={} is not connected", manager_id);
+        return Status::OK();
+    }
+    if (peer.local_index >= instances_.size() || peer.instances.empty()) {
+        UC_ERROR("[Transport][HIXL] disconnect failed: peer={} has invalid route", manager_id);
+        return Status::Error();
+    }
 
     const auto status = DisconnectRoute(peer, false);
     peer.connected = false;
+    if (status == Status::OK()) {
+        UC_DEBUG("[Transport][HIXL] disconnect completed: peer={}", manager_id);
+    }
     return status;
 }
 
 Status HixlTransport::ValidateTransferLocked(const Operation& batch, size_t instance_index) const
 {
     if (batch.target_manager.empty() || batch.ops.empty() || instance_index >= instances_.size()) {
+        UC_ERROR("[Transport][HIXL] invalid transfer: peer={} segments={} instance={} instances={}",
+                 batch.target_manager, batch.ops.size(), instance_index, instances_.size());
         return Status::InvalidParam();
     }
     for (const auto& item : batch.ops) {
         if (item.local_addr == nullptr || item.length == 0 || item.remote_addr == 0) {
+            UC_ERROR(
+                "[Transport][HIXL] invalid transfer segment: local_addr={} remote_addr={} "
+                "length={}",
+                item.local_addr, item.remote_addr, item.length);
             return Status::InvalidParam();
         }
 
@@ -434,7 +557,13 @@ Status HixlTransport::ValidateTransferLocked(const Operation& batch, size_t inst
                 break;
             }
         }
-        if (!registered) { return Status::InvalidParam(); }
+        if (!registered) {
+            UC_ERROR(
+                "[Transport][HIXL] transfer memory is not registered: local_addr={} length={} "
+                "instance={}",
+                item.local_addr, item.length, instance_index);
+            return Status::InvalidParam();
+        }
     }
     return Status::OK();
 }
@@ -451,10 +580,19 @@ Status HixlTransport::ExecuteSync(const Operation& batch)
     {
         std::shared_lock<std::shared_mutex> peer_lock(peers_mutex_);
         const auto peer_it = peers_.find(batch.target_manager);
-        if (peer_it == peers_.end()) { return Status::Error(); }
+        if (peer_it == peers_.end()) {
+            UC_ERROR("[Transport][HIXL] synchronous transfer failed: unknown peer={}",
+                     batch.target_manager);
+            return Status::Error();
+        }
         const auto& peer_state = peer_it->second;
         if (peer_state.local_index >= instances_.size() || peer_state.instances.empty() ||
             !peer_state.connected) {
+            UC_ERROR(
+                "[Transport][HIXL] synchronous transfer failed: peer={} connected={} "
+                "local_instance={} local_count={} remote_count={}",
+                batch.target_manager, peer_state.connected, peer_state.local_index,
+                instances_.size(), peer_state.instances.size());
             return Status::Error();
         }
         local_index = peer_state.local_index;
@@ -464,9 +602,15 @@ Status HixlTransport::ExecuteSync(const Operation& batch)
     {
         std::shared_lock<std::shared_mutex> memory_lock(memories_mutex_);
         const auto transfer_status = ValidateTransferLocked(batch, local_index);
-        if (transfer_status != Status::OK()) { return transfer_status; }
+        if (transfer_status != Status::OK()) {
+            UC_ERROR("[Transport][HIXL] synchronous transfer validation failed: peer={} status={}",
+                     batch.target_manager, transfer_status);
+            return transfer_status;
+        }
     }
 
+    UC_DEBUG("[Transport][HIXL] synchronous transfer started: peer={} opcode={} segments={}",
+             batch.target_manager, static_cast<int>(batch.opcode), batch.ops.size());
     return instances_[local_index]->TransferSync(remote_engine, batch.opcode, batch.ops,
                                                  transfer_timeout_ms_);
 }
@@ -484,10 +628,19 @@ Status HixlTransport::ExecuteAsync(const Operation& batch, TransferHandle& handl
     {
         std::shared_lock<std::shared_mutex> peer_lock(peers_mutex_);
         const auto peer_it = peers_.find(batch.target_manager);
-        if (peer_it == peers_.end()) { return Status::Error(); }
+        if (peer_it == peers_.end()) {
+            UC_ERROR("[Transport][HIXL] asynchronous transfer failed: unknown peer={}",
+                     batch.target_manager);
+            return Status::Error();
+        }
         const auto& peer_state = peer_it->second;
         if (peer_state.local_index >= instances_.size() || peer_state.instances.empty() ||
             !peer_state.connected) {
+            UC_ERROR(
+                "[Transport][HIXL] asynchronous transfer failed: peer={} connected={} "
+                "local_instance={} local_count={} remote_count={}",
+                batch.target_manager, peer_state.connected, peer_state.local_index,
+                instances_.size(), peer_state.instances.size());
             return Status::Error();
         }
         local_index = peer_state.local_index;
@@ -497,13 +650,21 @@ Status HixlTransport::ExecuteAsync(const Operation& batch, TransferHandle& handl
     {
         std::shared_lock<std::shared_mutex> memory_lock(memories_mutex_);
         const auto transfer_status = ValidateTransferLocked(batch, local_index);
-        if (transfer_status != Status::OK()) { return transfer_status; }
+        if (transfer_status != Status::OK()) {
+            UC_ERROR("[Transport][HIXL] asynchronous transfer validation failed: peer={} status={}",
+                     batch.target_manager, transfer_status);
+            return transfer_status;
+        }
     }
 
     hixl::TransferReq request = nullptr;
     const auto status =
         instances_[local_index]->TransferAsync(remote_engine, batch.opcode, batch.ops, request);
-    if (status != Status::OK()) { return status; }
+    if (status != Status::OK()) {
+        UC_ERROR("[Transport][HIXL] asynchronous transfer submission failed: peer={} status={}",
+                 batch.target_manager, status);
+        return status;
+    }
 
     {
         std::lock_guard<std::mutex> pending_lock(pending_mutex_);
@@ -511,19 +672,29 @@ Status HixlTransport::ExecuteAsync(const Operation& batch, TransferHandle& handl
         if (handle == kInvalidTransferHandle) { handle = next_transfer_handle_++; }
         pending_transfers_.emplace(handle, PendingTransfer{local_index, request});
     }
+    UC_DEBUG(
+        "[Transport][HIXL] asynchronous transfer tracked: peer={} opcode={} segments={} "
+        "instance={} handle={} request={}",
+        batch.target_manager, static_cast<int>(batch.opcode), batch.ops.size(), local_index, handle,
+        request);
     return Status::OK();
 }
 
 Status HixlTransport::GetStatus(TransferHandle handle, TransferStatus& status)
 {
     status = TransferStatus::Failed;
-    if (handle == kInvalidTransferHandle) { return Status::InvalidParam(); }
+    if (handle == kInvalidTransferHandle) {
+        UC_ERROR("[Transport][HIXL] get status failed: invalid handle");
+        return Status::InvalidParam();
+    }
     std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
     PendingTransfer pending;
     {
         std::lock_guard<std::mutex> pending_lock(pending_mutex_);
         const auto it = pending_transfers_.find(handle);
         if (it == pending_transfers_.end() || it->second.instance_index >= instances_.size()) {
+            UC_ERROR("[Transport][HIXL] get status failed: unknown handle={} instances={}", handle,
+                     instances_.size());
             return Status::Error();
         }
         pending = it->second;
@@ -535,12 +706,16 @@ Status HixlTransport::GetStatus(TransferHandle handle, TransferStatus& status)
     if (query_status != Status::OK()) {
         std::lock_guard<std::mutex> pending_lock(pending_mutex_);
         pending_transfers_.erase(handle);
+        UC_ERROR("[Transport][HIXL] get status query failed: handle={} request={} status={}",
+                 handle, pending.request, query_status);
         return query_status;
     }
     status = transfer_status;
     if (status != TransferStatus::Waiting) {
         std::lock_guard<std::mutex> pending_lock(pending_mutex_);
         pending_transfers_.erase(handle);
+        UC_DEBUG("[Transport][HIXL] asynchronous transfer completed: handle={} status={}", handle,
+                 static_cast<int>(status));
     }
     return Status::OK();
 }


### PR DESCRIPTION
## Changes

- `82383b2e fix(dram): isolate worker transport ports`
  - Offsets each DramStore worker’s TCP control and TransportManager ports by `device_id + 1`.
  - Adds configuration tests for scheduler and worker port allocation.

- `ed91538d chore(p2p): add transport logs`
  - Adds detailed error and debug logs for the control channel, TransportManager, HIXL instances, routing, memory registration, connection lifecycle, and transfers.

- `59fc09cd feat(dram): configure HIXL listen port from environment`
  - Adds `HIXL_LISTEN_PORT` support for DramPool and DramStore.
  - Uses default ports `26666` for DramPool and `36666` for DramStore.
  - Applies a worker port offset to avoid conflicts between multiple Store processes.

- `16ae0123 feat(dram): enable HIXLCS from environment`
  - Adds the `UCM_ENABLE_HIXLCS` environment switch.
  - Configures `LocalCommRes={"version":"1.3"}` for Pool and Store HIXL instances when set to `1`.

- `2a16eea1 test(dram): add DramPool e2e runner`
  - Adds an executable E2E script for launching DramPool and running offline inference.

- `a19420aa fix(dram): resolve P2P transport at runtime`
  - Extends the DramStore RPATH to locate `libucm_p2p_transport.so` in both build and installation directory layouts.