### PR TITLE
[Opt] Reuse DramStore OpType in DramPool

### DIFF
--- a/ucm/store/dram/cc/config.cc
+++ b/ucm/store/dram/cc/config.cc
@@ -42,9 +42,9 @@ constexpr std::size_t kMaxInflightRequestsPerNode = 128;
 std::size_t MaxReplySize(std::size_t entryCount)
 {
     DramPool::ProtocolManager protocol;
-    return std::max({protocol.GetPackedResponseSize(DramPool::KvOpcode::Lookup, entryCount),
-                     protocol.GetPackedResponseSize(DramPool::KvOpcode::Dump, entryCount),
-                     protocol.GetPackedResponseSize(DramPool::KvOpcode::Load, entryCount)});
+    return std::max({protocol.GetPackedResponseSize(OpType::LOOKUP, entryCount),
+                     protocol.GetPackedResponseSize(OpType::DUMP, entryCount),
+                     protocol.GetPackedResponseSize(OpType::LOAD, entryCount)});
 }
 
 Status RequiredString(const Detail::Dictionary& input, const char* key, std::string* output)

--- a/ucm/store/dram/cc/drampool/completion_poller.cc
+++ b/ucm/store/dram/cc/drampool/completion_poller.cc
@@ -267,7 +267,7 @@ void CompletionPoller::SettleDataTransfer(CompletionRecord& record,
         DumpLoadResult result = DumpLoadResult::Failed;
 
         // Settle metadata and buffer ownership before completing the request item.
-        if (record.opcode == KvOpcode::Dump) {
+        if (record.opcode == OpType::DUMP) {
             if (terminalStatus == transport::TransferStatus::Completed) {
                 const auto status = runtime_.metadata.StoreEnd(item.key);
                 if (status.Success()) {
@@ -292,7 +292,7 @@ void CompletionPoller::SettleDataTransfer(CompletionRecord& record,
                         record.request_id, record.data_handle, abortStatus);
                 }
             }
-        } else if (record.opcode == KvOpcode::Load) {
+        } else if (record.opcode == OpType::LOAD) {
             const auto releaseStatus = runtime_.metadata.LoadEnd(item.key);
             if (releaseStatus.Failure()) {
                 UC_ERROR("CompletionPoller LoadEnd failed, request_id={}, handle={}, error={}",

--- a/ucm/store/dram/cc/drampool/drampool_types.h
+++ b/ucm/store/dram/cc/drampool/drampool_types.h
@@ -101,7 +101,7 @@ struct CompletionRecord {
     bool timeout_reported{false};
 
     // State needed to construct the request's sole response.
-    KvOpcode opcode{KvOpcode::None};
+    OpType opcode{OpType::LOOKUP};
     std::uint64_t remote_resp_addr{0};
     transport::ManagerID peer_one_sided_id;
     std::vector<std::uint8_t> results;

--- a/ucm/store/dram/cc/drampool/task_worker.cc
+++ b/ucm/store/dram/cc/drampool/task_worker.cc
@@ -72,23 +72,22 @@ Status TaskWorker::ProcessOneRequest(RequestTaskPtr task)
     UC_DEBUG("TaskWorker processing request, request_id={}, opcode={}, peer={}",
              request->request_id, static_cast<int>(request->opcode), peerOneSidedId);
     switch (request->opcode) {
-        case KvOpcode::Dump: {
+        case OpType::DUMP: {
             const auto* dump = dynamic_cast<const KvDumpRequest*>(request.get());
             return dump == nullptr ? Status::InvalidParam("DUMP request type does not match opcode")
                                    : ProcessDump(*dump, peerOneSidedId);
         }
-        case KvOpcode::Load: {
+        case OpType::LOAD: {
             const auto* load = dynamic_cast<const KvLoadRequest*>(request.get());
             return load == nullptr ? Status::InvalidParam("LOAD request type does not match opcode")
                                    : ProcessLoad(*load, peerOneSidedId);
         }
-        case KvOpcode::Lookup: {
+        case OpType::LOOKUP: {
             const auto* lookup = dynamic_cast<const KvLookupRequest*>(request.get());
             return lookup == nullptr
                        ? Status::InvalidParam("LOOKUP request type does not match opcode")
                        : ProcessLookup(*lookup, peerOneSidedId);
         }
-        case KvOpcode::None: break;
     }
     return Status::InvalidParam("TaskWorker got invalid opcode");
 }
@@ -96,7 +95,7 @@ Status TaskWorker::ProcessOneRequest(RequestTaskPtr task)
 Status TaskWorker::ProcessDump(const KvDumpRequest& request,
                                const transport::ManagerID& peerOneSidedId)
 {
-    if (runtime_.protocol.GetPackedResponseSize(KvOpcode::Dump, request.batch_size) >
+    if (runtime_.protocol.GetPackedResponseSize(OpType::DUMP, request.batch_size) >
         g_config.flagBufferSlotSizeBytes) {
         return Status::InvalidParam("DUMP response exceeds configured flag buffer slot size");
     }
@@ -149,7 +148,7 @@ Status TaskWorker::ProcessDump(const KvDumpRequest& request,
     if (transfer_items.empty()) {
         UC_DEBUG("DUMP skips data transfer, request_id={}, batch_size={}", request.request_id,
                  request.batch_size);
-        return QueueResponse(KvOpcode::Dump, request.resp_addr, peerOneSidedId, std::move(results),
+        return QueueResponse(OpType::DUMP, request.resp_addr, peerOneSidedId, std::move(results),
                              request.request_id);
     }
 
@@ -164,14 +163,14 @@ Status TaskWorker::ProcessDump(const KvDumpRequest& request,
         for (const auto& item : transfer_items) {
             results[item.index_in_request] = static_cast<std::uint8_t>(DumpLoadResult::Failed);
         }
-        return QueueResponse(KvOpcode::Dump, request.resp_addr, peerOneSidedId, std::move(results),
+        return QueueResponse(OpType::DUMP, request.resp_addr, peerOneSidedId, std::move(results),
                              request.request_id);
     }
 
     CompletionRecord record;
     record.stage = CompletionStage::PollDataTransfer;
     record.request_id = request.request_id;
-    record.opcode = KvOpcode::Dump;
+    record.opcode = OpType::DUMP;
     record.data_handle = handle;
     record.remote_resp_addr = request.resp_addr;
     record.peer_one_sided_id = peerOneSidedId;
@@ -185,7 +184,7 @@ Status TaskWorker::ProcessDump(const KvDumpRequest& request,
 Status TaskWorker::ProcessLoad(const KvLoadRequest& request,
                                const transport::ManagerID& peerOneSidedId)
 {
-    if (runtime_.protocol.GetPackedResponseSize(KvOpcode::Load, request.batch_size) >
+    if (runtime_.protocol.GetPackedResponseSize(OpType::LOAD, request.batch_size) >
         g_config.flagBufferSlotSizeBytes) {
         return Status::InvalidParam("LOAD response exceeds configured flag buffer slot size");
     }
@@ -230,7 +229,7 @@ Status TaskWorker::ProcessLoad(const KvLoadRequest& request,
     if (transfer_items.empty()) {
         UC_DEBUG("LOAD skips data transfer, request_id={}, batch_size={}", request.request_id,
                  request.batch_size);
-        return QueueResponse(KvOpcode::Load, request.resp_addr, peerOneSidedId, std::move(results),
+        return QueueResponse(OpType::LOAD, request.resp_addr, peerOneSidedId, std::move(results),
                              request.request_id);
     }
 
@@ -245,14 +244,14 @@ Status TaskWorker::ProcessLoad(const KvLoadRequest& request,
         for (const auto& item : transfer_items) {
             results[item.index_in_request] = static_cast<std::uint8_t>(DumpLoadResult::Failed);
         }
-        return QueueResponse(KvOpcode::Load, request.resp_addr, peerOneSidedId, std::move(results),
+        return QueueResponse(OpType::LOAD, request.resp_addr, peerOneSidedId, std::move(results),
                              request.request_id);
     }
 
     CompletionRecord record;
     record.stage = CompletionStage::PollDataTransfer;
     record.request_id = request.request_id;
-    record.opcode = KvOpcode::Load;
+    record.opcode = OpType::LOAD;
     record.data_handle = handle;
     record.remote_resp_addr = request.resp_addr;
     record.peer_one_sided_id = peerOneSidedId;
@@ -266,7 +265,7 @@ Status TaskWorker::ProcessLoad(const KvLoadRequest& request,
 Status TaskWorker::ProcessLookup(const KvLookupRequest& request,
                                  const transport::ManagerID& peerOneSidedId)
 {
-    if (runtime_.protocol.GetPackedResponseSize(KvOpcode::Lookup, request.batch_size) >
+    if (runtime_.protocol.GetPackedResponseSize(OpType::LOOKUP, request.batch_size) >
         g_config.flagBufferSlotSizeBytes) {
         return Status::InvalidParam("LOOKUP response exceeds configured flag buffer slot size");
     }
@@ -280,7 +279,7 @@ Status TaskWorker::ProcessLookup(const KvLookupRequest& request,
 
     UC_DEBUG("LOOKUP metadata scan completed, request_id={}, batch_size={}", request.request_id,
              request.batch_size);
-    return QueueResponse(KvOpcode::Lookup, request.resp_addr, peerOneSidedId, std::move(results),
+    return QueueResponse(OpType::LOOKUP, request.resp_addr, peerOneSidedId, std::move(results),
                          request.request_id);
 }
 
@@ -303,7 +302,7 @@ void TaskWorker::LoadEndItems(const std::vector<TransferItem>& items)
     }
 }
 
-Status TaskWorker::QueueResponse(KvOpcode opcode, std::uint64_t responseAddr,
+Status TaskWorker::QueueResponse(OpType opcode, std::uint64_t responseAddr,
                                  const transport::ManagerID& peerOneSidedId,
                                  std::vector<std::uint8_t>&& results, std::uint64_t requestId)
 {

--- a/ucm/store/dram/cc/drampool/task_worker.h
+++ b/ucm/store/dram/cc/drampool/task_worker.h
@@ -45,7 +45,7 @@ private:
 
     void DeleteItemsMetadata(const std::vector<TransferItem>& items);
     void LoadEndItems(const std::vector<TransferItem>& items);
-    Status QueueResponse(KvOpcode opcode, std::uint64_t responseAddr,
+    Status QueueResponse(OpType opcode, std::uint64_t responseAddr,
                          const transport::ManagerID& peerOneSidedId,
                          std::vector<std::uint8_t>&& results, std::uint64_t requestId);
     Status SubmitCompletion(CompletionRecord&& record);

--- a/ucm/store/dram/cc/kv_protocol.cc
+++ b/ucm/store/dram/cc/kv_protocol.cc
@@ -116,9 +116,9 @@ void UnpackResults(const void* data, std::size_t resultCount, std::size_t result
     }
 }
 
-KvOpcode PeekOpcode(const void* data)
+OpType PeekOpcode(const void* data)
 {
-    return static_cast<KvOpcode>(static_cast<const std::uint8_t*>(data)[kOpcodeOffset]);
+    return static_cast<OpType>(static_cast<const std::uint8_t*>(data)[kOpcodeOffset]);
 }
 
 bool IsAllZeroKey(const BlockId& key)
@@ -127,13 +127,12 @@ bool IsAllZeroKey(const BlockId& key)
                        [](std::byte value) { return value == std::byte{}; });
 }
 
-const char* ProtocolName(KvOpcode opcode)
+const char* ProtocolName(OpType opcode)
 {
     switch (opcode) {
-        case KvOpcode::None: return "Unknown";
-        case KvOpcode::Dump: return "Dump";
-        case KvOpcode::Load: return "Load";
-        case KvOpcode::Lookup: return "Lookup";
+        case OpType::DUMP: return "Dump";
+        case OpType::LOAD: return "Load";
+        case OpType::LOOKUP: return "Lookup";
     }
     return "Unknown";
 }
@@ -153,8 +152,8 @@ Status ValidateRequestHeader(const Request& request)
     return Status::OK();
 }
 
-void PackHeader(std::uint8_t* out, KvOpcode opcode, std::uint64_t request_id,
-                std::uint64_t resp_addr, std::uint16_t batch_size)
+void PackHeader(std::uint8_t* out, OpType opcode, std::uint64_t request_id, std::uint64_t resp_addr,
+                std::uint16_t batch_size)
 {
     out[kOpcodeOffset] = static_cast<std::uint8_t>(opcode);
     std::memcpy(out + kRequestIdOffset, &request_id, sizeof(request_id));
@@ -162,7 +161,7 @@ void PackHeader(std::uint8_t* out, KvOpcode opcode, std::uint64_t request_id,
     std::memcpy(out + kLoadLookupBatchSizeOffset, &batch_size, sizeof(batch_size));
 }
 
-void PackDumpHeader(std::uint8_t* out, KvOpcode opcode, std::uint64_t request_id,
+void PackDumpHeader(std::uint8_t* out, OpType opcode, std::uint64_t request_id,
                     std::uint64_t resp_addr, std::uint32_t ttl, std::uint16_t batch_size)
 {
     out[kOpcodeOffset] = static_cast<std::uint8_t>(opcode);
@@ -175,7 +174,7 @@ void PackDumpHeader(std::uint8_t* out, KvOpcode opcode, std::uint64_t request_id
 template <typename RequestT>
 Status UnpackCommonRequestHeader(const void* data, std::size_t size, std::size_t headerSize,
                                  std::size_t batchSizeOffset, std::size_t entrySize,
-                                 KvOpcode expectedOpcode, RequestT& request)
+                                 OpType expectedOpcode, RequestT& request)
 {
     const std::string protocol = ProtocolName(expectedOpcode);
     if (!data || size < headerSize) {
@@ -254,7 +253,7 @@ Status KvDumpProtocol::UnpackResponse(const void* data, std::uint16_t result_cou
 
 Status KvDumpProtocol::ValidateRequest(const KvDumpRequest& req) const
 {
-    if (req.opcode != KvOpcode::Dump) { return Status::InvalidParam("Dump: opcode must be Dump"); }
+    if (req.opcode != OpType::DUMP) { return Status::InvalidParam("Dump: opcode must be Dump"); }
     auto header_status = ValidateRequestHeader(req);
     if (!header_status.Success()) { return header_status; }
 
@@ -274,7 +273,7 @@ Status KvDumpProtocol::UnpackRequest(const void* data, std::size_t size,
     auto req = std::make_unique<KvDumpRequest>();
     if (auto status =
             UnpackCommonRequestHeader(data, size, kKvDumpRequestHeaderSize, kDumpBatchSizeOffset,
-                                      kKvDumpEntrySize, KvOpcode::Dump, *req);
+                                      kKvDumpEntrySize, OpType::DUMP, *req);
         status.Failure()) {
         return status;
     }
@@ -357,7 +356,7 @@ Status KvLoadProtocol::UnpackResponse(const void* data, std::uint16_t result_cou
 
 Status KvLoadProtocol::ValidateRequest(const KvLoadRequest& req) const
 {
-    if (req.opcode != KvOpcode::Load) { return Status::InvalidParam("Load: opcode must be Load"); }
+    if (req.opcode != OpType::LOAD) { return Status::InvalidParam("Load: opcode must be Load"); }
     auto header_status = ValidateRequestHeader(req);
     if (!header_status.Success()) { return header_status; }
 
@@ -377,7 +376,7 @@ Status KvLoadProtocol::UnpackRequest(const void* data, std::size_t size,
     auto req = std::make_unique<KvLoadRequest>();
     if (auto status = UnpackCommonRequestHeader(data, size, kKvLoadRequestHeaderSize,
                                                 kLoadLookupBatchSizeOffset, kKvLoadEntrySize,
-                                                KvOpcode::Load, *req);
+                                                OpType::LOAD, *req);
         status.Failure()) {
         return status;
     }
@@ -457,7 +456,7 @@ Status KvLookupProtocol::UnpackResponse(const void* data, std::uint16_t result_c
 
 Status KvLookupProtocol::ValidateRequest(const KvLookupRequest& req) const
 {
-    if (req.opcode != KvOpcode::Lookup) {
+    if (req.opcode != OpType::LOOKUP) {
         return Status::InvalidParam("Lookup: opcode must be Lookup");
     }
     auto header_status = ValidateRequestHeader(req);
@@ -479,7 +478,7 @@ Status KvLookupProtocol::UnpackRequest(const void* data, std::size_t size,
     auto req = std::make_unique<KvLookupRequest>();
     if (auto status = UnpackCommonRequestHeader(data, size, kKvLookupRequestHeaderSize,
                                                 kLoadLookupBatchSizeOffset, kKvLookupEntrySize,
-                                                KvOpcode::Lookup, *req);
+                                                OpType::LOOKUP, *req);
         status.Failure()) {
         return status;
     }
@@ -517,12 +516,12 @@ Status KvLookupProtocol::PackResponse(void* data, const KvResponse& resp) const
 
 ProtocolManager::ProtocolManager()
 {
-    protocols_[KvOpcode::Dump] = std::make_unique<KvDumpProtocol>();
-    protocols_[KvOpcode::Load] = std::make_unique<KvLoadProtocol>();
-    protocols_[KvOpcode::Lookup] = std::make_unique<KvLookupProtocol>();
+    protocols_[OpType::DUMP] = std::make_unique<KvDumpProtocol>();
+    protocols_[OpType::LOAD] = std::make_unique<KvLoadProtocol>();
+    protocols_[OpType::LOOKUP] = std::make_unique<KvLookupProtocol>();
 }
 
-KvProtocol* ProtocolManager::GetProtocol(KvOpcode opcode) const
+KvProtocol* ProtocolManager::GetProtocol(OpType opcode) const
 {
     auto it = protocols_.find(opcode);
     return it != protocols_.end() ? it->second.get() : nullptr;
@@ -530,20 +529,20 @@ KvProtocol* ProtocolManager::GetProtocol(KvOpcode opcode) const
 
 // ---- Client side ----
 
-std::size_t ProtocolManager::GetPackedRequestSize(KvOpcode opcode, const KvRequest& req) const
+std::size_t ProtocolManager::GetPackedRequestSize(OpType opcode, const KvRequest& req) const
 {
     KvProtocol* proto = GetProtocol(opcode);
     if (!proto) { return 0; }
     return proto->GetPackedRequestSize(req);
 }
 
-std::size_t ProtocolManager::GetPackedResponseSize(KvOpcode opcode, std::size_t result_count) const
+std::size_t ProtocolManager::GetPackedResponseSize(OpType opcode, std::size_t result_count) const
 {
     auto* proto = GetProtocol(opcode);
     return proto ? proto->GetPackedResponseSize(result_count) : 0;
 }
 
-Status ProtocolManager::PackRequest(void* data, KvOpcode opcode, const KvRequest& req)
+Status ProtocolManager::PackRequest(void* data, OpType opcode, const KvRequest& req)
 {
     KvProtocol* proto = GetProtocol(opcode);
     if (!proto) { return Status::InvalidParam("unknown opcode in PackRequest"); }
@@ -582,7 +581,7 @@ Status ProtocolManager::IsResponseReady(const void* data, std::uint64_t expected
     }
 }
 
-Status ProtocolManager::UnpackResponse(const void* data, KvOpcode opcode,
+Status ProtocolManager::UnpackResponse(const void* data, OpType opcode,
                                        std::uint64_t expected_request_id,
                                        std::uint16_t result_count, KvResponse& out)
 {
@@ -603,7 +602,7 @@ Status ProtocolManager::UnpackRequest(const void* data, std::size_t size,
     if (!data || size < sizeof(std::uint8_t)) {
         return Status::InvalidParam("UnpackRequest: invalid data or missing opcode");
     }
-    KvOpcode opcode = PeekOpcode(data);
+    OpType opcode = PeekOpcode(data);
     KvProtocol* proto = GetProtocol(opcode);
     if (!proto) {
         return Status::InvalidParam("UnpackRequest: unknown opcode " +
@@ -612,7 +611,7 @@ Status ProtocolManager::UnpackRequest(const void* data, std::size_t size,
     return proto->UnpackRequest(data, size, out);
 }
 
-Status ProtocolManager::PackResponse(void* data, KvOpcode opcode, const KvResponse& resp)
+Status ProtocolManager::PackResponse(void* data, OpType opcode, const KvResponse& resp)
 {
     KvProtocol* proto = GetProtocol(opcode);
     if (!proto) { return Status::InvalidParam("unknown opcode in PackResponse"); }

--- a/ucm/store/dram/cc/kv_protocol.h
+++ b/ucm/store/dram/cc/kv_protocol.h
@@ -30,18 +30,12 @@
 #include <unordered_map>
 #include <vector>
 #include "status/status.h"
-#include "type/types.h"
+#include "types.h"
 
 namespace UC::DramPool {
 
 using BlockId = UC::Detail::BlockId;
-
-enum class KvOpcode : std::uint8_t {
-    None = 0x0,
-    Dump = 0x1,
-    Load = 0x2,
-    Lookup = 0x3,
-};
+using OpType = UC::Dram::OpType;
 
 enum class ResponseStatus : std::uint8_t {
     Pending = 0,
@@ -105,7 +99,7 @@ public:
 class KvRequest {
 public:
     virtual ~KvRequest() = default;
-    KvOpcode opcode{KvOpcode::None};
+    OpType opcode{OpType::LOOKUP};
     std::uint64_t request_id{0};
 };
 
@@ -218,20 +212,20 @@ public:
     ProtocolManager& operator=(const ProtocolManager&) = delete;
 
     // Client side
-    std::size_t GetPackedRequestSize(KvOpcode opcode, const KvRequest& req) const;
-    std::size_t GetPackedResponseSize(KvOpcode opcode, std::size_t result_count) const;
-    Status PackRequest(void* data, KvOpcode opcode, const KvRequest& req);
+    std::size_t GetPackedRequestSize(OpType opcode, const KvRequest& req) const;
+    std::size_t GetPackedResponseSize(OpType opcode, std::size_t result_count) const;
+    Status PackRequest(void* data, OpType opcode, const KvRequest& req);
     Status IsResponseReady(const void* data, std::uint64_t expected_request_id, bool& ready) const;
-    Status UnpackResponse(const void* data, KvOpcode opcode, std::uint64_t expected_request_id,
+    Status UnpackResponse(const void* data, OpType opcode, std::uint64_t expected_request_id,
                           std::uint16_t result_count, KvResponse& out);
     // Server side
     Status UnpackRequest(const void* data, std::size_t size, std::unique_ptr<KvRequest>& out);
-    Status PackResponse(void* data, KvOpcode opcode, const KvResponse& resp);
+    Status PackResponse(void* data, OpType opcode, const KvResponse& resp);
 
 private:
-    std::unordered_map<KvOpcode, std::unique_ptr<KvProtocol>> protocols_;
+    std::unordered_map<OpType, std::unique_ptr<KvProtocol>> protocols_;
 
-    KvProtocol* GetProtocol(KvOpcode opcode) const;
+    KvProtocol* GetProtocol(OpType opcode) const;
 };
 
 }  // namespace UC::DramPool

--- a/ucm/store/dram/cc/node_actor.cc
+++ b/ucm/store/dram/cc/node_actor.cc
@@ -91,7 +91,7 @@ Status NodeActor::EncodeRequest(const ReplySlot& replySlot, RequestId requestId,
     switch (op) {
         case OpType::LOOKUP: {
             DramPool::KvLookupRequest request;
-            request.opcode = DramPool::KvOpcode::Lookup;
+            request.opcode = OpType::LOOKUP;
             request.request_id = requestId;
             request.resp_addr = responseAddress;
             request.batch_size = batchSize;
@@ -104,7 +104,7 @@ Status NodeActor::EncodeRequest(const ReplySlot& replySlot, RequestId requestId,
         }
         case OpType::DUMP: {
             DramPool::KvDumpRequest request;
-            request.opcode = DramPool::KvOpcode::Dump;
+            request.opcode = OpType::DUMP;
             request.request_id = requestId;
             request.resp_addr = responseAddress;
             request.ttl = 0;
@@ -114,7 +114,7 @@ Status NodeActor::EncodeRequest(const ReplySlot& replySlot, RequestId requestId,
         }
         case OpType::LOAD: {
             DramPool::KvLoadRequest request;
-            request.opcode = DramPool::KvOpcode::Load;
+            request.opcode = OpType::LOAD;
             request.request_id = requestId;
             request.resp_addr = responseAddress;
             request.batch_size = batchSize;

--- a/ucm/store/dram/cc/reply_service.cc
+++ b/ucm/store/dram/cc/reply_service.cc
@@ -63,22 +63,10 @@ Status ReplyService::Init()
     return Status::OK();
 }
 
-UC::DramPool::KvOpcode ReplyService::ToOpcode(OpType op) noexcept
-{
-    switch (op) {
-        case OpType::LOOKUP: return DramPool::KvOpcode::Lookup;
-        case OpType::DUMP: return DramPool::KvOpcode::Dump;
-        case OpType::LOAD: return DramPool::KvOpcode::Load;
-    }
-    return DramPool::KvOpcode::None;
-}
-
 std::size_t ReplyService::ReplyPayloadSize(OpType op, std::size_t entryCount) const noexcept
 {
     if (entryCount == 0 || entryCount > kMaxProtocolBatchEntries) { return 0; }
-    const auto opcode = ToOpcode(op);
-    return opcode == DramPool::KvOpcode::None ? 0
-                                              : protocol_.GetPackedResponseSize(opcode, entryCount);
+    return protocol_.GetPackedResponseSize(op, entryCount);
 }
 
 bool ReplyService::CompletionReady(const Lease& lease) const noexcept
@@ -101,9 +89,8 @@ Status ReplyService::DecodeReply(const Lease& lease, std::vector<EntryResult>* e
         return Status::InvalidParam("invalid DramPool reply metadata");
     }
     DramPool::KvResponse response;
-    auto status =
-        protocol_.UnpackResponse(lease.slot.localAddr, ToOpcode(lease.op), lease.token.requestId,
-                                 static_cast<std::uint16_t>(lease.entryCount), response);
+    auto status = protocol_.UnpackResponse(lease.slot.localAddr, lease.op, lease.token.requestId,
+                                           static_cast<std::uint16_t>(lease.entryCount), response);
     if (status.Failure()) { return status; }
     if (response.results.size() != lease.entryCount) { return Status::DeserializeFailed(); }
 

--- a/ucm/store/dram/cc/reply_service.h
+++ b/ucm/store/dram/cc/reply_service.h
@@ -93,7 +93,6 @@ private:
 
     explicit ReplyService(Options options);
     Status Init();
-    static DramPool::KvOpcode ToOpcode(OpType op) noexcept;
     std::size_t ReplyPayloadSize(OpType op, std::size_t entryCount) const noexcept;
     bool CompletionReady(const Lease& lease) const noexcept;
     Status DecodeReply(const Lease& lease, std::vector<EntryResult>* entryResults);

--- a/ucm/store/test/case/dram/dram_reply_service_polling_test.cc
+++ b/ucm/store/test/case/dram/dram_reply_service_polling_test.cc
@@ -37,7 +37,7 @@
 namespace UC::Dram {
 namespace {
 
-Status PackReply(const ReplySlot& slot, DramPool::KvOpcode opcode, RequestId requestId,
+Status PackReply(const ReplySlot& slot, OpType opcode, RequestId requestId,
                  std::vector<std::uint8_t> results)
 {
     DramPool::ProtocolManager protocol;
@@ -95,7 +95,7 @@ TEST(ReplyServicePollingTest, PublishesObservedReplyAndKeepsLeaseUntilActorRelea
     auto acquired = service->Acquire(token, OpType::LOOKUP, 2);
     ASSERT_TRUE(acquired);
     auto slot = acquired.Value();
-    ASSERT_TRUE(PackReply(slot, DramPool::KvOpcode::Lookup, token.requestId, {1, 0}).Success());
+    ASSERT_TRUE(PackReply(slot, OpType::LOOKUP, token.requestId, {1, 0}).Success());
 
     auto event = collector.Wait(std::chrono::milliseconds{500});
     ASSERT_TRUE(event.has_value());
@@ -149,8 +149,7 @@ TEST(ReplyServicePollingTest, ReusesSlotWhilePreviousReplyEventIsBeingPublished)
 
     auto first = service->Acquire(firstToken, OpType::LOOKUP, 1);
     ASSERT_TRUE(first);
-    ASSERT_TRUE(
-        PackReply(first.Value(), DramPool::KvOpcode::Lookup, firstToken.requestId, {1}).Success());
+    ASSERT_TRUE(PackReply(first.Value(), OpType::LOOKUP, firstToken.requestId, {1}).Success());
     bool publishEntered = false;
     {
         std::unique_lock lock(mutex);
@@ -165,8 +164,7 @@ TEST(ReplyServicePollingTest, ReusesSlotWhilePreviousReplyEventIsBeingPublished)
         firstRelease = service->Release(firstToken, first.Value());
         second = service->Acquire(secondToken, OpType::LOOKUP, 1);
         if (second) {
-            secondPack =
-                PackReply(second.Value(), DramPool::KvOpcode::Lookup, secondToken.requestId, {1});
+            secondPack = PackReply(second.Value(), OpType::LOOKUP, secondToken.requestId, {1});
         }
     }
 
@@ -241,8 +239,7 @@ TEST(ReplyServicePollingTest, EventPublisherExceptionIsFatal)
                                     ? service->Acquire(token, OpType::LOOKUP, 1)
                                     : Expected<ReplySlot>{Status::Error()};
                 if (acquired &&
-                    PackReply(acquired.Value(), DramPool::KvOpcode::Lookup, token.requestId, {1})
-                        .Success()) {
+                    PackReply(acquired.Value(), OpType::LOOKUP, token.requestId, {1}).Success()) {
                     publishAttemptedFuture.wait();
                 }
                 service->Shutdown();

--- a/ucm/store/test/case/dram/drampool/completion_poller_test.cc
+++ b/ucm/store/test/case/dram/drampool/completion_poller_test.cc
@@ -144,7 +144,7 @@ protected:
         return entry;
     }
 
-    CompletionRecord MakeResponseRecord(KvOpcode opcode = KvOpcode::Lookup)
+    CompletionRecord MakeResponseRecord(OpType opcode = OpType::LOOKUP)
     {
         CompletionRecord record;
         record.stage = CompletionStage::SubmitResponse;
@@ -251,7 +251,7 @@ TEST_F(CompletionPollerTest, DataStatusApiFailureAbortsDumpAndAdvancesToResponse
     ReserveEntry(key);
     CompletionRecord record;
     record.stage = CompletionStage::PollDataTransfer;
-    record.opcode = KvOpcode::Dump;
+    record.opcode = OpType::DUMP;
     record.data_handle = transport::kInvalidTransferHandle;
     record.results = {ResultCode(DumpLoadResult::Ok)};
     record.transfer_items = {
@@ -272,7 +272,7 @@ TEST_F(CompletionPollerTest, CompletedDumpPublishesReservedMetadata)
     const auto key = KeyFromHex("a2");
     ReserveEntry(key);
     CompletionRecord record;
-    record.opcode = KvOpcode::Dump;
+    record.opcode = OpType::DUMP;
     record.results = {ResultCode(DumpLoadResult::Failed)};
     record.transfer_items = {
         TransferItem{0, key}
@@ -290,7 +290,7 @@ TEST_F(CompletionPollerTest, CompletedDumpDeletesEntryWhenStoreEndFails)
     const auto key = KeyFromHex("a3");
     PublishEntry(key);
     CompletionRecord record;
-    record.opcode = KvOpcode::Dump;
+    record.opcode = OpType::DUMP;
     record.results = {ResultCode(DumpLoadResult::Ok)};
     record.transfer_items = {
         TransferItem{0, key}
@@ -308,7 +308,7 @@ TEST_F(CompletionPollerTest, FailedDumpHandlesMissingMetadataAndOutOfRangeResult
     const auto missingKey = KeyFromHex("a5");
     ReserveEntry(reservedKey);
     CompletionRecord record;
-    record.opcode = KvOpcode::Dump;
+    record.opcode = OpType::DUMP;
     record.results = {ResultCode(DumpLoadResult::Ok)};
     record.transfer_items = {
         TransferItem{0, reservedKey},
@@ -330,7 +330,7 @@ TEST_F(CompletionPollerTest, CompletedLoadReleasesReaderAndReturnsSuccess)
     ASSERT_TRUE(metadata_->LoadBegin(key, loaded).Success());
     ASSERT_EQ(entry->refCnt, 1U);
     CompletionRecord record;
-    record.opcode = KvOpcode::Load;
+    record.opcode = OpType::LOAD;
     record.results = {ResultCode(DumpLoadResult::Failed)};
     record.transfer_items = {
         TransferItem{0, key}
@@ -349,7 +349,7 @@ TEST_F(CompletionPollerTest, FailedLoadReleasesReaderButKeepsFailureResult)
     EntryPtr loaded;
     ASSERT_TRUE(metadata_->LoadBegin(key, loaded).Success());
     CompletionRecord record;
-    record.opcode = KvOpcode::Load;
+    record.opcode = OpType::LOAD;
     record.results = {ResultCode(DumpLoadResult::Ok)};
     record.transfer_items = {
         TransferItem{0, key}
@@ -364,7 +364,7 @@ TEST_F(CompletionPollerTest, FailedLoadReleasesReaderButKeepsFailureResult)
 TEST_F(CompletionPollerTest, MissingLoadMetadataRemainsFailure)
 {
     CompletionRecord record;
-    record.opcode = KvOpcode::Load;
+    record.opcode = OpType::LOAD;
     record.results = {ResultCode(DumpLoadResult::Ok)};
     record.transfer_items = {
         TransferItem{0, KeyFromHex("b3")}
@@ -398,7 +398,7 @@ TEST_F(CompletionPollerTest, SubmitResponseRejectsMissingPeerAndUnknownOpcode)
     missingPeer.peer_one_sided_id.clear();
     EXPECT_TRUE(poller_->SubmitResponse(missingPeer));
 
-    auto unknownOpcode = MakeResponseRecord(KvOpcode::None);
+    auto unknownOpcode = MakeResponseRecord(static_cast<OpType>(0xFF));
     EXPECT_TRUE(poller_->SubmitResponse(unknownOpcode));
     EXPECT_EQ(unknownOpcode.local_resp_slot.localAddr, nullptr);
 }

--- a/ucm/store/test/case/dram/drampool/drampool_startup_test.cc
+++ b/ucm/store/test/case/dram/drampool/drampool_startup_test.cc
@@ -517,7 +517,7 @@ TEST(DramPoolServerTest, RequestReceiverLogsReceivedRequestFields)
         if (client.Init(clientControl).Failure()) { ::_exit(3); }
 
         KvLookupRequest request;
-        request.opcode = KvOpcode::Lookup;
+        request.opcode = OpType::LOOKUP;
         request.request_id = kRequestId;
         request.resp_addr = 0x1000;
         request.batch_size = 1;
@@ -530,7 +530,7 @@ TEST(DramPoolServerTest, RequestReceiverLogsReceivedRequestFields)
 
         const auto expected =
             "RequestReceiver received request, request_id=" + std::to_string(kRequestId) +
-            ", opcode=" + std::to_string(static_cast<int>(KvOpcode::Lookup));
+            ", opcode=" + std::to_string(static_cast<int>(OpType::LOOKUP));
         const auto logPath = logRoot / std::to_string(::getpid()) / "ucm.log";
         bool found = false;
         for (int attempt = 0; attempt < 200 && !found; ++attempt) {

--- a/ucm/store/test/case/dram/drampool/task_worker_test.cc
+++ b/ucm/store/test/case/dram/drampool/task_worker_test.cc
@@ -183,7 +183,7 @@ TEST_F(TaskWorkerTest, ProcessesRequestWithoutInitiatingPeerConnection)
     auto task = std::make_unique<RequestTask>();
     task->peer_one_sided_id = kTargetManager;
     task->request = std::make_unique<KvLookupRequest>();
-    task->request->opcode = KvOpcode::Lookup;
+    task->request->opcode = OpType::LOOKUP;
     task->request->request_id = kRequestId;
 
     EXPECT_TRUE(worker.ProcessOneRequest(std::move(task)).Success());
@@ -198,7 +198,7 @@ TEST_F(TaskWorkerTest, LookupReturnsHitAndMiss)
     PublishEntry(hitKey);
 
     KvLookupRequest request;
-    request.opcode = KvOpcode::Lookup;
+    request.opcode = OpType::LOOKUP;
     request.request_id = kRequestId;
     request.resp_addr = kResponseAddress;
     request.entries = {{hitKey}, {KeyFromHex("a2")}};
@@ -207,7 +207,7 @@ TEST_F(TaskWorkerTest, LookupReturnsHitAndMiss)
 
     const auto record = PopCompletion();
     EXPECT_EQ(record.stage, CompletionStage::SubmitResponse);
-    EXPECT_EQ(record.opcode, KvOpcode::Lookup);
+    EXPECT_EQ(record.opcode, OpType::LOOKUP);
     EXPECT_EQ(record.results, (std::vector<std::uint8_t>{LookupCode(LookupResult::Exists),
                                                          LookupCode(LookupResult::NotFound)}));
 }
@@ -218,7 +218,7 @@ TEST_F(TaskWorkerTest, DuplicateDumpIsIdempotent)
     PublishEntry(key);
 
     KvDumpRequest request;
-    request.opcode = KvOpcode::Dump;
+    request.opcode = OpType::DUMP;
     request.request_id = kRequestId;
     request.resp_addr = kResponseAddress;
     request.entries = {
@@ -241,7 +241,7 @@ TEST_F(TaskWorkerTest, DumpStopsAfterFirstStoreBeginFailure)
     PublishEntry(duplicateKey);
 
     KvDumpRequest request;
-    request.opcode = KvOpcode::Dump;
+    request.opcode = OpType::DUMP;
     request.request_id = kRequestId;
     request.resp_addr = kResponseAddress;
     request.entries = {
@@ -267,7 +267,7 @@ TEST_F(TaskWorkerTest, DumpSubmitFailureDeletesReservedMetadata)
     const auto key = KeyFromHex("a1");
 
     KvDumpRequest request;
-    request.opcode = KvOpcode::Dump;
+    request.opcode = OpType::DUMP;
     request.request_id = kRequestId;
     request.resp_addr = kResponseAddress;
     request.entries = {
@@ -289,7 +289,7 @@ TEST_F(TaskWorkerTest, LoadReportsMissingAndOversizedItems)
     const auto oversizedEntry = PublishEntry(oversizedKey);
 
     KvLoadRequest request;
-    request.opcode = KvOpcode::Load;
+    request.opcode = OpType::LOAD;
     request.request_id = kRequestId;
     request.resp_addr = kResponseAddress;
     request.entries = {
@@ -314,7 +314,7 @@ TEST_F(TaskWorkerTest, LoadSubmitFailureEndsAllPinnedItems)
     const auto secondEntry = PublishEntry(secondKey);
 
     KvLoadRequest request;
-    request.opcode = KvOpcode::Load;
+    request.opcode = OpType::LOAD;
     request.request_id = kRequestId;
     request.resp_addr = kResponseAddress;
     request.entries = {
@@ -339,7 +339,7 @@ TEST_F(TaskWorkerTest, RejectsResponsesLargerThanFlagBufferSlot)
     g_config.flagBufferSlotSizeBytes = 0;
 
     KvDumpRequest dump;
-    dump.opcode = KvOpcode::Dump;
+    dump.opcode = OpType::DUMP;
     dump.request_id = kRequestId;
     dump.batch_size = 1;
     dump.entries = {
@@ -348,7 +348,7 @@ TEST_F(TaskWorkerTest, RejectsResponsesLargerThanFlagBufferSlot)
     EXPECT_TRUE(ProcessDump(dump).Failure());
 
     KvLoadRequest load;
-    load.opcode = KvOpcode::Load;
+    load.opcode = OpType::LOAD;
     load.request_id = kRequestId;
     load.batch_size = 1;
     load.entries = {
@@ -357,7 +357,7 @@ TEST_F(TaskWorkerTest, RejectsResponsesLargerThanFlagBufferSlot)
     EXPECT_TRUE(ProcessLoad(load).Failure());
 
     KvLookupRequest lookup;
-    lookup.opcode = KvOpcode::Lookup;
+    lookup.opcode = OpType::LOOKUP;
     lookup.request_id = kRequestId;
     lookup.batch_size = 1;
     lookup.entries = {{KeyFromHex("a3")}};

--- a/ucm/store/test/case/dram/kv_protocol_test.cc
+++ b/ucm/store/test/case/dram/kv_protocol_test.cc
@@ -64,6 +64,13 @@ protected:
     ProtocolManager mgr_;
 };
 
+TEST(KvProtocolOpcodeTest, UsesDramStoreOpType)
+{
+    EXPECT_EQ(static_cast<std::uint8_t>(OpType::LOOKUP), 0x0);
+    EXPECT_EQ(static_cast<std::uint8_t>(OpType::DUMP), 0x1);
+    EXPECT_EQ(static_cast<std::uint8_t>(OpType::LOAD), 0x2);
+}
+
 TEST_F(KvProtocolTest, PackDumpRequestMatchesLayout)
 {
     KvDumpEntry entry;
@@ -73,7 +80,7 @@ TEST_F(KvProtocolTest, PackDumpRequestMatchesLayout)
     entry.idx = 0x12345678;
 
     KvDumpRequest req;
-    req.opcode = KvOpcode::Dump;
+    req.opcode = OpType::DUMP;
     req.request_id = kRequestId;
     req.resp_addr = 0x0102030405060708ULL;
     req.batch_size = 1;
@@ -84,7 +91,7 @@ TEST_F(KvProtocolTest, PackDumpRequestMatchesLayout)
     auto status = mgr_.PackRequest(packed.data(), req.opcode, req);
     ASSERT_TRUE(status.Success()) << status.ToString();
 
-    EXPECT_EQ(packed[0], static_cast<std::uint8_t>(KvOpcode::Dump));
+    EXPECT_EQ(packed[0], static_cast<std::uint8_t>(OpType::DUMP));
     ExpectLe64(packed, kRequestIdOffset, req.request_id);
     ExpectLe64(packed, kRespAddrOffset, req.resp_addr);
     ExpectLe32(packed, kDumpTtlOffset, req.ttl);
@@ -106,7 +113,7 @@ TEST_F(KvProtocolTest, PackLoadRequestMatchesLayout)
     entry.idx = 7;
 
     KvLoadRequest req;
-    req.opcode = KvOpcode::Load;
+    req.opcode = OpType::LOAD;
     req.request_id = kRequestId;
     req.resp_addr = 0x1111222233334444ULL;
     req.batch_size = 1;
@@ -116,7 +123,7 @@ TEST_F(KvProtocolTest, PackLoadRequestMatchesLayout)
     auto status = mgr_.PackRequest(packed.data(), req.opcode, req);
     ASSERT_TRUE(status.Success()) << status.ToString();
 
-    EXPECT_EQ(packed[0], static_cast<std::uint8_t>(KvOpcode::Load));
+    EXPECT_EQ(packed[0], static_cast<std::uint8_t>(OpType::LOAD));
     ExpectLe64(packed, kRequestIdOffset, req.request_id);
     ExpectLe64(packed, kRespAddrOffset, req.resp_addr);
     ExpectLe16(packed, kLoadLookupBatchSizeOffset, req.batch_size);
@@ -132,7 +139,7 @@ TEST_F(KvProtocolTest, PackLookupRequestMatchesLayout)
     entry1.key = KeyFromHex("40");
 
     KvLookupRequest req;
-    req.opcode = KvOpcode::Lookup;
+    req.opcode = OpType::LOOKUP;
     req.request_id = kRequestId;
     req.resp_addr = 0x1234000056780000ULL;
     req.batch_size = 2;
@@ -142,7 +149,7 @@ TEST_F(KvProtocolTest, PackLookupRequestMatchesLayout)
     auto status = mgr_.PackRequest(packed.data(), req.opcode, req);
     ASSERT_TRUE(status.Success()) << status.ToString();
 
-    EXPECT_EQ(packed[0], static_cast<std::uint8_t>(KvOpcode::Lookup));
+    EXPECT_EQ(packed[0], static_cast<std::uint8_t>(OpType::LOOKUP));
     ExpectLe64(packed, kRequestIdOffset, req.request_id);
     ExpectLe64(packed, kRespAddrOffset, req.resp_addr);
     ExpectLe16(packed, kLoadLookupBatchSizeOffset, req.batch_size);
@@ -159,7 +166,7 @@ TEST_F(KvProtocolTest, RejectsBatchSizeMismatch)
     entry.key = KeyFromHex("50");
 
     KvLookupRequest req;
-    req.opcode = KvOpcode::Lookup;
+    req.opcode = OpType::LOOKUP;
     req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 2;
@@ -176,7 +183,7 @@ TEST_F(KvProtocolTest, RejectsAllZeroKey)
     KvLookupEntry entry;
 
     KvLookupRequest req;
-    req.opcode = KvOpcode::Lookup;
+    req.opcode = OpType::LOOKUP;
     req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 1;
@@ -196,7 +203,7 @@ TEST_F(KvProtocolTest, RejectsZeroDumpLoadAddrAndLen)
     entry.len = 1;
 
     KvDumpRequest req;
-    req.opcode = KvOpcode::Dump;
+    req.opcode = OpType::DUMP;
     req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 1;
@@ -220,7 +227,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsWrongSize)
     entry.key = KeyFromHex("70");
 
     KvLookupRequest req;
-    req.opcode = KvOpcode::Lookup;
+    req.opcode = OpType::LOOKUP;
     req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 1;
@@ -243,7 +250,7 @@ TEST_F(KvProtocolTest, UnpackResponseReadsPackedResults)
                                  0x34, 0x12, static_cast<std::uint8_t>(ResponseStatus::Ready),
                                  0x8D, 0x01};
     KvResponse resp;
-    auto status = mgr_.UnpackResponse(lookupFlag, KvOpcode::Lookup, kRequestId, 9, resp);
+    auto status = mgr_.UnpackResponse(lookupFlag, OpType::LOOKUP, kRequestId, 9, resp);
     ASSERT_TRUE(status.Success()) << status.ToString();
     EXPECT_EQ(resp.results, (std::vector<std::uint8_t>{1, 0, 1, 1, 0, 0, 0, 1, 1}));
 
@@ -252,7 +259,7 @@ TEST_F(KvProtocolTest, UnpackResponseReadsPackedResults)
                                0x34, 0x12, static_cast<std::uint8_t>(ResponseStatus::Ready),
                                0x10, 0xF2, 0x03};
     resp.results.clear();
-    status = mgr_.UnpackResponse(dumpFlag, KvOpcode::Dump, kRequestId, 5, resp);
+    status = mgr_.UnpackResponse(dumpFlag, OpType::DUMP, kRequestId, 5, resp);
     ASSERT_TRUE(status.Success()) << status.ToString();
     EXPECT_EQ(resp.results, (std::vector<std::uint8_t>{0, 1, 2, 15, 3}));
 }
@@ -266,7 +273,7 @@ TEST_F(KvProtocolTest, ServerRoundTripDumpLoad)
     entry.idx = 0x55;
 
     KvLoadRequest req;
-    req.opcode = KvOpcode::Load;
+    req.opcode = OpType::LOAD;
     req.request_id = kRequestId;
     req.resp_addr = 0x9988776655443322ULL;
     req.batch_size = 1;
@@ -311,7 +318,7 @@ TEST_F(KvProtocolTest, ServerRoundTripLookup)
     KvLookupEntry e1;
     e1.key = KeyFromHex("a0");
     KvLookupRequest req;
-    req.opcode = KvOpcode::Lookup;
+    req.opcode = OpType::LOOKUP;
     req.request_id = kRequestId;
     req.resp_addr = 0x0E0E0E0E0E0E0E0EULL;
     req.batch_size = 2;
@@ -358,7 +365,7 @@ TEST_F(KvProtocolTest, DumpLoadMaxFieldValuesRoundTrip)
     entry.idx = 0xFFFFFFFFU;
 
     KvLoadRequest req;
-    req.opcode = KvOpcode::Load;
+    req.opcode = OpType::LOAD;
     req.request_id = std::numeric_limits<std::uint64_t>::max();
     req.resp_addr = 0xFFFFFFFFFFFFFFFFULL;
     req.batch_size = 1;
@@ -386,7 +393,7 @@ TEST_F(KvProtocolTest, DumpLoadMultiEntryRoundTrip)
 {
     constexpr std::uint16_t kBatch = 5;
     KvDumpRequest req;
-    req.opcode = KvOpcode::Dump;
+    req.opcode = OpType::DUMP;
     req.request_id = kRequestId;
     req.resp_addr = 0xA5A5A5A5A5A5A5A5ULL;
     req.batch_size = kBatch;
@@ -421,7 +428,7 @@ TEST_F(KvProtocolTest, LookupMultiEntryRoundTrip)
 {
     constexpr std::uint16_t kBatch = 4;
     KvLookupRequest req;
-    req.opcode = KvOpcode::Lookup;
+    req.opcode = OpType::LOOKUP;
     req.request_id = kRequestId;
     req.resp_addr = 0xB0B0B0B0B0B0B0B0ULL;
     req.batch_size = kBatch;
@@ -448,9 +455,11 @@ TEST_F(KvProtocolTest, LookupMultiEntryRoundTrip)
 // opcode validation
 // ---------------------------------------------------------------------------
 
-TEST_F(KvProtocolTest, RejectsNoneOpcodeOnDumpLoad)
+TEST_F(KvProtocolTest, RejectsUnknownOpcodeOnDumpLoad)
 {
-    KvDumpRequest req;  // opcode defaults to None
+    KvDumpRequest req;
+    const auto unknownOpcode = static_cast<OpType>(0xFF);
+    req.opcode = unknownOpcode;
     req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 1;
@@ -458,8 +467,8 @@ TEST_F(KvProtocolTest, RejectsNoneOpcodeOnDumpLoad)
         KvDumpEntry{KeyFromHex("10"), 0x2000, 0x100, 0}
     };
 
-    std::vector<std::uint8_t> buf(mgr_.GetPackedRequestSize(KvOpcode::Dump, req), 0);
-    auto status = mgr_.PackRequest(buf.data(), KvOpcode::None, req);
+    std::vector<std::uint8_t> buf(mgr_.GetPackedRequestSize(OpType::DUMP, req), 0);
+    auto status = mgr_.PackRequest(buf.data(), unknownOpcode, req);
     EXPECT_FALSE(status.Success());
     EXPECT_NE(status.ToString().find("opcode"), std::string::npos);
 }
@@ -467,7 +476,7 @@ TEST_F(KvProtocolTest, RejectsNoneOpcodeOnDumpLoad)
 TEST_F(KvProtocolTest, RejectsOpcodeMismatch)
 {
     KvDumpRequest req;
-    req.opcode = KvOpcode::Lookup;  // wrong opcode for a Dump request
+    req.opcode = OpType::LOOKUP;  // wrong opcode for a Dump request
     req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 1;
@@ -475,8 +484,8 @@ TEST_F(KvProtocolTest, RejectsOpcodeMismatch)
         KvDumpEntry{KeyFromHex("10"), 0x2000, 0x100, 0}
     };
 
-    std::vector<std::uint8_t> buf(mgr_.GetPackedRequestSize(KvOpcode::Dump, req), 0);
-    auto status = mgr_.PackRequest(buf.data(), KvOpcode::Dump, req);
+    std::vector<std::uint8_t> buf(mgr_.GetPackedRequestSize(OpType::DUMP, req), 0);
+    auto status = mgr_.PackRequest(buf.data(), OpType::DUMP, req);
     EXPECT_FALSE(status.Success());
     EXPECT_NE(status.ToString().find("opcode"), std::string::npos);
 }
@@ -498,7 +507,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsUnknownOpcode)
 TEST_F(KvProtocolTest, UnpackRequestRejectsExtraBytes)
 {
     KvLookupRequest req;
-    req.opcode = KvOpcode::Lookup;
+    req.opcode = OpType::LOOKUP;
     req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 1;
@@ -523,13 +532,13 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsNull)
 TEST_F(KvProtocolTest, UnpackRequestRejectsTruncatedHeaderForEveryOpcode)
 {
     struct TestCase {
-        KvOpcode opcode;
+        OpType opcode;
         std::size_t header_size;
     };
     const std::array<TestCase, 3> test_cases = {
-        {{KvOpcode::Dump, kKvDumpRequestHeaderSize},
-         {KvOpcode::Load, kKvLoadRequestHeaderSize},
-         {KvOpcode::Lookup, kKvLookupRequestHeaderSize}}
+        {{OpType::DUMP, kKvDumpRequestHeaderSize},
+         {OpType::LOAD, kKvLoadRequestHeaderSize},
+         {OpType::LOOKUP, kKvLookupRequestHeaderSize}}
     };
 
     for (const auto& test_case : test_cases) {
@@ -546,7 +555,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsTruncatedHeaderForEveryOpcode)
 TEST_F(KvProtocolTest, UnpackRequestRejectsSizeMismatch)
 {
     KvDumpRequest req;
-    req.opcode = KvOpcode::Dump;
+    req.opcode = OpType::DUMP;
     req.request_id = kRequestId;
     req.resp_addr = 0x1000;
     req.batch_size = 2;
@@ -573,7 +582,7 @@ TEST_F(KvProtocolTest, PackResponseRejectsNullData)
     KvResponse resp;
     resp.request_id = kRequestId;
     resp.results = {0x0};
-    auto status = mgr_.PackResponse(nullptr, KvOpcode::Dump, resp);
+    auto status = mgr_.PackResponse(nullptr, OpType::DUMP, resp);
     EXPECT_FALSE(status.Success());
 }
 
@@ -583,14 +592,14 @@ TEST_F(KvProtocolTest, PackResponseRejectsValuesThatDoNotFitWireWidth)
     KvResponse lookup;
     lookup.request_id = kRequestId;
     lookup.results = {2};
-    auto status = mgr_.PackResponse(flag, KvOpcode::Lookup, lookup);
+    auto status = mgr_.PackResponse(flag, OpType::LOOKUP, lookup);
     EXPECT_FALSE(status.Success()) << status.ToString();
     EXPECT_EQ(flag[kResponseStatusOffset], static_cast<std::uint8_t>(ResponseStatus::Pending));
 
     KvResponse dump;
     dump.request_id = kRequestId;
     dump.results = {16};
-    status = mgr_.PackResponse(flag, KvOpcode::Dump, dump);
+    status = mgr_.PackResponse(flag, OpType::DUMP, dump);
     EXPECT_FALSE(status.Success()) << status.ToString();
     EXPECT_EQ(flag[kResponseStatusOffset], static_cast<std::uint8_t>(ResponseStatus::Pending));
 }
@@ -600,7 +609,7 @@ TEST_F(KvProtocolTest, PackResponseLookupRejectsZeroCount)
     KvResponse resp;  // empty results
     resp.request_id = kRequestId;
     std::uint8_t flag[kResponseResultsOffset] = {0};
-    auto status = mgr_.PackResponse(flag, KvOpcode::Lookup, resp);
+    auto status = mgr_.PackResponse(flag, OpType::LOOKUP, resp);
     EXPECT_FALSE(status.Success());
 }
 
@@ -609,7 +618,7 @@ TEST_F(KvProtocolTest, PackResponseDumpLoadZeroErrcodes)
     KvResponse resp;  // empty, result_count=0
     resp.request_id = kRequestId;
     std::uint8_t flag[kResponseResultsOffset] = {0xFF};
-    auto status = mgr_.PackResponse(flag, KvOpcode::Dump, resp);
+    auto status = mgr_.PackResponse(flag, OpType::DUMP, resp);
     EXPECT_TRUE(status.Success());
     EXPECT_EQ(flag[kResponseStatusOffset], static_cast<std::uint8_t>(ResponseStatus::Ready));
 }
@@ -621,7 +630,7 @@ TEST_F(KvProtocolTest, PackResponseDumpLoadZeroErrcodes)
 TEST_F(KvProtocolTest, UnpackResponseRejectsNullData)
 {
     KvResponse resp;
-    auto status = mgr_.UnpackResponse(nullptr, KvOpcode::Dump, kRequestId, 1, resp);
+    auto status = mgr_.UnpackResponse(nullptr, OpType::DUMP, kRequestId, 1, resp);
     EXPECT_FALSE(status.Success());
 }
 
@@ -677,7 +686,7 @@ TEST_F(KvProtocolTest, UnpackResponseReturnsRetryWithoutChangingResultsWhilePend
     KvResponse response;
     response.results = {7, 8};
 
-    const auto status = mgr_.UnpackResponse(pending, KvOpcode::Dump, kRequestId, 2, response);
+    const auto status = mgr_.UnpackResponse(pending, OpType::DUMP, kRequestId, 2, response);
 
     EXPECT_EQ(status, Status::Retry());
     EXPECT_EQ(response.results, (std::vector<std::uint8_t>{7, 8}));
@@ -685,13 +694,13 @@ TEST_F(KvProtocolTest, UnpackResponseReturnsRetryWithoutChangingResultsWhilePend
 
 TEST_F(KvProtocolTest, PackedResponseSizesRoundUpAtBitBoundaries)
 {
-    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Lookup, 1), 10U);
-    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Lookup, 8), 10U);
-    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Lookup, 9), 11U);
-    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Dump, 1), 10U);
-    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Dump, 2), 10U);
-    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::Load, 3), 11U);
-    EXPECT_EQ(mgr_.GetPackedResponseSize(KvOpcode::None, 3), 0U);
+    EXPECT_EQ(mgr_.GetPackedResponseSize(OpType::LOOKUP, 1), 10U);
+    EXPECT_EQ(mgr_.GetPackedResponseSize(OpType::LOOKUP, 8), 10U);
+    EXPECT_EQ(mgr_.GetPackedResponseSize(OpType::LOOKUP, 9), 11U);
+    EXPECT_EQ(mgr_.GetPackedResponseSize(OpType::DUMP, 1), 10U);
+    EXPECT_EQ(mgr_.GetPackedResponseSize(OpType::DUMP, 2), 10U);
+    EXPECT_EQ(mgr_.GetPackedResponseSize(OpType::LOAD, 3), 11U);
+    EXPECT_EQ(mgr_.GetPackedResponseSize(static_cast<OpType>(0xFF), 3), 0U);
 }
 
 // ---------------------------------------------------------------------------
@@ -704,15 +713,15 @@ TEST_F(KvProtocolTest, ResponseSymmetryMultipleErrcodes)
     resp.request_id = kRequestId;
     resp.results = {0x0, 0x1, 0x2, 0xE, 0xF};
     constexpr std::uint16_t kCount = 5;
-    std::vector<std::uint8_t> flag(mgr_.GetPackedResponseSize(KvOpcode::Dump, kCount), 0xFF);
+    std::vector<std::uint8_t> flag(mgr_.GetPackedResponseSize(OpType::DUMP, kCount), 0xFF);
 
-    ASSERT_TRUE(mgr_.PackResponse(flag.data(), KvOpcode::Dump, resp).Success());
+    ASSERT_TRUE(mgr_.PackResponse(flag.data(), OpType::DUMP, resp).Success());
     EXPECT_EQ(flag, (std::vector<std::uint8_t>{0xF0, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34, 0x12,
                                                static_cast<std::uint8_t>(ResponseStatus::Ready),
                                                0x10, 0xE2, 0x0F}));
     KvResponse resp2;
     ASSERT_TRUE(
-        mgr_.UnpackResponse(flag.data(), KvOpcode::Dump, kRequestId, kCount, resp2).Success());
+        mgr_.UnpackResponse(flag.data(), OpType::DUMP, kRequestId, kCount, resp2).Success());
     ASSERT_EQ(resp2.results.size(), kCount);
     for (std::uint16_t i = 0; i < kCount; ++i) {
         EXPECT_EQ(resp2.results[i], resp.results[i]) << "result " << i;
@@ -726,13 +735,13 @@ TEST_F(KvProtocolTest, ResponseSymmetryMultipleErrcodes)
 TEST_F(KvProtocolTest, MultiRoundSequentialPacks)
 {
     for (std::uint8_t round = 0; round < 10; ++round) {
-        const auto opcode = (round % 2 == 0) ? KvOpcode::Dump : KvOpcode::Load;
+        const auto opcode = (round % 2 == 0) ? OpType::DUMP : OpType::LOAD;
         const auto resp_addr = 0x1000ULL * (round + 1);
         const auto addr = 0x2000ULL * (round + 1);
         const auto len = 0x100U * (round + 1);
 
         std::vector<std::uint8_t> packed;
-        if (opcode == KvOpcode::Dump) {
+        if (opcode == OpType::DUMP) {
             KvDumpRequest req;
             req.opcode = opcode;
             req.request_id = static_cast<std::uint64_t>(round) + 1U;
@@ -762,7 +771,7 @@ TEST_F(KvProtocolTest, MultiRoundSequentialPacks)
         std::unique_ptr<KvRequest> parsed;
         ASSERT_TRUE(mgr_.UnpackRequest(packed.data(), packed.size(), parsed).Success())
             << "round " << round;
-        if (opcode == KvOpcode::Dump) {
+        if (opcode == OpType::DUMP) {
             auto& dl = static_cast<KvDumpRequest&>(*parsed);
             EXPECT_EQ(dl.opcode, opcode) << "round " << round;
             EXPECT_EQ(dl.resp_addr, resp_addr) << "round " << round;
@@ -797,16 +806,16 @@ TEST_F(KvProtocolTest, LookupPackedResponseOverwritesNonZeroBufferAndRoundTrips)
     KvResponse resp;
     resp.request_id = kRequestId;
     resp.results = {1, 0, 1, 1, 0, 0, 0, 1, 1};
-    std::vector<std::uint8_t> flag(
-        mgr_.GetPackedResponseSize(KvOpcode::Lookup, resp.results.size()), 0xFF);
+    std::vector<std::uint8_t> flag(mgr_.GetPackedResponseSize(OpType::LOOKUP, resp.results.size()),
+                                   0xFF);
 
-    ASSERT_TRUE(mgr_.PackResponse(flag.data(), KvOpcode::Lookup, resp).Success());
+    ASSERT_TRUE(mgr_.PackResponse(flag.data(), OpType::LOOKUP, resp).Success());
     EXPECT_EQ(flag, (std::vector<std::uint8_t>{0xF0, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34, 0x12,
                                                static_cast<std::uint8_t>(ResponseStatus::Ready),
                                                0x8D, 0x01}));
 
     KvResponse unpacked;
-    ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), KvOpcode::Lookup, kRequestId,
+    ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), OpType::LOOKUP, kRequestId,
                                     static_cast<std::uint16_t>(resp.results.size()), unpacked)
                     .Success());
     EXPECT_EQ(unpacked.results, resp.results);
@@ -820,15 +829,15 @@ TEST_F(KvProtocolTest, FourBitResponseCoversEveryPackedByteValue)
             response.request_id = kRequestId;
             response.results = {static_cast<std::uint8_t>(low), static_cast<std::uint8_t>(high)};
             std::vector<std::uint8_t> flag(
-                mgr_.GetPackedResponseSize(KvOpcode::Dump, response.results.size()), 0xFFU);
+                mgr_.GetPackedResponseSize(OpType::DUMP, response.results.size()), 0xFFU);
 
-            ASSERT_TRUE(mgr_.PackResponse(flag.data(), KvOpcode::Dump, response).Success());
+            ASSERT_TRUE(mgr_.PackResponse(flag.data(), OpType::DUMP, response).Success());
             ASSERT_EQ(flag.size(), kResponseResultsOffset + 1U);
             EXPECT_EQ(flag[kResponseResultsOffset], static_cast<std::uint8_t>(low | (high << 4U)));
 
             KvResponse unpacked;
-            ASSERT_TRUE(mgr_.UnpackResponse(flag.data(), KvOpcode::Dump, kRequestId, 2U, unpacked)
-                            .Success());
+            ASSERT_TRUE(
+                mgr_.UnpackResponse(flag.data(), OpType::DUMP, kRequestId, 2U, unpacked).Success());
             EXPECT_EQ(unpacked.results, response.results);
         }
     }
@@ -843,15 +852,15 @@ TEST_F(KvProtocolTest, OneBitResponseCoversEveryPackedByteValue)
             response.results.push_back(static_cast<std::uint8_t>((byteValue >> bit) & 0x01U));
         }
         std::vector<std::uint8_t> flag(
-            mgr_.GetPackedResponseSize(KvOpcode::Lookup, response.results.size()), 0xFFU);
+            mgr_.GetPackedResponseSize(OpType::LOOKUP, response.results.size()), 0xFFU);
 
-        ASSERT_TRUE(mgr_.PackResponse(flag.data(), KvOpcode::Lookup, response).Success());
+        ASSERT_TRUE(mgr_.PackResponse(flag.data(), OpType::LOOKUP, response).Success());
         ASSERT_EQ(flag.size(), kResponseResultsOffset + 1U);
         EXPECT_EQ(flag[kResponseResultsOffset], static_cast<std::uint8_t>(byteValue));
 
         KvResponse unpacked;
         ASSERT_TRUE(
-            mgr_.UnpackResponse(flag.data(), KvOpcode::Lookup, kRequestId, 8U, unpacked).Success());
+            mgr_.UnpackResponse(flag.data(), OpType::LOOKUP, kRequestId, 8U, unpacked).Success());
         EXPECT_EQ(unpacked.results, response.results);
     }
 }
@@ -861,14 +870,14 @@ TEST_F(KvProtocolTest, ResponsePackingClearsUnusedBitsAndPreservesCanary)
     constexpr std::array<std::size_t, 12> kBoundaryCounts = {1,  2,  3,  7,   8,   9,
                                                              15, 16, 17, 255, 256, 257};
     for (const std::size_t count : kBoundaryCounts) {
-        for (const KvOpcode opcode : {KvOpcode::Dump, KvOpcode::Load, KvOpcode::Lookup}) {
+        for (const OpType opcode : {OpType::DUMP, OpType::LOAD, OpType::LOOKUP}) {
             KvResponse response;
             response.request_id = kRequestId;
             response.results.resize(count);
             for (std::size_t index = 0; index < count; ++index) {
                 response.results[index] = static_cast<std::uint8_t>(
-                    opcode == KvOpcode::Lookup ? (index + count) & 0x01U
-                                               : (index * 7U + count) & 0x0FU);
+                    opcode == OpType::LOOKUP ? (index + count) & 0x01U
+                                             : (index * 7U + count) & 0x0FU);
             }
 
             const std::size_t packedSize = mgr_.GetPackedResponseSize(opcode, count);
@@ -878,9 +887,9 @@ TEST_F(KvProtocolTest, ResponsePackingClearsUnusedBitsAndPreservesCanary)
                 EXPECT_EQ(flag[index], 0xA5U) << "count=" << count << ", index=" << index;
             }
 
-            if (opcode == KvOpcode::Lookup && count % 8U != 0U) {
+            if (opcode == OpType::LOOKUP && count % 8U != 0U) {
                 EXPECT_EQ(static_cast<unsigned>(flag[packedSize - 1U]) >> (count % 8U), 0U);
-            } else if (opcode != KvOpcode::Lookup && count % 2U != 0U) {
+            } else if (opcode != OpType::LOOKUP && count % 2U != 0U) {
                 EXPECT_EQ(flag[packedSize - 1U] & 0xF0U, 0U);
             }
 
@@ -896,7 +905,7 @@ TEST_F(KvProtocolTest, ResponsePackingClearsUnusedBitsAndPreservesCanary)
 TEST_F(KvProtocolTest, PackRequestRejectsNullTarget)
 {
     KvLookupRequest request;
-    request.opcode = KvOpcode::Lookup;
+    request.opcode = OpType::LOOKUP;
     request.request_id = kRequestId;
     request.resp_addr = 0x1000;
     request.batch_size = 1;
@@ -911,7 +920,7 @@ TEST_F(KvProtocolTest, PackRequestRejectsNullTarget)
 TEST_F(KvProtocolTest, RejectsRequestConcreteTypeMismatch)
 {
     KvLoadRequest request;
-    request.opcode = KvOpcode::Dump;
+    request.opcode = OpType::DUMP;
     request.request_id = kRequestId;
     request.resp_addr = 0x1000;
     request.batch_size = 1;
@@ -920,8 +929,8 @@ TEST_F(KvProtocolTest, RejectsRequestConcreteTypeMismatch)
     };
     std::array<std::uint8_t, kKvDumpRequestHeaderSize + kKvDumpEntrySize> packed{};
 
-    EXPECT_EQ(mgr_.GetPackedRequestSize(KvOpcode::Dump, request), 0U);
-    const auto status = mgr_.PackRequest(packed.data(), KvOpcode::Dump, request);
+    EXPECT_EQ(mgr_.GetPackedRequestSize(OpType::DUMP, request), 0U);
+    const auto status = mgr_.PackRequest(packed.data(), OpType::DUMP, request);
     EXPECT_TRUE(status.Failure());
     EXPECT_NE(status.ToString().find("type mismatch"), std::string::npos);
 }
@@ -931,7 +940,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsZeroHeaderFieldsForEveryOpcode)
     std::vector<std::pair<std::vector<std::uint8_t>, std::size_t>> packedRequests;
     {
         KvDumpRequest request;
-        request.opcode = KvOpcode::Dump;
+        request.opcode = OpType::DUMP;
         request.request_id = kRequestId;
         request.resp_addr = 0x1000;
         request.ttl = 10;
@@ -945,7 +954,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsZeroHeaderFieldsForEveryOpcode)
     }
     {
         KvLoadRequest request;
-        request.opcode = KvOpcode::Load;
+        request.opcode = OpType::LOAD;
         request.request_id = kRequestId;
         request.resp_addr = 0x1000;
         request.batch_size = 1;
@@ -958,7 +967,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsZeroHeaderFieldsForEveryOpcode)
     }
     {
         KvLookupRequest request;
-        request.opcode = KvOpcode::Lookup;
+        request.opcode = OpType::LOOKUP;
         request.request_id = kRequestId;
         request.resp_addr = 0x1000;
         request.batch_size = 1;
@@ -969,7 +978,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsZeroHeaderFieldsForEveryOpcode)
     }
 
     for (const auto& [packed, batchSizeOffset] : packedRequests) {
-        const auto opcode = static_cast<KvOpcode>(packed[kOpcodeOffset]);
+        const auto opcode = static_cast<OpType>(packed[kOpcodeOffset]);
         SCOPED_TRACE(static_cast<std::uint8_t>(opcode));
         auto malformed = packed;
         std::fill_n(malformed.begin() + kRequestIdOffset, sizeof(std::uint64_t), std::uint8_t{0});
@@ -1006,7 +1015,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsInvalidDumpLoadEntryFields)
     };
 
     KvDumpRequest dump;
-    dump.opcode = KvOpcode::Dump;
+    dump.opcode = OpType::DUMP;
     dump.request_id = kRequestId;
     dump.resp_addr = 0x1000;
     dump.ttl = 10;
@@ -1018,7 +1027,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsInvalidDumpLoadEntryFields)
     ASSERT_TRUE(mgr_.PackRequest(packedDump.data(), dump.opcode, dump).Success());
 
     KvLoadRequest load;
-    load.opcode = KvOpcode::Load;
+    load.opcode = OpType::LOAD;
     load.request_id = kRequestId;
     load.resp_addr = 0x1000;
     load.batch_size = 1;
@@ -1043,7 +1052,7 @@ TEST_F(KvProtocolTest, UnpackRequestRejectsInvalidDumpLoadEntryFields)
 TEST_F(KvProtocolTest, UnpackRequestFailurePreservesOutput)
 {
     std::vector<std::uint8_t> malformed(kKvLookupRequestHeaderSize + kKvLookupEntrySize, 0);
-    malformed[kOpcodeOffset] = static_cast<std::uint8_t>(KvOpcode::Lookup);
+    malformed[kOpcodeOffset] = static_cast<std::uint8_t>(OpType::LOOKUP);
     auto original = std::make_unique<KvLookupRequest>();
     auto* originalAddress = original.get();
     std::unique_ptr<KvRequest> output = std::move(original);


### PR DESCRIPTION
## Purpose
Use UC::Dram::OpType as the single operation type for DramStore and the shared DramPool protocol, eliminating the duplicate KvOpcode enum and ensuring opcode values stay consistent across the client-server boundary.

## Modifications

- Remove DramPool::KvOpcode enum and alias to UC::Dram::OpType in kv_protocol.h.
- Update ProtocolManager and all protocol pack/unpack methods to use OpType instead of KvOpcode.
- Update TaskWorker, CompletionPoller, NodeActor, ReplyService, and config code to use OpType directly, removing the ToOpcode conversion helper.
- Remove KvOpcode::None sentinel; unknown wire values are validated by the protocol map lookup instead.
- Update all affected unit tests to use OpType values.
- Add KvProtocolOpcodeTest.UsesDramStoreOpType to verify the shared enum contract.

## Test
Unit tests passed on Ascend container (build-dram-test, RUNTIME_ENVIRONMENT=ascend).

```
[==========] 42 tests from 2 test suites ran. (0 ms total)
[  PASSED  ] 42 tests.
[----------] 1 test from KvProtocolOpcodeTest
[----------] 41 tests from KvProtocolTest (2 ms total)
```