### PR TITLE
[Opt] Refactor ASU memory key propagation through KVBuffer

### DIFF
--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -350,17 +350,15 @@ Status AsuClientImpl::SubmitAsync(AsuOpType opType, const std::vector<KVBuffer>&
     ctx->opType = opType;
     ctx->viewSnapshot = snapshot;
     ctx->entries = entries;
-    auto registeredMrKeys = std::make_shared<RegisteredMrKeyMap>();
     {
         std::lock_guard<std::mutex> memoryLock{memoryMu_};
-        for (const auto& entry : entries) {
+        for (auto& entry : ctx->entries) {
+            // mrKey is client-owned metadata. Ignore any value supplied by the caller.
+            entry.mrKey.reset();
             auto iter = registeredRegions_.find(entry.buffer.handle);
-            if (iter != registeredRegions_.end()) {
-                registeredMrKeys->emplace(iter->first, iter->second.tokenId);
-            }
+            if (iter != registeredRegions_.end()) { entry.mrKey = iter->second.tokenId; }
         }
     }
-    ctx->registeredMrKeys = std::move(registeredMrKeys);
     ctx->entryStatus.assign(entries.size(), Status::OK());
 
     auto status = taskManager_.Submit(std::move(ctx), taskId);

--- a/ucm/transport/kv/asu/client/src/client_task_manager.cpp
+++ b/ucm/transport/kv/asu/client/src/client_task_manager.cpp
@@ -265,7 +265,6 @@ Status ClientTaskManager::BuildTransportTasks(const ClientTaskPtr& task)
         auto transportTask = std::make_shared<TransportTask>();
         transportTask->asuId = asuId;
         transportTask->transport = snapshot->transports.at(asuId);
-        transportTask->registeredMrKeys = task->registeredMrKeys;
         transportTask->originalIndices.reserve(indices.size());
         if (task->opType == AsuOpType::QUERY || task->opType == AsuOpType::DELETE) {
             transportTask->keys.reserve(indices.size());

--- a/ucm/transport/kv/asu/common/task_context.h
+++ b/ucm/transport/kv/asu/common/task_context.h
@@ -30,7 +30,6 @@
 #include <cstdint>
 #include <memory>
 #include <mutex>
-#include <unordered_map>
 #include <vector>
 #include "asu_transport/types.h"
 
@@ -81,7 +80,6 @@ inline bool IsKeyBatchOp(AsuOpType opType)
 inline bool IsKeepAliveOp(AsuOpType opType) { return opType == AsuOpType::KEEP_ALIVE; }
 
 using TransportSubBatchList = std::vector<TransportSubBatchContext>;
-using RegisteredMrKeyMap = std::unordered_map<MRHandle, std::uint32_t>;
 
 struct TransportTask {
     TransportTask();
@@ -92,7 +90,6 @@ struct TransportTask {
     std::weak_ptr<AsuTransport> transport;
     std::vector<CacheKey> keys;
     std::vector<KVBuffer> entries;
-    std::shared_ptr<const RegisteredMrKeyMap> registeredMrKeys;
     std::vector<std::size_t> originalIndices;
     std::vector<Status> entryStatus;
     bool clientCompleted{false};
@@ -122,7 +119,6 @@ struct ClientTask {
     AsuOpType opType{AsuOpType::LOAD};
     std::shared_ptr<ViewSnapshot> viewSnapshot;
     std::vector<KVBuffer> entries;
-    std::shared_ptr<const RegisteredMrKeyMap> registeredMrKeys;
     std::vector<CacheKey> keys;
     std::vector<TransportTaskPtr> transportTasks;
     std::vector<Status> entryStatus;

--- a/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
@@ -69,7 +69,7 @@ struct TestState {
     std::unordered_map<AsuId, Status> checkResultStatus;
     std::vector<AsuId> registerCalls;
     std::vector<AsuId> providerBindCalls;
-    RegisteredMrKeyMap submittedMrKeys;
+    std::vector<KVBuffer> submittedEntries;
     std::vector<AsuId> unregisterCalls;
     bool failRegister{false};
     bool failProviderBind{false};
@@ -246,9 +246,7 @@ public:
         if (!task) {
             return Status::Error(StatusCode::INVALID_ARGUMENT, "fake transport task is null");
         }
-        if (task->registeredMrKeys != nullptr) {
-            state_->submittedMrKeys = *task->registeredMrKeys;
-        }
+        state_->submittedEntries = task->entries;
         state_->submittedOpTypes.emplace_back(task->opType);
         switch (task->opType) {
             case AsuOpType::QUERY: {
@@ -1359,6 +1357,7 @@ TEST(AsuClientImplTest, MemoryRegister_NewIndependentProviderBindsRememberedRegi
     EXPECT_EQ(QueryAndWait(*client, {MakeCacheKey("k05")}, queryResult).code,
               StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(WaitForFetchCount(viewServer, 2));
+    ASSERT_TRUE(client->Shutdown().ok());
 
     EXPECT_EQ(state->createdProviders, std::uint32_t{3});
     EXPECT_EQ(state->providerBindCalls, std::vector<AsuId>({10, 20}));
@@ -1929,7 +1928,7 @@ TEST(AsuClientImplTest, SnapshotRefresh_ReusesTransportAndBindsProviderForAddedA
     EXPECT_EQ(state->providerBindCalls, std::vector<AsuId>({10, 20}));
 }
 
-TEST(AsuClientImplTest, MemoryRegister_StoreTaskCarriesRegisteredTokenMetadata)
+TEST(AsuClientImplTest, MemoryRegister_StoreTaskCarriesMrKeyInEntry)
 {
     auto state = std::make_shared<TestState>();
     auto client = CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
@@ -1946,8 +1945,9 @@ TEST(AsuClientImplTest, MemoryRegister_StoreTaskCarriesRegisteredTokenMetadata)
     TaskResult result;
     ASSERT_TRUE(client->Wait(taskId, 100, result).ok());
 
-    ASSERT_EQ(state->submittedMrKeys.size(), std::size_t{1});
-    EXPECT_EQ(state->submittedMrKeys.at(registeredRegions[0].handle), registeredRegions[0].tokenId);
+    ASSERT_EQ(state->submittedEntries.size(), std::size_t{1});
+    ASSERT_TRUE(state->submittedEntries[0].mrKey.has_value());
+    EXPECT_EQ(*state->submittedEntries[0].mrKey, registeredRegions[0].tokenId);
 }
 
 TEST(AsuClientImplTest,

--- a/ucm/transport/kv/asu/test/transport/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/sqe_request_test.cpp
@@ -149,15 +149,11 @@ std::vector<KVBuffer> MakeEntries(std::size_t count)
     return entries;
 }
 
-RegisteredMrKeyMap MakeRegisteredMrKeys(const std::vector<KVBuffer>& entries,
-                                        std::uint32_t tokenBase)
+void SetMrKeys(std::vector<KVBuffer>& entries, std::uint32_t tokenBase)
 {
-    RegisteredMrKeyMap registeredMrKeys;
     for (std::size_t index = 0; index < entries.size(); ++index) {
-        registeredMrKeys.emplace(entries[index].buffer.handle,
-                                 tokenBase + static_cast<std::uint32_t>(index));
+        entries[index].mrKey = tokenBase + static_cast<std::uint32_t>(index);
     }
-    return registeredMrKeys;
 }
 
 std::uint32_t PackedBatchEntryMrKey(const std::uint32_t* sqe, std::size_t entryIndex)
@@ -231,15 +227,14 @@ TEST_F(SqeRequestTest, SubmitBatchStoreAllocatesFlagBufferAndBuildsRequest)
     entries[0].offset = kAlignmentBytes;
     entries[1].offset = kAlignmentBytes * 2;
     entries[2].offset = kAlignmentBytes * 3;
+    SetMrKeys(entries, 0xABCD0000);
     IoScheduler::ScheduledIoBatch subBatch{
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
     TransportSubBatchContext subBatchContext;
     transport_->nextRequestCid_.store(41, std::memory_order_relaxed);
-    const auto registeredMrKeys = MakeRegisteredMrKeys(entries, 0xABCD0000);
-
     const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
-        AsuOpType::BATCH_STORE, subBatch, registeredMrKeys, subBatchContext);
+        AsuOpType::BATCH_STORE, subBatch, subBatchContext);
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(subBatchContext.flagBuffer.length, kFlagBufferHeaderSize + (entries.size() + 1) / 2);
@@ -272,14 +267,13 @@ TEST_F(SqeRequestTest, SubmitStoreUsesStoreOpcodeAndRequest)
 {
     auto entries = MakeEntries(1);
     entries[0].offset = kAlignmentBytes;
+    SetMrKeys(entries, 0xABCD0000);
     IoScheduler::ScheduledIoBatch subBatch{
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
     TransportSubBatchContext subBatchContext;
-    const auto registeredMrKeys = MakeRegisteredMrKeys(entries, 0xABCD0000);
-
     const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
-        AsuOpType::STORE, subBatch, registeredMrKeys, subBatchContext);
+        AsuOpType::STORE, subBatch, subBatchContext);
 
     ASSERT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(subBatchContext.opType, AsuOpType::STORE);
@@ -311,14 +305,14 @@ TEST_F(SqeRequestTest, SubmitBatchStorePacksSqeIntoDeviceSendBuffer)
     CreateTaskExecutor(deviceTransport);
 
     auto entries = MakeEntries(3);
-    const auto registeredMrKeys = MakeRegisteredMrKeys(entries, 0x12340000);
+    SetMrKeys(entries, 0x12340000);
     IoScheduler::ScheduledIoBatch subBatch{
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
     TransportSubBatchContext subBatchContext;
 
     const auto status = deviceTransport.taskExecutor_->BuildEntrySubBatchRequest(
-        AsuOpType::BATCH_STORE, subBatch, registeredMrKeys, subBatchContext);
+        AsuOpType::BATCH_STORE, subBatch, subBatchContext);
 
     ASSERT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(subBatchContext.sendSge.memory_type, MemoryType::ASCEND_DEVICE);
@@ -337,15 +331,14 @@ TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
     auto entries = MakeEntries(2);
     entries[0].offset = kAlignmentBytes * 4;
     entries[1].offset = kAlignmentBytes * 5;
+    SetMrKeys(entries, 0x76540000);
     IoScheduler::ScheduledIoBatch subBatch{
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
     TransportSubBatchContext subBatchContext;
     transport_->nextRequestCid_.store(9, std::memory_order_relaxed);
-    const auto registeredMrKeys = MakeRegisteredMrKeys(entries, 0x76540000);
-
     const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
-        AsuOpType::BATCH_LOAD, subBatch, registeredMrKeys, subBatchContext);
+        AsuOpType::BATCH_LOAD, subBatch, subBatchContext);
 
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(subBatchContext.opType, AsuOpType::BATCH_LOAD);
@@ -364,14 +357,13 @@ TEST_F(SqeRequestTest, SubmitLoadUsesRetrieveOpcodeAndRequest)
 {
     auto entries = MakeEntries(1);
     entries[0].offset = kAlignmentBytes * 4;
+    SetMrKeys(entries, 0x76540000);
     IoScheduler::ScheduledIoBatch subBatch{
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
     TransportSubBatchContext subBatchContext;
-    const auto registeredMrKeys = MakeRegisteredMrKeys(entries, 0x76540000);
-
     const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
-        AsuOpType::LOAD, subBatch, registeredMrKeys, subBatchContext);
+        AsuOpType::LOAD, subBatch, subBatchContext);
 
     ASSERT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(subBatchContext.opType, AsuOpType::LOAD);
@@ -388,10 +380,8 @@ TEST_F(SqeRequestTest, SubmitBatchStoreRejectsUnregisteredEntryBuffer)
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
     TransportSubBatchContext subBatchContext;
-    const RegisteredMrKeyMap registeredMrKeys;
-
     const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
-        AsuOpType::BATCH_STORE, subBatch, registeredMrKeys, subBatchContext);
+        AsuOpType::BATCH_STORE, subBatch, subBatchContext);
 
     EXPECT_EQ(status.code, StatusCode::BUFFER_NOT_REGISTERED);
     EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
@@ -473,6 +463,7 @@ TEST_F(SqeRequestTest, SubmitExistDisablesSeekControlWhenScDisabled)
 TEST_F(SqeRequestTest, AllocationFailureMarksWholeSubBatchFailed)
 {
     auto entries = MakeEntries(2);
+    SetMrKeys(entries, 0x45670000);
     IoScheduler::ScheduledIoBatch subBatch{
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
@@ -487,10 +478,8 @@ TEST_F(SqeRequestTest, AllocationFailureMarksWholeSubBatchFailed)
                     .ok());
     uninitializedFlagTransport.protocolManager_ = std::make_unique<ProtocolManager>();
     CreateTaskExecutor(uninitializedFlagTransport);
-    const auto registeredMrKeys = MakeRegisteredMrKeys(entries, 0x45670000);
-
     const auto status = uninitializedFlagTransport.taskExecutor_->BuildEntrySubBatchRequest(
-        AsuOpType::BATCH_STORE, subBatch, registeredMrKeys, subBatchContext);
+        AsuOpType::BATCH_STORE, subBatch, subBatchContext);
 
     EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
     EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);

--- a/ucm/transport/kv/asu/trans/include/asu_transport/types.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/types.h
@@ -165,6 +165,8 @@ struct KVBuffer {
     CacheKey key;
     Buffer buffer;
     std::uint32_t offset{0};  // target buffer offset
+    // Resolved by AsuClient from buffer.handle before the entry reaches the transport.
+    std::optional<std::uint32_t> mrKey;
 };
 
 // Describes a registered memory region returned by registration or reused for binding.

--- a/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
@@ -60,15 +60,12 @@ Status TransportTaskExecutor::PrepareTaskSubBatches(
         }
         const auto entries = BatchView<KVBuffer>{ctx.entries.data(), ctx.entries.size()};
         const auto subBatches = ioScheduler_.SplitForAsu(entries, opType);
-        static const RegisteredMrKeyMap emptyRegisteredMrKeys;
-        const auto& registeredMrKeys =
-            ctx.registeredMrKeys == nullptr ? emptyRegisteredMrKeys : *ctx.registeredMrKeys;
         subBatchContexts.reserve(subBatches.size());
         for (std::size_t index = 0; index < subBatches.size(); ++index) {
             const auto& subBatch = subBatches[index];
             auto& subBatchContext = subBatchContexts.emplace_back();
             const auto subBatchStatus =
-                BuildEntrySubBatchRequest(opType, subBatch, registeredMrKeys, subBatchContext);
+                BuildEntrySubBatchRequest(opType, subBatch, subBatchContext);
             if (!subBatchStatus.ok()) {
                 UC_ERROR(
                     "Build entry sub-batch request failed index={} batch_size={} code={} "

--- a/ucm/transport/kv/asu/trans/src/sqe_request.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.cpp
@@ -42,21 +42,14 @@ namespace {
 
 constexpr std::size_t kFlagBufferHeaderSize = 16;
 
-Status ResolveSqeMrKeys(const BatchView<KVBuffer>& entries,
-                        const RegisteredMrKeyMap& registeredMrKeys,
-                        std::vector<std::uint32_t>& mrKeys)
+Status ValidateSqeMrKeys(const BatchView<KVBuffer>& entries)
 {
-    mrKeys.clear();
-    mrKeys.reserve(entries.size);
     for (std::size_t index = 0; index < entries.size; ++index) {
-        const auto handle = entries[index].buffer.handle;
-        auto iter = registeredMrKeys.find(handle);
-        if (iter == registeredMrKeys.end()) {
+        if (!entries[index].mrKey.has_value()) {
             return Status::Error(
                 StatusCode::BUFFER_NOT_REGISTERED,
                 "entry buffer is not registered, entryIndex=" + std::to_string(index));
         }
-        mrKeys.emplace_back(iter->second);
     }
     return Status::OK();
 }
@@ -197,8 +190,7 @@ Status PackSubBatchRequest(ProtocolManager& protocolManager, BufferManager& send
 
 KvBatchStoreRequest BuildBatchStoreRequest(
     const BatchView<KVBuffer>& entries, const std::unordered_map<std::string, std::string>& attrs,
-    std::uint16_t cid, const ScatterGatherEntry& flagBuffer,
-    const std::vector<std::uint32_t>& mrKeys)
+    std::uint16_t cid, const ScatterGatherEntry& flagBuffer)
 {
     KvBatchStoreRequest request;
     request.cid = cid;
@@ -216,7 +208,7 @@ KvBatchStoreRequest BuildBatchStoreRequest(
         entry.key = entries[index].key;
         entry.offset = entries[index].offset;
         entry.buffer_addr = entries[index].buffer.region.addr;
-        entry.mr_key = mrKeys[index];
+        entry.mr_key = *entries[index].mrKey;
         entry.length = static_cast<std::uint32_t>(entries[index].buffer.region.size);
         request.entries.emplace_back(std::move(entry));
     }
@@ -225,7 +217,7 @@ KvBatchStoreRequest BuildBatchStoreRequest(
 
 KvStoreRequest BuildStoreRequest(const KVBuffer& entry,
                                  const std::unordered_map<std::string, std::string>& attrs,
-                                 std::uint16_t cid, std::uint32_t mrKey)
+                                 std::uint16_t cid)
 {
     KvStoreRequest request;
     request.cid = cid;
@@ -234,7 +226,7 @@ KvStoreRequest BuildStoreRequest(const KVBuffer& entry,
     request.dspec = GetTransportConfigAttr<std::uint8_t>(attrs, "dspec");
     request.buffer_addr = entry.buffer.region.addr;
     request.buffer_length = static_cast<std::uint32_t>(entry.buffer.region.size);
-    request.mr_key = mrKey;
+    request.mr_key = *entry.mrKey;
     request.offset = entry.offset;
     request.lr = GetTransportConfigAttr<bool>(attrs, "lr");
     request.length = request.buffer_length;
@@ -244,14 +236,14 @@ KvStoreRequest BuildStoreRequest(const KVBuffer& entry,
 
 KvRetrieveRequest BuildRetrieveRequest(const KVBuffer& entry,
                                        const std::unordered_map<std::string, std::string>& attrs,
-                                       std::uint16_t cid, std::uint32_t mrKey)
+                                       std::uint16_t cid)
 {
     KvRetrieveRequest request;
     request.cid = cid;
     request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
     request.buffer_addr = entry.buffer.region.addr;
     request.buffer_length = static_cast<std::uint32_t>(entry.buffer.region.size);
-    request.mr_key = mrKey;
+    request.mr_key = *entry.mrKey;
     request.offset = entry.offset;
     request.lr = GetTransportConfigAttr<bool>(attrs, "lr");
     request.length = request.buffer_length;
@@ -261,8 +253,7 @@ KvRetrieveRequest BuildRetrieveRequest(const KVBuffer& entry,
 
 KvBatchRetrieveRequest BuildBatchRetrieveRequest(
     const BatchView<KVBuffer>& entries, const std::unordered_map<std::string, std::string>& attrs,
-    std::uint16_t cid, const ScatterGatherEntry& flagBuffer,
-    const std::vector<std::uint32_t>& mrKeys)
+    std::uint16_t cid, const ScatterGatherEntry& flagBuffer)
 {
     KvBatchRetrieveRequest request;
     request.cid = cid;
@@ -278,7 +269,7 @@ KvBatchRetrieveRequest BuildBatchRetrieveRequest(
         entry.key = entries[index].key;
         entry.offset = entries[index].offset;
         entry.buffer_addr = entries[index].buffer.region.addr;
-        entry.mr_key = mrKeys[index];
+        entry.mr_key = *entries[index].mrKey;
         entry.length = static_cast<std::uint32_t>(entries[index].buffer.region.size);
         request.entries.emplace_back(std::move(entry));
     }
@@ -339,32 +330,25 @@ KvKeepAliveRequest BuildKeepAliveRequest(std::uint16_t cid, const ScatterGatherE
 std::unique_ptr<SqeRequest> BuildSqeRequest(
     KvOpcode opcode, const SubBatchRequestSource& source,
     const std::unordered_map<std::string, std::string>& attrs, std::uint16_t cid,
-    const ScatterGatherEntry& flagBuffer, const std::vector<std::uint32_t>* mrKeys,
-    TransportSubBatchContext& subBatchContext)
+    const ScatterGatherEntry& flagBuffer, TransportSubBatchContext& subBatchContext)
 {
     switch (opcode) {
         case KvOpcode::Store:
-            if (source.entries == nullptr || source.entries->size != 1 || mrKeys == nullptr ||
-                mrKeys->size() != 1) {
-                return nullptr;
-            }
+            if (source.entries == nullptr || source.entries->size != 1) { return nullptr; }
             return std::make_unique<KvStoreRequest>(
-                BuildStoreRequest(source.entries->data[0], attrs, cid, (*mrKeys)[0]));
+                BuildStoreRequest(source.entries->data[0], attrs, cid));
         case KvOpcode::Retrieve:
-            if (source.entries == nullptr || source.entries->size != 1 || mrKeys == nullptr ||
-                mrKeys->size() != 1) {
-                return nullptr;
-            }
+            if (source.entries == nullptr || source.entries->size != 1) { return nullptr; }
             return std::make_unique<KvRetrieveRequest>(
-                BuildRetrieveRequest(source.entries->data[0], attrs, cid, (*mrKeys)[0]));
+                BuildRetrieveRequest(source.entries->data[0], attrs, cid));
         case KvOpcode::BatchRetrieve:
-            if (source.entries == nullptr || mrKeys == nullptr) { return nullptr; }
+            if (source.entries == nullptr) { return nullptr; }
             return std::make_unique<KvBatchRetrieveRequest>(
-                BuildBatchRetrieveRequest(*source.entries, attrs, cid, flagBuffer, *mrKeys));
+                BuildBatchRetrieveRequest(*source.entries, attrs, cid, flagBuffer));
         case KvOpcode::BatchStore:
-            if (source.entries == nullptr || mrKeys == nullptr) { return nullptr; }
+            if (source.entries == nullptr) { return nullptr; }
             return std::make_unique<KvBatchStoreRequest>(
-                BuildBatchStoreRequest(*source.entries, attrs, cid, flagBuffer, *mrKeys));
+                BuildBatchStoreRequest(*source.entries, attrs, cid, flagBuffer));
         case KvOpcode::Delete:
             if (source.keys == nullptr) { return nullptr; }
             return std::make_unique<KvDeleteRequest>(
@@ -388,17 +372,16 @@ std::unique_ptr<SqeRequest> BuildSqeRequest(
 
 Status TransportTaskExecutor::BuildEntrySubBatchRequest(
     AsuOpType opType, const IoScheduler::ScheduledIoBatch& subBatch,
-    const RegisteredMrKeyMap& registeredMrKeys, TransportSubBatchContext& subBatchContext)
+    TransportSubBatchContext& subBatchContext)
 {
     const auto source = SubBatchRequestSource::FromEntries(subBatch.entries);
     subBatchContext.entryStatus.assign(subBatch.entries.size, Status::OK());
     const auto opcode = ToKvOpcode(opType);
 
-    std::vector<std::uint32_t> mrKeys;
-    auto resolveStatus = ResolveSqeMrKeys(subBatch.entries, registeredMrKeys, mrKeys);
-    if (!resolveStatus.ok()) {
-        SetSubBatchBuildFailed(subBatchContext, resolveStatus);
-        return resolveStatus;
+    auto validationStatus = ValidateSqeMrKeys(subBatch.entries);
+    if (!validationStatus.ok()) {
+        SetSubBatchBuildFailed(subBatchContext, validationStatus);
+        return validationStatus;
     }
 
     const auto cid = AllocateRequestCid();
@@ -407,7 +390,7 @@ Status TransportTaskExecutor::BuildEntrySubBatchRequest(
     if (!status.ok()) { return status; }
 
     auto request = BuildSqeRequest(opcode, source, config_.attrs, subBatchContext.cid,
-                                   subBatchContext.flagBuffer, &mrKeys, subBatchContext);
+                                   subBatchContext.flagBuffer, subBatchContext);
     return PackSubBatchRequest(*protocolManager_, sendBufferManager_, opcode, *request,
                                subBatchContext);
 }
@@ -425,7 +408,7 @@ Status TransportTaskExecutor::SubmitKeySubBatchRequest(
     if (!status.ok()) { return status; }
 
     auto request = BuildSqeRequest(opcode, source, config_.attrs, subBatchContext.cid,
-                                   subBatchContext.flagBuffer, nullptr, subBatchContext);
+                                   subBatchContext.flagBuffer, subBatchContext);
     return PackSubBatchRequest(*protocolManager_, sendBufferManager_, opcode, *request,
                                subBatchContext);
 }
@@ -442,7 +425,7 @@ Status TransportTaskExecutor::SubmitKeepAliveRequest(TransportSubBatchContext& s
     if (!status.ok()) { return status; }
 
     auto request = BuildSqeRequest(opcode, source, config_.attrs, subBatchContext.cid,
-                                   subBatchContext.flagBuffer, nullptr, subBatchContext);
+                                   subBatchContext.flagBuffer, subBatchContext);
     return PackSubBatchRequest(*protocolManager_, sendBufferManager_, opcode, *request,
                                subBatchContext);
 }

--- a/ucm/transport/kv/asu/trans/src/transport_task_executor.h
+++ b/ucm/transport/kv/asu/trans/src/transport_task_executor.h
@@ -73,7 +73,6 @@ private:
                                  std::vector<TransportSubBatchContext>& subBatchContexts);
     Status BuildEntrySubBatchRequest(AsuOpType opType,
                                      const IoScheduler::ScheduledIoBatch& subBatch,
-                                     const RegisteredMrKeyMap& registeredMrKeys,
                                      TransportSubBatchContext& subBatchContext);
     Status SubmitKeySubBatchRequest(AsuOpType opType,
                                     const IoScheduler::ScheduledKeyBatch& subBatch,


### PR DESCRIPTION
## Purpose

Move registered memory-key metadata from task-level lookup maps into each `KVBuffer` entry. This keeps the buffer and the key required to access it together throughout the ASU submission pipeline, removes duplicated task metadata, and eliminates handle-to-key lookups from the transport layer.

Related issue: N/A

## Modifications

- Add `std::optional<std::uint32_t> mrKey` to `KVBuffer`.
- Resolve `mrKey` from the registered memory handle in `AsuClient` before task submission.
- Reset caller-provided `mrKey` values before resolution so registration state remains client-owned.
- Preserve zero as a valid memory key by using `std::optional` to represent unresolved keys.
- Remove `RegisteredMrKeyMap` and `registeredMrKeys` from `ClientTask` and `TransportTask`.
- Remove task-level key-map propagation from `ClientTaskManager`, `AsuSubmitFlow`, and `TransportTaskExecutor`.
- Build SQEs directly from each entry's `mrKey` and return `BUFFER_NOT_REGISTERED` when it is unresolved.
- Update client and SQE tests for per-buffer memory keys.
- Stabilize `MemoryRegister_NewIndependentProviderBindsRememberedRegions` by shutting down the client before provider-state assertions, ensuring the background refresh thread has joined.

## Test

Local verification:

- `clang-format 20.1.3 --dry-run --Werror`: passed for all 9 modified C++ files.
- `bash format.sh`: passed (`codespell`, `black`, `isort`, and `actionlint`).
- ASU unit tests: 364/364 passed.
- `git diff --check`: passed.

GitHub Actions: no workflow run or commit status is currently reported for the PR head commit.

## Additional context

- Screenshots: N/A (no UI changes).
