### PR TITLE
docs(installer): align selector with published artifacts

### DIFF
--- a/docs-next/docs/en/user-guide/index.md
+++ b/docs-next/docs/en/user-guide/index.md
@@ -1,0 +1,12 @@
+# User Guide
+
+Install, deploy, and run UCM. Start with the installer, choose a model family,
+then follow the serving-engine and deployment guidance for your environment.
+
+## Sections
+
+- [Installation](installation.md) — select a published artifact and get the matching command
+- [Model Tour](model-tour/index.md) — model-family catalogs and engine-specific launch guidance
+- [Getting Started](engines/index.md) — vLLM, vLLM Ascend, and SGLang integration
+- [Deploy](deploy/index.md) — container and Kubernetes deployment
+- [Core Capabilities & Troubleshooting](capabilities/index.md)

--- a/docs-next/docs/en/user-guide/installation.md
+++ b/docs-next/docs/en/user-guide/installation.md
@@ -2,18 +2,19 @@
 
 UCM is delivered as Docker images, a Helm chart, Python wheels, and source
 builds. Use the installer below to get the exact command for your stack, then
-follow the engine-specific guide for the remaining steps.
+follow the engine-specific guide for the remaining steps. The available
+integrated artifacts are the `0.7.58 Preview/Fork` release.
 
 !!! tip "How to use"
 
-    Select your UCM version, engine, device, OS, architecture, and install
-    method below — the matching install command appears automatically.
+    Select your UCM version, engine, compute platform, architecture, and
+    install method below — the matching install command appears automatically.
 
 ## Installer
 
 <div id="ucm-install-selector" class="ucm-install">
   <div class="ucm-install__rows" id="ucm-install-rows"></div>
-  <div class="ucm-install__output">
+  <section class="ucm-install__output" aria-labelledby="ucm-cmd-label">
     <div class="ucm-install__cmdhead">
       <span class="ucm-install__cmdtitle" id="ucm-cmd-label">Run this command</span>
       <button class="ucm-install__copy" id="ucm-copy" type="button" title="Copy command" aria-label="Copy command">
@@ -23,75 +24,89 @@ follow the engine-specific guide for the remaining steps.
     </div>
     <pre class="ucm-install__cmd"><code id="ucm-cmd"></code></pre>
     <p class="ucm-install__note" id="ucm-note"></p>
-  </div>
+    <p class="ucm-install__status" id="ucm-status" aria-live="polite" aria-atomic="true"></p>
+  </section>
 </div>
 
 <script>
 (function () {
-  var VERSION = "0.5.0";
+  var VERSION = "0.7.58";
   var DIMS = {
-    version: ["0.5.0"],
-    engine:  ["vLLM", "vLLM Ascend", "SGLang", "MindIE"],
-    device:  ["GPU (CUDA)", "NPU (Ascend)"],
-    os:      ["Ubuntu", "openEuler"],
+    version: ["0.7.58 Preview/Fork"],
+    engine:  ["vLLM", "vLLM Ascend", "SGLang"],
+    device:  ["CUDA", "NPU A2", "NPU A3", "NPU A5"],
     arch:    ["amd64", "arm64"],
-    method:  ["Docker", "Helm chart", "pip wheel", "Source build"]
+    method:  ["Docker Image", "Helm chart", "pip wheel", "Source build"]
   };
-  var DEFAULTS = { version:"0.5.0", engine:"vLLM", device:"GPU (CUDA)", os:"Ubuntu", arch:"amd64", method:"Docker" };
-  var LABELS = { version:"UCM version", engine:"Engine", device:"Device", os:"Operating system", arch:"Architecture", method:"Install method" };
-  var ORDER = ["version","engine","device","os","arch","method"];
-  var ENGINE_DEVICE = { "vLLM":"GPU (CUDA)", "vLLM Ascend":"NPU (Ascend)", "SGLang":"GPU (CUDA)", "MindIE":"NPU (Ascend)" };
+  var DEFAULTS = { version:"0.7.58 Preview/Fork", engine:"vLLM", device:"CUDA", arch:"amd64", method:"Docker Image" };
+  var LABELS = { version:"UCM version", engine:"Engine", device:"Compute platform", arch:"Architecture", method:"Install method" };
+  var ORDER = ["version","engine","device","arch","method"];
+  var ENGINE_DEVICES = {
+    "vLLM": ["CUDA"],
+    "vLLM Ascend": ["NPU A2", "NPU A3", "NPU A5"],
+    "SGLang": ["CUDA"]
+  };
+  var UNAVAILABLE_COMPUTE = {
+    "NPU A5": "No UCM-integrated A5 image, wheel profile, Dockerfile, or setup platform is published."
+  };
+  var DOCKER_IMAGES = {
+    "vLLM|CUDA": "ghcr.io/supermarioyl/vllm-openai:v0.21.0-ucm-0.7.58-r1",
+    "vLLM Ascend|NPU A2": "ghcr.io/supermarioyl/vllm-ascend:v0.22.1rc1-ucm-0.7.58-r1",
+    "vLLM Ascend|NPU A3": "ghcr.io/supermarioyl/vllm-ascend:v0.22.1rc1-a3-ucm-0.7.58-r1"
+  };
+  var RELEASE_URL = "https://github.com/SuperMarioYL/unified-cache-management/releases/download/v" + VERSION + "/";
 
-  function cmd(state) {
-    var v = state.version, e = state.engine, d = state.device, o = state.os, a = state.arch, m = state.method;
-    if (ENGINE_DEVICE[e] && ENGINE_DEVICE[e] !== d) return null;
-    if (m === "Docker") {
-      if (e === "vLLM" && d === "GPU (CUDA)") {
-        return "docker run --gpus all --rm -p 8000:8000 \\\n  -e HICACHE_ENGINE=vllm \\\n  -v $(pwd)/config.yaml:/app/config.yaml \\\n  ghcr.io/modelengine-group/ucm-vllm:" + v + " \\\n  --model glm-4.5 --hicache-storage-backend ucmconn";
-      }
-      if (e === "vLLM Ascend" && d === "NPU (Ascend)") {
-        return "docker run --device /dev/davinci0 --device /dev/davinci_manager \\\n  --device /dev/hisi_hdc --rm -p 8000:8000 \\\n  -e HICACHE_ENGINE=vllm-ascend \\\n  -v $(pwd)/config.yaml:/app/config.yaml \\\n  ghcr.io/modelengine-group/ucm-vllm-ascend:" + v;
-      }
-      if (e === "SGLang" && d === "GPU (CUDA)") {
-        return "docker run --gpus all --rm -p 30000:30000 \\\n  -v $(pwd)/config.yaml:/app/config.yaml \\\n  ghcr.io/modelengine-group/ucm-sglang:" + v + " \\\n  --model glm-4.5";
-      }
-      if (e === "MindIE" && d === "NPU (Ascend)") {
-        return "docker run --device /dev/davinci0 --device /dev/davinci_manager \\\n  --device /dev/hisi_hdc --rm -p 1024:1024 \\\n  ghcr.io/modelengine-group/ucm-mindie:" + v;
-      }
+ function cmd(state) {
+   var e = state.engine, d = state.device, a = state.arch, m = state.method;
+    if (UNAVAILABLE_COMPUTE[d]) return null;
+   if (!ENGINE_DEVICES[e] || ENGINE_DEVICES[e].indexOf(d) === -1) return null;
+    if (m === "Docker Image") {
+      var image = DOCKER_IMAGES[e + "|" + d];
+      if (!image) return null;
+      return "docker pull " + image;
     }
     if (m === "Helm chart") {
-      return "helm repo add ucm https://modelengine-group.github.io/charts\nhelm install ucm ucm/unified-cache-pd \\\n  --version " + v.replace("rc1","-rc.1") + " \\\n  --set engine=" + e.toLowerCase().replace(/\s/g,"-") + " \\\n  --set device=" + (d.indexOf("NPU")===0?"npu":"gpu") + " \\\n  --set architecture=" + a;
+      return "helm install ucm " + RELEASE_URL + "unified-cache-pd-0.7.58.tgz";
     }
     if (m === "pip wheel") {
-      if (e === "vLLM")        return "pip install ucm-vllm==" + v + " --find-links https://github.com/ModelEngine-Group/unified-cache-management/releases";
-      if (e === "vLLM Ascend") return "pip install ucm-vllm-ascend==" + v;
-      if (e === "SGLang")      return "pip install ucm-sglang==" + v;
-      return null;
+      var wheelArch = a === "amd64" ? "x86_64" : "aarch64";
+      var wheel = d === "CUDA" ? "uc_manager_cuda-0.7.58-cp312-cp312-manylinux_2_28_" + wheelArch + ".whl" :
+        d === "NPU A2" ? "uc_manager_cann_a2-0.7.58-cp312-cp312-linux_" + wheelArch + ".whl" :
+        d === "NPU A3" ? "uc_manager_cann_a3-0.7.58-cp312-cp312-linux_" + wheelArch + ".whl" : null;
+      return wheel ? "pip install " + RELEASE_URL + wheel : null;
     }
     if (m === "Source build") {
-      return "git clone https://github.com/ModelEngine-Group/unified-cache-management.git\ncd unified-cache-management\npip install -e .\n# Then apply the engine integration patch (see engine guide)";
+      var platform = d === "CUDA" ? "cuda" : d === "NPU A2" ? "ascend" : d === "NPU A3" ? "ascend-a3" : null;
+      return platform ? "git clone --branch v0.7.58 https://github.com/SuperMarioYL/unified-cache-management.git\ncd unified-cache-management\nPLATFORM=" + platform + " pip install -e ." : null;
     }
     return null;
   }
 
   var NOTE = {
-    "Helm chart": "Deploys UCM with Kubernetes. See the Deploy guide for the full Helm values reference.",
-    "Source build": "Recommended for development. Apply the engine integration patch documented in the engine guide.",
-    "pip wheel": "Prebuilt wheels are published with each release. Requires the matching engine already installed.",
-    "Docker": "Prebuilt images bundle the engine. See the engine guide for runtime configuration."
+    "Helm chart": "Uses the verified Preview/Fork chart artifact. See the Deploy guide for runtime values.",
+    "Source build": "Builds the Preview/Fork tag with the setup platform selected by compute platform.",
+    "pip wheel": "Uses the exact Preview/Fork GitHub Release wheel matching the selected compute platform and CPU architecture.",
+    "Docker Image": "Verified Preview/Fork images: the OCI index covers amd64 and arm64, the image userland is fixed by the image, and no official ModelEngine-Group UCM GHCR package was publicly readable on 2026-08-20."
   };
+
+  function unavailableReason(s) {
+    if (s.method === "Docker Image" && s.engine === "SGLang") {
+      return "SGLang Docker Image is unavailable because no published UCM SGLang image was found.";
+    }
+    return "This combination is not available. Try a different engine, compute platform, or install method.";
+  }
 
   function buildRows() {
     var root = document.getElementById("ucm-install-rows");
     root.innerHTML = "";
     ORDER.forEach(function (dim) {
-      var row = document.createElement("div");
+      var row = document.createElement("fieldset");
       row.className = "ucm-install__row";
-      var label = document.createElement("span");
+      var label = document.createElement("legend");
       label.className = "ucm-install__rowlabel";
       label.textContent = LABELS[dim];
       var group = document.createElement("div");
-      group.className = "ucm-install__group";
+      group.className = "ucm-install__group ucm-install__group--" + dim;
       DIMS[dim].forEach(function (opt) {
         var id = "ucm-" + dim + "-" + opt.replace(/[^a-z0-9]/gi,"");
         var lab = document.createElement("label");
@@ -101,7 +116,15 @@ follow the engine-specific guide for the remaining steps.
         inp.type = "radio"; inp.name = "ucm-" + dim; inp.value = opt; inp.id = id;
         if (opt === DEFAULTS[dim]) inp.checked = true;
         var sp = document.createElement("span");
-        sp.textContent = opt;
+        if (dim === "device" && UNAVAILABLE_COMPUTE[opt]) {
+          inp.disabled = true;
+          lab.classList.add("ucm-install__opt--disabled");
+          lab.title = UNAVAILABLE_COMPUTE[opt];
+          inp.setAttribute("aria-label", opt + " unavailable: " + UNAVAILABLE_COMPUTE[opt]);
+          sp.textContent = opt + " · N/A";
+        } else {
+          sp.textContent = opt;
+        }
         lab.appendChild(inp); lab.appendChild(sp);
         group.appendChild(lab);
       });
@@ -119,13 +142,7 @@ follow the engine-specific guide for the remaining steps.
     return s;
   }
 
-  function updateActive(inp) {
-    if (!inp) return;
-    var group = inp.closest(".ucm-install__group");
-    if (!group) return;
-    group.querySelectorAll(".ucm-install__opt").forEach(function(l){ l.classList.remove("is-active"); });
-    inp.closest(".ucm-install__opt").classList.add("is-active");
-  }
+  var copyResetTimer;
 
   function render() {
     var s = state();
@@ -134,30 +151,58 @@ follow the engine-specific guide for the remaining steps.
     var labelEl = document.getElementById("ucm-cmd-label");
     var noteEl = document.getElementById("ucm-note");
     var copy = document.getElementById("ucm-copy");
+    var status = document.getElementById("ucm-status");
     if (code) {
       codeEl.textContent = code;
-      codeEl.parentElement.style.display = "";
-      copy.style.display = "";
+      codeEl.parentElement.hidden = false;
+      copy.hidden = false;
       labelEl.textContent = s.method + " \u00b7 " + s.engine + " \u00b7 " + s.device;
       noteEl.textContent = NOTE[s.method] || "";
       noteEl.classList.remove("ucm-install__note--err");
+      status.textContent = "Command updated: " + s.method + " for " + s.engine + " on " + s.device + ".";
     } else {
       codeEl.textContent = "";
-      codeEl.parentElement.style.display = "none";
-      copy.style.display = "none";
+      codeEl.parentElement.hidden = true;
+      copy.hidden = true;
       labelEl.textContent = "Not available";
-      noteEl.textContent = "This combination is not available. Try a different engine, device, or method.";
+      noteEl.textContent = unavailableReason(s);
       noteEl.classList.add("ucm-install__note--err");
+      status.textContent = noteEl.textContent;
     }
   }
 
   function onEngineChange() {
     var s = state();
-    var want = ENGINE_DEVICE[s.engine];
-    if (want && s.device !== want) {
-      var target = document.querySelector('input[name="ucm-device"][value="'+want+'"]');
-      if (target) { target.checked = true; updateActive(target); }
+    var compatible = ENGINE_DEVICES[s.engine] || [];
+    if (compatible.indexOf(s.device) === -1) {
+      var target = document.querySelector('input[name="ucm-device"][value="'+compatible[0]+'"]');
+      if (target) target.checked = true;
     }
+  }
+
+  async function copyCommand() {
+    var text = document.getElementById("ucm-cmd").textContent;
+    var label = this.querySelector(".ucm-install__copy-label");
+    var status = document.getElementById("ucm-status");
+    var feedback;
+    if (!navigator.clipboard || !navigator.clipboard.writeText) {
+      feedback = "Copy unavailable";
+    } else {
+      try {
+        await navigator.clipboard.writeText(text);
+        feedback = "Copied";
+      } catch (err) {
+        feedback = "Copy failed";
+      }
+    }
+    label.textContent = feedback;
+    status.textContent = feedback;
+    clearTimeout(copyResetTimer);
+    copyResetTimer = setTimeout(function(){
+      label.textContent = "Copy";
+      status.textContent = "";
+      copyResetTimer = null;
+    }, 1500);
   }
 
   function init() {
@@ -165,26 +210,14 @@ follow the engine-specific guide for the remaining steps.
     if (!root || root.dataset.ready) return;
     root.dataset.ready = "1";
     buildRows();
-    ORDER.forEach(function(dim){
-      var c = document.querySelector('input[name="ucm-'+dim+'"]:checked');
-      updateActive(c);
-    });
     root.addEventListener("change", function(ev){
       if (ev.target.matches('input[type=radio]')) {
-        updateActive(ev.target);
         var dim = ev.target.name.replace("ucm-","");
         if (dim === "engine") onEngineChange();
         render();
       }
     });
-    document.getElementById("ucm-copy").addEventListener("click", function(){
-      var text = document.getElementById("ucm-cmd").textContent;
-      if (navigator.clipboard) navigator.clipboard.writeText(text);
-      var lbl = this.querySelector(".ucm-install__copy-label");
-      var prev = lbl.textContent;
-      lbl.textContent = "Copied";
-      setTimeout(function(){ lbl.textContent = prev; }, 1500);
-    });
+    document.getElementById("ucm-copy").addEventListener("click", copyCommand);
     render();
   }
 
@@ -196,119 +229,203 @@ follow the engine-specific guide for the remaining steps.
 
 <style>
 .ucm-install {
+  --ucm-install-muted: var(--md-default-fg-color--light);
+  --ucm-install-accent: #00695c;
+  --ucm-install-accent-contrast: #fff;
+  --ucm-install-focus: #00695c;
+  --ucm-install-control-height: 2.15rem;
+  --ucm-install-option-bg: #edf1f0;
+  --ucm-install-option-fg: #4e5c59;
+  --ucm-install-terminal: #08201f;
+  --ucm-install-terminal-rule: #1f504c;
+  --ucm-install-terminal-fg: #e3f5f0;
   margin: 1.2em 0;
-  border: 1px solid var(--md-default-fg-color--lighter);
-  border-radius: 4px;
-  overflow: hidden;
-  background: var(--md-default-bg-color);
+  max-width: 100%;
+  border: 0;
+  border-radius: 0;
+  overflow: visible;
+  background: transparent;
 }
-.ucm-install__rows { display: flex; flex-direction: column; }
+[data-md-color-scheme="slate"] .ucm-install {
+  --ucm-install-muted: var(--md-default-fg-color--light);
+  --ucm-install-accent: #62d9c8;
+  --ucm-install-accent-contrast: #08201f;
+  --ucm-install-focus: #8be7d8;
+  --ucm-install-option-bg: #263431;
+  --ucm-install-option-fg: #d2e3df;
+}
+.ucm-install *, .ucm-install *::before, .ucm-install *::after { box-sizing: border-box; }
+.ucm-install__rows { display: flex; flex-direction: column; gap: .08rem; }
 .ucm-install__row {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  padding: 6px 16px;
-  border-bottom: 1px solid var(--md-default-fg-color--lightest);
+  display: block;
+  position: relative;
+  min-inline-size: 0;
+  margin: 0;
+  padding: .16rem 0 .16rem 8.75rem;
+  border: 0;
 }
 .ucm-install__rowlabel {
-  flex: 0 0 140px;
+  position: absolute;
+  inset-block-start: 50%;
+  inset-inline-start: 0;
+  transform: translateY(-50%);
+  min-width: 0;
+  padding: 0;
   font-size: 0.82rem;
   font-weight: 600;
-  color: var(--md-default-fg-color--light);
+  color: var(--ucm-install-muted);
 }
-/* Segmented control: buttons joined into one bar, divided by borders */
-.ucm-install__group { display: flex; flex-wrap: wrap; flex: 1 1 auto; min-width: 0; }
+.ucm-install__group { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .35rem; min-width: 0; }
+.ucm-install__group--version { display: flex; }
+.ucm-install__group--engine { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.ucm-install__group--device,
+.ucm-install__group--method { grid-template-columns: repeat(4, minmax(0, 1fr)); }
 .ucm-install__opt {
   position: relative;
-  flex: 1 1 0;
-  display: inline-flex;
+  height: var(--ucm-install-control-height);
+  min-width: 0;
+  cursor: pointer;
+}
+.ucm-install__group--version .ucm-install__opt { width: max-content; }
+.ucm-install__opt span {
+  display: flex;
   align-items: center;
   justify-content: center;
-  text-align: center;
-  padding: 6px 16px;
-  font-size: 0.82rem;
+  width: 100%;
+  height: 100%;
+  padding: 0 .5rem;
+  border: 0;
+  border-radius: 4px;
+  background: var(--ucm-install-option-bg);
+  color: var(--ucm-install-option-fg);
+  font-size: .78rem;
   font-weight: 500;
-  border: 1px solid var(--md-default-fg-color--lighter);
-  border-radius: 0;
-  background: var(--md-default-bg-color);
-  color: var(--md-default-fg-color--light);
-  cursor: pointer;
-  margin-left: -1px;
-  transition: all 0.12s ease;
+  line-height: 1;
+  text-align: center;
+  white-space: nowrap;
+  transition: background-color .16s ease, border-color .16s ease, color .16s ease, box-shadow .16s ease;
   user-select: none;
 }
-.ucm-install__group .ucm-install__opt:first-child { margin-left: 0; }
-.ucm-install__opt:hover {
-  color: var(--md-primary-fg-color);
-  border-color: var(--md-primary-fg-color);
+.ucm-install__opt:hover span {
+  color: var(--ucm-install-accent);
+  background: color-mix(in srgb, var(--ucm-install-accent) 10%, var(--ucm-install-option-bg));
+}
+.ucm-install__opt input {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  margin: -1px;
+  opacity: 0;
+  clip-path: inset(50%);
+}
+.ucm-install__opt input:checked + span {
+  background: var(--ucm-install-accent);
+  color: var(--ucm-install-accent-contrast);
+}
+.ucm-install__opt--disabled { cursor: not-allowed; }
+.ucm-install__opt--disabled span {
+  color: var(--ucm-install-muted);
+  opacity: .62;
+  text-decoration: line-through;
+}
+.ucm-install label:focus-within span {
+  outline: 2px solid var(--ucm-install-focus);
+  outline-offset: 2px;
+  position: relative;
   z-index: 1;
 }
-.ucm-install__opt input { position: absolute; opacity: 0; pointer-events: none; }
-.ucm-install__opt.is-active {
-  background: var(--md-primary-fg-color);
-  border-color: var(--md-primary-fg-color);
-  color: var(--md-primary-bg-color, #fff);
-  z-index: 2;
-}
-.ucm-install__output { padding: 0; background: var(--md-default-fg-color--lightest); }
+.ucm-install__output { margin-top: .7rem; overflow: hidden; border-radius: 6px; background: var(--ucm-install-terminal); color: var(--ucm-install-terminal-fg); }
 .ucm-install__cmdhead {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 16px;
-  background: var(--md-default-fg-color--lighter);
+  gap: 1rem;
+  padding: .75rem 1.15rem;
+  border-bottom: 1px solid var(--ucm-install-terminal-rule);
 }
 .ucm-install__cmdtitle {
   font-size: 0.72rem;
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--md-default-fg-color--light);
+  color: #a8d6ce;
 }
 .ucm-install__copy {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 4px 10px;
+  flex: 0 0 auto;
+  padding: .32rem .62rem;
   font-size: 0.75rem;
+  border: 1px solid #4b827a;
   border-radius: 4px;
-  border: 1px solid var(--md-default-fg-color);
   background: transparent;
-  color: var(--md-default-fg-color--light);
+  color: #d8f1eb;
   cursor: pointer;
-  transition: all 0.12s ease;
+  transition: background-color .16s ease, border-color .16s ease, color .16s ease;
 }
 .ucm-install__copy:hover {
-  background: var(--md-primary-fg-color);
-  border-color: var(--md-primary-fg-color);
-  color: #fff;
+  background: var(--ucm-install-accent);
+  border-color: var(--ucm-install-accent);
+  color: var(--ucm-install-accent-contrast);
 }
+.ucm-install__copy:focus-visible { outline: 2px solid #b8f1e6; outline-offset: 2px; }
 .ucm-install__cmd {
   margin: 0;
-  padding: 16px;
-  background: var(--md-default-fg-color--lightest);
+  max-width: 100%;
+  padding: 1rem 1.15rem;
+  background: transparent;
   border-radius: 0;
   overflow-x: auto;
+  overflow-y: hidden;
+  overflow-wrap: normal;
+  word-break: normal;
 }
+.ucm-install__cmd .md-clipboard, .ucm-install__cmd .md-code__button { display: none; }
 .ucm-install__cmd code {
+  display: block;
+  width: max-content;
+  min-width: 100%;
+  overflow: visible !important;
+  background: transparent;
   font-family: var(--md-code-font-family, monospace);
   font-size: 0.82rem;
   line-height: 1.6;
   white-space: pre;
-  color: var(--md-default-fg-color);
+  word-break: normal;
+  color: var(--ucm-install-terminal-fg);
 }
 .ucm-install__note {
   margin: 0;
-  padding: 10px 16px;
+  padding: .72rem 1.15rem;
   font-size: 0.78rem;
-  color: var(--md-default-fg-color--light);
-  background: var(--md-default-bg-color);
-  border-top: 1px solid var(--md-default-fg-color--lightest);
+  color: #b9d5cf;
+  border-top: 1px solid var(--ucm-install-terminal-rule);
 }
-.ucm-install__note--err { color: var(--md-accent-fg-color); font-weight: 500; }
-@media (max-width: 600px) {
-  .ucm-install__row { flex-direction: column; align-items: stretch; gap: 6px; }
-  .ucm-install__rowlabel { flex: none; }
+.ucm-install__note--err { color: #ffc6c1; font-weight: 500; }
+.ucm-install__status {
+  position: absolute;
+  inline-size: 1px;
+  block-size: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+@media (max-width: 720px) {
+  .ucm-install__row { padding: .2rem 0; }
+  .ucm-install__rowlabel { position: static; transform: none; margin-bottom: .22rem; }
+  .ucm-install__group { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .35rem; }
+  .ucm-install__group--version { display: flex; }
+  .ucm-install__group--engine,
+  .ucm-install__group--method { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 360px) {
+  .ucm-install__cmdhead, .ucm-install__cmd, .ucm-install__note { padding-inline: .85rem; }
+  .ucm-install__group { grid-template-columns: 1fr; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ucm-install__opt span, .ucm-install__copy { transition: none; }
 }
 </style>
 
@@ -321,7 +438,6 @@ matches your selection:
 - [vLLM (CUDA)](engines/index.md)
 - [vLLM Ascend (NPU)](engines/index.md)
 - [SGLang](engines/index.md)
-- [MindIE](engines/index.md)
 
 For Kubernetes deployment with Helm, see
 [GLM PD Best Practice](model-tour/index.md).

--- a/docs-next/docs/en/user-guide/model-tour/deepseek/ascend.md
+++ b/docs-next/docs/en/user-guide/model-tour/deepseek/ascend.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for DeepSeek deployment recipes on vLLM Ascend with UCM.
+
+**What to add**
+
+- Supported DeepSeek models and A2/A3/A5 validation status
+- Tested vLLM Ascend, CANN, and UCM versions
+- UCM configuration and serving command
+- Verification request, expected result, and hardware notes

--- a/docs-next/docs/en/user-guide/model-tour/deepseek/index.md
+++ b/docs-next/docs/en/user-guide/model-tour/deepseek/index.md
@@ -1,0 +1,28 @@
+# DeepSeek
+
+DeepSeek model tutorials currently published by vLLM Ascend.
+
+## Models
+
+| Model | vLLM Ascend latest guide |
+| --- | --- |
+| DeepSeek-V3 & 3.1 | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/DeepSeek-V3.1.html) |
+| DeepSeek-V3.2 | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/DeepSeek-V3.2.html) |
+| DeepSeek-V4-Flash | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/DeepSeek-V4-Flash.html) |
+| DeepSeek-V4-Pro | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/DeepSeek-V4-Pro.html) |
+| DeepSeek-R1 | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/DeepSeek-R1.html) |
+| DeepSeek-OCR-2 | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/DeepSeekOCR2.html) |
+
+## Serving engine
+
+=== "vLLM"
+
+    --8<-- "docs/en/user-guide/model-tour/deepseek/vllm.md"
+
+=== "vLLM Ascend"
+
+    --8<-- "docs/en/user-guide/model-tour/deepseek/ascend.md"
+
+=== "SGLang"
+
+    --8<-- "docs/en/user-guide/model-tour/deepseek/sglang.md"

--- a/docs-next/docs/en/user-guide/model-tour/deepseek/sglang.md
+++ b/docs-next/docs/en/user-guide/model-tour/deepseek/sglang.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for DeepSeek deployment recipes on SGLang with UCM.
+
+**What to add**
+
+- Supported DeepSeek models and tested SGLang/UCM versions
+- Installation and launch command
+- UCM configuration
+- Verification request, expected result, and known limitations

--- a/docs-next/docs/en/user-guide/model-tour/deepseek/vllm.md
+++ b/docs-next/docs/en/user-guide/model-tour/deepseek/vllm.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for DeepSeek deployment recipes on vLLM with UCM.
+
+**What to add**
+
+- Supported DeepSeek models and tested vLLM/UCM versions
+- Docker Image or wheel installation
+- UCM configuration and `vllm serve` command
+- Verification request, expected result, and known limitations

--- a/docs-next/docs/en/user-guide/model-tour/glm/ascend.md
+++ b/docs-next/docs/en/user-guide/model-tour/glm/ascend.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for GLM deployment recipes on vLLM Ascend with UCM.
+
+**What to add**
+
+- Supported GLM models and A2/A3/A5 validation status
+- Tested vLLM Ascend, CANN, and UCM versions
+- UCM configuration and serving command
+- Verification request, expected result, and hardware notes

--- a/docs-next/docs/en/user-guide/model-tour/glm/index.md
+++ b/docs-next/docs/en/user-guide/model-tour/glm/index.md
@@ -1,0 +1,25 @@
+# GLM
+
+Zhipu GLM model tutorials currently published by vLLM Ascend.
+
+## Models
+
+| Model | vLLM Ascend latest guide |
+| --- | --- |
+| GLM-4.x(4.5/4.6/4.7) | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/GLM4.x.html) |
+| GLM-5 & GLM-5.1 | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/GLM5.html) |
+| GLM-5.2 | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/GLM5.2.html) |
+
+## Serving engine
+
+=== "vLLM"
+
+    --8<-- "docs/en/user-guide/model-tour/glm/vllm.md"
+
+=== "vLLM Ascend"
+
+    --8<-- "docs/en/user-guide/model-tour/glm/ascend.md"
+
+=== "SGLang"
+
+    --8<-- "docs/en/user-guide/model-tour/glm/sglang.md"

--- a/docs-next/docs/en/user-guide/model-tour/glm/sglang.md
+++ b/docs-next/docs/en/user-guide/model-tour/glm/sglang.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for GLM deployment recipes on SGLang with UCM.
+
+**What to add**
+
+- Supported GLM models and tested SGLang/UCM versions
+- Installation and launch command
+- UCM configuration
+- Verification request, expected result, and known limitations

--- a/docs-next/docs/en/user-guide/model-tour/glm/vllm.md
+++ b/docs-next/docs/en/user-guide/model-tour/glm/vllm.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for GLM deployment recipes on vLLM with UCM.
+
+**What to add**
+
+- Supported GLM models and tested vLLM/UCM versions
+- Docker Image or wheel installation
+- UCM configuration and `vllm serve` command
+- Verification request, expected result, and known limitations

--- a/docs-next/docs/en/user-guide/model-tour/index.md
+++ b/docs-next/docs/en/user-guide/model-tour/index.md
@@ -1,5 +1,37 @@
 # Model Tour
 
-Per-model deployment recipes. Each model page gives the Docker pull, the vLLM serve + UCM launch command (CUDA and NPU), the UCM config, and a verify curl.
+Explore UCM deployment recipes by model family. Each family keeps its model
+catalog in one place and presents engine-specific guidance as tabs on the same
+page.
 
-Select a model series below.
+The family tables mirror the current
+[vLLM Ascend Model Tutorials](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/).
+Only model tutorials published under `latest` are listed.
+
+## vLLM Ascend runtime images
+
+vLLM Ascend uses shared runtime images rather than a different image for every
+model. Pull the image for the target hardware, then follow the model-specific
+official guide for model weights, environment variables, and launch arguments.
+
+### Official runtime images
+
+| Hardware | Official image pull |
+| --- | --- |
+| Atlas A2 | `docker pull quay.io/ascend/vllm-ascend:v0.23.0` |
+| Atlas A3 | `docker pull quay.io/ascend/vllm-ascend:v0.23.0-a3` |
+
+## Model families
+
+- [GLM](glm/index.md)
+- [Qwen](qwen3/index.md)
+- [DeepSeek](deepseek/index.md)
+- [MiniMax](minimax/index.md)
+- [Kimi](kimi/index.md)
+
+For openEuler images, append `-openeuler` to the A2 tag or use
+`v0.23.0-a3-openeuler` for A3. A5 is not included in the runtime-image table
+because the referenced model guides do not provide a common, verified A5
+deployment contract. Each family page keeps the current model catalog and
+official vLLM Ascend links directly above the **vLLM**, **vLLM Ascend**, and
+**SGLang** tabs.

--- a/docs-next/docs/en/user-guide/model-tour/kimi/ascend.md
+++ b/docs-next/docs/en/user-guide/model-tour/kimi/ascend.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for Kimi deployment recipes on vLLM Ascend with UCM.
+
+**What to add**
+
+- Supported Kimi models and A2/A3/A5 validation status
+- Tested vLLM Ascend, CANN, and UCM versions
+- UCM configuration and serving command
+- Verification request, expected result, and hardware notes

--- a/docs-next/docs/en/user-guide/model-tour/kimi/index.md
+++ b/docs-next/docs/en/user-guide/model-tour/kimi/index.md
@@ -1,0 +1,25 @@
+# Kimi
+
+Moonshot AI Kimi model tutorials currently published by vLLM Ascend.
+
+## Models
+
+| Model | vLLM Ascend latest guide |
+| --- | --- |
+| Kimi-K2-Thinking | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Kimi-K2-Thinking.html) |
+| Kimi-K2.5 | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Kimi-K2.5.html) |
+| Kimi-K2.6 | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Kimi-K2.6.html) |
+
+## Serving engine
+
+=== "vLLM"
+
+    --8<-- "docs/en/user-guide/model-tour/kimi/vllm.md"
+
+=== "vLLM Ascend"
+
+    --8<-- "docs/en/user-guide/model-tour/kimi/ascend.md"
+
+=== "SGLang"
+
+    --8<-- "docs/en/user-guide/model-tour/kimi/sglang.md"

--- a/docs-next/docs/en/user-guide/model-tour/kimi/sglang.md
+++ b/docs-next/docs/en/user-guide/model-tour/kimi/sglang.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for Kimi deployment recipes on SGLang with UCM.
+
+**What to add**
+
+- Supported Kimi models and tested SGLang/UCM versions
+- Installation and launch command
+- UCM configuration
+- Verification request, expected result, and known limitations

--- a/docs-next/docs/en/user-guide/model-tour/kimi/vllm.md
+++ b/docs-next/docs/en/user-guide/model-tour/kimi/vllm.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for Kimi deployment recipes on vLLM with UCM.
+
+**What to add**
+
+- Supported Kimi models and tested vLLM/UCM versions
+- Docker Image or wheel installation
+- UCM configuration and `vllm serve` command
+- Verification request, expected result, and known limitations

--- a/docs-next/docs/en/user-guide/model-tour/minimax/ascend.md
+++ b/docs-next/docs/en/user-guide/model-tour/minimax/ascend.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for MiniMax deployment recipes on vLLM Ascend with UCM.
+
+**What to add**
+
+- Supported MiniMax models and A2/A3/A5 validation status
+- Tested vLLM Ascend, CANN, and UCM versions
+- UCM configuration and serving command
+- Verification request, expected result, and hardware notes

--- a/docs-next/docs/en/user-guide/model-tour/minimax/index.md
+++ b/docs-next/docs/en/user-guide/model-tour/minimax/index.md
@@ -1,0 +1,24 @@
+# MiniMax
+
+MiniMax model tutorials currently published by vLLM Ascend.
+
+## Models
+
+| Model | vLLM Ascend latest guide |
+| --- | --- |
+| MiniMax-M2 | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/MiniMax-M2.html) |
+| MiniMax-M3 | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/MiniMax-M3.html) |
+
+## Serving engine
+
+=== "vLLM"
+
+    --8<-- "docs/en/user-guide/model-tour/minimax/vllm.md"
+
+=== "vLLM Ascend"
+
+    --8<-- "docs/en/user-guide/model-tour/minimax/ascend.md"
+
+=== "SGLang"
+
+    --8<-- "docs/en/user-guide/model-tour/minimax/sglang.md"

--- a/docs-next/docs/en/user-guide/model-tour/minimax/sglang.md
+++ b/docs-next/docs/en/user-guide/model-tour/minimax/sglang.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for MiniMax deployment recipes on SGLang with UCM.
+
+**What to add**
+
+- Supported MiniMax models and tested SGLang/UCM versions
+- Installation and launch command
+- UCM configuration
+- Verification request, expected result, and known limitations

--- a/docs-next/docs/en/user-guide/model-tour/minimax/vllm.md
+++ b/docs-next/docs/en/user-guide/model-tour/minimax/vllm.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for MiniMax deployment recipes on vLLM with UCM.
+
+**What to add**
+
+- Supported MiniMax models and tested vLLM/UCM versions
+- Docker Image or wheel installation
+- UCM configuration and `vllm serve` command
+- Verification request, expected result, and known limitations

--- a/docs-next/docs/en/user-guide/model-tour/qwen3/ascend.md
+++ b/docs-next/docs/en/user-guide/model-tour/qwen3/ascend.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for Qwen deployment recipes on vLLM Ascend with UCM.
+
+**What to add**
+
+- Supported Qwen models and A2/A3/A5 validation status
+- Tested vLLM Ascend, CANN, and UCM versions
+- UCM configuration and serving command
+- Verification request, expected result, and hardware notes

--- a/docs-next/docs/en/user-guide/model-tour/qwen3/index.md
+++ b/docs-next/docs/en/user-guide/model-tour/qwen3/index.md
@@ -1,0 +1,43 @@
+# Qwen
+
+Alibaba Qwen model tutorials currently published by vLLM Ascend.
+
+## Models
+
+| Model | vLLM Ascend latest guide |
+| --- | --- |
+| Qwen3-Dense(0.6B/1.7B/4B/8B/14B/32B) | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3-Dense.html) |
+| Qwen-VL-Dense(8B/32B) | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen-VL-Dense.html) |
+| Qwen3-30B-A3B | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3-30B-A3B.html) |
+| Qwen3-235B-A22B | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3-235B-A22B.html) |
+| Qwen3-VL-30B-A3B-Instruct | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3-VL-30B-A3B-Instruct.html) |
+| Qwen3-VL-235B-A22B-Instruct | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3-VL-235B-A22B-Instruct.html) |
+| Qwen3-Coder-30B-A3B | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3-Coder-30B-A3B.html) |
+| Qwen3-Embedding | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3-Embedding.html) |
+| Qwen3-VL-Embedding | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3-VL-Embedding.html) |
+| Qwen3-Reranker | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3-Reranker.html) |
+| Qwen3-VL-Reranker | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3-VL-Reranker.html) |
+| Qwen3-Next | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3-Next.html) |
+| Qwen3-Omni-30B-A3B-Thinking | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3-Omni-30B-A3B-Thinking.html) |
+| Qwen3.5-27B & Qwen3.6-27B | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3.5-27B-Qwen3.6-27B.html) |
+| Qwen3.5-Dense (2B/4B/9B) | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3.5-Dense.html) |
+| Qwen3.5-397B-A17B | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3.5-397B-A17B.html) |
+| Qwen3.6-35B-A3B | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3.6-35B-A3B.html) |
+| Qwen3.8-2.4T-A95B | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3.8-2.4T-A95B.html) |
+| Qwen3.8-27B | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3.8-27B.html) |
+| Qwen3-ASR-1.7B | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen3-ASR-1.7B.html) |
+| Qwen2.5-Math-RM-72B | [Official guide](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/Qwen2.5-Math-RM-72B.html) |
+
+## Serving engine
+
+=== "vLLM"
+
+    --8<-- "docs/en/user-guide/model-tour/qwen3/vllm.md"
+
+=== "vLLM Ascend"
+
+    --8<-- "docs/en/user-guide/model-tour/qwen3/ascend.md"
+
+=== "SGLang"
+
+    --8<-- "docs/en/user-guide/model-tour/qwen3/sglang.md"

--- a/docs-next/docs/en/user-guide/model-tour/qwen3/sglang.md
+++ b/docs-next/docs/en/user-guide/model-tour/qwen3/sglang.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for Qwen deployment recipes on SGLang with UCM.
+
+**What to add**
+
+- Supported Qwen models and tested SGLang/UCM versions
+- Installation and launch command
+- UCM configuration
+- Verification request, expected result, and known limitations

--- a/docs-next/docs/en/user-guide/model-tour/qwen3/vllm.md
+++ b/docs-next/docs/en/user-guide/model-tour/qwen3/vllm.md
@@ -1,0 +1,10 @@
+**Status:** Placeholder
+
+This tab is reserved for Qwen deployment recipes on vLLM with UCM.
+
+**What to add**
+
+- Supported Qwen models and tested vLLM/UCM versions
+- Docker Image or wheel installation
+- UCM configuration and `vllm serve` command
+- Verification request, expected result, and known limitations

--- a/docs-next/mkdocs.yml
+++ b/docs-next/mkdocs.yml
@@ -111,9 +111,21 @@ extra:
 nav:
   - Home: index.md
   - User Guide:
+      - user-guide/index.md
       - Installation: user-guide/installation.md
-      - Model Tour: user-guide/model-tour/index.md
       - Getting Started: user-guide/engines/index.md
+      - Model Tour:
+          - user-guide/model-tour/index.md
+          - GLM:
+              - user-guide/model-tour/glm/index.md
+          - Qwen:
+              - user-guide/model-tour/qwen3/index.md
+          - DeepSeek:
+              - user-guide/model-tour/deepseek/index.md
+          - MiniMax:
+              - user-guide/model-tour/minimax/index.md
+          - Kimi:
+              - user-guide/model-tour/kimi/index.md
       - Deploy: user-guide/deploy/index.md
       - Core Capabilities & Troubleshooting: user-guide/capabilities/index.md
   - Developer Guide:


### PR DESCRIPTION
## Summary

- Refine the `docs-next` installer into a compact, flat button selector with
  semantic radio groups, responsive/mobile layout, dark theme, keyboard focus,
  live command updates, and truthful Copy feedback.
- Remove MindIE and the non-functional OS selector; expose CUDA and Ascend
  A2/A3/A5 as distinct compute platforms, with A5 visibly disabled and also
  rejected at the command boundary because UCM has no A5 release profile.


