### PR TITLE
[Feat] Enable Store Health by default

### DIFF
--- a/docs/source/user-guide/metrics/health_metrics.md
+++ b/docs/source/user-guide/metrics/health_metrics.md
@@ -1,6 +1,6 @@
 # UCM Health Metrics
 
-UCM Pipeline Store can enable health probes and circuit breaking for individual Store stages. Health metrics answer two different questions:
+UCM Pipeline Store enables health probes and circuit breaking for individual Store stages by default. Set `store_health.enabled` to `false` to disable them. Health metrics answer two different questions:
 
 - How many health probes succeeded or failed during a time window?
 - Is a Store currently blocked from accepting new requests by its circuit breaker?

--- a/docs/source/user-guide/prefix-cache/pipeline_store.md
+++ b/docs/source/user-guide/prefix-cache/pipeline_store.md
@@ -109,9 +109,9 @@ persist_token_threshold: 0
 
 Parameters inside `ucm_connector_config`:
 
-* **store_health.enabled** *(optional, default: false)*
+* **store_health.enabled** *(optional, default: true)*
   Whether to wrap each Store in the Pipeline with `HealthBreakerStore`.
-  Set it to `true` to enable automatic health probing, circuit breaking, and recovery.
+  Set it to `false` to disable automatic health probing, circuit breaking, and recovery.
   This setting does not control a Breaker explicitly added as a Store by a custom Pipeline implementation.
 
 * **io_direct** (optional, default: `false`):  

--- a/ucm/store/pipeline/cc/store_health_config.h
+++ b/ucm/store/pipeline/cc/store_health_config.h
@@ -31,7 +31,7 @@
 namespace UC::PipelineStore {
 
 struct StoreHealthConfig {
-    bool enabled{false};
+    bool enabled{true};
     std::chrono::milliseconds healthCheckInterval{std::chrono::seconds(10)};
     std::chrono::milliseconds healthCheckTimeout{std::chrono::seconds(3)};
     size_t healthWindowSize{8};

--- a/ucm/store/test/case/pipeline/health_breaker_store_test.cc
+++ b/ucm/store/test/case/pipeline/health_breaker_store_test.cc
@@ -400,7 +400,7 @@ TEST(UCHealthBreakerStoreTest, HealthyOperationsPassThroughWithoutChangingWindow
 TEST(UCHealthBreakerStoreTest, StoreHealthConfigDefaults)
 {
     StoreHealthConfig config;
-    EXPECT_FALSE(config.enabled);
+    EXPECT_TRUE(config.enabled);
     EXPECT_EQ(config.healthCheckInterval, std::chrono::seconds(10));
     EXPECT_EQ(config.healthCheckTimeout, std::chrono::seconds(3));
 }


### PR DESCRIPTION
## Summary
- enable Pipeline Store health probing and circuit breaking by default
- retain store_health.enabled: false as an explicit opt-out
- update the default-value unit test and user documentation

## Why
Store health metrics and automatic circuit-breaker protection should be available without additional configuration.

## Impact
Each Pipeline Store stage is wrapped by HealthBreakerStore by default. Existing users can preserve the previous behavior by setting store_health.enabled to false.

## Verification
- pre-commit run on all changed files
- git diff --check