### PR TITLE
[Fix] resolve GLM‑5.2 layout issue on vllm‑ascend (>0.23.0rc1)

### DIFF
--- a/test/suites/Unit/test_kv_cache_layout.py
+++ b/test/suites/Unit/test_kv_cache_layout.py
@@ -338,30 +338,60 @@ class KVCacheLayoutTest(unittest.TestCase):
 
         self.assertTrue(supported)
 
-    def test_cuda_tensor_role_pattern_mapping_is_extensible(self):
-        class ExtendedCUDAKVCacheLayout(SharedIndexerKVCacheLayout):
-            CUDA_TENSOR_ROLE_PATTERNS = {
-                "indexer": (
-                    *SharedIndexerKVCacheLayout.CUDA_TENSOR_ROLE_PATTERNS["indexer"],
-                    re.compile(
-                        r"(?:^|\.)selector\.cache(?:\.|$)",
-                        re.IGNORECASE,
-                    ),
-                ),
-            }
-
+    def test_tensor_role_mapping(self):
         self.assertEqual(
-            SharedIndexerKVCacheLayout._cuda_cache_role(
+            SharedIndexerKVCacheLayout._cache_role(
                 "model.layers.0.self_attn.indexer.k_cache"
             ),
             "indexer",
         )
         self.assertEqual(
-            SharedIndexerKVCacheLayout._cuda_cache_role(
-                "model.layers.0.self_attn.attn"
-            ),
+            SharedIndexerKVCacheLayout._cache_role("model.layers.0.self_attn.attn"),
             "attention",
         )
+
+    def test_ascend_separate_indexer_uses_semantic_order(self):
+        indexer = FakeTensor(0x100000, 32768)
+        attention_0 = (
+            FakeTensor(0x200000, 131072),
+            FakeTensor(0x300000, 16384),
+        )
+        attention_1 = (
+            FakeTensor(0x400000, 131072),
+            FakeTensor(0x500000, 16384),
+        )
+        kvcaches = {
+            "model.layers.0.self_attn.indexer.k_cache": (indexer,),
+            "model.layers.0.self_attn": attention_0,
+            "model.layers.1.self_attn": attention_1,
+        }
+        vllm_config = SimpleNamespace(
+            additional_config={},
+            parallel_config=SimpleNamespace(pipeline_parallel_size=1),
+            model_config=SimpleNamespace(
+                hf_text_config=SimpleNamespace(num_hidden_layers=2),
+                hf_config=SimpleNamespace(
+                    text_config=SimpleNamespace(indexer_types=["full", "shared"])
+                ),
+            ),
+        )
+
+        self.assertTrue(
+            SharedIndexerKVCacheLayout.supports(vllm_config, {"use_layerwise": True})
+        )
+        layout = SharedIndexerKVCacheLayout(
+            kvcaches,
+            {"use_layerwise": True},
+            vllm_config,
+            SimpleNamespace(num_blocks=2),
+        )
+
+        self.assertEqual(layout.tensor_size_list, [131072, 16384, 32768])
+        self.assertEqual(
+            layout.base_ptrs[0].tolist(),
+            [0x200000, 0x300000, 0x100000],
+        )
+        self.assertEqual(layout.base_ptrs[1, 2], 0)
 
     def test_cuda_shared_indexer_uses_semantic_order_and_padding(self):
         layer_2_indexer = "model.layers.2.router.indexer.cache_storage"

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -77,14 +77,19 @@ logger = init_logger(__name__)
 
 def _has_shared_indexer_layers(vllm_config: "VllmConfig") -> bool:
     model_config = getattr(vllm_config, "model_config", None)
-    hf_text_config = getattr(model_config, "hf_text_config", None)
-    indexer_types = getattr(hf_text_config, "indexer_types", None)
-    if not isinstance(indexer_types, (list, tuple)):
-        return False
-    return any(
-        isinstance(indexer_type, str) and indexer_type.lower() == "shared"
-        for indexer_type in indexer_types
+    configs = (
+        getattr(model_config, "hf_text_config", None),
+        getattr(model_config, "hf_config", None),
+        getattr(getattr(model_config, "hf_config", None), "text_config", None),
     )
+    for config in configs:
+        indexer_types = getattr(config, "indexer_types", None)
+        if isinstance(indexer_types, (list, tuple)) and any(
+            isinstance(indexer_type, str) and indexer_type.lower() == "shared"
+            for indexer_type in indexer_types
+        ):
+            return True
+    return False
 
 
 def _short_list(values: list[int], limit: int = 12) -> list[int]:
@@ -346,57 +351,67 @@ class KVCacheLayout:
         self.num_blocks = self.kv_cache_config.num_blocks
         self._build_layout(kvcaches)
 
+    @staticmethod
+    def _tensor_infos(
+        layer_name: str,
+        kv_layer,
+        _role: str | None = None,
+    ) -> tuple[KVCacheTensorInfo, ...]:
+        """Describe tensor components in one vLLM KV-cache entry."""
+        tensor_infos = []
+
+        def handle_tensor(tensor: torch.Tensor, size_dims) -> None:
+            bytes_per_block = math.prod(
+                int(tensor.shape[dim]) for dim in size_dims
+            ) * int(tensor.element_size())
+            tensor_infos.append(
+                KVCacheTensorInfo(
+                    ptr=int(tensor[0].data_ptr()),
+                    bytes_per_block=bytes_per_block,
+                    buffer_size=int(tensor.shape[0]) * bytes_per_block,
+                )
+            )
+
+        if isinstance(kv_layer, torch.Tensor):
+            if kv_layer.dim() == 5:
+                num_blocks_first = kv_layer.shape[0] != 2 and kv_layer.shape[1] == 2
+                if num_blocks_first:
+                    handle_tensor(kv_layer, (-4, -3, -2, -1))
+                elif kv_layer.shape[0] == 2:
+                    handle_tensor(kv_layer[0], (-3, -2, -1))
+                    handle_tensor(kv_layer[1], (-3, -2, -1))
+                else:
+                    raise ValueError(
+                        "Unsupported 5D KV cache layout: expected "
+                        "[num_blocks, 2, ...] or [2, num_blocks, ...], "
+                        f"layer={layer_name}, shape={tuple(kv_layer.shape)}."
+                    )
+            elif kv_layer.dim() == 3:
+                handle_tensor(kv_layer, (-2, -1))
+            else:
+                raise ValueError(
+                    "Unsupported KV cache tensor shape: "
+                    f"layer={layer_name}, shape={tuple(kv_layer.shape)}."
+                )
+        elif isinstance(kv_layer, Tuple):
+            for tensor in kv_layer:
+                handle_tensor(tensor, (-3, -2, -1))
+        else:
+            raise TypeError(
+                f"Unsupported KV cache type: layer={layer_name}, "
+                f"type={type(kv_layer)}."
+            )
+        return tuple(tensor_infos)
+
     def _collect_tensor_rows(self, kvcaches):
         num_rows = len(set(self.layer_name_to_id.values()))
         tensor_rows = [[] for _ in range(num_rows)]
         row_layer_ids = [None for _ in range(num_rows)]
 
         for layer_name, kv_layer in kvcaches.items():
-
-            def handle_tensor(t: torch.Tensor, size_dims):
-                stride = math.prod([t.shape[i] for i in size_dims]) * t.element_size()
-                tensor_rows[local_layer_id].append(
-                    KVCacheTensorInfo(
-                        ptr=int(t[0].data_ptr()),
-                        bytes_per_block=int(stride),
-                        buffer_size=int(t.shape[0]) * int(stride),
-                    )
-                )
-
             local_layer_id = self.layer_name_to_id[layer_name] - self.first_layer_id
             row_layer_ids[local_layer_id] = self.layer_name_to_id[layer_name]
-            if isinstance(kv_layer, torch.Tensor):
-                if kv_layer.dim() == 5:
-                    num_blocks_first = kv_layer.shape[0] != 2 and kv_layer.shape[1] == 2
-                    if num_blocks_first:
-                        # CUDA: [num_blocks, 2, block_size, num_head, head_dim].
-                        # K and V are contiguous within each block, so expose
-                        # the complete block as one store segment.
-                        handle_tensor(kv_layer, (-4, -3, -2, -1))
-                    elif kv_layer.shape[0] == 2:
-                        # [2, num_blocks, block_size, num_head, head_dim].
-                        # K and V are stored in separate contiguous buffers.
-                        handle_tensor(kv_layer[0], (-3, -2, -1))
-                        handle_tensor(kv_layer[1], (-3, -2, -1))
-                    else:
-                        raise ValueError(
-                            "Unsupported 5D KV cache layout: expected "
-                            "[num_blocks, 2, ...] or [2, num_blocks, ...] "
-                            f"but got {tuple(kv_layer.shape)}"
-                        )
-                elif kv_layer.dim() == 3:
-                    # [num_blocks, block_size, head_dim]
-                    handle_tensor(kv_layer, (-2, -1))
-                else:
-                    raise ValueError(
-                        f"Unsupported kv cache tensor shape: {kv_layer.shape}"
-                    )
-            elif isinstance(kv_layer, Tuple):
-                # vllm_ascend >= 0.10.0, ([num_blocks, block_size, num_head, head_dim], ...)
-                for tensor in kv_layer:
-                    handle_tensor(tensor, (-3, -2, -1))
-            else:
-                raise TypeError(f"Unsupported kv cache type: {type(kv_layer)}")
+            tensor_rows[local_layer_id].extend(self._tensor_infos(layer_name, kv_layer))
 
         return tensor_rows, row_layer_ids
 
@@ -522,7 +537,7 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
     mask behavior to the generic KV cache layout.
     """
 
-    CUDA_TENSOR_ROLE_PATTERNS = {
+    TENSOR_ROLE_PATTERNS = {
         "indexer": (
             re.compile(
                 r"(?:^|\.)indexer(?:\.|$)",
@@ -530,7 +545,7 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
             ),
         ),
     }
-    CUDA_DEFAULT_TENSOR_ROLE = "attention"
+    DEFAULT_TENSOR_ROLE = "attention"
 
     @classmethod
     def supports(cls, vllm_config: "VllmConfig", ucm_config: dict) -> bool:
@@ -594,8 +609,8 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
         return "shared"
 
     @classmethod
-    def _cuda_cache_role(cls, layer_name: str) -> str:
-        """Classify a CUDA cache using the extensible role-pattern mapping."""
+    def _cache_role(cls, layer_name: str) -> str:
+        """Classify an attention or Indexer cache independently of platform."""
         path_components = [
             component for component in layer_name.lower().split(".") if component
         ]
@@ -604,10 +619,29 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
                 path_components = path_components[index + 2 :]
                 break
         semantic_name = ".".join(path_components)
-        for role, patterns in cls.CUDA_TENSOR_ROLE_PATTERNS.items():
+        for role, patterns in cls.TENSOR_ROLE_PATTERNS.items():
             if any(pattern.search(semantic_name) for pattern in patterns):
                 return role
-        return cls.CUDA_DEFAULT_TENSOR_ROLE
+        return cls.DEFAULT_TENSOR_ROLE
+
+    def _collect_role_tensors(self, kvcaches, tensor_infos):
+        """Group cache entries by layer and semantic role."""
+        layer_tensors: dict[int, dict[str, Optional[tuple[KVCacheTensorInfo, ...]]]] = (
+            {}
+        )
+        for layer_name, kv_layer in kvcaches.items():
+            layer_id = self.layer_name_to_id[layer_name]
+            layer = layer_tensors.setdefault(
+                layer_id, {"attention": None, "indexer": None}
+            )
+            slot = self._cache_role(layer_name)
+            if layer[slot] is not None:
+                raise ValueError(
+                    f"Duplicate Shared Indexer {slot} cache for "
+                    f"layer {layer_id}: {layer_name}."
+                )
+            layer[slot] = tensor_infos(layer_name, kv_layer, slot)
+        return layer_tensors
 
     @staticmethod
     def _cuda_tensor_infos(
@@ -773,23 +807,7 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
         Layers without an independent Indexer keep the same copy schema by
         receiving a metadata-only ghost segment in the Indexer slot.
         """
-        layer_tensors: dict[int, dict[str, Optional[tuple[KVCacheTensorInfo, ...]]]] = (
-            {}
-        )
-        for layer_name, tensor in kvcaches.items():
-            layer_id = self.layer_name_to_id[layer_name]
-            layer = layer_tensors.setdefault(
-                layer_id, {"attention": None, "indexer": None}
-            )
-
-            # Classification is independent of dict order and exact suffixes.
-            slot = self._cuda_cache_role(layer_name)
-            if layer[slot] is not None:
-                raise ValueError(
-                    f"Duplicate CUDA Shared Indexer {slot} cache for "
-                    f"layer {layer_id}: {layer_name}."
-                )
-            layer[slot] = self._cuda_tensor_infos(layer_name, tensor, slot)
+        layer_tensors = self._collect_role_tensors(kvcaches, self._cuda_tensor_infos)
 
         row_layer_ids = sorted(layer_tensors)
         self.first_layer_id = row_layer_ids[0]
@@ -856,50 +874,74 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
         )
 
     def _build_ascend_layout(self, kvcaches) -> None:
-        """Build the existing Ascend SFA C8/BF16/mixed layerwise layout."""
-        tensor_rows, row_layer_ids = self._collect_tensor_rows(kvcaches)
-        if not tensor_rows or not tensor_rows[0]:
-            raise ValueError("KV cache layout must contain at least one tensor")
+        """Build Ascend SFA C8/BF16/mixed layerwise layout by cache role.
+
+        vLLM-Ascend used to append an optional Indexer cache after the MLA
+        cache in one tuple. Newer versions register it under an independent
+        ``*.indexer.*`` cache entry. Grouping only by numeric layer id makes
+        the latter dependent on dictionary insertion order, so classify the
+        entries before assembling the fixed UCM slot order.
+        """
 
         additional_config = getattr(self.vllm_config, "additional_config", None) or {}
         sfa_c8 = bool(additional_config.get("enable_sparse_sfa_c8", False))
         li_c8 = bool(additional_config.get("enable_sparse_li_c8", False))
         base_tensor_count = 1 if sfa_c8 else 2
+        max_extra_count = 2 if li_c8 else 1
 
-        base_sizes = [
-            tensor.bytes_per_block for tensor in tensor_rows[0][:base_tensor_count]
-        ]
-        if len(base_sizes) != base_tensor_count:
-            raise ValueError("The first Shared Indexer layer has no SFA base tensor.")
+        layer_tensors = self._collect_role_tensors(kvcaches, self._tensor_infos)
 
-        for layer_id, row in zip(row_layer_ids, tensor_rows):
-            current_sizes = [
-                tensor.bytes_per_block for tensor in row[:base_tensor_count]
-            ]
-            if current_sizes != base_sizes:
+        if not layer_tensors:
+            raise ValueError("KV cache layout must contain at least one tensor")
+
+        row_layer_ids = sorted(layer_tensors)
+        self.first_layer_id = row_layer_ids[0]
+        layers = []
+        for layer_id in row_layer_ids:
+            attention = layer_tensors[layer_id]["attention"]
+            if attention is None or len(attention) < base_tensor_count:
+                count = 0 if attention is None else len(attention)
                 raise ValueError(
-                    "Shared Indexer layers must have identical SFA base tensors: "
-                    f"expected={base_sizes}, layer={layer_id}, "
-                    f"actual={current_sizes}."
+                    "Ascend Shared Indexer layer has insufficient SFA base "
+                    f"tensors: layer={layer_id}, expected={base_tensor_count}, "
+                    f"actual={count}."
                 )
 
-        max_extra_count = 2 if li_c8 else 1
-        layers = []
-        for layer_id, row in zip(row_layer_ids, tensor_rows):
-            extras = row[base_tensor_count:]
+            # Legacy versions keep Indexer/scale after the base SFA tensors in
+            # the attention tuple. Newer versions expose them in an independent
+            # Indexer entry. Seeing both would be ambiguous and must not result
+            # in a silent duplicate store segment.
+            legacy_extras = attention[base_tensor_count:]
+            separate_indexer = layer_tensors[layer_id]["indexer"]
+            if legacy_extras and separate_indexer is not None:
+                raise ValueError(
+                    "Ascend Shared Indexer layer exposes both legacy and "
+                    f"separate Indexer caches: layer={layer_id}."
+                )
+            extras = separate_indexer if separate_indexer is not None else legacy_extras
             if len(extras) > max_extra_count:
                 raise ValueError(
-                    "Unsupported Shared Indexer tensors after the SFA cache: "
+                    "Unsupported Ascend Shared Indexer cache components: "
                     f"layer={layer_id}, count={len(extras)}."
                 )
             layers.append(
                 SharedIndexerLayerInfo(
                     layer_id=layer_id,
-                    sfa_tensors=tuple(row[:base_tensor_count]),
+                    sfa_tensors=tuple(attention[:base_tensor_count]),
                     indexer=extras[0] if extras else None,
                     scale=extras[1] if len(extras) == 2 else None,
                 )
             )
+
+        base_sizes = [tensor.bytes_per_block for tensor in layers[0].sfa_tensors]
+        for layer in layers:
+            current_sizes = [tensor.bytes_per_block for tensor in layer.sfa_tensors]
+            if current_sizes != base_sizes:
+                raise ValueError(
+                    "Shared Indexer layers must have identical SFA base tensors: "
+                    f"expected={base_sizes}, layer={layer.layer_id}, "
+                    f"actual={current_sizes}."
+                )
 
         c8_layers = [layer for layer in layers if layer.scale is not None]
         bf16_layers = [


### PR DESCRIPTION
## Purpose

vLLM Ascend has aligned its GLM-5.2 indexer cache allocation and tensor organization with the upstream vLLM implementation in [[PR #11647](https://github.com/vllm-project/vllm-ascend/pull/11647)]. In particular, the SFA KV cache and indexer cache are now allocated through separate cache specs instead of being bundled together.

The current UCM adaptation still relies on the previous indexer tensor layout, so it needs to be updated accordingly.

## Modifications

* Updated `_build_ascend_layout` in `ucm_connector.py` to align with the CUDA implementation.
* Added compatibility handling for earlier vLLM Ascend versions.
* Updated the corresponding test cases.

## Test

Verified with:

* `vllm-ascend 0.26.0-nightly`
* `vllm-ascend 0.23.0rc1`
