### PR TITLE
[feat: docs-next] rewrite quickstart docs

### DIFF
--- a/docs-next/docs/en/developer-guide/build_from_source.md
+++ b/docs-next/docs/en/developer-guide/build_from_source.md
@@ -1,0 +1,219 @@
+# Building and Installing UCM from Source
+
+This guide explains how to build Unified Cache Management (UCM) from source code for development or customization purposes.
+
+If you just want to use UCM, refer to the [Quickstart (vLLM)](../user-guide/quick_start/quickstart_vllm.md) or [Quickstart (vLLM-Ascend)](../user-guide/quick_start/quickstart_vllm_ascend.md), which describe installation via Docker images or pip.
+
+## Step 1: Prepare the Framework Environment
+
+Before building UCM from source, prepare the inference framework environment that UCM integrates with.
+
+### vLLM (CUDA Platform)
+
+For the sake of environment isolation and simplicity, we recommend preparing the vLLM environment by pulling the official, pre-built vLLM Docker image.
+
+```bash
+docker pull vllm/vllm-openai:<vllm_version>
+```
+
+Then run your own container:
+
+```bash
+# Use `--ipc=host` to make sure the shared memory is large enough.
+docker run \
+    --gpus all \
+    --network=host \
+    --ipc=host \
+    -v <path_to_your_models>:/home/model \
+    -v <path_to_your_storage>:/home/storage \
+    --entrypoint /bin/bash \
+    --name <name_of_your_container> \
+    -it vllm/vllm-openai:<vllm_version>
+```
+
+Refer to [Set up using docker](https://docs.vllm.ai/en/latest/getting_started/installation/gpu.html#set-up-using-docker) for more information to run your own vLLM container.
+
+### vLLM-Ascend (Ascend Platform)
+
+Work in a ready vLLM-Ascend environment. Please refer to the [vLLM-Ascend Installation](https://vllm-ascend.readthedocs.io/en/latest/installation.html#requirements) guide to meet the required dependencies and prepare the corresponding version of the vLLM-Ascend environment.
+
+### SGLang (CUDA Platform)
+
+For the sake of environment isolation and simplicity, we recommend preparing the SGLang environment by pulling the official, pre-built SGLang Docker image.
+
+```bash
+docker pull lmsysorg/sglang:v0.5.9
+```
+
+Then run your own container:
+
+```bash
+# Use `--ipc=host` to make sure the shared memory is large enough.
+docker run \
+    --gpus all \
+    --network=host \
+    --ipc=host \
+    -v <path_to_your_models>:/home/model \
+    -v <path_to_your_storage>:/home/storage \
+    --entrypoint /bin/bash \
+    --name <name_of_your_container> \
+    -it lmsysorg/sglang:v0.5.9
+```
+
+Refer to [Using docker](https://docs.sglang.io/get_started/install.html#method-3-using-docker) for more information to run your own SGLang container.
+
+### MindIE-LLM (Ascend Platform)
+
+Prepare a MindIE-LLM 2.3.0 environment with the Ascend runtime/toolkit installed. For details, refer to the [MindIE-LLM official documentation](https://gitcode.com/Ascend/MindIE-LLM/blob/dev/docs/zh/user_guide/quick_start/quick_start.md).
+
+## Step 2: Build UCM from Source
+
+### CUDA Platform (vLLM)
+
+Follow the commands below to install unified-cache-management from source code:
+
+**Note:** The sparse module was not compiled by default. To enable it, set the environment variable `export ENABLE_SPARSE=TRUE` before you build.
+
+```bash
+# Replace <branch_or_tag_name> with the branch or tag name needed
+git clone --depth 1 --branch <branch_or_tag_name> https://github.com/ModelEngine-Group/unified-cache-management.git
+cd unified-cache-management
+export PLATFORM=cuda
+pip install -v -e . --no-build-isolation
+```
+
+### Ascend Platform (vLLM-Ascend)
+
+```bash
+# Replace <branch_or_tag_name> with the branch or tag name needed
+git clone --depth 1 --branch <branch_or_tag_name> https://github.com/ModelEngine-Group/unified-cache-management.git
+cd unified-cache-management
+export PLATFORM=ascend
+pip install -v -e . --no-build-isolation
+```
+
+>**Note:** For the Atlas A3 series, the `PLATFORM` variable should be set to `ascend-a3`.
+
+### SGLang (CUDA Platform)
+
+Follow the commands below to install unified-cache-management:
+
+```bash
+# Replace <branch_or_tag_name> with the branch or tag name needed
+git clone --depth 1 --branch <branch_or_tag_name> https://github.com/ModelEngine-Group/unified-cache-management.git
+cd unified-cache-management
+export PLATFORM=cuda
+pip install -v -e . --no-build-isolation
+```
+
+### MindIE-LLM (Ascend Platform)
+
+Clone the repository and install UCM with MindIE-LLM support enabled:
+
+```bash
+git clone --depth 1 https://github.com/ModelEngine-Group/unified-cache-management.git
+cd unified-cache-management
+export PLATFORM=ascend
+export UCM_ENABLE_MINDIE=1
+export UCM_CXX11_ABI=1  # Or 0. This must match the target MindIE/PyTorch ABI.
+pip install -v -e . --no-build-isolation
+cd ..
+```
+
+> **Note:** Packages built without `UCM_ENABLE_MINDIE=1` do **not** contain MindIE-LLM integration code.
+>
+> **ABI requirement:** When `UCM_ENABLE_MINDIE=1`, you must also set `UCM_CXX11_ABI=0` or `1`. The value must match the target MindIE/PyTorch ABI.
+
+## Step 3: Enable UCM Integration
+
+### vLLM / vLLM-Ascend
+
+UCM integrates with vLLM / vLLM-Ascend automatically at runtime — no manual patching of the source code is required.
+
+Enable the patch hook by setting the following environment variable before launching the inference service:
+
+```bash
+export ENABLE_UCM_PATCH=1
+```
+
+>**Note:** To enable Sparse Attention (vLLM 0.11.0), also set `export ENABLE_SPARSE=1`.
+
+### MindIE-LLM
+
+No runtime environment variables are needed for MindIE-LLM. Once UCM is installed with MindIE support (`UCM_ENABLE_MINDIE=1`), the patch is applied automatically when `mindie_llm` is first imported.
+
+## Alternative: Build Docker Images from Source
+
+If you prefer to build the UCM Docker images from source code, use the Dockerfile provided under the `docker/` directory for the engine version you need. Each Dockerfile automatically invokes the corresponding build script to compile the wheel, installs from the built package, and (where applicable) applies the integration patch.
+
+### vLLM (CUDA Platform)
+
+Check the `docker/` directory for available Dockerfile versions (e.g. `v0.20.2`, `v0.18.0`, `v0.17.0`, `v0.11.0`), then build with the desired version:
+
+```bash
+git clone --depth 1 --branch <branch_or_tag_name> https://github.com/ModelEngine-Group/unified-cache-management.git
+cd unified-cache-management
+# Replace <vllm_version> with the version you need (e.g. v0.20.2)
+docker build -t ucm-vllm:latest -f ./docker/Dockerfile.ucm-vllm-cuda-<vllm_version> ./
+```
+
+For vLLM (v0.11.0) with sparse attention support:
+
+```bash
+docker build -t ucm-vllm-sparse:latest -f ./docker/Dockerfile.ucm-vllm-cuda-v0.11.0 ./
+```
+
+### vLLM-Ascend (Ascend Platform)
+
+Check the `docker/` directory for available Dockerfile versions (e.g. `v0.20.2`, `v0.18.0`, `v0.17.0`, `v0.11.0`), then build with the desired version:
+
+```bash
+git clone --depth 1 --branch <branch_or_tag_name> https://github.com/ModelEngine-Group/unified-cache-management.git
+cd unified-cache-management
+# Replace <vllm_ascend_version> with the version you need (e.g. v0.20.2)
+docker build -t ucm-vllm:latest -f ./docker/Dockerfile.ucm-vllm-ascend.a2-<vllm_ascend_version> ./
+```
+
+For vLLM-Ascend (v0.11.0) with sparse attention support:
+
+```bash
+docker build -t ucm-vllm-sparse:latest -f ./docker/Dockerfile.ucm-vllm-ascend.a2-v0.11.0 ./
+```
+
+### SGLang (CUDA Platform)
+
+Download the pre-built `lmsysorg/sglang:v0.5.9` docker image and build the unified-cache-management docker image by the commands below:
+
+```bash
+# Replace <branch_or_tag_name> with the branch or tag name needed
+git clone --depth 1 --branch <branch_or_tag_name> https://github.com/ModelEngine-Group/unified-cache-management.git
+cd unified-cache-management
+docker build -t ucm-sglang:latest -f ./docker/Dockerfile.ucm-sglang-cuda-v0.5.5 ./
+```
+
+### MindIE-LLM (Ascend Platform)
+
+Use the provided MindIE-LLM Dockerfile (Ascend base, MindIE-LLM 2.3.0):
+
+```bash
+git clone --depth 1 https://github.com/ModelEngine-Group/unified-cache-management.git
+cd unified-cache-management
+docker build -t ucm-mindie:latest -f ./docker/Dockerfile.ucm-mindie-ascend.a2-v2 ./
+```
+
+This Dockerfile:
+
+* uses `swr.cn-south-1.myhuaweicloud.com/ascendhub/mindie:2.3.0-800I-A2-py311-openeuler24.03-lts`
+* sets `UCM_ENABLE_MINDIE=1`
+* sets `UCM_CXX11_ABI` (default `1`, override with `--build-arg UCM_CXX11_ABI=0|1` to match your target environment)
+* installs UCM with MindIE-LLM support
+* applies the patch during image build
+
+### Docker Build Scripts
+
+The Dockerfiles invoke the following build scripts to compile the wheel:
+
+- `scripts/build_cuda.sh` — builds the wheel for the CUDA platform
+- `scripts/build_ascend.sh` — builds the wheel for the Ascend platform
+- `scripts/build_mindie.sh` — builds the wheel for MindIE
+- `scripts/build_sglang.sh` — builds the wheel for SGLang

--- a/docs-next/docs/en/index.md
+++ b/docs-next/docs/en/index.md
@@ -77,7 +77,12 @@ various scenarios, including multi-turn dialogue and long-context reasoning task
 
     Integrate UCM with vLLM, vLLM Ascend, SGLang, and MindIE.
 
-    [:octicons-arrow-right-24: Getting Started](user-guide/engines/index.md)
+    [:octicons-arrow-right-24: Getting Started](user-guide/quick_start/index.md)
+
+    - [vLLM](user-guide/quick_start/quickstart_vllm.md)
+    - [vLLM Ascend](user-guide/quick_start/quickstart_vllm_ascend.md)
+    - [SGLang](user-guide/quick_start/quickstart_sglang.md)
+    - [MindIE](user-guide/quick_start/quickstart_mindie_llm.md)
 
 -   :material-view-grid-plus: **Compatibility Matrix**
 

--- a/docs-next/docs/en/reference/api-parameters.md
+++ b/docs-next/docs/en/reference/api-parameters.md
@@ -36,7 +36,7 @@ as structured data):
 - No conflicts with task pages.
 
 **First-draft approach**: extract parameters already in use from
-`model-tour/*`, `capabilities/prefix-cache/*`, and `engines/*` into a table,
+`model-tour/*`, `capabilities/prefix-cache/*`, and `quick_start/*` into a table,
 then back-validate task-page consistency.
 
 **Owner**: _(to be assigned)_

--- a/docs-next/docs/en/reference/troubleshooting.md
+++ b/docs-next/docs/en/reference/troubleshooting.md
@@ -1,0 +1,249 @@
+# Troubleshooting
+
+This page lists common error codes, log messages, and troubleshooting steps for UCM.
+
+## Error Codes
+
+UCM uses the following error codes in its underlying C++ stores. These codes appear in log messages and exception outputs.
+
+| Error Code | Name | Meaning | Common Cause |
+|------------|------|---------|--------------|
+| **0** | `OK` | Success | Operation completed normally |
+| **-1** | `Error` | General error | Unclassified error, check the attached message |
+| **-50000** | `InvalidParam` | Invalid parameter | Parameter is illegal, empty, or has wrong format |
+| **-50001** | `OutOfMemory` | Out of memory | Memory allocation failed |
+| **-50002** | `OsApiError` | OS API error | System call failed (e.g. file I/O, thread operation) |
+| **-50003** | `DuplicateKey` | Duplicate key | Attempting to insert a key that already exists |
+| **-50004** | `Retry` | Retry required | Transient error, retry recommended |
+| **-50005** | `NotFound` | Not found | Requested object or resource does not exist |
+| **-50006** | `SerializeFailed` | Serialization failed | Error during data serialization |
+| **-50007** | `DeserializeFailed` | Deserialization failed | Error during data deserialization |
+| **-50008** | `Unsupported` | Unsupported operation | Feature or operation not supported in current context |
+| **-50009** | `NoSpace` | No space | Storage space (disk/cache) is full |
+| **-50010** | `Timeout` | Timeout | Operation timed out |
+
+## Common Issues
+
+### Installation & Build Issues
+
+#### `PLATFORM` environment variable not set
+
+**Log message**:
+```
+WARNING: PLATFORM environment variable is not set!
+Please set PLATFORM to one of: cuda, ascend, ascend-a3, musa, maca
+```
+
+**Cause**: The `PLATFORM` env var is required for building UCM. Without it, the build defaults to `simu` (simulation mode) which is only for CI testing.
+
+**Solution**:
+```bash
+export PLATFORM=cuda       # For CUDA
+export PLATFORM=ascend     # For Ascend A2
+export PLATFORM=ascend-a3  # For Ascend A3
+pip install -v -e . --no-build-isolation
+```
+
+#### Build fails with CMake errors
+
+**Cause**: Missing build dependencies (`cmake`, `gcc`, or CUDA toolkit not in path).
+
+**Solution**:
+1. Ensure `cmake >= 3.18` is installed: `cmake --version`
+2. Ensure the CUDA toolkit is installed and `nvcc` is accessible: `nvcc --version`
+3. For Ascend, ensure the CANN toolkit is properly installed
+
+#### `pip install` fails with wheel build errors
+
+**Cause**: Building C++ extensions requires a proper compiler environment. On some systems, `--no-build-isolation` may fail if the build toolchain is not set up.
+
+**Solution**: Use the pre-built Docker image or wheel package from [PyPI](https://pypi.org/project/uc-manager/) instead.
+
+---
+
+### Configuration Issues
+
+#### Error Code -50000 (InvalidParam)
+
+**Typical log**:
+```
+invalid param ... InvalidParam(...)
+```
+
+**Common causes**:
+- YAML configuration file has syntax errors
+- Required parameter is missing
+- Parameter value type is wrong (e.g. string where integer is expected)
+
+**Solution**:
+1. Check YAML syntax: validate with `python -c "import yaml; yaml.safe_load(open('your_config.yaml'))"`
+2. Verify parameter names match the [Pipeline Store](https://ucm.readthedocs.io/en/latest/user-guide/prefix-cache/pipeline_store.html) or [NFS Store](https://ucm.readthedocs.io/en/latest/user-guide/prefix-cache/nfs_store.html) documentation
+3. Ensure `storage_backends` path is a valid string, not empty
+
+#### `UCM_CONFIG_FILE` not found
+
+**Log message**:
+```
+UCM config file not found: <path>
+```
+
+**Cause**: The config file path in `kv_connector_extra_config` is incorrect or the file does not exist.
+
+**Solution**: Verify the file path exists and is accessible from the container or process. In Docker, ensure the file is mounted or copied into the container.
+
+#### Unsupported connector type
+
+**Log message**:
+```
+Unsupported connector type: <name>
+```
+
+**Cause**: The `ucm_connector_name` in the config is not a registered connector.
+
+**Solution**: Use one of the supported connector names: `UcmPipelineStore` or `UcmNfsStore`.
+
+#### Unknown store pipeline
+
+**Log message**:
+```
+unknown store pipeline: <name>
+```
+
+**Cause**: The `store_pipeline` value is not registered in the PipelineStore registry.
+
+**Solution**: Use a registered pipeline such as `"Cache|Posix"`, `"Cache|Ds3fs"`, `"Cache|Compress|Posix"`, etc. See `ucm/store/pipeline/connector.py` for all registered pipelines.
+
+---
+
+### Runtime Issues
+
+#### Error Code -50001 (OutOfMemory)
+
+**Common causes**:
+- `cache_buffer_capacity_gb` is set too large for available `/dev/shm`
+- Multiple DP instances on the same node each allocate their own CacheStore buffer
+- MLA models require more shared memory
+
+**Solution**:
+1. Check system memory: `free -h`
+2. Check shared memory: `df -h /dev/shm`
+3. Reduce `cache_buffer_capacity_gb` in the config (default is 256 GB)
+4. When running multiple DP instances on one node, reduce the value proportionally
+
+#### Error Code -50002 (OsApiError)
+
+**Common causes**:
+- The `storage_backends` directory does not exist
+- Permission denied on the storage directory
+- Disk I/O error or filesystem issue
+
+**Solution**:
+1. Verify the path exists: `ls <storage_backends_path>`
+2. Check write permissions: `touch <storage_backends_path>/test_file && rm <storage_backends_path>/test_file`
+3. For NFS mounts, verify the mount is healthy: `mount | grep <path>`
+4. Check system logs: `dmesg | tail` or `journalctl -xe`
+
+#### Error Code -50009 (NoSpace)
+
+**Common causes**:
+- Disk space is full at the `storage_backends` path
+- `posix_capacity_gb` is set larger than actual disk capacity
+- GC is not enabled or not aggressive enough
+
+**Solution**:
+1. Check disk space: `df -h <storage_backends_path>`
+2. Set `posix_capacity_gb` to a value matching your available disk capacity (e.g. set to 80% of actual capacity)
+3. GC is automatically enabled when `posix_capacity_gb > 0` — verify it is set correctly
+
+#### Error Code -50010 (Timeout)
+
+**Common causes**:
+- Network or storage bandwidth is abnormal (e.g. NFS mount degraded)
+- System load is too high (CPU, I/O saturation)
+- `timeout_ms` is set too low for the workload
+
+**Solution**:
+1. Test storage bandwidth using `vdbench` or `fio` on the mount point or local disk to verify the environment is healthy
+2. Check system load: `top` or `htop`
+3. Check network: `ping` and `iperf` for NFS over network
+4. Increase `timeout_ms` if needed (default 30000 ms)
+5. For NFS mounts, check mount options — adding `noac` or adjusting `actimeo` may help
+
+---
+
+### vLLM Integration Issues
+
+#### Prefix Caching not working (no cache hits)
+
+**Log message**:
+```
+request_id: xxx, total_blocks_num: N, hit hbm: 0, hit external: 0
+```
+
+**Cause**: First-time requests have no cached KV blocks. Subsequent requests with the same prefix should show hits.
+
+**Solution**:
+1. Run the same request twice — the second should hit cached blocks
+2. Verify `--no-enable-prefix-caching` is not accidentally enabled (it disables vLLM's native HBM prefix cache, used only for SSD benchmarking)
+3. Verify the `UCM_CONFIG_FILE` path is correct in the launch command
+
+#### `Unsupported device platform for UCMDirectConnector`
+
+**Cause**: The current platform is neither CUDA nor Ascend NPU.
+
+**Solution**: UCM currently supports CUDA and Ascend platforms only. Check the [Support Matrix](../user-guide/support-matrix/support_matrix.md) for details.
+
+#### KV dump/load errors
+
+**Typical logs**:
+```
+dump kv cache failed. <error>
+wait for dump kv cache failed. <error>
+submit dump task failed. <error>
+```
+
+**Cause**: Store backend (Posix/NFS) encountered I/O errors during KV cache transfer.
+
+**Solution**:
+1. Check storage backend health (disk space, permissions, network)
+2. Set `UC_LOGGER_LEVEL=debug` for detailed transfer logs:
+   ```
+   [UC][D] Cache task(...) dispatching.
+   [UC][D] Posix task(...) dispatching.
+   ```
+3. Check if the error code matches one from the [Error Codes](#error-codes) table above
+
+---
+
+### Log Debugging
+
+To view detailed UCM transfer logs, set the environment variable:
+
+```bash
+export UC_LOGGER_LEVEL=debug
+```
+
+This produces per-task logs with task IDs, operation types, data sizes, and timing:
+
+```
+[UC][D] Cache task({task_id},{operation},{subtask_number},{size}) dispatching. [PID,TID]
+[UC][D] Cache task({task_id},{operation},{subtask_number},{size}) finished, cost {time}ms. [PID,TID]
+[UC][D] Posix task({task_id},{operation},{subtask_number},{size}) dispatching. [PID,TID]
+[UC][D] Posix task({task_id},{operation},{subtask_number},{size}) finished, cost {time}ms. [PID,TID]
+```
+
+| Field | Meaning |
+|-------|---------|
+| `task_id` | Unique identifier for the store task |
+| `operation` | Cache Store: `DUMP` (Device→Host) or `LOAD` (Host→Device); Posix Store: `Cache2Backend` (dump to storage) or `Backend2Cache` (load from storage) |
+| `subtask_number` | Number of subtasks in this operation |
+| `size` | Total data size transferred in bytes |
+| `cost` | Execution time in ms |
+
+To customize the log directory:
+
+```bash
+export UCM_LOG_PATH=my_log_dir
+```
+
+By default, logs are placed under the `log` directory relative to where the vLLM service was started.

--- a/docs-next/docs/en/user-guide/diagnostics/trace-mode.md
+++ b/docs-next/docs/en/user-guide/diagnostics/trace-mode.md
@@ -82,6 +82,7 @@ difference is the UCM config file contents.
 Take the Qwen/Qwen2.5-14B-Instruct model as an example:
 
 ```bash
+export ENABLE_UCM_PATCH=1
 vllm serve Qwen/Qwen2.5-14B-Instruct \
   --max-model-len 32000 \
   --tensor-parallel-size 2 \

--- a/docs-next/docs/en/user-guide/engines/index.md
+++ b/docs-next/docs/en/user-guide/engines/index.md
@@ -1,1 +1,0 @@
-Placeholder: this page will hold the engine integration quickstarts for vLLM, vLLM-Ascend, SGLang, and MindIE.

--- a/docs-next/docs/en/user-guide/index.md
+++ b/docs-next/docs/en/user-guide/index.md
@@ -6,8 +6,8 @@ then follow the serving-engine and deployment guidance for your environment.
 ## Sections
 
 - [Installation](installation.md) — select a published artifact and get the matching command
-- [Getting Started](engines/index.md) — vLLM, vLLM Ascend, and SGLang integration
-- [Support Matrix](support-matrix/index.md) — supported models, platforms, and feature coverage
+- [Getting Started](quick_start/index.md) — vLLM, vLLM Ascend, and SGLang integration
+- [Support Matrix](support-matrix/support_matrix.md) — supported models, platforms, and feature coverage
 - [Deploy](deploy/index.md) — container and Kubernetes deployment
 - [Deployment Frameworks](frameworks/index.md) — deploy with pyMotor or Kubernetes
 - [Model Tour](model-tour/index.md) — model-family catalogs and engine-specific launch guidance

--- a/docs-next/docs/en/user-guide/installation.md
+++ b/docs-next/docs/en/user-guide/installation.md
@@ -432,12 +432,18 @@ integrated artifacts are the `0.7.58 Preview/Fork` release.
 ## Next steps
 
 The installer gives you the bootstrap command. For engine integration patches,
-runtime configuration, and serving options, follow the engine guide that
+runtime configuration, and serving options, follow the quick start guide that
 matches your selection:
 
-- [vLLM (CUDA)](engines/index.md)
-- [vLLM Ascend (NPU)](engines/index.md)
-- [SGLang](engines/index.md)
+- [vLLM (CUDA)](quick_start/quickstart_vllm.md)
+- [vLLM Ascend (NPU)](quick_start/quickstart_vllm_ascend.md)
+- [SGLang](quick_start/quickstart_sglang.md)
+- [MindIE](quick_start/quickstart_mindie_llm.md)
+
+For capacity planning, see the
+[KV Cache Calculator](../toolkit/kv-cache-calculator.md).
+For common problems, see
+[Troubleshooting](../reference/troubleshooting.md).
 
 For Kubernetes deployment with Helm, see
 [GLM PD Best Practice](model-tour/index.md).

--- a/docs-next/docs/en/user-guide/quick_start/index.md
+++ b/docs-next/docs/en/user-guide/quick_start/index.md
@@ -1,0 +1,56 @@
+# Getting Started
+
+UCM integrates with the following inference engines by plugging in a KV
+connector / patched store at runtime. Each engine has its own quick start guide
+covering installation, configuration, and launching inference.
+
+## Which guide should I follow?
+
+Pick the guide that matches the engine you use. All guides assume UCM is
+already installed; if it is not, see the [Installation](../installation.md)
+guide first.
+
+<div class="grid cards" markdown>
+
+-   :material-home-account: **vLLM (CUDA)**
+
+    ---
+
+    Run UCM with vLLM on GPU (CUDA) platforms, including prefix caching and
+    sparse attention. Docker, pip, and runtime integration steps.
+
+    [:octicons-arrow-right-24: vLLM quick start](quickstart_vllm.md)
+
+-   :material-chip: **vLLM-Ascend (NPU)**
+
+    ---
+
+    Run UCM with vLLM-Ascend on Ascend NPU platforms, including the upgrade
+    deployment steps for the Ascend environment.
+
+    [:octicons-arrow-right-24: vLLM-Ascend quick start](quickstart_vllm_ascend.md)
+
+-   :material-tools: **SGLang (CUDA)**
+
+    ---
+
+    Run UCM with SGLang on GPU (CUDA) platforms via the hierarchical cache
+    configuration.
+
+    [:octicons-arrow-right-24: SGLang quick start](quickstart_sglang.md)
+
+-   :material-server: **MindIE (NPU Ascend)**
+
+    ---
+
+    Run UCM with MindIE-LLM on Ascend NPU platforms, including MindIE-LLM
+    patching and `mindie_llm_server` configuration.
+
+    [:octicons-arrow-right-24: MindIE quick start](quickstart_mindie_llm.md)
+
+</div>
+
+## Building from source
+
+If you prefer to build UCM from source code rather than using Docker images or
+pip wheels, see [Building and Installing UCM from Source](../../developer-guide/build_from_source.md).

--- a/docs-next/docs/en/user-guide/quick_start/quickstart_mindie_llm.md
+++ b/docs-next/docs/en/user-guide/quick_start/quickstart_mindie_llm.md
@@ -1,0 +1,96 @@
+# Quickstart-MindIE-LLM
+
+This guide shows how to install UCM with MindIE-LLM support, patch the required MindIE-LLM Python modules, configure `mindie_llm`, and launch `mindie_llm_server` with UCM as the KV cache backend on Ascend.
+
+## Prerequisites
+
+- MindIE-LLM 2.3.0
+- Python >= 3.10
+- Ascend runtime/toolkit installed and available in the environment. For details, refer to the [MindIE-LLM official documentation](https://gitcode.com/Ascend/MindIE-LLM/blob/dev/docs/zh/user_guide/quick_start/quick_start.md).
+
+## Step 1: Install UCM
+
+UCM can be installed via Docker.
+
+If you want to build UCM from source code (e.g. for development or customization), see [Building and Installing UCM from Source](../../developer-guide/build_from_source.md).
+
+## Step 2: Prepare the UCM configuration
+
+UCM for MindIE-LLM provides Prefix Cache integration through patched MindIE-LLM modules. You can use the packaged config at `ucm/integration/mindie/ucm_config.json` or provide your own config file.
+
+Minimal example:
+
+```json
+{
+  "storage_backends": ["/path/to/kvcache"],
+  "mindie_config_path": "/usr/local/lib/python3.11/site-packages/mindie_llm/conf/config.json",
+  "block_elem_size": 2
+}
+```
+
+Save this file as `ucm_config.json` and replace the example paths with paths from your environment.
+
+Key notes:
+
+* By default, the patch is applied when `mindie_llm` is first imported after UCM is installed.
+* The hook copies the patched `uc_utils.py`, `unifiedcache_mempool.py`, and `prefix_cache_plugin.py` files into the installed `mindie_llm` package.
+* In the provided Docker image, the patch is already applied during image build, so runtime import uses the patched files directly.
+
+## Step 3: Launch MindIE-LLM with UCM
+
+Locate the installed `mindie_llm` package:
+
+```bash
+python -c "import mindie_llm, os; print(os.path.dirname(mindie_llm.__file__))"
+```
+
+Then locate `conf/config.json` under that directory.
+
+Ensure the service user can read the configuration file. For example:
+
+```bash
+chmod 640 <path-to-mindie_llm>/conf/config.json
+```
+
+In `config.json`, add or update the `kvPoolConfig` section under `BackendConfig`:
+
+```json
+"BackendConfig": {
+  "kvPoolConfig": {
+    "backend": "unifiedcache",
+    "configPath": "/path/to/your/ucm_config.json",
+    "asyncWrite": true
+  }
+}
+```
+
+Update `config.json` with the service IP, port, model path, and any other required MindIE-LLM settings.
+
+Run `mindie_llm_server` to start the service.
+
+If the following message is displayed, the service has started successfully:
+
+```bash
+Daemon start success!
+```
+
+After startup, inspect the MindIE-LLM logs to confirm that the `unifiedcache` backend is loaded successfully.
+
+## Troubleshooting
+
+### MindIE-LLM code is not patched
+
+* Confirm that `UCM_ENABLE_MINDIE=1` was set before installation.
+* Confirm that `UCM_CXX11_ABI=0` or `1` was set correctly before installation.
+* Reinstall UCM.
+* Verify that `mindie_llm` is already installed.
+
+### `configPath` not found
+
+* Use an absolute path.
+* Ensure the file is readable by the service user.
+
+### Service starts but the UCM backend is not enabled
+
+* Recheck `BackendConfig.kvPoolConfig`.
+* Inspect MindIE-LLM startup logs.

--- a/docs-next/docs/en/user-guide/quick_start/quickstart_sglang.md
+++ b/docs-next/docs/en/user-guide/quick_start/quickstart_sglang.md
@@ -1,0 +1,169 @@
+# Quickstart-SGLang
+This document describes how to install unified-cache-management with SGLang on cuda platform.
+
+## Prerequisites
+- SGLang >= v0.5.9, device=cuda
+
+## Step 1: UCM Installation
+
+We offer 2 options to install UCM.
+
+If you want to build UCM from source code (e.g. for development or customization), see [Building and Installing UCM from Source](../../developer-guide/build_from_source.md).
+
+### Option 1: Setup from docker
+
+#### Official pre-built image
+
+```bash
+docker pull unifiedcachemanager/ucm-sglang:latest
+```
+
+Then run your container using following command.
+```bash
+# Use `--ipc=host` to make sure the shared memory is large enough.
+docker run --rm \
+    --gpus all \
+    --network=host \
+    --ipc=host \
+    -v <path_to_your_models>:/home/model \
+    -v <path_to_your_storage>:/home/storage \
+    --name <name_of_your_container> \
+    -it unifiedcachemanager/ucm-sglang:latest
+```
+
+To build the UCM Docker image from source code, see [Building and Installing UCM from Source](../../developer-guide/build_from_source.md).
+
+
+### Option 2: Install by pip
+1. Prepare SGLang Environment
+
+    It is recommended to use a pre-built SGLang docker image. Follow the guide in [Option 1: Setup from docker](#option-1-setup-from-docker) or pull the official image directly:
+    ```bash
+    docker pull lmsysorg/sglang:v0.5.9
+    ```
+
+2. Install by pip
+
+    Install by pip or find the pre-build wheels on [Pypi](https://pypi.org/project/uc-manager/).
+    ```bash
+    export PLATFORM=cuda
+    pip install uc-manager
+    ```
+## Step 2: Configuration
+
+### Feature : Prefix Caching
+
+UCM configuration is passed to SGLang via `--hicache-storage-backend-extra-config` in JSON format:
+
+```bash
+HICACHE_CONFIG='{
+  "backend_name":"unifiedcache",
+  "module_path":"ucm.integration.sglang.unifiedcache_store",
+  "class_name":"UnifiedCacheStore",
+  "interface_v1":1,
+  "kv_connector_extra_config":{
+    "ucm_connector_name":"UcmPipelineStore",
+    "ucm_connector_config":{
+      "storage_backends":"/mnt/test"
+    }
+  }
+}'
+```
+
+Note: Replace `/mnt/test` with your actual storage directory.
+
+## Step 3: Launching Inference
+
+### Offline Inference
+
+SGLang already provides an offline batch inference example. No UCM-specific code changes are required; just pass the same hierarchical cache flags as the server.
+
+```bash
+# Prefix cache config (reuse from Step 2)
+HICACHE_CONFIG='{
+  "backend_name":"unifiedcache",
+  "module_path":"ucm.integration.sglang.unifiedcache_store",
+  "class_name":"UnifiedCacheStore",
+  "interface_v1":1,
+  "kv_connector_extra_config":{
+    "ucm_connector_name":"UcmPipelineStore",
+    "ucm_connector_config":{
+      "storage_backends":"/mnt/test"
+    }
+  }
+}'
+
+python3 /path/to/sglang/examples/runtime/engine/offline_batch_inference.py \
+  --model-path Qwen/Qwen2.5-14B-Instruct \
+  --tensor-parallel-size 2 \
+  --page-size 128 \
+  --trust-remote-code \
+  --enable-hierarchical-cache \
+  --hicache-mem-layout page_first \
+  --hicache-write-policy write_through \
+  --hicache-storage-backend dynamic \
+  --hicache-storage-prefetch-policy wait_complete \
+  --hicache-storage-backend-extra-config "$HICACHE_CONFIG"
+```
+
+**⚠️ Make sure to replace `Qwen/Qwen2.5-14B-Instruct` with your actual model path or HF repo ID.**
+
+**⚠️ Make sure to replace `/mnt/test` (inside `HICACHE_CONFIG`) with your actual storage directory.**
+
+### OpenAI-Compatible Online API
+
+To start the SGLang server with the Qwen/Qwen2.5-14B-Instruct model, run:
+
+```bash
+# Prefix cache config (reuse from Step 2)
+HICACHE_CONFIG='{
+  "backend_name":"unifiedcache",
+  "module_path":"ucm.integration.sglang.unifiedcache_store",
+  "class_name":"UnifiedCacheStore",
+  "interface_v1":1,
+  "kv_connector_extra_config":{
+    "ucm_connector_name":"UcmPipelineStore",
+    "ucm_connector_config":{
+      "storage_backends":"/mnt/test"
+    }
+  }
+}'
+
+python3 -m sglang.launch_server \
+  --model-path Qwen/Qwen2.5-14B-Instruct \
+  --tensor-parallel-size 2 \
+  --page-size 128 \
+  --port 7800 \
+  --trust-remote-code \
+  --enable-hierarchical-cache \
+  --hicache-mem-layout page_first \
+  --hicache-write-policy write_through \
+  --hicache-storage-backend dynamic \
+  --hicache-storage-prefetch-policy wait_complete \
+  --hicache-storage-backend-extra-config "$HICACHE_CONFIG"
+```
+
+**⚠️ Make sure to replace `Qwen/Qwen2.5-14B-Instruct` with your actual model path or HF repo ID.**
+
+**⚠️ Make sure to replace `/mnt/test` (inside `HICACHE_CONFIG`) with your actual storage directory.**
+
+If you see logs like:
+
+```bash
+INFO:     Started server process [32890]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+```
+
+Then you can interact with the API:
+
+```bash
+curl http://localhost:7800/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen2.5-14B-Instruct",
+    "prompt": "Hello!",
+    "max_tokens": 64,
+    "temperature": 0
+  }'
+```

--- a/docs-next/docs/en/user-guide/quick_start/quickstart_vllm.md
+++ b/docs-next/docs/en/user-guide/quick_start/quickstart_vllm.md
@@ -1,0 +1,114 @@
+# Quickstart-vLLM
+This document describes how to install unified-cache-management with vllm on cuda platform.
+
+## Prerequisites
+- vllm >=0.9.1, device=cuda (Sparse Feature is supported in vllm 0.9.2 and v0.11.0)
+
+## UCM Installation
+
+We offer 2 options to install UCM.
+
+If you want to build UCM from source code (e.g. for development or customization), see [Building and Installing UCM from Source](../../developer-guide/build_from_source.md).
+
+### Option 1: Setup from docker
+
+Run your container using following command.
+```bash
+# Use `--ipc=host` to make sure the shared memory is large enough.
+docker run --rm \
+    --gpus all \
+    --network=host \
+    --ipc=host \
+    -v <path_to_your_models>:/home/model \
+    -v <path_to_your_storage>:/home/storage \
+    --name <name_of_your_container> \
+    -it unifiedcachemanager/ucm:latest
+
+```
+
+To build the UCM Docker image from source code, see [Building and Installing UCM from Source](../../developer-guide/build_from_source.md).
+
+
+### Option 2: Install by pip
+
+Find the pre-build wheels on [Pypi](https://pypi.org/project/uc-manager/).
+```SH
+# It is recommended to use a pre-built vLLM docker image by `docker pull vllm/vllm-openai:<vllm_version>`
+export PLATFORM=cuda
+pip install uc-manager
+```
+
+> **Note:** If installing via `pip install`, you need to manually add the `config.yaml` file, similar to the [ucm_config_example.yaml](https://github.com/ModelEngine-Group/unified-cache-management/blob/develop/examples/ucm_config_example.yaml), because PyPI packages do not include YAML files.
+
+### Enable UCM Integration
+
+UCM integrates with vLLM automatically at runtime — no manual patching of the vLLM source code is required.
+
+Simply enable the patch hook by setting the following environment variable before launching vLLM:
+```bash
+export ENABLE_UCM_PATCH=1
+```
+
+UCM detects your vLLM version and applies the required patches on the fly.
+
+>**Note:** To enable Sparse Attention (vLLM 0.11.0), also set `export ENABLE_SPARSE=1`.
+
+
+## Launching Inference
+
+
+
+For online inference , vLLM with our connector can also be deployed as a server that implements the OpenAI API protocol.
+
+To start the vLLM server with the Qwen/Qwen2.5-14B-Instruct model, run:
+
+```bash
+export ENABLE_UCM_PATCH=1
+vllm serve Qwen/Qwen2.5-14B-Instruct \
+--max-model-len 20000 \
+--tensor-parallel-size 2 \
+--gpu_memory_utilization 0.87 \
+--block_size 128 \
+--trust-remote-code \
+--port 7800 \
+--enforce-eager \
+--kv-transfer-config \
+'{
+    "kv_connector": "UCMConnector",
+    "kv_connector_module_path": "ucm.integration.vllm.ucm_connector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {"UCM_CONFIG_FILE": "/workspace/unified-cache-management/examples/ucm_config_example.yaml"}
+}'
+```
+**⚠️ Make sure to replace `Qwen/Qwen2.5-14B-Instruct` with your actual model path or Hugging Face repo ID.**
+
+**⚠️ Make sure to replace `"/workspace/unified-cache-management/examples/ucm_config_example.yaml"` with your actual config file path. For a sample configuration, see the [ucm_config_example.yaml](https://github.com/ModelEngine-Group/unified-cache-management/blob/develop/examples/ucm_config_example.yaml).**
+
+
+If you see log as below:
+
+```bash
+INFO:     Started server process [32890]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+```
+
+Congratulations, you have successfully started the vLLM server with UCM!
+
+After successfully started the vLLM server，you can interact with the API as following:
+
+```bash
+curl http://localhost:7800/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen2.5-14B-Instruct",
+    "prompt": "You are a highly specialized assistant whose mission is to faithfully reproduce English literary texts verbatim, without any deviation, paraphrasing, or omission. Your primary responsibility is accuracy: every word, every punctuation mark, and every line must appear exactly as in the original source. Core Principles: Verbatim Reproduction: If the user asks for a passage, you must output the text word-for-word. Do not alter spelling, punctuation, capitalization, or line breaks. Do not paraphrase, summarize, modernize, or \"improve\" the language. Consistency: The same input must always yield the same output. Do not generate alternative versions or interpretations. Clarity of Scope: Your role is not to explain, interpret, or critique. You are not a storyteller or commentator, but a faithful copyist of English literary and cultural texts. Recognizability: Because texts must be reproduced exactly, they will carry their own cultural recognition. You should not add labels, introductions, or explanations before or after the text. Coverage: You must handle passages from classic literature, poetry, speeches, or cultural texts. Regardless of tone—solemn, visionary, poetic, persuasive—you must preserve the original form, structure, and rhythm by reproducing it precisely. Success Criteria: A human reader should be able to compare your output directly with the original and find zero differences. The measure of success is absolute textual fidelity. Your function can be summarized as follows: verbatim reproduction only, no paraphrase, no commentary, no embellishment, no omission. Please reproduce verbatim the opening sentence of the United States Declaration of Independence (1776), starting with \"When in the Course of human events\" and continuing word-for-word without paraphrasing.",
+    "max_tokens": 100,
+    "temperature": 0
+  }'
+```
+
+### Running with Other Models
+
+To run UCM with other models, first check which models are supported in the [Support Matrix](../support-matrix/support_matrix.md). Then refer to the official [vLLM Recipes](https://recipes.vllm.ai/) for the specific model's serving command and parameters. You only need to add the `--kv-transfer-config` argument as shown in the example above to enable UCM integration.
+

--- a/docs-next/docs/en/user-guide/quick_start/quickstart_vllm_ascend.md
+++ b/docs-next/docs/en/user-guide/quick_start/quickstart_vllm_ascend.md
@@ -1,0 +1,115 @@
+# Quickstart-vLLM-Ascend
+This document describes how to install unified-cache-management with vllm-ascend on ascend platform.
+
+## Prerequisites
+vllm-ascend: >=v0.9.1 (vllm == 0.9.2 to use the Sparse Feature)
+
+**Please refer to the [vLLM-Ascend Installation](https://vllm-ascend.readthedocs.io/en/latest/installation.html#requirements) guide to meet the required dependencies, and prepare the corresponding version of the vllm-ascend environment as needed.**
+
+## UCM Installation
+
+We offer 2 options to install UCM.
+
+If you want to build UCM from source code (e.g. for development or customization), see [Building and Installing UCM from Source](../../developer-guide/build_from_source.md).
+
+### Option 1: Install by pip
+Install by pip or find the pre-build wheels on [Pypi](https://pypi.org/project/uc-manager/).
+```
+export PLATFORM=ascend
+pip install uc-manager
+```
+> **Note:** If installing via `pip install`, you need to manually add the `config.yaml` file, similar to the [ucm_config_example.yaml](https://github.com/ModelEngine-Group/unified-cache-management/blob/develop/examples/ucm_config_example.yaml), because PyPI packages do not include YAML files.
+
+### Enable UCM Integration
+
+UCM integrates with vLLM and vLLM-Ascend automatically at runtime — no manual patching of the source code is required.
+
+Simply enable the patch hook by setting the following environment variable before launching vLLM-Ascend:
+```bash
+export ENABLE_UCM_PATCH=1
+```
+
+UCM detects your vLLM and vLLM-Ascend versions and applies the required patches on the fly.
+
+### Option 2: Setup from docker
+
+#### Build image from pre-built package
+
+```bash
+# Update DEVICE according to your device (/dev/davinci[0-7])
+export DEVICE=/dev/davinci7
+# Update the vllm-ascend image
+docker run --rm \
+    --network=host \
+    --device $DEVICE \
+    --device /dev/davinci_manager \
+    --device /dev/devmm_svm \
+    --device /dev/hisi_hdc \
+    -v /usr/local/dcmi:/usr/local/dcmi \
+    -v /usr/local/bin/npu-smi:/usr/local/bin/npu-smi \
+    -v /usr/local/Ascend/driver/lib64/:/usr/local/Ascend/driver/lib64/ \
+    -v /usr/local/Ascend/driver/version.info:/usr/local/Ascend/driver/version.info \
+    -v /etc/ascend_install.info:/etc/ascend_install.info \
+    -v /root/.cache:/root/.cache \
+    -v <path_to_your_models>:/app/model \
+    -v <path_to_your_storage>:/app/storage \
+    --name <name_of_your_container> \
+    -it <image_id> bash
+```
+
+## Launching Inference
+
+For online inference, vLLM with our connector can also be deployed as a server that implements the OpenAI API protocol.
+
+To start the vLLM server with the Qwen/Qwen2.5-14B-Instruct model, run:
+
+```bash
+export ENABLE_UCM_PATCH=1
+vllm serve Qwen/Qwen2.5-14B-Instruct \
+--max-model-len 20000 \
+--tensor-parallel-size 2 \
+--gpu_memory_utilization 0.87 \
+--block_size 128 \
+--trust-remote-code \
+--port 7800 \
+--enforce-eager \
+--kv-transfer-config \
+'{
+    "kv_connector": "UCMConnector",
+    "kv_connector_module_path": "ucm.integration.vllm.ucm_connector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {"UCM_CONFIG_FILE": "/workspace/unified-cache-management/examples/ucm_config_example.yaml"}
+}'
+```
+**⚠️ Make sure to replace `Qwen/Qwen2.5-14B-Instruct` with your actual model path or Hugging Face repo ID.**
+
+**⚠️ Make sure to replace `"/workspace/unified-cache-management/examples/ucm_config_example.yaml"` with your actual config file path. For a sample configuration, see the [ucm_config_example.yaml](https://github.com/ModelEngine-Group/unified-cache-management/blob/develop/examples/ucm_config_example.yaml).**
+
+
+If you see log as below:
+
+```bash
+INFO:     Started server process [32890]
+INFO:     Waiting for application startup.
+INFO:     Application startup complete.
+```
+
+Congratulations, you have successfully started the vLLM server with UCM!
+
+After successfully started the vLLM server，you can interact with the API as following:
+
+```bash
+curl http://localhost:7800/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen2.5-14B-Instruct",
+    "prompt": "You are a highly specialized assistant whose mission is to faithfully reproduce English literary texts verbatim, without any deviation, paraphrasing, or omission. Your primary responsibility is accuracy: every word, every punctuation mark, and every line must appear exactly as in the original source. Core Principles: Verbatim Reproduction: If the user asks for a passage, you must output the text word-for-word. Do not alter spelling, punctuation, capitalization, or line breaks. Do not paraphrase, summarize, modernize, or \"improve\" the language. Consistency: The same input must always yield the same output. Do not generate alternative versions or interpretations. Clarity of Scope: Your role is not to explain, interpret, or critique. You are not a storyteller or commentator, but a faithful copyist of English literary and cultural texts. Recognizability: Because texts must be reproduced exactly, they will carry their own cultural recognition. You should not add labels, introductions, or explanations before or after the text. Coverage: You must handle passages from classic literature, poetry, speeches, or cultural texts. Regardless of tone—solemn, visionary, poetic, persuasive—you must preserve the original form, structure, and rhythm by reproducing it precisely. Success Criteria: A human reader should be able to compare your output directly with the original and find zero differences. The measure of success is absolute textual fidelity. Your function can be summarized as follows: verbatim reproduction only, no paraphrase, no commentary, no embellishment, no omission. Please reproduce verbatim the opening sentence of the United States Declaration of Independence (1776), starting with \"When in the Course of human events\" and continuing word-for-word without paraphrasing.",
+    "max_tokens": 100,
+    "temperature": 0
+  }'
+
+```
+
+### Running with Other Models
+
+To run UCM with other models, first check which models are supported in the [Support Matrix](../support-matrix/support_matrix.md). Then refer to the official [vLLM Recipes](https://recipes.vllm.ai/) and [vLLM-Ascend Model Tutorials](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/index.html) for the specific model's serving command and parameters. You only need to add the `--kv-transfer-config` argument as shown in the example above to enable UCM integration.

--- a/docs-next/docs/en/user-guide/support-matrix/support_matrix.md
+++ b/docs-next/docs/en/user-guide/support-matrix/support_matrix.md
@@ -1,0 +1,77 @@
+# Feature and Model Support Matrix
+
+This page provides an overview of UCM (Unified Cache Manager) compatibility across different models and inference frameworks.
+Use this matrix as a compatibility reference for model selection, deployment, and feature validation.
+
+## Legend 🧭
+
+| Symbol | Description |
+|--------|-------------|
+| ✅ | Fully supported |
+| ❌ | Not supported |
+| 🟡 | Not tested or verified |
+
+## Model Support and Feature Compatibility 🧩
+
+### Prefix Cache Support
+
+This section presents prefix cache support for each model across the supported inference frameworks.
+This information serves as a reference for evaluating framework compatibility in deployments that require prefix cache.
+
+| Model | vLLM<br>(main) | vLLM-Ascend<br>(main) | SGLang<br>(main) |
+|-------|:-----------:|:------------------:|:------:|
+| DeepSeek V3.2 | ✅ | ✅ | ✅ |
+| DeepSeek R1 | ✅ | ✅ | ✅ |
+| DeepSeek V3/3.1 | ✅ | ✅ | ✅ |
+| DeepSeek V4 Pro | ✅ | ✅ | ❌ |
+| DeepSeek V4 Flash | ✅ | ✅ | ❌ |
+| Qwen3.6 | ✅ | ✅ | ❌ |
+| Qwen3.5 | ✅ | ✅ | ❌ |
+| Qwen3 | ✅ | ✅ | ✅ |
+| Qwen3-Moe | ✅ | ✅ | ✅ |
+| Qwen3-Next | ✅ | ✅ | ❌ |
+| Qwen2.5 | ✅ | ✅ | ✅ |
+| GLM-5.2 | ✅ | ✅ | ❌ |
+| GLM-5.1 | ✅ | ✅ | ❌ |
+| GLM-5 | ✅ | ✅ | ❌ |
+| GLM-4.x | ✅ | ✅ | ✅ |
+| MiniMax-M2.5 | ✅ | ✅ | ✅ |
+| MiniMax-M2.7 | ✅ | ✅ | ✅ |
+| MiniMax-M3 | ❌ | ❌ | ❌ |
+| Kimi-K2.5 | ❌ | ❌ | ❌ |
+
+> **Note**: The table lists a selected set of representative models.
+> See [**Prefix Cache**](https://ucm.readthedocs.io/en/latest/user-guide/prefix-cache/index.html) for more details.
+
+### Inference Enhancement Features
+
+This section presents support information for inference enhancement features, including Sparse Attention, ReRoPE, and CacheBlend, across the listed models and framework versions.
+
+| Model | GsaOnDevice<br>vLLM / vLLM-Ascend 0.11.0 | ReRoPE<br>vLLM 0.11.0 | CacheBlend<br>vLLM 0.9.2 |
+|-------|:-------------------------:|:------------------------:|:---------------------:|
+| DeepSeek V3.2 | ✅ | ✅ | ✅ |
+| DeepSeek R1 | ✅ | ✅ | ✅ |
+| DeepSeek V3/3.1 | ✅ | ✅ | ✅ |
+| Qwen3 | ✅ | ✅ | ✅ |
+| Qwen2.5 | ✅ | ✅ | ✅ |
+
+> **Note**: See [**Sparse Attention**](https://ucm.readthedocs.io/en/latest/user-guide/sparse-attention/index.html) and [**ReRoPE**](https://ucm.readthedocs.io/en/latest/user-guide/rerope/rerope.html) for more details.
+
+## Supported Compute Platforms and Devices
+
+This section presents the currently supported compute platforms and devices.
+
+| Compute Platform | Vendor | Device |
+|:----------------:|:------:|:------:|
+| CANN | Ascend | 910C, 910B |
+| CUDA | NVIDIA | H100, H20, L40, L20 |
+| MUSA | Mthreads | S5000 |
+| MACA | MetaX | C500 |
+
+> **Note**: The table shows only selected platforms.
+
+## Notes and Limitations 📌
+
+- This matrix is provided as a compatibility reference for the configurations listed on this page.
+- Actual behavior may vary depending on hardware, runtime settings, backend changes, and model variants.
+- This support matrix is continuously updated. **For the latest information, please refer to the GitHub issues and pull requests.**

--- a/docs-next/docs/zh/index.md
+++ b/docs-next/docs/zh/index.md
@@ -78,7 +78,7 @@ hide:
 
     将 UCM 与 vLLM、vLLM Ascend、SGLang、MindIE 集成。
 
-    [:octicons-arrow-right-24: 快速开始](user-guide/engines/index.md)
+    [:octicons-arrow-right-24: 引擎](user-guide/quick_start/quickstart_vllm.md)
 
 -   :material-view-grid-plus: **兼容性矩阵**
 

--- a/docs-next/docs/zh/user-guide/diagnostics/trace-mode.md
+++ b/docs-next/docs/zh/user-guide/diagnostics/trace-mode.md
@@ -75,6 +75,7 @@ Trace 模式作为 OpenAI 兼容的 vLLM 服务器部署。以与正常 UCM 部�
 以 Qwen/Qwen2.5-14B-Instruct 模型为例：
 
 ```bash
+export ENABLE_UCM_PATCH=1
 vllm serve Qwen/Qwen2.5-14B-Instruct \
   --max-model-len 32000 \
   --tensor-parallel-size 2 \

--- a/docs-next/mkdocs.yml
+++ b/docs-next/mkdocs.yml
@@ -144,7 +144,12 @@ nav:
   - User Guide:
       - user-guide/index.md
       - Installation: user-guide/installation.md
-      - Getting Started: user-guide/engines/index.md
+      - Getting Started:
+          - Getting Started: user-guide/quick_start/index.md
+          - vLLM (CUDA): user-guide/quick_start/quickstart_vllm.md
+          - vLLM Ascend (NPU): user-guide/quick_start/quickstart_vllm_ascend.md
+          - SGLang (CUDA): user-guide/quick_start/quickstart_sglang.md
+          - MindIE (NPU Ascend): user-guide/quick_start/quickstart_mindie_llm.md
       - Support Matrix: user-guide/support-matrix/index.md
       - Deploy: user-guide/deploy/index.md
       - Deployment Frameworks:
@@ -172,8 +177,11 @@ nav:
       - Diagnostics:
           - Overview: user-guide/diagnostics/index.md
           - Trace Mode: user-guide/diagnostics/trace-mode.md
+      - Support Matrix: user-guide/support-matrix/support_matrix.md
+      
   - Developer Guide:
       - Architecture: developer-guide/architecture.md
+      - Build from Source: developer-guide/build_from_source.md
       - Capability Principles: developer-guide/capability-principles.md
       - Add Metrics: developer-guide/add-metrics.md
       - Extending Store: developer-guide/extending-store.md

--- a/docs/source/developer-guide/build_from_source.md
+++ b/docs/source/developer-guide/build_from_source.md
@@ -1,0 +1,87 @@
+# Building and Installing UCM from Source
+
+This guide explains how to build Unified Cache Management (UCM) from source code for development or customization purposes.
+
+If you just want to use UCM, refer to the [Quickstart (vLLM)](../getting-started/quickstart_vllm.md) or [Quickstart (vLLM-Ascend)](../getting-started/quickstart_vllm_ascend.md), which describe installation via Docker images or pip.
+
+## Step 1: Prepare the Framework Environment
+
+Before building UCM from source, prepare the inference framework environment that UCM integrates with.
+
+### vLLM (CUDA Platform)
+
+For the sake of environment isolation and simplicity, we recommend preparing the vLLM environment by pulling the official, pre-built vLLM Docker image.
+
+```bash
+docker pull vllm/vllm-openai:<vllm_version>
+```
+
+Then run your own container:
+
+```bash
+# Use `--ipc=host` to make sure the shared memory is large enough.
+docker run \
+    --gpus all \
+    --network=host \
+    --ipc=host \
+    -v <path_to_your_models>:/home/model \
+    -v <path_to_your_storage>:/home/storage \
+    --entrypoint /bin/bash \
+    --name <name_of_your_container> \
+    -it vllm/vllm-openai:<vllm_version>
+```
+
+Refer to [Set up using docker](https://docs.vllm.ai/en/latest/getting_started/installation/gpu.html#set-up-using-docker) for more information to run your own vLLM container.
+
+### vLLM-Ascend (Ascend Platform)
+
+Work in a ready vLLM-Ascend environment. Please refer to the [vLLM-Ascend Installation](https://vllm-ascend.readthedocs.io/en/latest/installation.html#requirements) guide to meet the required dependencies and prepare the corresponding version of the vLLM-Ascend environment.
+
+## Step 2: Build UCM from Source
+
+### CUDA Platform (vLLM)
+
+Follow the commands below to install unified-cache-management from source code:
+
+**Note:** The sparse module was not compiled by default. To enable it, set the environment variable `export ENABLE_SPARSE=TRUE` before you build.
+
+```bash
+# Replace <branch_or_tag_name> with the branch or tag name needed
+git clone --depth 1 --branch <branch_or_tag_name> https://github.com/ModelEngine-Group/unified-cache-management.git
+cd unified-cache-management
+export PLATFORM=cuda
+pip install -v -e . --no-build-isolation
+```
+
+### Ascend Platform (vLLM-Ascend)
+
+```bash
+# Replace <branch_or_tag_name> with the branch or tag name needed
+git clone --depth 1 --branch <branch_or_tag_name> https://github.com/ModelEngine-Group/unified-cache-management.git
+cd unified-cache-management
+export PLATFORM=ascend
+pip install -v -e . --no-build-isolation
+```
+
+>**Note:** For the Atlas A3 series, the `PLATFORM` variable should be set to `ascend-a3`.
+
+## Step 3: Enable UCM Integration
+
+UCM integrates with vLLM / vLLM-Ascend automatically at runtime — no manual patching of the source code is required.
+
+Enable the patch hook by setting the following environment variable before launching the inference service:
+
+```bash
+export ENABLE_UCM_PATCH=1
+```
+
+>**Note:** To enable Sparse Attention (vLLM 0.11.0), also set `export ENABLE_SPARSE=1`.
+
+## Alternative: Build via Docker Build Scripts
+
+When building the Docker images from source, the Dockerfile automatically invokes the corresponding build script to compile the wheel and installs from the built package:
+
+- `scripts/build_cuda.sh` — builds the wheel for the CUDA platform
+- `scripts/build_ascend.sh` — builds the wheel for the Ascend platform
+- `scripts/build_mindie.sh` — builds the wheel for MindIE
+- `scripts/build_sglang.sh` — builds the wheel for SGLang

--- a/docs/source/getting-started/quickstart_vllm.md
+++ b/docs/source/getting-started/quickstart_vllm.md
@@ -6,7 +6,9 @@ This document describes how to install unified-cache-management with vllm on cud
 
 ## Step 1: UCM Installation
 
-We offer 3 options to install UCM.
+We offer 2 options to install UCM.
+
+If you want to build UCM from source code (e.g. for development or customization), see [Building and Installing UCM from Source](../developer-guide/build_from_source.md).
 
 ### Option 1: Setup from docker
 
@@ -58,119 +60,13 @@ docker build --build-arg INSTALL_MODE=package \
 ```
 
 
-### Option 2: Build from source
+### Option 2: Install by pip
 1. Prepare vLLM Environment
 
-    For the sake of environment isolation and simplicity, we recommend preparing the vLLM environment by pulling the official, pre-built vLLM Docker image.
-
+    It is recommended to use a pre-built vLLM docker image. Follow the guide in [Option 1: Setup from docker](#option-1-setup-from-docker) or pull the official image directly:
     ```bash
     docker pull vllm/vllm-openai:<vllm_version>
     ```
-    Use the following command to run your own container:
-    ```bash
-    # Use `--ipc=host` to make sure the shared memory is large enough.
-    docker run \
-        --gpus all \
-        --network=host \
-        --ipc=host \
-        -v <path_to_your_models>:/home/model \
-        -v <path_to_your_storage>:/home/storage \
-        --entrypoint /bin/bash \
-        --name <name_of_your_container> \
-        -it vllm/vllm-openai:<vllm_version>
-    ```
-    Refer to [Set up using docker](https://docs.vllm.ai/en/latest/getting_started/installation/gpu.html#set-up-using-docker) for more information to run your own vLLM container.
-
-2. Build From Source Code
-
-    Follow commands below to install unified-cache-management:
-
-    **Note:** The sparse module was not compiled by default. To enable it, set the environment variable `export ENABLE_SPARSE=TRUE` before you build.
-
-    ```bash
-    # Replace <branch_or_tag_name> with the branch or tag name needed
-    git clone --depth 1 --branch <branch_or_tag_name> https://github.com/ModelEngine-Group/unified-cache-management.git
-    cd unified-cache-management
-    export PLATFORM=cuda
-    pip install -v -e . --no-build-isolation
-    ```
-
-3. Apply vLLM Integration Patches
-
-    To integrate UCM with vLLM, you can choose between a dynamic **monkey patch** (recommended) and a manual **git patch**.
-
-    >**Recommendation**: We highly recommend the Monkey Patch approach for its non-invasive nature and ease of use.
-
-    #### Option A: Monkey Patch (Recommended)
-
-    This method enables UCM features dynamically at runtime via environment variables, requiring no source code modifications.
-    It automatically detects the vLLM version and applies patches only when needed — you can safely keep it enabled regardless of your vLLM version.
-    Available for vLLM ≥ 0.11.0 (not supported on 0.9.2, which requires Manual Git Patch).
-
-    1. Enable Monkey Patch:
-    ```bash
-    export ENABLE_UCM_PATCH=1
-    ```
-
-    2. Enable Sparse Attention (Optional, vLLM 0.11.0 only):
-    ```bash
-    export ENABLE_SPARSE=1
-    ```
-
-    **Note:**
-    - ReRoPE support is currently only available via the Git Patch method.
-
-    #### Option B: Manual Git Patch (Legacy/Alternative, only available for vLLM 0.9.2 and 0.11.0)
-
-    If you prefer modifying the source code directly, follow these steps:
-    
-    ##### 1. Navigate to the vLLM source directory:
-    ```bash
-    cd <path_to_vllm>
-    ```
-    ##### 2. Apply the patch that corresponds to your vLLM version and requirements:
-    
-    ###### vLLM 0.9.2
-    - Full UCM integration (recommended):
-    ```bash
-    git apply <path_to_ucm>/ucm/integration/vllm/patch/0.9.2/vllm-adapt.patch
-    ```
-
-    - Sparse attention only:
-    ```bash
-    git apply <path_to_ucm>/ucm/integration/vllm/patch/0.9.2/vllm-adapt-sparse.patch
-    ```
-
-    - ReRoPE support only:
-    ```bash
-    git apply <path_to_ucm>/ucm/integration/vllm/patch/0.9.2/vllm-adapt-rerope.patch
-    ```
-
-    ###### vLLM 0.11.0
-
-    - Full UCM integration (recommended):
-    ```bash
-    git apply <path_to_ucm>/ucm/integration/vllm/patch/0.11.0/vllm-adapt.patch
-    ```
-
-    - Sparse attention only:
-    ```bash
-    git apply <path_to_ucm>/ucm/integration/vllm/patch/0.11.0/vllm-adapt-sparse.patch
-    ```
-
-    - ReRoPE support only:
-    ```bash
-    git apply <path_to_ucm>/ucm/integration/vllm/patch/0.11.0/vllm-adapt-rerope.patch
-    ```
-
-    Choose the patch according to your development needs.
-    If you are working on **sparse attention** or **ReRoPE** independently, applying only the corresponding patch is sufficient.
-
-
-### Option 3: Install by pip
-1. Prepare vLLM Environment
-
-    It is recommended to use a pre-build vllm docker image, please follow the guide in Option 2.
 
 2. install by pip
 
@@ -180,6 +76,19 @@ docker build --build-arg INSTALL_MODE=package \
     pip install uc-manager
     ```
 > **Note:** If installing via `pip install`, you need to manually add the `config.yaml` file, similar to `unified-cache-management/examples/ucm_config_example.yaml`, because PyPI packages do not include YAML files.
+
+### Enable UCM Integration
+
+UCM integrates with vLLM automatically at runtime — no manual patching of the vLLM source code is required.
+
+Simply enable the patch hook by setting the following environment variable before launching vLLM:
+```bash
+export ENABLE_UCM_PATCH=1
+```
+
+UCM detects your vLLM version and applies the required patches on the fly.
+
+>**Note:** To enable Sparse Attention (vLLM 0.11.0), also set `export ENABLE_SPARSE=1`.
 
 ## Step 2: Configuration
 
@@ -200,7 +109,7 @@ You may directly edit the example file at `unified-cache-management/examples/ucm
 
 ### Feature 2:  Sparsity
 
-The sparse module was not compiled by default. To enable it, set the environment variable `export ENABLE_SPARSE=TRUE` and re-compile the code you built. And uncomment `ucm_sparse_config` code block in `unified-cache-management/examples/ucm_config_example.yaml`.
+The sparse module was not compiled by default. To enable it, set the environment variable `export ENABLE_SPARSE=TRUE` and build the package again (see [Building and Installing UCM from Source](../developer-guide/build_from_source.md)). And uncomment `ucm_sparse_config` code block in `unified-cache-management/examples/ucm_config_example.yaml`.
 
 ## Step 3: Launching Inference
 

--- a/docs/source/getting-started/quickstart_vllm_ascend.md
+++ b/docs/source/getting-started/quickstart_vllm_ascend.md
@@ -8,73 +8,11 @@ vllm-ascend: >=v0.9.1 (vllm == 0.9.2 to use the Sparse Feature)
 
 ## Step 1: UCM Installation
 
-We offer 3 options to install UCM.
+We offer 2 options to install UCM.
 
-### Option 1: Build from source
+If you want to build UCM from source code (e.g. for development or customization), see [Building and Installing UCM from Source](../developer-guide/build_from_source.md).
 
-1、Follow commands below to install unified-cache-management from source code:
-**Note:** The sparse module was not compiled by default. To enable it, set the environment variable `export ENABLE_SPARSE=TRUE` before you build.
-```bash
-# Replace <branch_or_tag_name> with the branch or tag name needed
-git clone --depth 1 --branch <branch_or_tag_name> https://github.com/ModelEngine-Group/unified-cache-management.git
-cd unified-cache-management
-export PLATFORM=ascend
-pip install -v -e . --no-build-isolation
-cd ..
-```
-
->**Note:** For the Atlas A3 series, the `PLATFORM` variable should be set to `ascend-a3`.
-
-2、Apply vLLM and vLLM-Ascend Integration Patches
-
-To enable Unified Cache Management (UCM) integration, you need to apply patches to both vLLM and vLLM-Ascend source trees.
-
-#### Option A: Monkey Patch (Recommended)
-
-This method enables UCM features dynamically at runtime via environment variables, requiring no source code modifications.
-It automatically detects the vLLM version and applies patches only when needed — you can safely keep it enabled regardless of your vLLM version.
-Available for vLLM ≥ 0.11.0 (not supported on 0.9.2, which requires Manual Git Patch).
-
-1. Enable Monkey Patch:
-```bash
-export ENABLE_UCM_PATCH=1
-```
-
-2. Enable Sparse Attention (supported on v0.11.0):
-```bash
-export ENABLE_SPARSE=1
-```
-
-#### Option B: Manual Git Patch (Legacy/Alternative, only supported for v0.9.2 and v0.11.0)
-
-If you prefer modifying the source code directly, follow these steps:
-
-**Step 1:** Apply the vLLM Patch
-
-First, apply the standard vLLM integration patch in the vLLM source directory:
-    
-```bash
-cd <path_to_vllm>
-# Replace <vLLM_VERSION> with 0.9.2 or 0.11.0
-git apply <patch_to_ucm>/ucm/integration/vllm/patch/<vLLM_VERSION>/vllm-adapt.patch
-```
-    
-**Step 2:** Apply the vLLM-Ascend Patch
-
-Then, switch to the vLLM-Ascend source directory and apply the Ascend-specific patch:
-
-```bash
-cd <path_to_vllm_ascend>
-# Replace <vLLM_VERSION> with 0.9.2 or 0.11.0
-git apply <patch_to_ucm>/ucm/integration/vllm/patch/<vLLM_VERSION>/vllm-ascend-adapt.patch
-```
-
->**Note:**
-    The ReRoPE algorithm is not supported on Ascend at the moment.
-    Only the standard UCM integration is applicable for vLLM-Ascend.
-
-
-### Option 2: Install by pip
+### Option 1: Install by pip
 Install by pip or find the pre-build wheels on [Pypi](https://pypi.org/project/uc-manager/).
 ```
 export PLATFORM=ascend
@@ -82,7 +20,20 @@ pip install uc-manager
 ```
 > **Note:** If installing via `pip install`, you need to manually add the `config.yaml` file, similar to `unified-cache-management/examples/ucm_config_example.yaml`, because PyPI packages do not include YAML files.
 
-### Option 3: Setup from docker
+### Enable UCM Integration
+
+UCM integrates with vLLM and vLLM-Ascend automatically at runtime — no manual patching of the source code is required.
+
+Simply enable the patch hook by setting the following environment variable before launching vLLM-Ascend:
+```bash
+export ENABLE_UCM_PATCH=1
+```
+
+UCM detects your vLLM and vLLM-Ascend versions and applies the required patches on the fly.
+
+>**Note:** To enable Sparse Attention (supported on v0.11.0), also set `export ENABLE_SPARSE=1`.
+
+### Option 2: Setup from docker
 
 #### Build image from source
 Check the `docker/` directory for available Dockerfile versions (e.g. `v0.20.2`, `v0.18.0`, `v0.17.0`, `v0.11.0`), then build with the desired version:
@@ -156,7 +107,7 @@ You may directly edit the example file at `unified-cache-management/examples/ucm
 
 ### Feature 2:  Sparsity
 
-The sparse module was not compiled by default. To enable it, set the environment variable `export ENABLE_SPARSE=TRUE` and re-compile the code you built. And uncomment `ucm_sparse_config` code block in `unified-cache-management/examples/ucm_config_example.yaml`. Additionally, if you want to run GSA, you also need to set the environment variable `export VLLM_HASH_ATTENTION=1`.
+The sparse module was not compiled by default. To enable it, set the environment variable `export ENABLE_SPARSE=TRUE` and build the package again (see [Building and Installing UCM from Source](../developer-guide/build_from_source.md)). And uncomment `ucm_sparse_config` code block in `unified-cache-management/examples/ucm_config_example.yaml`. Additionally, if you want to run GSA, you also need to set the environment variable `export VLLM_HASH_ATTENTION=1`.
 
 ## Step 3: Launching Inference
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -69,6 +69,7 @@ user-guide/trace_mode
 :::{toctree}
 :caption: Developer Guide
 :maxdepth: 1
+developer-guide/build_from_source
 developer-guide/contribute
 developer-guide/deepdive_ucm
 developer-guide/add_metrics


### PR DESCRIPTION
## Modifications 

- Refer to quick start documents in index page
<img width="1521" height="616" alt="image" src="https://github.com/user-attachments/assets/02ceda1a-e056-41e2-8f64-2138ec8025a5" />

- Move the content of `build from source` from quick start documents to `developer guide`
<img width="1564" height="1154" alt="image" src="https://github.com/user-attachments/assets/a3c4910e-3c47-4821-a205-005dba09639c" />

- quick start documents 
