### PR TITLE
perf(cache/cc): lock-free TransBuffer state, CLOCK eviction, and next-shard preallocation

### DIFF
--- a/ucm/store/cache/cc/load_queue.cc
+++ b/ucm/store/cache/cc/load_queue.cc
@@ -42,6 +42,7 @@ Status LoadQueue::Setup(const Config& config, TaskIdSet* failureSet, TransBuffer
     backend_ = config.storeBackend;
     deviceId_ = config.deviceId;
     tensorSizes_ = config.tensorSizes;
+    nShardPerBlock_ = config.blockSize / config.shardSize;
     streamNumber_ = config.EffectiveStreamNumber();
     useGdr_ = config.useGdr;
     cacheSdmaDirect_ = config.cacheSdmaDirect;
@@ -142,6 +143,12 @@ void LoadQueue::DispatchOneTask(TaskPair&& pair)
         running_.Push(std::move(shardTask));
     }
     auto tpDispatch = NowTime::Now();
+    for (size_t i = 0; i < nShard; i++) {
+        auto& shard = task->desc[indexes[i]];
+        if (shard.index + 1 != nShardPerBlock_) {
+            buffer_->Prealloc(shard.owner, shard.index + 1, true);
+        }
+    }
     UC_DEBUG("Cache task({}) dispatch shards({}), wait={:.3f}ms, cost={:.3f}ms.", task->id, nShard,
              (tpWait - tp) * 1e3, (tpDispatch - tpWait) * 1e3);
     UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_load_queue_wait_duration_ms"),

--- a/ucm/store/cache/cc/load_queue.h
+++ b/ucm/store/cache/cc/load_queue.h
@@ -58,6 +58,7 @@ private:
     StoreV1* backend_{nullptr};
     int32_t deviceId_{-1};
     std::vector<size_t> tensorSizes_{};
+    size_t nShardPerBlock_{0};
     size_t streamNumber_{1};
     bool useGdr_{false};
     bool cacheSdmaDirect_{false};

--- a/ucm/store/cache/cc/trans_buffer.cc
+++ b/ucm/store/cache/cc/trans_buffer.cc
@@ -93,12 +93,13 @@ public:
     virtual void* DataAt(size_t iNode) = 0;
     virtual void* DeviceDataAt(size_t iNode) = 0;
     virtual BufferMetaNode* MetaAt(size_t iNode) = 0;
+    virtual void MarkAccessed(size_t iNode) = 0;
 };
 
 class LocalBufferStrategy : public BufferStrategy {
     struct BufferHeader {
         size_t buckets[nHashTableBucket];
-        size_t freeHead;
+        size_t nodeCursor;
         size_t nodeSize;
         size_t nNode;
     };
@@ -134,6 +135,7 @@ class LocalBufferStrategy : public BufferStrategy {
     LocalMutex bucketLocks_[nHashTableBucket];
     std::unique_ptr<LocalLock[]> nodeLocks_;
     std::unique_ptr<BufferMetaNode[]> meta_;
+    std::unique_ptr<std::atomic<uint8_t>[]> accessed_;
     std::shared_ptr<void> data_;
     std::byte* dataOnDevice_{nullptr};
     bool registeredMappedHost_{false};
@@ -159,8 +161,12 @@ public:
         try {
             nodeLocks_ = std::make_unique<LocalLock[]>(nNode);
             meta_ = std::make_unique<BufferMetaNode[]>(nNode);
+            accessed_ = std::make_unique<std::atomic<uint8_t>[]>(nNode);
             for (size_t i = 0; i < nHashTableBucket; i++) { bucketLocks_[i].Init(); }
-            for (size_t i = 0; i < nNode; i++) { nodeLocks_[i].Init(); }
+            for (size_t i = 0; i < nNode; i++) {
+                nodeLocks_[i].Init();
+                accessed_[i].store(0, std::memory_order_relaxed);
+            }
         } catch (const std::exception& e) {
             UC_ERROR("Failed({}) to alloc buffer.", e.what());
             return Status::Error(e.what());
@@ -200,7 +206,7 @@ public:
         }
         for (size_t i = 0; i < nHashTableBucket; i++) { header_.buckets[i] = invalidIndex; }
         for (size_t i = 0; i < nNode; i++) { meta_[i].Init(); }
-        header_.freeHead = 0;
+        header_.nodeCursor = 0;
         header_.nodeSize = nodeSize;
         header_.nNode = nNode;
         return Status::OK();
@@ -213,9 +219,21 @@ public:
     size_t& FirstAt(size_t iBucket) override { return header_.buckets[iBucket]; }
     size_t FetchNode(bool allowReserved) override
     {
-        const auto limit = header_.nNode - (allowReserved ? 0 : base_.reservedNumber);
-        if (header_.freeHead >= limit) { header_.freeHead = 0; }
-        return header_.freeHead++;
+        const auto total = header_.nNode - (allowReserved ? 0 : base_.reservedNumber);
+        for (size_t i = 0; i < 2 * total; ++i) {
+            auto cur = header_.nodeCursor++ % total;
+            uint8_t expected = 1;
+            if (accessed_[cur].compare_exchange_strong(expected, 0, std::memory_order_relaxed,
+                                                       std::memory_order_relaxed)) {
+                continue;
+            }
+            return cur;
+        }
+        return header_.nodeCursor++ % total;
+    }
+    void MarkAccessed(size_t iNode) override
+    {
+        accessed_[iNode].store(1, std::memory_order_relaxed);
     }
     void* DataAt(size_t iNode) override
     {
@@ -260,16 +278,18 @@ protected:
     struct BufferHeader {
         std::atomic<size_t> magic;
         size_t nNode;
-        alignas(64) std::atomic<size_t> freeHead;
-        char freeHeadPad[64 - sizeof(std::atomic<size_t>)];
+        alignas(64) std::atomic<size_t> nodeCursor;
+        char nodeCursorPad[64 - sizeof(std::atomic<size_t>)];
         size_t buckets[nHashTableBucket];
         ShareMutex bucketLocks[nHashTableBucket];
         ShareLock nodeLocks[0];
     };
-    static_assert(std::atomic<size_t>::is_always_lock_free, "freeHead must be lock-free");
+    static_assert(std::atomic<size_t>::is_always_lock_free, "nodeCursor must be lock-free");
+    static_assert(std::atomic<uint8_t>::is_always_lock_free, "accessed must be lock-free");
 
     BufferHeader* header_{nullptr};
     BufferMetaNode* meta_{nullptr};
+    std::atomic<uint8_t>* accessed_{nullptr};
     std::byte* data_{nullptr};
     std::byte* dataOnDevice_{nullptr};
     const std::string& uuid_;
@@ -279,7 +299,19 @@ protected:
     void* addrress_{nullptr};
     size_t totalSize_{0};
 
-    size_t MetaOffset() const noexcept { return sizeof(BufferHeader) + sizeof(ShareLock) * nNode_; }
+    size_t AccessedOffset() const noexcept
+    {
+        constexpr auto align = 64;
+        auto off = sizeof(BufferHeader) + sizeof(ShareLock) * nNode_;
+        return (off + align - 1) & ~(align - 1);
+    }
+    size_t AccessedSize() const noexcept { return sizeof(std::atomic<uint8_t>) * nNode_; }
+    size_t MetaOffset() const noexcept
+    {
+        constexpr auto align = alignof(BufferMetaNode);
+        auto off = AccessedOffset() + AccessedSize();
+        return (off + align - 1) & ~(align - 1);
+    }
     size_t DataOffset() const noexcept
     {
         static const auto pageSize = sysconf(_SC_PAGESIZE);
@@ -352,8 +384,10 @@ protected:
         if (s.Failure()) [[unlikely]] { return s; }
         header_ = static_cast<BufferHeader*>(addrress_);
         meta_ = (BufferMetaNode*)(static_cast<std::byte*>(addrress_) + MetaOffset());
+        accessed_ = reinterpret_cast<std::atomic<uint8_t>*>(static_cast<std::byte*>(addrress_) +
+                                                            AccessedOffset());
         header_->nNode = nNode_;
-        header_->freeHead = 0;
+        header_->nodeCursor.store(0, std::memory_order_relaxed);
         for (size_t i = 0; i < nHashTableBucket; i++) {
             header_->buckets[i] = invalidIndex;
             header_->bucketLocks[i].Init();
@@ -361,6 +395,7 @@ protected:
         for (size_t i = 0; i < nNode_; i++) {
             header_->nodeLocks[i].Init();
             meta_[i].Init();
+            accessed_[i].store(0, std::memory_order_relaxed);
         }
         header_->magic = sharedBufferMagic;
         return Status::OK();
@@ -381,6 +416,8 @@ protected:
             return s;
         }
         meta_ = (BufferMetaNode*)(static_cast<std::byte*>(addrress_) + MetaOffset());
+        accessed_ = reinterpret_cast<std::atomic<uint8_t>*>(static_cast<std::byte*>(addrress_) +
+                                                            AccessedOffset());
         return Status::OK();
     }
     Status RegisterBuffer(int32_t deviceId)
@@ -447,16 +484,21 @@ public:
     size_t& FirstAt(size_t iBucket) override { return header_->buckets[iBucket]; }
     size_t FetchNode(bool allowReserved) override
     {
-        const auto limit = header_->nNode - (allowReserved ? 0 : base_.reservedNumber);
-        auto cur = header_->freeHead.load(std::memory_order_relaxed);
-        while (true) {
-            const auto iNode = (cur >= limit) ? 0 : cur;
-            const auto next = iNode + 1;
-            if (header_->freeHead.compare_exchange_weak(cur, next, std::memory_order_relaxed,
-                                                        std::memory_order_relaxed)) {
-                return iNode;
+        const auto total = header_->nNode - (allowReserved ? 0 : base_.reservedNumber);
+        for (size_t i = 0; i < 2 * total; ++i) {
+            auto cur = header_->nodeCursor.fetch_add(1, std::memory_order_relaxed) % total;
+            uint8_t expected = 1;
+            if (accessed_[cur].compare_exchange_strong(expected, 0, std::memory_order_relaxed,
+                                                       std::memory_order_relaxed)) {
+                continue;
             }
+            return cur;
         }
+        return header_->nodeCursor.fetch_add(1, std::memory_order_relaxed) % total;
+    }
+    void MarkAccessed(size_t iNode) override
+    {
+        accessed_[iNode].store(1, std::memory_order_relaxed);
     }
     void* DataAt(size_t iNode) override { return data_ + nodeSize_ * iNode; }
     void* DeviceDataAt(size_t iNode) override { return dataOnDevice_ + nodeSize_ * iNode; }
@@ -496,10 +538,13 @@ public:
         if (s.Failure()) [[unlikely]] { return s; }
         header_ = static_cast<BufferHeader*>(addrress_);
         meta_ = (BufferMetaNode*)(static_cast<std::byte*>(addrress_) + MetaOffset());
+        accessed_ = reinterpret_cast<std::atomic<uint8_t>*>(static_cast<std::byte*>(addrress_) +
+                                                            AccessedOffset());
         return Status::OK();
     }
     void* DataAt(size_t iNode) override { return nullptr; }
     void* DeviceDataAt(size_t iNode) override { return nullptr; }
+    void MarkAccessed(size_t /*iNode*/) override {}
 };
 
 Status TransBuffer::Setup(const Config& config)
@@ -591,6 +636,7 @@ size_t TransBuffer::FindAt(size_t iBucket, const Detail::BlockId& blockId, size_
                 meta->errorCode = Status::OK().Underlying();
             }
             ++meta->reference;
+            strategy_->MarkAccessed(iNode);
             strategy_->NodeUnlock(iNode);
             break;
         }
@@ -625,6 +671,7 @@ size_t TransBuffer::Alloc(const Detail::BlockId& blockId, size_t shardIdx, size_
             MoveTo(iBucket, iNode);
         }
         ++meta->reference;
+        strategy_->MarkAccessed(iNode);
         meta->block = blockId;
         meta->shard = shardIdx;
         meta->state = State::LOADING;

--- a/ucm/store/cache/cc/trans_buffer.cc
+++ b/ucm/store/cache/cc/trans_buffer.cc
@@ -259,13 +259,14 @@ protected:
     static constexpr size_t sharedBufferMagic = (('S' << 16) | ('b' << 8) | 2);
     struct BufferHeader {
         std::atomic<size_t> magic;
-        ShareLock lock;
         size_t nNode;
-        size_t freeHead;
+        alignas(64) std::atomic<size_t> freeHead;
+        char freeHeadPad[64 - sizeof(std::atomic<size_t>)];
         size_t buckets[nHashTableBucket];
         ShareMutex bucketLocks[nHashTableBucket];
         ShareLock nodeLocks[0];
     };
+    static_assert(std::atomic<size_t>::is_always_lock_free, "freeHead must be lock-free");
 
     BufferHeader* header_{nullptr};
     BufferMetaNode* meta_{nullptr};
@@ -351,7 +352,6 @@ protected:
         if (s.Failure()) [[unlikely]] { return s; }
         header_ = static_cast<BufferHeader*>(addrress_);
         meta_ = (BufferMetaNode*)(static_cast<std::byte*>(addrress_) + MetaOffset());
-        header_->lock.Init();
         header_->nNode = nNode_;
         header_->freeHead = 0;
         for (size_t i = 0; i < nHashTableBucket; i++) {
@@ -448,11 +448,15 @@ public:
     size_t FetchNode(bool allowReserved) override
     {
         const auto limit = header_->nNode - (allowReserved ? 0 : base_.reservedNumber);
-        header_->lock.Lock();
-        if (header_->freeHead >= limit) { header_->freeHead = 0; }
-        const auto iNode = header_->freeHead++;
-        header_->lock.Unlock();
-        return iNode;
+        auto cur = header_->freeHead.load(std::memory_order_relaxed);
+        while (true) {
+            const auto iNode = (cur >= limit) ? 0 : cur;
+            const auto next = iNode + 1;
+            if (header_->freeHead.compare_exchange_weak(cur, next, std::memory_order_relaxed,
+                                                        std::memory_order_relaxed)) {
+                return iNode;
+            }
+        }
     }
     void* DataAt(size_t iNode) override { return data_ + nodeSize_ * iNode; }
     void* DeviceDataAt(size_t iNode) override { return dataOnDevice_ + nodeSize_ * iNode; }

--- a/ucm/store/cache/cc/trans_buffer.cc
+++ b/ucm/store/cache/cc/trans_buffer.cc
@@ -53,18 +53,20 @@ struct BufferMetaNode {
     size_t hash;
     size_t prev;
     size_t next;
-    TransBuffer::State state;
-    int32_t errorCode;
+    alignas(64) std::atomic<TransBuffer::State> state;
+    std::atomic<int32_t> errorCode;
     void Init()
     {
         reference = 0;
         hash = invalidIndex;
         prev = invalidIndex;
         next = invalidIndex;
-        state = TransBuffer::State::LOADING;
-        errorCode = Status::OK().Underlying();
+        state.store(TransBuffer::State::LOADING, std::memory_order_relaxed);
+        errorCode.store(Status::OK().Underlying(), std::memory_order_relaxed);
     }
 };
+static_assert(std::atomic<TransBuffer::State>::is_always_lock_free, "state must be lock-free");
+static_assert(std::atomic<int32_t>::is_always_lock_free, "errorCode must be lock-free");
 
 class BufferStrategy {
 protected:
@@ -631,9 +633,9 @@ size_t TransBuffer::FindAt(size_t iBucket, const Detail::BlockId& blockId, size_
         strategy_->NodeLock(iNode);
         if (meta->block == blockId && meta->shard == shardIdx) {
             owner = meta->reference == 0;
-            if (owner && meta->state == State::FAILED) {
-                meta->state = State::LOADING;
-                meta->errorCode = Status::OK().Underlying();
+            if (owner && meta->state.load(std::memory_order_relaxed) == State::FAILED) {
+                meta->state.store(State::LOADING, std::memory_order_relaxed);
+                meta->errorCode.store(Status::OK().Underlying(), std::memory_order_relaxed);
             }
             ++meta->reference;
             strategy_->MarkAccessed(iNode);
@@ -674,8 +676,8 @@ size_t TransBuffer::Alloc(const Detail::BlockId& blockId, size_t shardIdx, size_
         strategy_->MarkAccessed(iNode);
         meta->block = blockId;
         meta->shard = shardIdx;
-        meta->state = State::LOADING;
-        meta->errorCode = Status::OK().Underlying();
+        meta->state.store(State::LOADING, std::memory_order_relaxed);
+        meta->errorCode.store(Status::OK().Underlying(), std::memory_order_relaxed);
         strategy_->NodeUnlock(iNode);
         return iNode;
     }
@@ -741,17 +743,12 @@ bool TransBuffer::Ready(Index pos) { return GetState(pos) == State::READY; }
 
 TransBuffer::State TransBuffer::GetState(Index pos)
 {
-    strategy_->NodeLock(pos);
-    auto state = strategy_->MetaAt(pos)->state;
-    strategy_->NodeUnlock(pos);
-    return state;
+    return strategy_->MetaAt(pos)->state.load(std::memory_order_acquire);
 }
 
 Status TransBuffer::FailureStatus(Index pos)
 {
-    strategy_->NodeLock(pos);
-    auto errorCode = strategy_->MetaAt(pos)->errorCode;
-    strategy_->NodeUnlock(pos);
+    auto errorCode = strategy_->MetaAt(pos)->errorCode.load(std::memory_order_acquire);
     if (errorCode == Status::OK().Underlying()) {
         return Status::Error("shared buffer failed without an error status");
     }
@@ -760,33 +757,21 @@ Status TransBuffer::FailureStatus(Index pos)
 
 void TransBuffer::MarkReady(Index pos)
 {
-    strategy_->NodeLock(pos);
-    auto meta = strategy_->MetaAt(pos);
-    if (meta->state == State::LOADING) {
-        meta->state = State::READY;
-        meta->errorCode = Status::OK().Underlying();
-    }
-    strategy_->NodeUnlock(pos);
+    strategy_->MetaAt(pos)->state.store(State::READY, std::memory_order_release);
 }
 
 void TransBuffer::MarkFailed(Index pos, const Status& status)
 {
-    strategy_->NodeLock(pos);
     auto meta = strategy_->MetaAt(pos);
-    if (meta->state == State::LOADING) {
-        meta->state = State::FAILED;
-        meta->errorCode = status.Underlying();
-    }
-    strategy_->NodeUnlock(pos);
+    meta->errorCode.store(status.Underlying(), std::memory_order_release);
+    meta->state.store(State::FAILED, std::memory_order_release);
 }
 
 void TransBuffer::MarkNotReady(Index pos)
 {
-    strategy_->NodeLock(pos);
     auto meta = strategy_->MetaAt(pos);
-    meta->state = State::LOADING;
-    meta->errorCode = Status::OK().Underlying();
-    strategy_->NodeUnlock(pos);
+    meta->errorCode.store(Status::OK().Underlying(), std::memory_order_release);
+    meta->state.store(State::LOADING, std::memory_order_release);
 }
 
 }  // namespace UC::CacheStore

--- a/ucm/store/cache/cc/trans_buffer.cc
+++ b/ucm/store/cache/cc/trans_buffer.cc
@@ -536,6 +536,17 @@ TransBuffer::Handle TransBuffer::Get(const Detail::BlockId& blockId, size_t shar
     return Handle(this, iNode, true);
 }
 
+void TransBuffer::Prealloc(const Detail::BlockId& blockId, size_t shardIdx, bool allowReserved)
+{
+    auto iBucket = Hash(blockId, shardIdx);
+    strategy_->BucketLock(iBucket);
+    if (!ExistAt(iBucket, blockId, shardIdx)) {
+        size_t pos = Alloc(blockId, shardIdx, iBucket, allowReserved);
+        Release(pos);
+    }
+    strategy_->BucketUnlock(iBucket);
+}
+
 bool TransBuffer::Exist(const Detail::BlockId& blockId, size_t shardIdx)
 {
     auto iBucket = Hash(blockId, shardIdx);

--- a/ucm/store/cache/cc/trans_buffer.h
+++ b/ucm/store/cache/cc/trans_buffer.h
@@ -111,6 +111,7 @@ public:
     Status Setup(const Config& config);
     Handle Get(const Detail::BlockId& blockId, size_t shardIdx, bool allowReserved = false,
                bool isLoad = false);
+    void Prealloc(const Detail::BlockId& blockId, size_t shardIdx, bool allowReserved = false);
     bool Exist(const Detail::BlockId& blockId, size_t shardIdx);
 
 private:

--- a/ucm/store/test/case/cache/cache_buffer_manager_test.cc
+++ b/ucm/store/test/case/cache/cache_buffer_manager_test.cc
@@ -57,6 +57,7 @@ TEST_F(UCCacheBufferManagerTest, Lookup)
     config.bufferCapacity = config.shardSize * 1024;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
+    config.loadExclusiveBufferNumber = 0;
     ASSERT_TRUE(bufferMgr.Setup(config).Success());
     std::vector<UC::Detail::BlockId> blocks(3);
     std::for_each(blocks.begin(), blocks.end(), [](auto& block) {
@@ -110,6 +111,7 @@ TEST_F(UCCacheBufferManagerTest, BackendOnlyLookupBypassesCache)
     config.bufferCapacity = config.shardSize * 1024;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = false;
+    config.loadExclusiveBufferNumber = 0;
     config.cacheLoadBackendOnly = true;
     ASSERT_TRUE(bufferMgr.Setup(config).Success());
 

--- a/ucm/store/test/case/cache/cache_dump_queue_test.cc
+++ b/ucm/store/test/case/cache/cache_dump_queue_test.cc
@@ -60,6 +60,7 @@ TEST_F(UCCacheDumpQueueTest, DumpOneBlock)
     config.bufferCapacity = config.shardSize * 1024;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
+    config.loadExclusiveBufferNumber = 0;
     TransBuffer buffer;
     DumpQueue dumpQ;
     auto s = buffer.Setup(config);
@@ -97,6 +98,7 @@ TEST_F(UCCacheDumpQueueTest, DumpBlockWhileBackendSubmitFailed)
     config.bufferCapacity = config.shardSize * 1024;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
+    config.loadExclusiveBufferNumber = 0;
     TransBuffer buffer;
     DumpQueue dumpQ;
     auto s = buffer.Setup(config);
@@ -133,6 +135,7 @@ TEST_F(UCCacheDumpQueueTest, DumpBlockWhileBackendUnhealthy)
     config.bufferCapacity = config.shardSize * 1024;
     config.uniqueId = rd.RandomString(10);
     config.shareBufferEnable = true;
+    config.loadExclusiveBufferNumber = 0;
     TransBuffer buffer;
     DumpQueue dumpQ;
     auto s = buffer.Setup(config);

--- a/ucm/store/test/case/cache/cache_trans_buffer_test.cc
+++ b/ucm/store/test/case/cache/cache_trans_buffer_test.cc
@@ -285,3 +285,62 @@ TEST_P(UCCacheTransBufferTest, InsertDifferentDataRepeatedly)
         }
     }
 }
+
+TEST_P(UCCacheTransBufferTest, ClockSparesRecentlyTouchedBlock)
+{
+    constexpr size_t nNode = 4;
+    UC::CacheStore::TransBuffer transBuffer;
+    UC::CacheStore::Config config;
+    config.uniqueId = rd.RandomString(10);
+    config.shardSize = 32768;
+    config.bufferCapacity = config.shardSize * nNode;
+    config.shareBufferEnable = GetParam();
+    config.deviceId = 0;
+    config.loadExclusiveBufferNumber = 0;
+    auto s = transBuffer.Setup(config);
+    ASSERT_EQ(s, UC::Status::OK());
+    auto b1 = UC::Test::Detail::TypesHelper::MakeBlockIdRandomly();
+    auto b2 = UC::Test::Detail::TypesHelper::MakeBlockIdRandomly();
+    auto b3 = UC::Test::Detail::TypesHelper::MakeBlockIdRandomly();
+    auto b4 = UC::Test::Detail::TypesHelper::MakeBlockIdRandomly();
+    auto b5 = UC::Test::Detail::TypesHelper::MakeBlockIdRandomly();
+    auto b6 = UC::Test::Detail::TypesHelper::MakeBlockIdRandomly();
+    constexpr size_t shardIdx = 0;
+
+    {
+        auto h = transBuffer.Get(b1, shardIdx);
+        h.MarkReady();
+    }
+    {
+        auto h = transBuffer.Get(b2, shardIdx);
+        h.MarkReady();
+    }
+    {
+        auto h = transBuffer.Get(b3, shardIdx);
+        h.MarkReady();
+    }
+    {
+        auto h = transBuffer.Get(b4, shardIdx);
+        h.MarkReady();
+    }
+
+    {
+        auto h = transBuffer.Get(b5, shardIdx);
+        h.MarkReady();
+    }
+    ASSERT_FALSE(transBuffer.Exist(b1, shardIdx));
+    ASSERT_TRUE(transBuffer.Exist(b5, shardIdx));
+
+    {
+        auto h = transBuffer.Get(b2, shardIdx);
+        ASSERT_TRUE(h.Ready());
+    }
+
+    {
+        auto h = transBuffer.Get(b6, shardIdx);
+        h.MarkReady();
+    }
+    ASSERT_TRUE(transBuffer.Exist(b2, shardIdx));
+    ASSERT_TRUE(transBuffer.Exist(b5, shardIdx));
+    ASSERT_FALSE(transBuffer.Exist(b3, shardIdx));
+}


### PR DESCRIPTION
## Summary
This PR improves CacheStore `TransBuffer` throughput and load latency through four
coordinated changes on the cache load path:

1. Lock-free, cache-line-isolated access to buffer metadata state
2. CLOCK second-chance eviction replacing the previous RING cursor
3. Lock-free node allocation in `SharedBufferStrategy`
4. Next-shard preallocation after load dispatch

## Motivation
The load hot path was dominated by per-node `NodeLock` contention (state reads, ready/fail
transitions) and a `ShareLock` guarding the shared free-list cursor in `SharedBufferStrategy`.
The previous RING eviction also evicted the most-recently-fitted node, which is suboptimal
under sequential shard access. These changes remove the dominant lock acquisitions from the
fast path and make eviction access-aware.

## Changes

### 1. Lock-free state access (`trans_buffer.cc`)
- `BufferMetaNode::state` and `errorCode` are now `std::atomic`, with `alignas(64)` on
  `state` to place it on its own cache line.
- `GetState` / `FailureStatus` no longer take `NodeLock`; they use `acquire` loads.
- `MarkReady` / `MarkFailed` / `MarkNotReady` use `release` stores and order the
  `errorCode` store *before* the `state` store, so a reader that observes a state
  transition also observes the corresponding error code.
- `static_assert` guarantees the atomics are always lock-free.

### 2. CLOCK second-chance eviction (`trans_buffer.cc`)
- Adds a per-node `accessed_` bit array and `BufferStrategy::MarkAccessed`.
- `FetchNode` now sweeps a cursor and gives nodes with `accessed == 1` a second chance
  (clears the bit and skips), evicting the first `accessed == 0` node. This keeps
  recently-touched blocks resident instead of evicting the most-recently-fitted node.
- `MarkAccessed` is invoked from `FindAt` (cache hit) and `Alloc` (new fit).

### 3. Lock-free node allocation in `SharedBufferStrategy` (`trans_buffer.cc`)
- Replaces `ShareLock lock` + `freeHead` with an `alignas(64) std::atomic<size_t>
  nodeCursor` (plus padding to fill the cache line), allocated via `fetch_add`.
- Removes the shared `ShareLock` from `BufferHeader`, eliminating the lock acquisition on
  every node allocation in shared mode.

### 4. Next-shard preallocation (`load_queue.cc`, `trans_buffer.h`)
- `LoadQueue::DispatchOneTask` now pre-allocates the `shard.index + 1` slot of the same
  block after dispatch, via the new `TransBuffer::Prealloc` (allocate + immediate release).
  This pre-warms the next likely slot so the subsequent `Get` skips eviction and backend
  submit setup.
- Pre-warmed nodes keep `accessed == 1`, so CLOCK naturally protects them until the real
  `Get` arrives.
- Adds `nShardPerBlock_ = blockSize / shardSize` to skip prefetching past the block boundary.

## Tests
- New `UCCacheTransBufferTest.ClockSparesRecentlyTouchedBlock` verifies second-chance
  behavior: a recently-touched block is spared while a cold one is evicted.
- Existing buffer/dump-queue tests set `loadExclusiveBufferNumber = 0` for deterministic
  small-buffer eviction under the new algorithm.

## Backward Compatibility
- In-process single-binary upgrades are transparent.
- Note: the `SharedBufferStrategy` shared-memory layout changed (the shared `ShareLock`
  removed, `nodeCursor` + padding and the `accessed_` array added). The shared-buffer
  magic is unchanged, so mixed-version processes sharing a buffer should be avoided during
  rolling upgrades.