### PR TITLE
[fix]Update hotness for fawa and direct connector

### DIFF
--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -855,6 +855,42 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
             return 0
         return reverse_idx + 1
 
+    def _prefetch_hit_key_hotness(
+        self,
+        fa_hbm_hit_keys: list[bytes],
+        all_hit_keys: list[bytes],
+    ) -> None:
+        """Best-effort GC hotness update for FAWA's two backing stores.
+
+        External FA keys are already touched by ``lookup_on_prefix``, so the
+        FA store only needs the local-HBM prefix that lookup did not inspect.
+        WA uses ``lookup_on_reverse``, which touches only the selected boundary;
+        update every reusable boundary key so sparse WA snapshots age together
+        with the corresponding FA prefix. Missing sparse WA files are harmless:
+        store ``prefetch`` is a hint and Posix simply ignores a failed ``utime``.
+        """
+
+        if self.fa_store is None:
+            raise RuntimeError("FA store is not initialized.")
+        if self.wa_store is None:
+            raise RuntimeError("WA store is not initialized.")
+
+        updates = (
+            ("FA", self.fa_store, fa_hbm_hit_keys),
+            ("WA", self.wa_store, all_hit_keys),
+        )
+        for label, store, keys in updates:
+            if not keys:
+                continue
+            try:
+                store.prefetch(keys)
+            except Exception as e:
+                # Prefetch is only a GC hotness hint. A failure must not turn a
+                # valid cache hit into a scheduler-side miss.
+                logger.warning(
+                    f"FAWA {label} hotness update failed. " f"{type(e).__name__}: {e}"
+                )
+
     @fawa_latency_metric(
         "fawa_scheduler_get_num_new_matched_tokens_ms",
     )
@@ -866,17 +902,28 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         wa_hbm_hit_block_num = num_computed_tokens // self.hash_block_size
         wa_computed_tokens = wa_hbm_hit_block_num * self.hash_block_size
 
-        if (
-            request.num_tokens <= self.persist_token_threshold
-            or request.num_tokens <= (wa_computed_tokens + self.load_tokens_threshold)
-        ):
+        if request.num_tokens <= self.persist_token_threshold:
             return 0, False
+        skip_external_load = request.num_tokens <= (
+            wa_computed_tokens + self.load_tokens_threshold
+        )
+        if skip_external_load and wa_hbm_hit_block_num <= 0:
+            return 0, False
+
         canonical_hashes = self.generate_hash(
             self.hash_block_size, request.all_token_ids, self._seed
         )
+        fa_hbm_hit_keys = canonical_hashes[:wa_hbm_hit_block_num]
+
+        # Even when no external load is worthwhile, the local-HBM prefix is a
+        # cache hit and should remain hot in both FAWA backing stores.
+        if skip_external_load:
+            self._prefetch_hit_key_hotness(fa_hbm_hit_keys, fa_hbm_hit_keys)
+            return 0, False
 
         external_keys = canonical_hashes[wa_hbm_hit_block_num:]
         if not external_keys:
+            self._prefetch_hit_key_hotness(fa_hbm_hit_keys, fa_hbm_hit_keys)
             return 0, False
 
         external_hit_blocks = 0
@@ -891,6 +938,10 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
                 self._record_counter("connector_lookup_errors_total")
 
         total_hit_block_num = wa_hbm_hit_block_num + external_hit_blocks
+        self._prefetch_hit_key_hotness(
+            fa_hbm_hit_keys,
+            canonical_hashes[:total_hit_block_num],
+        )
         num_total_hit_tokens = (
             external_hit_blocks * self.hash_block_size + wa_computed_tokens
         )

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -1468,6 +1468,36 @@ class UCMDirectConnector(KVConnectorBase_V1):
         if other_rank_block_ids:
             self.store.prefetch(other_rank_block_ids)
 
+    def _prefetch_direct_hit_key_hotness(
+        self,
+        hbm_hit_block_ids: list[bytes],
+        all_hit_block_ids: list[bytes],
+    ) -> None:
+        """Best-effort GC hotness update for keys skipped by scheduler lookup.
+
+        Rank 0 external keys are already touched by ``lookup_on_prefix``. The
+        local-HBM prefix is not part of that lookup, while other TP ranks do not
+        perform scheduler-side lookup at all, so update those two sets here.
+        """
+
+        if hbm_hit_block_ids:
+            try:
+                self.store.prefetch(hbm_hit_block_ids)
+            except Exception as e:
+                logger.warning(
+                    "UCM rank-0 HBM hotness update failed. " f"{type(e).__name__}: {e}"
+                )
+
+        if all_hit_block_ids:
+            try:
+                self._prefetch_other_rank_hashes(all_hit_block_ids)
+            except Exception as e:
+                # Prefetch is only a GC hotness hint. A failure must not turn a
+                # valid cache hit into a scheduler-side miss.
+                logger.warning(
+                    "UCM other-rank hotness update failed. " f"{type(e).__name__}: {e}"
+                )
+
     def get_num_new_matched_tokens(
         self,
         request: "Request",
@@ -1511,15 +1541,21 @@ class UCMDirectConnector(KVConnectorBase_V1):
                     )
                     + 1
                 )
-                self._prefetch_other_rank_hashes(
-                    external_block_ids[:external_hit_hashes]
-                )
                 external_hit_blocks = external_hit_hashes // self.cp_world_size
             except Exception as e:
                 logger.error(
                     f"request {request.request_id} look up error. {type(e).__name__}: {e}"
                 )
                 self._record_counter("connector_lookup_errors_total")
+
+        hbm_hit_hashes = hbm_hit_block_num * self.cp_world_size
+        total_hit_hashes = (
+            hbm_hit_block_num + external_hit_blocks
+        ) * self.cp_world_size
+        self._prefetch_direct_hit_key_hotness(
+            ucm_block_ids[:hbm_hit_hashes],
+            ucm_block_ids[:total_hit_hashes],
+        )
 
         logger.info_once(
             f"request_id: {request.request_id}, "

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -335,7 +335,7 @@ class KVCacheLayout:
         self.buffer_sizes: np.ndarray
         self.tensor_size_lists: np.ndarray
         self.block_stride_lists: np.ndarray
-        self.use_layerwise = ucm_config.get("use_layerwise", False)
+        self.use_layerwise = ucm_config.get("use_layerwise", True)
         self.kv_cache_config = kv_cache_config
         self.vllm_config = vllm_config
         self.pp_size = self.vllm_config.parallel_config.pipeline_parallel_size
@@ -551,7 +551,7 @@ class SharedIndexerKVCacheLayout(KVCacheLayout):
     def supports(cls, vllm_config: "VllmConfig", ucm_config: dict) -> bool:
         device_type = getattr(current_platform, "device_type", None)
         return (
-            bool(ucm_config.get("use_layerwise", False))
+            bool(ucm_config.get("use_layerwise", True))
             and device_type in ("npu", "cuda")
             and _has_shared_indexer_layers(vllm_config)
         )
@@ -1562,6 +1562,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
             f"total_blocks_num: {len(ucm_block_ids)}, "
             f"hit hbm: {hbm_hit_block_num * self.cp_world_size}, "
             f"hit external: {external_hit_blocks * self.cp_world_size}"
+            f"total tokens: {request.all_token_ids}"
         )
 
         if not external_block_ids:
@@ -2488,7 +2489,7 @@ class UCMCPConnector(UCMLayerWiseConnector):
         kv_cache_config: Optional["KVCacheConfig"] = None,
     ):
         super().__init__(vllm_config, role, kv_cache_config)
-        self.use_layerwise = self.launch_config.get("use_layerwise", False)
+        self.use_layerwise = self.launch_config.get("use_layerwise", True)
 
         try:
             from vllm.distributed import get_dcp_group, get_pcp_group
@@ -2815,11 +2816,13 @@ class UCMConnector(KVConnectorBase_V1, SupportsHMA):
             if role == KVConnectorRole.WORKER
             else "scheduler" if role == KVConnectorRole.SCHEDULER else None
         )
+        if role == KVConnectorRole.WORKER and self._worker_rank == 0:
+            logger.info(f"UCM worker rank 0 KV cache config: {kv_cache_config!r}")
         self._setup_ucm_metrics(vllm_config, role)
         logger.info(f"self.launch_config: {self.launch_config}")
 
         use_layerwise = (
-            self.launch_config.get("use_layerwise", False)
+            self.launch_config.get("use_layerwise", True)
             if self.launch_config is not None
             else False
         )


### PR DESCRIPTION
## Purpose

Ensure cache files reused through local HBM hits remain hot in external storage and are not incorrectly reclaimed by Posix GC.

Store `prefetch` currently acts as a best-effort hotness hint by updating file timestamps. However, scheduler-side lookup only touches external-hit keys:

- Direct UCM did not update hotness for the local-HBM prefix.
- FAWA reverse lookup only touched the final matching WA boundary.
- Keys belonging to other TP ranks were not fully covered for HBM hits.

## Modifications

- Added best-effort hit-key hotness updates to `UCMDirectConnector`:
  - Prefetch rank-0 HBM-hit keys skipped by `lookup_on_prefix`.
  - Prefetch the complete effective hit range for other TP ranks.
  - Support pure-HBM-hit requests before the early-return path.
  - Respect CP block boundaries and exclude partial external hash groups.

- Added FAWA hotness updates:
  - Prefetch HBM-hit keys in the FA Store.
  - Prefetch all reusable boundary keys in the WA Store.
  - Cover pure-HBM-hit and external-load-threshold early-return paths.

- Kept hotness updates best-effort:
  - Prefetch failures only emit warnings.
  - A hotness-update failure does not invalidate a valid cache hit or reduce the reported external-hit range.

- Added unit tests covering:
  - Direct HBM and external hits.
  - Pure HBM hits.
  - CP partial-hit boundaries.
  - FAWA FA/WA hotness updates.
  - Prefetch failure isolation.