### PR TITLE
[fix]Add warning log when patch is not enabled

### DIFF
--- a/ucm/integration/vllm/patch/apply_patch.py
+++ b/ucm/integration/vllm/patch/apply_patch.py
@@ -138,7 +138,9 @@ def apply_all_patches() -> None:
         from ucm.integration.vllm.patch.logger_patch import patch_logger
 
         if not ENABLE_UCM_PATCH:
-            logger.warning("UCM patching is disabled. Set ENABLE_UCM_PATCH=1 to enable it.")
+            logger.warning(
+                "UCM patching is disabled. Set ENABLE_UCM_PATCH=1 to enable it."
+            )
             return
 
         version = get_vllm_version()

--- a/ucm/integration/vllm/patch/apply_patch.py
+++ b/ucm/integration/vllm/patch/apply_patch.py
@@ -138,7 +138,7 @@ def apply_all_patches() -> None:
         from ucm.integration.vllm.patch.logger_patch import patch_logger
 
         if not ENABLE_UCM_PATCH:
-            logger.warning(f"UCM patching is disabled. Set ENABLE_UCM_PATCH=1 to enable it.")
+            logger.warning("UCM patching is disabled. Set ENABLE_UCM_PATCH=1 to enable it.")
             return
 
         version = get_vllm_version()

--- a/ucm/integration/vllm/patch/apply_patch.py
+++ b/ucm/integration/vllm/patch/apply_patch.py
@@ -138,6 +138,7 @@ def apply_all_patches() -> None:
         from ucm.integration.vllm.patch.logger_patch import patch_logger
 
         if not ENABLE_UCM_PATCH:
+            logger.warning(f"UCM patching is disabled. Set ENABLE_UCM_PATCH=1 to enable it.")
             return
 
         version = get_vllm_version()

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -1562,7 +1562,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
             f"total_blocks_num: {len(ucm_block_ids)}, "
             f"hit hbm: {hbm_hit_block_num * self.cp_world_size}, "
             f"hit external: {external_hit_blocks * self.cp_world_size}"
-            f"total tokens: {request.all_token_ids}"
+            f"total tokens: {len(request.all_token_ids)}"
         )
 
         if not external_block_ids:


### PR DESCRIPTION
## Purpose
本 PR 包含两处与日志相关的修复:
1. 当 UCM patch 未启用时,在 `apply_all_patches` 中输出 warning 日志,提示用户如何开启,便于排查"patch 未生效"的问题。
2. `get_num_new_matched_tokens` 的统计日志原先会打印完整的 `request.all_token_ids` 列表,数据量大且可能含敏感内容,改为仅打印 token 数量。

## Modifications
- `ucm/integration/vllm/patch/apply_patch.py`:在 `ENABLE_UCM_PATCH` 为 False 的 early return 分支前增加 `logger.warning`。
- `ucm/integration/vllm/ucm_connector.py`:将日志中的 `{request.all_token_ids}` 改为 `{len(request.all_token_ids)}`。
