### PR TITLE
[fix]strip vllm version & align vllm-ascend patch selection to vllm version

### DIFF
--- a/ucm/integration/vllm/patch/apply_patch.py
+++ b/ucm/integration/vllm/patch/apply_patch.py
@@ -43,14 +43,24 @@ ENABLE_SPARSE = os.getenv("ENABLE_SPARSE", "0").lower() in (
 ENABLE_UCM_PATCH = os.environ.get("ENABLE_UCM_PATCH", "").lower() in ("1", "true")
 
 
+def _strip_build(v: Optional[str]) -> Optional[str]:
+    """Strip only build/local metadata (the +xxx suffix), e.g. 0.26.0+empty -> 0.26.0."""
+    if not v:
+        return None
+    return str(v).strip().split("+", 1)[0]
+
+
+def _norm_version(v: Optional[str]) -> Optional[str]:
+    if not v:
+        return None
+    # common suffixes: 0.11.0.post1 / 0.11.0rc1
+    v = v.split(".post", 1)[0]
+    v = v.split("rc", 1)[0]
+    return v
+
+
 def _read_vllm_ascend_version_raw() -> Optional[str]:
     """Read vllm_ascend version string, stripping only build metadata (+xxx)."""
-
-    def _strip_build(v: Optional[str]) -> Optional[str]:
-        if not v:
-            return None
-        return str(v).strip().split("+", 1)[0]
-
     try:
         from importlib.metadata import PackageNotFoundError, version
 
@@ -70,15 +80,6 @@ def _read_vllm_ascend_version_raw() -> Optional[str]:
         return None
 
 
-def _norm_vllm_ascend_version(v: Optional[str]) -> Optional[str]:
-    if not v:
-        return None
-    # common suffixes: 0.11.0.post1 / 0.11.0rc1
-    v = v.split(".post", 1)[0]
-    v = v.split("rc", 1)[0]
-    return v
-
-
 def get_vllm_ascend_version_full() -> Optional[str]:
     """Detect vllm_ascend version preserving rc/post suffixes (e.g. 0.18.0rc1)."""
     return _read_vllm_ascend_version_raw()
@@ -86,30 +87,38 @@ def get_vllm_ascend_version_full() -> Optional[str]:
 
 def get_vllm_ascend_version() -> Optional[str]:
     """Detect normalized vllm_ascend version (e.g. 0.18.0rc1 -> 0.18.0)."""
-    return _norm_vllm_ascend_version(_read_vllm_ascend_version_raw())
+    return _norm_version(_read_vllm_ascend_version_raw())
 
 
 _vllm_version: Optional[str] = None
 
 
-def get_vllm_version() -> Optional[str]:
-    """Detect vLLM version."""
-    global _vllm_version
-    if _vllm_version is not None:
-        return _vllm_version
-
+def _read_vllm_version_raw() -> Optional[str]:
+    """Read vLLM version string from the installed module, stripping build metadata."""
     try:
-        # Try to get version from vllm module
         import vllm as vllm_pkg
 
-        vllm_version = vllm_pkg.__version__
-        return vllm_version
+        return _strip_build(getattr(vllm_pkg, "__version__", None))
     except ImportError:
         logger.warning("vLLM is not installed")
         return None
     except Exception as e:
         logger.warning(f"Failed to detect vLLM version: {e}")
         return None
+
+
+def get_vllm_version_full() -> Optional[str]:
+    """Detect vLLM version preserving rc/post suffixes (e.g. 0.26.0rc1)."""
+    return _read_vllm_version_raw()
+
+
+def get_vllm_version() -> Optional[str]:
+    """Detect normalized vLLM version (e.g. 0.26.0+empty / 0.26.0rc1 -> 0.26.0)."""
+    global _vllm_version
+    if _vllm_version is not None:
+        return _vllm_version
+    _vllm_version = _norm_version(_read_vllm_version_raw())
+    return _vllm_version
 
 
 def get_supported_versions() -> list[str]:
@@ -155,6 +164,22 @@ def apply_all_patches() -> None:
             )
 
         ascend_version = get_vllm_ascend_version()
+        logger.info(
+            f"Detected vLLM version: {get_vllm_version_full()} "
+            f"(normalized: {version})"
+        )
+        logger.info(
+            f"Detected vllm-ascend version: {get_vllm_ascend_version_full()} "
+            f"(normalized: {ascend_version})"
+        )
+        # vLLM and vllm-ascend share per-version patch directories (v0XYZ), so
+        # their versions must align; when they disagree, vLLM is authoritative.
+        if ascend_version is not None and ascend_version != version:
+            logger.warning(
+                f"vllm-ascend version ({ascend_version}) differs from vLLM version "
+                f"({version}); aligning vllm-ascend patch selection to {version}."
+            )
+            ascend_version = version
         # UCM PATCH: vllm-ascend registers UCMConnector as an alias for the
         # concrete UCMConnectorV1 class used by MultiConnector metrics.
         if ascend_version in {


### PR DESCRIPTION
## Purpose

vllm 与 vllm-ascend 是独立版本号体系，且官方镜像里 **vllm-ascend 的nightly版本不更新**——代码已跟 vllm 走，但版本串停在旧值。例如 `quay.io/ascend/vllm-ascend:DeepSeekV4-flash-0731` 里 `vllm=0.25.1`、`vllm-ascend=0.19.1rc2.dev1265`（归一化 `0.19.1`），而 vllm-ascend 实际代码已是 0.25.1 时代。

旧 `apply_patch.py` 在此场景下两个问题：

1. vllm 侧用裸 `vllm.__version__`（带 `+empty`），`0.25.1+empty` 不匹配 `supported_versions` → 误报"无可用 patch"，且 `match version` 全 miss；vllm-ascend 侧早有归一化，两边不对称。
2. ascend 按过时版本串 `0.19.1` 选 patch → 命中 `case "0.19.1"`(v0191)，但实际代码是 0.25.1 → patch 对不上。

本 PR：vllm 也做归一化；两版本不一致时以 vllm 为准把 ascend patch 选择对齐到 vllm 版本；打印两边版本号；不一致告警。

## Modifications

`ucm/integration/vllm/patch/apply_patch.py`：

- `_strip_build` 提到模块级、`_norm_vllm_ascend_version` 改名 `_norm_version`，vllm / vllm-ascend 共用。
- 新增 `_read_vllm_version_raw()` + `get_vllm_version_full()`（与 ascend 侧对称）；`get_vllm_version()` 改为返回归一化版本（剥 `+build` / `rc` / `.post`），保留缓存。
- `apply_all_patches()` 打两条 `Detected vLLM/vllm-ascend version` 日志（含 build 剥离后的原始串 + 归一化值）。
- 两边归一化版本不一致时，把用于选 patch 的 `ascend_version` 局部变量对齐到 vllm 版本并打 `warning`（`ascend_version` 为空则不动，避免误入不存在的 patch 目录）。
- 只改 `apply_all_patches` 内部局部变量，**不动** `get_vllm_ascend_version()` / `get_vllm_ascend_version_full()` 的返回值（v0180 sfa_v1 按 rc 选子补丁等仍用真实版本，未受影响）。

## Test

910B3×8 容器（dev_bugfix 分支 `pip install -e`，镜像同上）跑 DSV4 + DSpark + UCM serve：

```
[UC][I] Detected vLLM version: 0.25.1 (normalized: 0.25.1)
[UC][I] Detected vllm-ascend version: 0.19.1rc2.dev1265 (normalized: 0.19.1)
[UC][W] vllm-ascend version (0.19.1) differs from vLLM version (0.25.1); aligning vllm-ascend patch selection to 0.25.1.
[UC][I] UCM patching vllm-ascend 0.25.1 for hybrid cache recovery and CPU affinity...
[UC][I] UCM patch initialization completed!
```

- 对齐后选中 v0251 patch，在 worker 初始化经 `@when_imported` 实际触发并 apply 成功（`CompressAttentionManager.allocate_new_computed_blocks`、`find_longest_cache_hit`、`do_mamba_copy_block` 等），反证 ascend 代码确为 0.25.1 时代、对齐方向正确。
- serve `Application startup complete`，`curl /v1/chat/completions` 正常返回（`system_fingerprint: vllm-0.25.1-tp8-ep`）。