### PR TITLE
[Feat] Add precise mode to Posix GC for global-hotness reclamation

### DIFF
--- a/ucm/store/posix/cc/global_config.h
+++ b/ucm/store/posix/cc/global_config.h
@@ -46,6 +46,8 @@ struct Config {
     size_t dataDirShardBytes{3};
     bool posixGcEnable{true};
     double posixGcRecyclePercent{0.1};
+    bool posixGcPreciseMode{true};
+    double posixGcCandidateExtraPercent{0.1};
     size_t posixGcConcurrency{16};
     size_t posixGcCheckIntervalSec{30};
     size_t posixCapacityGb{0};

--- a/ucm/store/posix/cc/posix_store.cc
+++ b/ucm/store/posix/cc/posix_store.cc
@@ -198,6 +198,8 @@ private:
         inConfig.GetNumber("data_dir_shard_bytes", config.dataDirShardBytes);
         inConfig.Get("posix_gc_enable", config.posixGcEnable);
         inConfig.Get("posix_gc_recycle_percent", config.posixGcRecyclePercent);
+        inConfig.Get("posix_gc_precise_mode", config.posixGcPreciseMode);
+        inConfig.Get("posix_gc_candidate_extra_percent", config.posixGcCandidateExtraPercent);
         inConfig.GetNumber("posix_gc_concurrency", config.posixGcConcurrency);
         inConfig.GetNumber("posix_gc_check_interval_sec", config.posixGcCheckIntervalSec);
         inConfig.GetNumber("posix_capacity_gb", config.posixCapacityGb);
@@ -242,30 +244,23 @@ private:
                 return Status::InvalidParam("invalid cpu core({})", core);
             }
         }
-        if (config.deviceId == -1) { return Status::OK(); }
-        if (config.tensorSize == 0 || config.shardSize < config.tensorSize ||
-            config.blockSize < config.shardSize || config.shardSize % config.tensorSize != 0 ||
-            config.blockSize % config.shardSize != 0) {
-            return Status::InvalidParam("invalid size({},{},{})", config.tensorSize,
-                                        config.shardSize, config.blockSize);
-        }
-        if (config.ioEngine == "aio") {
-            if (config.openConcurrency == 0 || config.commitConcurrency == 0) {
-                return Status::InvalidParam("invalid aio concurrency({},{})",
-                                            config.openConcurrency, config.commitConcurrency);
-            }
-        } else if (config.ioEngine == "psync") {
-            if (config.dataTransConcurrency == 0) {
-                return Status::InvalidParam("invalid psync concurrency({})",
-                                            config.dataTransConcurrency);
-            }
-        } else {
-            return Status::InvalidParam("invalid io engine({})", config.ioEngine);
-        }
         if (config.posixGcEnable && config.posixCapacityGb > 0) {
             if (config.posixGcRecyclePercent <= 0 || config.posixGcRecyclePercent > 1.0) {
                 return Status::InvalidParam("invalid gc recycle percent({})",
                                             config.posixGcRecyclePercent);
+            }
+            if (config.posixGcPreciseMode) {
+                if (config.posixGcCandidateExtraPercent <= 0 ||
+                    config.posixGcCandidateExtraPercent >= 1.0) {
+                    return Status::InvalidParam("invalid gc candidate extra percent({})",
+                                                config.posixGcCandidateExtraPercent);
+                }
+                if (config.posixGcRecyclePercent + config.posixGcCandidateExtraPercent > 1.0) {
+                    return Status::InvalidParam(
+                        "gc recycle percent({}) plus candidate extra percent({}) must not exceed "
+                        "1.0",
+                        config.posixGcRecyclePercent, config.posixGcCandidateExtraPercent);
+                }
             }
             if (config.posixGcConcurrency == 0) {
                 return Status::InvalidParam("invalid gc concurrency({})",
@@ -303,6 +298,26 @@ private:
                 }
             }
         }
+        if (config.deviceId == -1) { return Status::OK(); }
+        if (config.tensorSize == 0 || config.shardSize < config.tensorSize ||
+            config.blockSize < config.shardSize || config.shardSize % config.tensorSize != 0 ||
+            config.blockSize % config.shardSize != 0) {
+            return Status::InvalidParam("invalid size({},{},{})", config.tensorSize,
+                                        config.shardSize, config.blockSize);
+        }
+        if (config.ioEngine == "aio") {
+            if (config.openConcurrency == 0 || config.commitConcurrency == 0) {
+                return Status::InvalidParam("invalid aio concurrency({},{})",
+                                            config.openConcurrency, config.commitConcurrency);
+            }
+        } else if (config.ioEngine == "psync") {
+            if (config.dataTransConcurrency == 0) {
+                return Status::InvalidParam("invalid psync concurrency({})",
+                                            config.dataTransConcurrency);
+            }
+        } else {
+            return Status::InvalidParam("invalid io engine({})", config.ioEngine);
+        }
         return Status::OK();
     }
     void ShowConfig(const Config& config)
@@ -329,6 +344,11 @@ private:
             UC_INFO("Set {}::PosixGcEnable to {}.", ns, config.posixGcEnable);
             UC_INFO("Set {}::PosixCapacityGb to {}.", ns, config.posixCapacityGb);
             UC_INFO("Set {}::PosixGcRecyclePercent to {}.", ns, config.posixGcRecyclePercent);
+            UC_INFO("Set {}::PosixGcPreciseMode to {}.", ns, config.posixGcPreciseMode);
+            if (config.posixGcPreciseMode) {
+                UC_INFO("Set {}::PosixGcCandidateExtraPercent to {}.", ns,
+                        config.posixGcCandidateExtraPercent);
+            }
             UC_INFO("Set {}::PosixGcConcurrency to {}.", ns, config.posixGcConcurrency);
             UC_INFO("Set {}::PosixGcCheckIntervalSec to {}.", ns, config.posixGcCheckIntervalSec);
             UC_INFO("Set {}::PosixGcTriggerThresholdRatio to {}.", ns,

--- a/ucm/store/posix/cc/shard_gc.cc
+++ b/ucm/store/posix/cc/shard_gc.cc
@@ -22,6 +22,8 @@
  * SOFTWARE.
  * */
 #include "shard_gc.h"
+#include <algorithm>
+#include <unordered_map>
 #include "logger/logger.h"
 #include "metrics_api.h"
 #include "thread/cpu_affinity.h"
@@ -153,6 +155,7 @@ void ShardGarbageCollector::RunGcCycle()
 
 bool ShardGarbageCollector::Execute()
 {
+    if (config_.posixGcPreciseMode) { return ExecutePrecise(); }
     auto waiter = std::make_shared<Latch>();
     auto shards = layout_->SampleShards(1.0);
     waiter->Set(shards.size());
@@ -161,6 +164,62 @@ bool ShardGarbageCollector::Execute()
         gcPool_.Push({ShardTaskContext::Type::GC, shard, waiter, nullptr, &gcLimited});
     }
     waiter->Wait();
+    return gcLimited.load();
+}
+
+bool ShardGarbageCollector::ExecutePrecise()
+{
+    const auto shards = layout_->SampleShards(1.0);
+    std::atomic<bool> gcLimited{false};
+    std::vector<std::vector<FileInfo>> perShard(shards.size());
+    {
+        auto waiter = std::make_shared<Latch>();
+        waiter->Set(shards.size());
+        for (size_t i = 0; i < shards.size(); i++) {
+            gcPool_.Push({ShardTaskContext::Type::COLLECT, shards[i], waiter, nullptr, &gcLimited,
+                          &perShard[i]});
+        }
+        waiter->Wait();
+    }
+
+    size_t candidateCount = 0;
+    for (const auto& shardCandidates : perShard) { candidateCount += shardCandidates.size(); }
+    if (candidateCount == 0) { return false; }
+
+    std::vector<FileInfo> merged;
+    merged.reserve(candidateCount);
+    for (auto& shardCandidates : perShard) {
+        merged.insert(merged.end(), shardCandidates.begin(), shardCandidates.end());
+        shardCandidates.clear();
+        shardCandidates.shrink_to_fit();
+    }
+
+    const auto candidatePercent =
+        config_.posixGcRecyclePercent + config_.posixGcCandidateExtraPercent;
+    size_t victimCount = static_cast<size_t>(static_cast<double>(candidateCount) *
+                                             config_.posixGcRecyclePercent / candidatePercent);
+    if (victimCount == 0) { return false; }
+    victimCount = std::min(victimCount, merged.size());
+    std::nth_element(
+        merged.begin(), merged.begin() + victimCount - 1, merged.end(),
+        [](const FileInfo& lhs, const FileInfo& rhs) { return lhs.mtime < rhs.mtime; });
+
+    std::unordered_map<std::string, std::vector<Detail::BlockId>> victimsByShard;
+    for (size_t i = 0; i < victimCount; i++) {
+        victimsByShard[layout_->ShardOf(merged[i].blockId)].push_back(merged[i].blockId);
+    }
+    UC_DEBUG("GC precise: candidates={}, deleting={} across {} shard(s)", candidateCount,
+             victimCount, victimsByShard.size());
+
+    {
+        auto waiter = std::make_shared<Latch>();
+        waiter->Set(victimsByShard.size());
+        for (const auto& [shard, victims] : victimsByShard) {
+            gcPool_.Push({ShardTaskContext::Type::DELETE, shard, waiter, nullptr, nullptr, nullptr,
+                          &victims});
+        }
+        waiter->Wait();
+    }
     return gcLimited.load();
 }
 
@@ -203,15 +262,34 @@ void ShardGarbageCollector::OnTaskTimeout(const ShardTaskContext& ctx, ssize_t t
 
 void ShardGarbageCollector::ProcessTask(ShardTaskContext& ctx)
 {
-    if (ctx.type == ShardTaskContext::Type::SAMPLE) {
-        size_t count = layout_->CountFilesInShard(ctx.shard);
-        ctx.sampledFiles->fetch_add(count, std::memory_order_relaxed);
-    } else {
-        auto filesToDelete = layout_->GetOldestFiles(ctx.shard, config_.posixGcRecyclePercent,
-                                                     config_.posixGcMaxRecycleCountPerShard);
-        for (const auto& blockId : filesToDelete) { layout_->RemoveFile(blockId); }
-        if (filesToDelete.size() >= config_.posixGcMaxRecycleCountPerShard) {
-            ctx.gcLimited->store(true, std::memory_order_relaxed);
+    switch (ctx.type) {
+        case ShardTaskContext::Type::SAMPLE: {
+            size_t count = layout_->CountFilesInShard(ctx.shard);
+            ctx.sampledFiles->fetch_add(count, std::memory_order_relaxed);
+            break;
+        }
+        case ShardTaskContext::Type::COLLECT: {
+            const auto candidatePercent =
+                config_.posixGcRecyclePercent + config_.posixGcCandidateExtraPercent;
+            *ctx.candidates = layout_->GetColdestCandidates(ctx.shard, candidatePercent,
+                                                            config_.posixGcMaxRecycleCountPerShard);
+            if (ctx.candidates->size() >= config_.posixGcMaxRecycleCountPerShard) {
+                ctx.gcLimited->store(true, std::memory_order_relaxed);
+            }
+            break;
+        }
+        case ShardTaskContext::Type::DELETE: {
+            for (const auto& blockId : *ctx.victims) { layout_->RemoveFile(blockId); }
+            break;
+        }
+        case ShardTaskContext::Type::GC: {
+            auto filesToDelete = layout_->GetOldestFiles(ctx.shard, config_.posixGcRecyclePercent,
+                                                         config_.posixGcMaxRecycleCountPerShard);
+            for (const auto& blockId : filesToDelete) { layout_->RemoveFile(blockId); }
+            if (filesToDelete.size() >= config_.posixGcMaxRecycleCountPerShard) {
+                ctx.gcLimited->store(true, std::memory_order_relaxed);
+            }
+            break;
         }
     }
     ctx.waiter->Done();

--- a/ucm/store/posix/cc/shard_gc.h
+++ b/ucm/store/posix/cc/shard_gc.h
@@ -42,12 +42,14 @@
 namespace UC::PosixStore {
 
 struct ShardTaskContext {
-    enum class Type { GC, SAMPLE };
+    enum class Type { GC, SAMPLE, COLLECT, DELETE };
     Type type;
     std::string shard;
     std::shared_ptr<Latch> waiter;
     std::atomic<size_t>* sampledFiles{nullptr};
     std::atomic<bool>* gcLimited{nullptr};
+    std::vector<FileInfo>* candidates{nullptr};
+    const std::vector<Detail::BlockId>* victims{nullptr};
 };
 
 class ShardGarbageCollector {
@@ -61,6 +63,7 @@ public:
 private:
     Status ValidateAndInitCapacity();
     bool Execute();
+    bool ExecutePrecise();
     std::tuple<bool, size_t, size_t> ShouldTrigger();
     void RunGcCycle();
     void ProcessTask(ShardTaskContext& ctx);

--- a/ucm/store/posix/cc/space_layout.cc
+++ b/ucm/store/posix/cc/space_layout.cc
@@ -38,11 +38,6 @@ namespace UC::PosixStore {
 static const std::string DATA_ROOT = "data";
 static const std::string ACTIVATED_FILE_EXTENSION = ".tmp";
 
-struct FileInfo {
-    Detail::BlockId blockId;
-    time_t mtime;
-};
-
 struct MtimeComparator {
     bool operator()(const FileInfo& lhs, const FileInfo& rhs) const
     {
@@ -267,6 +262,35 @@ std::vector<Detail::BlockId> SpaceLayout::GetOldestFiles(const std::string& shar
     result.reserve(recycleNum);
     while (!heap->Empty()) {
         result.push_back(heap->Top().blockId);
+        heap->Pop();
+    }
+    return result;
+}
+
+std::string SpaceLayout::ShardOf(const Detail::BlockId& blockId) const
+{
+    if (!dataDirShard_) { return DATA_ROOT; }
+    return FileShardName(DataFileName(blockId));
+}
+
+std::vector<FileInfo> SpaceLayout::GetColdestCandidates(const std::string& shard,
+                                                        double candidatePercent,
+                                                        size_t maxCandidateCount) const
+{
+    std::string shardPath = storageBackends_.front();
+    shardPath += shard;
+    auto heap = std::make_unique<TopNHeap<FileInfo, MtimeComparator>>(maxCandidateCount);
+    size_t totalFiles = ScanFilesInShard(shardPath, *heap);
+    if (totalFiles == 0) { return {}; }
+    size_t candidateNum = static_cast<size_t>(totalFiles * candidatePercent);
+    if (candidateNum == 0) { return {}; }
+    candidateNum = std::min(candidateNum, maxCandidateCount);
+    size_t skipCount = heap->Size() - std::min<size_t>(candidateNum, heap->Size());
+    for (size_t i = 0; i < skipCount; ++i) { heap->Pop(); }
+    std::vector<FileInfo> result;
+    result.reserve(heap->Size());
+    while (!heap->Empty()) {
+        result.push_back(heap->Top());
         heap->Pop();
     }
     return result;

--- a/ucm/store/posix/cc/space_layout.h
+++ b/ucm/store/posix/cc/space_layout.h
@@ -24,11 +24,17 @@
 #ifndef UNIFIEDCACHE_POSIX_STORE_CC_SPACE_LAYOUT_H
 #define UNIFIEDCACHE_POSIX_STORE_CC_SPACE_LAYOUT_H
 
+#include <ctime>
 #include "global_config.h"
 #include "status/status.h"
 #include "type/types.h"
 
 namespace UC::PosixStore {
+
+struct FileInfo {
+    Detail::BlockId blockId;
+    time_t mtime;
+};
 
 class SpaceLayout {
 private:
@@ -47,6 +53,9 @@ public:
     size_t CountFilesInShard(const std::string& shard) const;
     std::vector<Detail::BlockId> GetOldestFiles(const std::string& shard, double recyclePercent,
                                                 size_t maxRecycleCount) const;
+    std::vector<FileInfo> GetColdestCandidates(const std::string& shard, double candidatePercent,
+                                               size_t maxCandidateCount) const;
+    std::string ShardOf(const Detail::BlockId& blockId) const;
 
 private:
     std::vector<std::string> RelativeRoots() const;


### PR DESCRIPTION
## Purpose

Posix Store's shard GC currently **reclaims the coldest 10% within each directory independently**.
blockId is an md5 digest, and files are sharded across 4096 directories by its first 3 hex characters. Data written at the same moment scatters across different directories, and each directory's hot/cold distribution is independent. The result is **per-directory relative hotness** rather than global hotness:
<img width="755" height="611" alt="ad26430d-da68-4204-b6d7-b988ef3eb3ce" src="https://github.com/user-attachments/assets/defd8336-ed3d-4773-aaa1-3caf04524cd9" />
So a block ranked "5% coldest in its directory" gets evicted while one ranked "60% coldest in another" survives — even when the latter is genuinely colder.

## Modifications 

Adds a `posix_gc_precise_mode` switch. **On by default; the performance-mode code path is untouched** and behaves exactly as before this PR.
<img width="743" height="681" alt="a320080c-fc0f-4712-92cd-76b176673f9d" src="https://github.com/user-attachments/assets/c0299270-3952-4e58-ad3d-e7dac5568fb3" />



## Configuration

```yaml
posix_gc_precise_mode: true            # master switch, on by default
posix_gc_candidate_extra_percent: 0.1   # headroom, precise mode only

Validation (only when precise_mode: true):

- 0 < candidate_extra_percent < 1.0
- recycle_percent + candidate_extra_percent <= 1.0

Out-of-range values return InvalidParam and refuse startup rather than being silently clamped.

