### PR TITLE
[Fix] Improve signal handler: distinguish fatal vs interrupt signals

### DIFF
--- a/ucm/shared/infra/logger/cc/spdlog_logger.h
+++ b/ucm/shared/infra/logger/cc/spdlog_logger.h
@@ -66,13 +66,25 @@ public:
 
     void register_at_exit()
     {
-        std::signal(SIGSEGV, &_signal_handler);
-        std::signal(SIGABRT, &_signal_handler);
-        std::signal(SIGFPE, &_signal_handler);
-        std::signal(SIGILL, &_signal_handler);
-        std::signal(SIGINT, &_signal_handler);
+        std::signal(SIGSEGV, &_fatal_signal_handler);
+        std::signal(SIGABRT, &_fatal_signal_handler);
+        std::signal(SIGFPE, &_fatal_signal_handler);
+        std::signal(SIGILL, &_fatal_signal_handler);
+        std::signal(SIGINT, &_interrupt_signal_handler);
     }
-    static void _signal_handler(int signum) { Logger::GetInstance().Flush(); }
+
+    static void _fatal_signal_handler(int signum)
+    {
+        Logger::GetInstance().Flush();
+        std::signal(signum, SIG_DFL);
+        std::raise(signum);
+    }
+
+    static void _interrupt_signal_handler(int signum)
+    {
+        Logger::GetInstance().Flush();
+        std::exit(128 + signum);
+    }
 
     void Log(Level&& lv, SourceLocation&& loc, std::string&& msg);
     void LogFileOnly(Level&& lv, SourceLocation&& loc, std::string&& msg);


### PR DESCRIPTION
## What does this PR do?

Improves the signal handling logic in spdlog_logger.h by splitting the single _signal_handler into two specialized handlers.

## Changes

### Before
All signals (SIGSEGV, SIGABRT, SIGFPE, SIGILL, SIGINT) were handled by a single handler that only flushed logs:
`cpp
static void _signal_handler(int signum) { Logger::GetInstance().Flush(); }
``n
### After
Split into two handlers with appropriate behavior:

1. **_fatal_signal_handler** (for SIGSEGV, SIGABRT, SIGFPE, SIGILL):
   - Flush logs to disk
   - Restore default signal handler (SIG_DFL)
   - Re-raise signal to generate core dump

2. **_interrupt_signal_handler** (for SIGINT / Ctrl+C):
   - Flush logs to disk
   - Exit gracefully with code 128 + signum`n
## Motivation

- The old handler only flushed logs but did not terminate the process properly, leaving the process in an undefined state.
- Fatal signals (segfault, abort, etc.) should produce a core dump for debugging.
- Interrupt signals (Ctrl+C) should exit cleanly with a standard exit code.
- This follows Unix signal handling conventions.

## Testing

- [x] Code compiles successfully
- [ ] Manual testing: send SIGSEGV/SIGINT to verify behavior
