### PR TITLE
feat(transport): add P2P transport module

### DIFF
--- a/ucm/CMakeLists.txt
+++ b/ucm/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(shared)
+add_subdirectory(transport)
 add_subdirectory(integration)
 if(BUILD_UCM_STORE)
     add_subdirectory(store)

--- a/ucm/transport/CMakeLists.txt
+++ b/ucm/transport/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(p2p)

--- a/ucm/transport/p2p/CMakeLists.txt
+++ b/ucm/transport/p2p/CMakeLists.txt
@@ -1,0 +1,171 @@
+if(NOT (RUNTIME_ENVIRONMENT STREQUAL "ascend"
+        OR RUNTIME_ENVIRONMENT STREQUAL "ascend-a3"
+        OR RUNTIME_ENVIRONMENT STREQUAL "simu"))
+    return()
+endif()
+
+if(NOT DEFINED ASCEND_ROOT)
+    if(DEFINED ENV{ASCEND_HOME_PATH})
+        set(ASCEND_ROOT "$ENV{ASCEND_HOME_PATH}" CACHE PATH "Path to Ascend root directory")
+    elseif(DEFINED ENV{ASCEND_TOOLKIT_HOME})
+        set(ASCEND_ROOT "$ENV{ASCEND_TOOLKIT_HOME}" CACHE PATH "Path to Ascend root directory")
+    else()
+        set(ASCEND_ROOT "/usr/local/Ascend/ascend-toolkit/latest" CACHE PATH
+            "Path to Ascend root directory")
+    endif()
+endif()
+
+if(NOT DEFINED HIXL_ROOT AND DEFINED ENV{HIXL_ROOT})
+    set(HIXL_ROOT "$ENV{HIXL_ROOT}" CACHE PATH "HIXL installation prefix")
+endif()
+if(NOT DEFINED HIXL_INCLUDE_DIR AND DEFINED ENV{HIXL_INCLUDE_DIR})
+    set(HIXL_INCLUDE_DIR "$ENV{HIXL_INCLUDE_DIR}" CACHE PATH "Directory containing hixl headers")
+endif()
+if(NOT DEFINED HIXL_LIB_DIR AND DEFINED ENV{HIXL_LIB_DIR})
+    set(HIXL_LIB_DIR "$ENV{HIXL_LIB_DIR}" CACHE PATH "Directory containing the HIXL library")
+endif()
+
+set(P2P_ASCEND_ROOT_HINTS ${ASCEND_ROOT})
+foreach(P2P_ASCEND_PARENT_HINT
+        "${ASCEND_ROOT}" "${ASCEND_ROOT}/.." "${ASCEND_ROOT}/../..")
+    file(GLOB P2P_CANN_ROOT_HINTS LIST_DIRECTORIES true
+        "${P2P_ASCEND_PARENT_HINT}/cann-*"
+    )
+    list(APPEND P2P_ASCEND_ROOT_HINTS ${P2P_CANN_ROOT_HINTS})
+endforeach()
+list(REMOVE_DUPLICATES P2P_ASCEND_ROOT_HINTS)
+
+set(P2P_HIXL_INCLUDE_HINTS
+    ${HIXL_INCLUDE_DIR}
+    ${HIXL_ROOT}
+    ${HIXL_ROOT}/include
+    ${HIXL_ROOT}/aarch64-linux/include
+    ${HIXL_ROOT}/arm64-linux/include
+)
+foreach(P2P_ASCEND_ROOT_HINT IN LISTS P2P_ASCEND_ROOT_HINTS)
+    list(APPEND P2P_HIXL_INCLUDE_HINTS
+        ${P2P_ASCEND_ROOT_HINT}
+        ${P2P_ASCEND_ROOT_HINT}/include
+        ${P2P_ASCEND_ROOT_HINT}/aarch64-linux/include
+        ${P2P_ASCEND_ROOT_HINT}/arm64-linux/include
+    )
+endforeach()
+
+find_path(P2P_HIXL_INCLUDE_DIR
+    NAMES hixl/hixl.h
+    HINTS ${P2P_HIXL_INCLUDE_HINTS}
+)
+
+set(P2P_HIXL_LIBRARY_HINTS
+    ${HIXL_LIB_DIR}
+    ${HIXL_ROOT}
+    ${HIXL_ROOT}/lib
+    ${HIXL_ROOT}/lib64
+    ${HIXL_ROOT}/aarch64-linux/lib64
+    ${HIXL_ROOT}/arm64-linux/lib64
+)
+foreach(P2P_ASCEND_ROOT_HINT IN LISTS P2P_ASCEND_ROOT_HINTS)
+    list(APPEND P2P_HIXL_LIBRARY_HINTS
+        ${P2P_ASCEND_ROOT_HINT}
+        ${P2P_ASCEND_ROOT_HINT}/lib
+        ${P2P_ASCEND_ROOT_HINT}/lib64
+        ${P2P_ASCEND_ROOT_HINT}/aarch64-linux/lib64
+        ${P2P_ASCEND_ROOT_HINT}/arm64-linux/lib64
+    )
+endforeach()
+
+find_library(P2P_HIXL_LIBRARY
+    NAMES cann_hixl
+    HINTS ${P2P_HIXL_LIBRARY_HINTS}
+)
+
+find_library(P2P_METADEF_LIBRARY
+    NAMES metadef
+    HINTS ${P2P_HIXL_LIBRARY_HINTS}
+)
+
+set(P2P_TRANSPORT_SOURCES
+    src/common/binary_codec.cpp
+    src/control/control_channel.cpp
+    src/control/control_protocol.cpp
+    src/core/transport_manager.cpp
+    src/channels/tcp/tcp_message_channel.cpp
+)
+
+set(P2P_HIXL_AVAILABLE OFF)
+if(UCM_RUNTIME_ASCEND_FAMILY
+   AND P2P_HIXL_INCLUDE_DIR
+   AND P2P_HIXL_LIBRARY
+   AND P2P_METADEF_LIBRARY)
+    set(P2P_HIXL_AVAILABLE ON)
+    list(APPEND P2P_TRANSPORT_SOURCES
+        src/common/acl_runtime_context.cpp
+        src/protocols/hixl/hixl_instance.cpp
+        src/protocols/hixl/hixl_transport.cpp
+    )
+    message(STATUS "P2P HIXL transport backend is enabled")
+elseif(UCM_RUNTIME_ASCEND_FAMILY)
+    message(STATUS
+        "P2P HIXL transport backend is disabled: "
+        "hixl/hixl.h, libcann_hixl, or libmetadef was not found"
+    )
+else()
+    message(STATUS
+        "P2P HIXL transport backend is disabled for "
+        "RUNTIME_ENVIRONMENT=${RUNTIME_ENVIRONMENT}"
+    )
+endif()
+
+add_library(ucm_p2p_transport SHARED ${P2P_TRANSPORT_SOURCES})
+target_include_directories(ucm_p2p_transport
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:ucm/transport/p2p/include>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${UCM_ROOT_DIR}/ucm/shared/infra
+)
+target_compile_definitions(ucm_p2p_transport PRIVATE SPDLOG_FMT_EXTERNAL)
+target_link_libraries(ucm_p2p_transport
+    PUBLIC
+        infra_status
+    PRIVATE
+        infra_logger
+        pthread
+        rt
+)
+if(P2P_HIXL_AVAILABLE)
+    target_compile_definitions(ucm_p2p_transport PRIVATE UCM_P2P_HAS_HIXL)
+    target_include_directories(ucm_p2p_transport PRIVATE
+        ${ASCEND_ROOT}/include
+        ${ASCEND_ROOT}/aarch64-linux/include
+        ${ASCEND_ROOT}/arm64-linux/include
+        ${P2P_HIXL_INCLUDE_DIR}
+    )
+    target_link_directories(ucm_p2p_transport PRIVATE
+        ${ASCEND_ROOT}/lib64
+        ${ASCEND_ROOT}/aarch64-linux/lib64
+        ${ASCEND_ROOT}/aarch64-linux/devlib
+        ${ASCEND_ROOT}/arm64-linux/lib64
+        ${ASCEND_ROOT}/arm64-linux/devlib
+    )
+    target_link_libraries(ucm_p2p_transport PRIVATE
+        ascendcl
+        ${P2P_HIXL_LIBRARY}
+        ${P2P_METADEF_LIBRARY}
+    )
+endif()
+set_target_properties(ucm_p2p_transport PROPERTIES
+    INSTALL_RPATH "$ORIGIN"
+)
+
+file(RELATIVE_PATH P2P_INSTALL_REL_PATH ${UCM_ROOT_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+install(TARGETS ucm_p2p_transport
+    LIBRARY DESTINATION ${P2P_INSTALL_REL_PATH}
+    COMPONENT ucm
+)
+install(DIRECTORY include/
+    DESTINATION ${P2P_INSTALL_REL_PATH}/include
+    COMPONENT ucm
+    FILES_MATCHING PATTERN "*.h"
+)

--- a/ucm/transport/p2p/include/channels/tcp/tcp_message_channel.h
+++ b/ucm/transport/p2p/include/channels/tcp/tcp_message_channel.h
@@ -1,0 +1,91 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include "core/transport.h"
+
+namespace transport {
+
+class TcpMessageChannel final {
+public:
+    TcpMessageChannel();
+    ~TcpMessageChannel();
+
+    TcpMessageChannel(const TcpMessageChannel&) = delete;
+    TcpMessageChannel& operator=(const TcpMessageChannel&) = delete;
+
+    Status Init(const Endpoint& local);
+    Status Send(const Endpoint& peer, const void* data, size_t length);
+    Status Receive(Endpoint& peer, Metadata& data);
+    Status Shutdown();
+
+private:
+    using Socket = int;
+
+    struct Message {
+        Endpoint peer;
+        Metadata data;
+    };
+
+    struct Connection {
+        Socket socket = -1;
+        Endpoint peer;
+        std::shared_ptr<std::mutex> send_mutex;
+        Metadata receive_buffer;
+    };
+
+    void CloseConnectionSocketLocked(const Connection& connection);
+    void CloseSocketLocked(Socket socket);
+    void CloseAllLocked();
+    Status StartIoThread();
+    void RunEventLoop(std::promise<Status> startup);
+    void RegisterConnectionEvents(int epoll_fd, std::unordered_set<Socket>& registered);
+    void HandleAcceptEvent(Socket listen_socket);
+    void HandleConnectionEvent(int epoll_fd, std::unordered_set<Socket>& registered, Socket socket);
+    void RemoveConnection(int epoll_fd, std::unordered_set<Socket>& registered, Socket socket);
+    bool BindPeerLocked(Socket socket, const Endpoint& peer);
+
+    Endpoint local_;
+    Socket listen_socket_ = -1;
+    std::mutex mutex_;
+    std::condition_variable receive_cv_;
+    std::deque<Message> receive_queue_;
+    std::unordered_map<Socket, Connection> connections_;
+    std::unordered_map<std::string, Socket> peer_sockets_;
+    std::thread io_thread_;
+    bool stopping_ = false;
+};
+
+}  // namespace transport

--- a/ucm/transport/p2p/include/control/control_channel.h
+++ b/ucm/transport/p2p/include/control/control_channel.h
@@ -1,0 +1,88 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <thread>
+#include "core/transport.h"
+
+namespace transport {
+
+class ControlChannel final {
+public:
+    using RequestHandler = std::function<Status(const Metadata& request, Metadata& response)>;
+
+    ControlChannel();
+    ~ControlChannel();
+
+    ControlChannel(const ControlChannel&) = delete;
+    ControlChannel& operator=(const ControlChannel&) = delete;
+    ControlChannel(ControlChannel&&) = delete;
+    ControlChannel& operator=(ControlChannel&&) = delete;
+
+    Status Init(const Endpoint& endpoint, RequestHandler handler);
+    Status Request(const Endpoint& endpoint, const Metadata& request, Metadata& response);
+    void Close();
+
+private:
+    class SocketHandle final {
+    public:
+        SocketHandle();
+        explicit SocketHandle(int socket);
+        ~SocketHandle();
+
+        SocketHandle(const SocketHandle&) = delete;
+        SocketHandle& operator=(const SocketHandle&) = delete;
+        SocketHandle(SocketHandle&& other) noexcept;
+        SocketHandle& operator=(SocketHandle&& other) noexcept;
+
+        bool Valid() const;
+        int Get() const;
+        int Release();
+        void Reset(int socket = -1);
+
+    private:
+        int socket_;
+    };
+
+    Status Listen(const Endpoint& endpoint);
+    Status StartAccepting();
+    Status Connect(const Endpoint& endpoint);
+    Status AcceptSocket(SocketHandle& socket);
+
+    Endpoint endpoint_;
+    SocketHandle listen_socket_;
+    SocketHandle socket_;
+    mutable std::mutex mutex_;
+    std::thread accept_thread_;
+    std::atomic<bool> stop_accept_{false};
+    uint32_t max_receive_frame_size_ = 4 * 1024 * 1024;
+    RequestHandler request_handler_;
+};
+
+}  // namespace transport

--- a/ucm/transport/p2p/include/control/control_protocol.h
+++ b/ucm/transport/p2p/include/control/control_protocol.h
@@ -1,0 +1,58 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include "core/transport.h"
+
+namespace transport {
+
+enum class ControlOperation : uint32_t {
+    ExchangeMetadata = 0,
+    Connect = 1,
+    Disconnect = 2,
+};
+
+inline const char* ControlOperationName(ControlOperation operation) noexcept
+{
+    switch (operation) {
+        case ControlOperation::ExchangeMetadata: return "exchange-metadata";
+        case ControlOperation::Connect: return "connect";
+        case ControlOperation::Disconnect: return "disconnect";
+    }
+    return "unknown";
+}
+
+struct ControlRequest {
+    ControlOperation operation;
+    std::optional<TransportProtocol> protocol;
+    ManagerID manager_id;
+    Metadata payload;
+};
+
+Status EncodeControlRequest(const ControlRequest& request, Metadata& out);
+Status DecodeControlRequest(const Metadata& in, ControlRequest& request);
+
+}  // namespace transport

--- a/ucm/transport/p2p/include/core/transport.h
+++ b/ucm/transport/p2p/include/core/transport.h
@@ -1,0 +1,124 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+#include "status/status.h"
+
+namespace transport {
+
+using Status = UC::Status;
+using ManagerID = std::string;
+using MemoryHandle = uint64_t;
+using TransferHandle = uint64_t;
+// Opaque transport-specific bytes exchanged between peers for route, endpoint,
+// and registered-memory discovery. The manager and control channel must not
+// interpret the contents.
+using Metadata = std::vector<uint8_t>;
+
+constexpr MemoryHandle kInvalidMemoryHandle = 0;
+constexpr TransferHandle kInvalidTransferHandle = 0;
+
+struct Endpoint {
+    std::string host = "127.0.0.1";
+    uint16_t port = 0;
+
+    std::string ToString() const { return port == 0 ? host : host + ":" + std::to_string(port); }
+};
+
+enum class Opcode {
+    Read,
+    Write,
+};
+
+enum class TransportProtocol : uint32_t {
+    Hixl = 0,
+};
+
+enum class TransferStatus {
+    Waiting,
+    Completed,
+    Failed,
+};
+
+enum class MemoryType {
+    Host,
+    Device,
+};
+
+enum class OperationDirect {
+    LocalDeviceDevice,  // Same local device only.
+    LocalDeviceHost,
+    RemoteDeviceHost,
+};
+
+struct MemoryRegion {
+    void* addr = nullptr;
+    uint64_t length = 0;
+    MemoryType type = MemoryType::Host;
+    int32_t device_id = -1;
+};
+
+struct InitAttrs {
+    virtual ~InitAttrs() = default;
+};
+
+struct Segment {
+    void* local_addr = nullptr;
+    uint64_t remote_addr = 0;
+    uint64_t length = 0;
+};
+
+struct Operation {
+    Opcode opcode = Opcode::Read;
+    OperationDirect direct = OperationDirect::RemoteDeviceHost;
+    ManagerID target_manager;
+    std::vector<Segment> ops;
+};
+
+class Transport {
+public:
+    virtual ~Transport() = default;
+
+    virtual TransportProtocol Protocol() const = 0;
+    virtual Status Init(const InitAttrs& options) = 0;
+    virtual Status Shutdown() = 0;
+
+    virtual Status RegisterMemory(const MemoryRegion& memory, MemoryHandle& handle) = 0;
+    virtual Status UnregisterMemory(MemoryHandle handle) = 0;
+    virtual Status ExportMetadata(const ManagerID& manager_id, Metadata& out) = 0;
+    virtual Status ImportMetadata(const ManagerID& manager_id, const Metadata& metadata) = 0;
+    virtual Status Connect(const ManagerID& manager_id) = 0;
+    virtual Status Disconnect(const ManagerID& manager_id) = 0;
+    virtual Status ExecuteSync(const Operation& request) = 0;
+    virtual Status ExecuteAsync(const Operation& request, TransferHandle& handle) = 0;
+    virtual Status GetStatus(TransferHandle handle, TransferStatus& status) = 0;
+};
+
+using TransportPtr = std::shared_ptr<Transport>;
+
+}  // namespace transport

--- a/ucm/transport/p2p/include/core/transport_init_attrs.h
+++ b/ucm/transport/p2p/include/core/transport_init_attrs.h
@@ -1,0 +1,54 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+#include "core/transport.h"
+
+namespace transport {
+
+enum class HixlRole : uint8_t {
+    Server = 0,
+    Client = 1,
+    Bidirectional = 2,
+};
+
+struct HixlInitAttrs : public InitAttrs {
+    struct Instance {
+        int32_t port = 0;
+        int32_t device_id = -1;
+        std::map<std::string, std::string> options;
+    };
+
+    std::string ip = "127.0.0.1";
+    std::vector<Instance> instances;
+    HixlRole role = HixlRole::Bidirectional;
+    int32_t connect_timeout_ms = 1000;
+    int32_t transfer_timeout_ms = 1000;
+};
+
+}  // namespace transport

--- a/ucm/transport/p2p/include/core/transport_manager.h
+++ b/ucm/transport/p2p/include/core/transport_manager.h
@@ -1,0 +1,107 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "control/control_channel.h"
+#include "control/control_protocol.h"
+#include "core/transport.h"
+#include "core/transport_init_attrs.h"
+
+namespace transport {
+
+class TransportManager {
+public:
+    explicit TransportManager(ManagerID manager_id);
+    ~TransportManager();
+
+    TransportManager(const TransportManager&) = delete;
+    TransportManager& operator=(const TransportManager&) = delete;
+
+    Status Init();
+    Status InstallTransport(TransportProtocol protocol, const InitAttrs& options);
+
+    Status ExchangeMetadata(const ManagerID& manager_id);
+    Status Shutdown();
+
+    Status RegisterMemory(const MemoryRegion& memory, MemoryHandle& handle);
+    Status UnregisterMemory(MemoryHandle handle);
+
+    Status Connect(TransportProtocol protocol, const ManagerID& manager_id);
+    Status Disconnect(TransportProtocol protocol, const ManagerID& manager_id);
+    Status ExecuteSync(const Operation& batch);
+    Status ExecuteAsync(const Operation& batch, TransferHandle& handle);
+    Status GetStatus(TransferHandle handle, TransferStatus& status);
+
+private:
+    struct InstalledTransport {
+        TransportProtocol protocol;
+        TransportPtr transport;
+    };
+
+    struct MemoryRecord {
+        MemoryRegion region;
+        std::unordered_map<TransportProtocol, MemoryHandle> transport_handles;
+    };
+
+    struct TransferRecord {
+        Transport* transport = nullptr;
+        TransferHandle transport_handle = kInvalidTransferHandle;
+    };
+
+    TransportPtr CreateTransport(TransportProtocol protocol) const;
+    Status FindTransport(Operation& batch, Transport*& transport);
+    Status ExportLocalMetadata(const ManagerID& manager_id, Metadata& out);
+    Status ImportMetadata(const Metadata& metadata, const ManagerID& manager_id);
+    Status HandleMetadataExchange(const ManagerID& manager_id, const Metadata& remote_metadata,
+                                  Metadata& local_metadata);
+    Status HandleControlRequest(const Metadata& request, Metadata& response);
+    Status CoordinateConnectionWithPeer(ControlOperation operation, TransportProtocol protocol,
+                                        const ManagerID& manager_id);
+    Status ApplyConnectionLocally(ControlOperation operation, TransportProtocol protocol,
+                                  const ManagerID& manager_id);
+    Endpoint LocalEndpoint() const;
+    Status ParseManagerID(const ManagerID& manager_id, Endpoint& endpoint) const;
+
+    ManagerID manager_id_;
+    Endpoint local_endpoint_;
+    std::shared_ptr<ControlChannel> control_;
+    mutable std::recursive_mutex peer_mutex_;
+    std::set<std::pair<TransportProtocol, ManagerID>> connections_;
+    bool shutting_down_ = false;
+    std::unordered_map<TransportProtocol, Transport*> protocol_map_;
+    std::vector<InstalledTransport> transports_;
+    std::unordered_map<MemoryHandle, std::unique_ptr<MemoryRecord>> memories_;
+    std::mutex transfers_mutex_;
+    std::unordered_map<TransferHandle, TransferRecord> transfers_;
+    TransferHandle next_transfer_handle_ = 1;
+};
+
+}  // namespace transport

--- a/ucm/transport/p2p/include/protocols/hixl/hixl_transport.h
+++ b/ucm/transport/p2p/include/protocols/hixl/hixl_transport.h
@@ -1,0 +1,105 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "core/transport.h"
+#include "core/transport_init_attrs.h"
+#include "hixl/hixl_types.h"
+
+namespace transport {
+
+class HixlInstance;
+
+struct HixlInstanceInfo {
+    Endpoint endpoint;
+    int32_t device_id = -1;
+};
+
+class HixlTransport final : public Transport {
+public:
+    HixlTransport();
+    ~HixlTransport() override;
+
+    HixlTransport(const HixlTransport&) = delete;
+    HixlTransport& operator=(const HixlTransport&) = delete;
+
+    TransportProtocol Protocol() const override;
+    Status Init(const InitAttrs& attrs) override;
+    Status Init(const HixlInitAttrs& attrs);
+    Status Shutdown() override;
+    Status RegisterMemory(const MemoryRegion& memory, MemoryHandle& handle) override;
+    Status UnregisterMemory(MemoryHandle handle) override;
+    Status ExportMetadata(const ManagerID& manager_id, Metadata& out) override;
+    Status ImportMetadata(const ManagerID& manager_id, const Metadata& metadata) override;
+    Status Connect(const ManagerID& manager_id) override;
+    Status Disconnect(const ManagerID& manager_id) override;
+    Status ExecuteSync(const Operation& request) override;
+    Status ExecuteAsync(const Operation& request, TransferHandle& handle) override;
+    Status GetStatus(TransferHandle handle, TransferStatus& status) override;
+
+private:
+    struct Peer {
+        std::vector<HixlInstanceInfo> instances;
+        HixlRole role = HixlRole::Bidirectional;
+        size_t local_index = SIZE_MAX;
+        bool connected = false;
+    };
+
+    struct LocalMemoryRecord {
+        MemoryRegion region;
+        std::unordered_map<size_t, hixl::MemHandle> native_handles;
+    };
+
+    struct PendingTransfer {
+        size_t instance_index = SIZE_MAX;
+        hixl::TransferReq request = nullptr;
+    };
+
+    Status ValidateTransferLocked(const Operation& batch, size_t instance_index) const;
+    Status BuildRouteLocked(const ManagerID& manager_id, Peer& peer);
+    Status DisconnectRoute(const Peer& peer, bool ignore_failure);
+
+    int32_t connect_timeout_ms_ = 1000;
+    int32_t transfer_timeout_ms_ = 1000;
+    HixlRole role_ = HixlRole::Bidirectional;
+    std::vector<std::unique_ptr<HixlInstance>> instances_;
+    std::unordered_map<ManagerID, Peer> peers_;
+    std::unordered_map<MemoryHandle, std::unique_ptr<LocalMemoryRecord>> memories_;
+    std::unordered_map<TransferHandle, PendingTransfer> pending_transfers_;
+    TransferHandle next_transfer_handle_ = 1;
+    mutable std::shared_mutex lifecycle_mutex_;
+    mutable std::shared_mutex peers_mutex_;
+    mutable std::shared_mutex memories_mutex_;
+    mutable std::mutex pending_mutex_;
+};
+
+}  // namespace transport

--- a/ucm/transport/p2p/src/channels/tcp/tcp_message_channel.cpp
+++ b/ucm/transport/p2p/src/channels/tcp/tcp_message_channel.cpp
@@ -1,0 +1,553 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "channels/tcp/tcp_message_channel.h"
+#include <algorithm>
+#include <arpa/inet.h>
+#include <cerrno>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <future>
+#include <mutex>
+#include <netdb.h>
+#include <sys/epoll.h>
+#include <sys/socket.h>
+#include <thread>
+#include <unistd.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+#include "common/binary_codec.h"
+
+#ifndef MSG_NOSIGNAL
+#define MSG_NOSIGNAL 0
+#endif
+
+namespace transport {
+namespace {
+
+using Socket = int;
+constexpr Socket kInvalidSocket = -1;
+constexpr uint32_t kMaxFrameSize = 4 * 1024 * 1024;
+constexpr int kListenBacklog = 16;
+constexpr size_t kEncodedEndpointOverhead = sizeof(uint32_t) + sizeof(uint16_t);
+
+void CloseSocket(Socket socket)
+{
+    if (socket != kInvalidSocket) {
+        ::shutdown(socket, SHUT_RDWR);
+        close(socket);
+    }
+}
+
+Status EncodeMessage(const Endpoint& local, const void* data, size_t length, Metadata& frame)
+{
+    frame.clear();
+    if (local.host.size() > UINT32_MAX) { return Status::InvalidParam(); }
+    const auto header_size = kEncodedEndpointOverhead + local.host.size();
+    if (header_size > kMaxFrameSize || length > kMaxFrameSize - header_size) {
+        return Status::InvalidParam();
+    }
+    if (!detail::AppendString(frame, local.host) || !detail::AppendU16(frame, local.port)) {
+        return Status::InvalidParam();
+    }
+    if (length != 0) {
+        const auto* bytes = static_cast<const uint8_t*>(data);
+        frame.insert(frame.end(), bytes, bytes + length);
+    }
+    return Status::OK();
+}
+
+bool DecodeMessage(const Metadata& frame, Endpoint& peer, Metadata& data)
+{
+    size_t offset = 0;
+    if (!detail::ReadString(frame, offset, peer.host) ||
+        !detail::ReadU16(frame, offset, peer.port)) {
+        return false;
+    }
+    data.assign(frame.begin() + static_cast<ptrdiff_t>(offset), frame.end());
+    return true;
+}
+
+Status SendAll(Socket socket, const void* data, size_t length)
+{
+    const auto* cursor = static_cast<const char*>(data);
+    while (length > 0) {
+        const auto chunk = static_cast<int>(std::min<size_t>(length, 64 * 1024));
+        const int sent = ::send(socket, cursor, chunk, MSG_NOSIGNAL);
+        if (sent <= 0) { return Status::Error(); }
+        cursor += sent;
+        length -= static_cast<size_t>(sent);
+    }
+    return Status::OK();
+}
+
+Status SendFrame(Socket socket, const Metadata& data)
+{
+    if (socket == kInvalidSocket || data.size() > UINT32_MAX) { return Status::InvalidParam(); }
+    const uint32_t network_length = htonl(static_cast<uint32_t>(data.size()));
+    auto status = SendAll(socket, &network_length, sizeof(network_length));
+    if (status != Status::OK() || data.empty()) { return status; }
+    return SendAll(socket, data.data(), data.size());
+}
+
+Status ConnectSocket(const Endpoint& endpoint, Socket& socket)
+{
+    if (endpoint.host.empty() || endpoint.port == 0) { return Status::InvalidParam(); }
+
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    addrinfo* results = nullptr;
+    const auto port = std::to_string(endpoint.port);
+    if (getaddrinfo(endpoint.host.c_str(), port.c_str(), &hints, &results) != 0) {
+        return Status::Error();
+    }
+
+    Status status = Status::Error();
+    for (auto* item = results; item != nullptr; item = item->ai_next) {
+        const auto candidate = ::socket(item->ai_family, item->ai_socktype, item->ai_protocol);
+        if (candidate == kInvalidSocket) { continue; }
+        if (::connect(candidate, item->ai_addr, static_cast<int>(item->ai_addrlen)) == 0) {
+            socket = candidate;
+            status = Status::OK();
+            break;
+        }
+        CloseSocket(candidate);
+    }
+    freeaddrinfo(results);
+    return status;
+}
+
+Status ListenSocket(const Endpoint& endpoint, int backlog, Socket& socket)
+{
+    if (endpoint.port == 0 || backlog <= 0) { return Status::InvalidParam(); }
+
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+
+    addrinfo* results = nullptr;
+    const auto port = std::to_string(endpoint.port);
+    const char* host = endpoint.host.empty() ? nullptr : endpoint.host.c_str();
+    if (getaddrinfo(host, port.c_str(), &hints, &results) != 0) { return Status::Error(); }
+
+    Status status = Status::Error();
+    for (auto* item = results; item != nullptr; item = item->ai_next) {
+        const auto candidate = ::socket(item->ai_family, item->ai_socktype, item->ai_protocol);
+        if (candidate == kInvalidSocket) { continue; }
+        int yes = 1;
+        if (setsockopt(candidate, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&yes),
+                       sizeof(yes)) != 0) {
+            CloseSocket(candidate);
+            continue;
+        }
+        if (::bind(candidate, item->ai_addr, static_cast<int>(item->ai_addrlen)) == 0 &&
+            ::listen(candidate, backlog) == 0) {
+            socket = candidate;
+            status = Status::OK();
+            break;
+        }
+        CloseSocket(candidate);
+    }
+    freeaddrinfo(results);
+    return status;
+}
+
+Status ReceiveAvailableFrames(Socket socket, Metadata& buffer, std::vector<Metadata>& frames,
+                              uint32_t max_frame_size, bool& closed)
+{
+    closed = false;
+    char chunk[64 * 1024];
+    for (;;) {
+        const auto received = ::recv(socket, chunk, sizeof(chunk), MSG_DONTWAIT);
+        if (received > 0) {
+            buffer.insert(buffer.end(), chunk, chunk + received);
+            continue;
+        }
+        if (received == 0) {
+            closed = true;
+            return Status::OK();
+        }
+        if (errno == EAGAIN || errno == EWOULDBLOCK) { break; }
+        if (errno == EINTR) { continue; }
+        return Status::Error();
+    }
+
+    size_t offset = 0;
+    while (buffer.size() - offset >= sizeof(uint32_t)) {
+        uint32_t network_length = 0;
+        std::copy_n(buffer.data() + offset, sizeof(network_length),
+                    reinterpret_cast<uint8_t*>(&network_length));
+        const auto length = ntohl(network_length);
+        if (length > max_frame_size) { return Status::InvalidParam(); }
+        if (buffer.size() - offset - sizeof(uint32_t) < length) { break; }
+        const auto payload_begin = offset + sizeof(uint32_t);
+        frames.emplace_back(buffer.begin() + static_cast<ptrdiff_t>(payload_begin),
+                            buffer.begin() + static_cast<ptrdiff_t>(payload_begin + length));
+        offset = payload_begin + length;
+    }
+    if (offset != 0) {
+        buffer.erase(buffer.begin(), buffer.begin() + static_cast<ptrdiff_t>(offset));
+    }
+    return Status::OK();
+}
+
+}  // namespace
+
+void TcpMessageChannel::CloseConnectionSocketLocked(const Connection& connection)
+{
+    if (connection.send_mutex) {
+        std::lock_guard<std::mutex> send_lock(*connection.send_mutex);
+        CloseSocket(connection.socket);
+        return;
+    }
+    CloseSocket(connection.socket);
+}
+
+void TcpMessageChannel::CloseSocketLocked(Socket socket)
+{
+    if (socket == kInvalidSocket) { return; }
+    auto connection_it = connections_.find(socket);
+    if (connection_it != connections_.end()) {
+        if (!connection_it->second.peer.host.empty() && connection_it->second.peer.port != 0) {
+            const auto peer_it = peer_sockets_.find(connection_it->second.peer.ToString());
+            if (peer_it != peer_sockets_.end() && peer_it->second == socket) {
+                peer_sockets_.erase(peer_it);
+            }
+        }
+        CloseConnectionSocketLocked(connection_it->second);
+        connections_.erase(connection_it);
+        return;
+    }
+    CloseSocket(socket);
+}
+
+void TcpMessageChannel::CloseAllLocked()
+{
+    CloseSocket(listen_socket_);
+    listen_socket_ = kInvalidSocket;
+    for (const auto& item : connections_) { CloseConnectionSocketLocked(item.second); }
+    connections_.clear();
+    peer_sockets_.clear();
+}
+
+TcpMessageChannel::TcpMessageChannel() = default;
+
+TcpMessageChannel::~TcpMessageChannel()
+{
+    if (Shutdown() != Status::OK()) {}
+}
+
+Status TcpMessageChannel::StartIoThread()
+{
+    if (io_thread_.joinable()) { return Status::OK(); }
+    std::promise<Status> startup;
+    auto startup_result = startup.get_future();
+    io_thread_ = std::thread(
+        [this, startup = std::move(startup)]() mutable { RunEventLoop(std::move(startup)); });
+    const auto status = startup_result.get();
+    if (status != Status::OK() && io_thread_.joinable()) { io_thread_.join(); }
+    return status;
+}
+
+void TcpMessageChannel::RunEventLoop(std::promise<Status> startup)
+{
+    const int epoll_fd = epoll_create1(EPOLL_CLOEXEC);
+    if (epoll_fd < 0) {
+        startup.set_value(Status::Error());
+        return;
+    }
+
+    Socket active_listen_socket = kInvalidSocket;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        active_listen_socket = listen_socket_;
+    }
+    if (active_listen_socket == kInvalidSocket) {
+        ::close(epoll_fd);
+        startup.set_value(Status::Error());
+        return;
+    }
+
+    epoll_event event{};
+    event.events = EPOLLIN | EPOLLHUP | EPOLLERR;
+    event.data.fd = active_listen_socket;
+    if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, active_listen_socket, &event) != 0) {
+        ::close(epoll_fd);
+        startup.set_value(Status::Error());
+        return;
+    }
+
+    startup.set_value(Status::OK());
+    std::unordered_set<Socket> registered;
+    while (true) {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (stopping_) { break; }
+        }
+        RegisterConnectionEvents(epoll_fd, registered);
+
+        const int max_events = static_cast<int>(std::max<size_t>(registered.size() + 1, 1));
+        std::vector<epoll_event> events(static_cast<size_t>(max_events));
+        const int ready = epoll_wait(epoll_fd, events.data(), max_events, 100);
+        if (ready <= 0) { continue; }
+
+        for (int index = 0; index < ready; ++index) {
+            const Socket socket = events[index].data.fd;
+            if ((events[index].events & (EPOLLIN | EPOLLHUP | EPOLLERR)) == 0) { continue; }
+            if (socket == active_listen_socket) {
+                HandleAcceptEvent(active_listen_socket);
+            } else {
+                HandleConnectionEvent(epoll_fd, registered, socket);
+            }
+        }
+    }
+
+    for (const auto socket : registered) {
+        if (epoll_ctl(epoll_fd, EPOLL_CTL_DEL, socket, nullptr) != 0) { continue; }
+    }
+    ::close(epoll_fd);
+}
+
+void TcpMessageChannel::RegisterConnectionEvents(int epoll_fd,
+                                                 std::unordered_set<Socket>& registered)
+{
+    std::lock_guard<std::mutex> lock(mutex_);
+    for (const auto& item : connections_) {
+        const Socket socket = item.first;
+        if (registered.find(socket) != registered.end()) { continue; }
+        epoll_event event{};
+        event.events = EPOLLIN | EPOLLHUP | EPOLLERR;
+        event.data.fd = socket;
+        if (epoll_ctl(epoll_fd, EPOLL_CTL_ADD, socket, &event) == 0) { registered.insert(socket); }
+    }
+}
+
+void TcpMessageChannel::HandleAcceptEvent(Socket active_listen_socket)
+{
+    const auto accepted = ::accept(active_listen_socket, nullptr, nullptr);
+    if (accepted == kInvalidSocket) { return; }
+
+    Connection connection;
+    connection.socket = accepted;
+    connection.send_mutex = std::make_shared<std::mutex>();
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (stopping_) {
+            CloseSocket(accepted);
+            return;
+        }
+        connections_.emplace(accepted, std::move(connection));
+    }
+}
+
+void TcpMessageChannel::HandleConnectionEvent(int epoll_fd, std::unordered_set<Socket>& registered,
+                                              Socket socket)
+{
+    std::vector<Metadata> frames;
+    bool closed = false;
+    Status receive_status = Status::OK();
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = connections_.find(socket);
+        if (it == connections_.end()) { return; }
+        receive_status = ReceiveAvailableFrames(socket, it->second.receive_buffer, frames,
+                                                kMaxFrameSize, closed);
+    }
+    if (receive_status != Status::OK()) {
+        RemoveConnection(epoll_fd, registered, socket);
+        return;
+    }
+
+    bool drop_socket = false;
+    for (const auto& frame : frames) {
+        Message message;
+        if (!DecodeMessage(frame, message.peer, message.data)) {
+            drop_socket = true;
+            continue;
+        }
+
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            auto connection_it = connections_.find(socket);
+            if (connection_it == connections_.end()) {
+                drop_socket = true;
+            } else {
+                const auto peer_bound = !connection_it->second.peer.host.empty() &&
+                                        connection_it->second.peer.port != 0;
+                if (!peer_bound && !BindPeerLocked(socket, message.peer)) { drop_socket = true; }
+            }
+            receive_queue_.emplace_back(std::move(message));
+        }
+        receive_cv_.notify_one();
+    }
+    if (closed || drop_socket) { RemoveConnection(epoll_fd, registered, socket); }
+}
+
+void TcpMessageChannel::RemoveConnection(int epoll_fd, std::unordered_set<Socket>& registered,
+                                         Socket socket)
+{
+    epoll_ctl(epoll_fd, EPOLL_CTL_DEL, socket, nullptr);
+    registered.erase(socket);
+    std::lock_guard<std::mutex> lock(mutex_);
+    CloseSocketLocked(socket);
+}
+
+bool TcpMessageChannel::BindPeerLocked(Socket socket, const Endpoint& peer)
+{
+    auto connection_it = connections_.find(socket);
+    if (connection_it == connections_.end()) { return false; }
+
+    const auto peer_id = peer.ToString();
+    auto existing = peer_sockets_.find(peer_id);
+    connection_it->second.peer = peer;
+    if (existing != peer_sockets_.end() &&
+        connections_.find(existing->second) == connections_.end()) {
+        peer_sockets_.erase(existing);
+        existing = peer_sockets_.end();
+    }
+    if (existing == peer_sockets_.end()) { peer_sockets_[peer_id] = socket; }
+    return true;
+}
+
+Status TcpMessageChannel::Init(const Endpoint& local)
+{
+    if (local.host.empty() || local.port == 0) { return Status::InvalidParam(); }
+    const auto shutdown_status = Shutdown();
+    if (shutdown_status != Status::OK()) { return shutdown_status; }
+
+    Socket listen_socket = kInvalidSocket;
+    auto status = ListenSocket(local, kListenBacklog, listen_socket);
+    if (status != Status::OK()) { return status; }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        local_ = local;
+        listen_socket_ = listen_socket;
+        stopping_ = false;
+    }
+
+    status = StartIoThread();
+    if (status != Status::OK()) { Shutdown(); }
+    return status;
+}
+
+Status TcpMessageChannel::Send(const Endpoint& peer, const void* data, size_t length)
+{
+    if (peer.host.empty() || peer.port == 0 || (data == nullptr && length != 0) ||
+        length > UINT32_MAX) {
+        return Status::InvalidParam();
+    }
+
+    Endpoint local;
+    std::string peer_id;
+    Socket socket = kInvalidSocket;
+    std::shared_ptr<std::mutex> send_mutex;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (stopping_ || listen_socket_ == kInvalidSocket) { return Status::Error(); }
+        local = local_;
+        peer_id = peer.ToString();
+        auto peer_it = peer_sockets_.find(peer_id);
+        if (peer_it != peer_sockets_.end()) {
+            const auto connection_it = connections_.find(peer_it->second);
+            if (connection_it != connections_.end()) {
+                socket = connection_it->second.socket;
+                send_mutex = connection_it->second.send_mutex;
+            } else {
+                peer_sockets_.erase(peer_it);
+            }
+        }
+    }
+
+    if (socket == kInvalidSocket) {
+        Socket connected = kInvalidSocket;
+        auto status = ConnectSocket(peer, connected);
+        if (status != Status::OK()) { return status; }
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (stopping_) {
+                CloseSocket(connected);
+                return Status::Error();
+            }
+            Connection connection;
+            connection.socket = connected;
+            connection.peer = peer;
+            connection.send_mutex = std::make_shared<std::mutex>();
+            socket = connected;
+            send_mutex = connection.send_mutex;
+            connections_.emplace(connected, std::move(connection));
+            peer_sockets_[peer_id] = connected;
+        }
+    }
+
+    if (socket == kInvalidSocket || !send_mutex) { return Status::Error(); }
+
+    Metadata frame;
+    auto status = EncodeMessage(local, data, length, frame);
+    if (status != Status::OK()) { return status; }
+    {
+        std::lock_guard<std::mutex> send_lock(*send_mutex);
+        status = SendFrame(socket, frame);
+    }
+    if (status != Status::OK()) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        CloseSocketLocked(socket);
+    }
+    return status;
+}
+
+Status TcpMessageChannel::Receive(Endpoint& peer, Metadata& data)
+{
+    std::unique_lock<std::mutex> lock(mutex_);
+    receive_cv_.wait(lock, [this]() { return stopping_ || !receive_queue_.empty(); });
+    if (receive_queue_.empty()) { return Status::Error(); }
+    auto message = std::move(receive_queue_.front());
+    receive_queue_.pop_front();
+    peer = std::move(message.peer);
+    data = std::move(message.data);
+    return Status::OK();
+}
+
+Status TcpMessageChannel::Shutdown()
+{
+    std::thread io_thread;
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        stopping_ = true;
+        receive_cv_.notify_all();
+        CloseAllLocked();
+        receive_queue_.clear();
+        io_thread = std::move(io_thread_);
+    }
+    if (io_thread.joinable()) { io_thread.join(); }
+    return Status::OK();
+}
+
+}  // namespace transport

--- a/ucm/transport/p2p/src/common/acl_runtime_context.cpp
+++ b/ucm/transport/p2p/src/common/acl_runtime_context.cpp
@@ -1,0 +1,58 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "common/acl_runtime_context.h"
+#include "logger/logger.h"
+
+namespace transport {
+
+WithAclRuntimeContext::WithAclRuntimeContext(aclrtContext context) : context_(context)
+{
+    if (context == nullptr) {
+        status_ = Status::Error();
+        return;
+    }
+    const auto get_status = aclrtGetCurrentContext(&previous_);
+    if (get_status != ACL_ERROR_NONE) { previous_ = nullptr; }
+    if (previous_ != context) {
+        const auto set_status = aclrtSetCurrentContext(context);
+        if (set_status != ACL_ERROR_NONE) {
+            UC_ERROR("transport set runtime context failed: aclrtSetCurrentContext returned {}",
+                     static_cast<int>(set_status));
+            status_ = Status::Error();
+        }
+    }
+}
+
+WithAclRuntimeContext::~WithAclRuntimeContext()
+{
+    if (status_ == Status::OK() && previous_ != nullptr && previous_ != context_) {
+        const auto status = aclrtSetCurrentContext(previous_);
+        if (status != ACL_ERROR_NONE) {
+            UC_ERROR("transport restore runtime context failed: aclrtSetCurrentContext returned {}",
+                     static_cast<int>(status));
+        }
+    }
+}
+
+}  // namespace transport

--- a/ucm/transport/p2p/src/common/acl_runtime_context.h
+++ b/ucm/transport/p2p/src/common/acl_runtime_context.h
@@ -1,0 +1,47 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include "acl/acl.h"
+#include "core/transport.h"
+
+namespace transport {
+
+class WithAclRuntimeContext {
+public:
+    explicit WithAclRuntimeContext(aclrtContext context);
+    ~WithAclRuntimeContext();
+
+    WithAclRuntimeContext(const WithAclRuntimeContext&) = delete;
+    WithAclRuntimeContext& operator=(const WithAclRuntimeContext&) = delete;
+
+    Status status() const { return status_; }
+
+private:
+    aclrtContext context_ = nullptr;
+    aclrtContext previous_ = nullptr;
+    Status status_ = Status::OK();
+};
+
+}  // namespace transport

--- a/ucm/transport/p2p/src/common/binary_codec.cpp
+++ b/ucm/transport/p2p/src/common/binary_codec.cpp
@@ -1,0 +1,142 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "common/binary_codec.h"
+#include <climits>
+
+namespace transport::detail {
+
+uint64_t PtrToU64(const void* ptr)
+{
+    return static_cast<uint64_t>(reinterpret_cast<uintptr_t>(ptr));
+}
+
+void* U64ToPtr(uint64_t value) { return reinterpret_cast<void*>(static_cast<uintptr_t>(value)); }
+
+bool AppendU64(Metadata& out, uint64_t value)
+{
+    for (int shift = 56; shift >= 0; shift -= 8) {
+        out.push_back(static_cast<uint8_t>((value >> shift) & 0xff));
+    }
+    return true;
+}
+
+bool ReadU64(const Metadata& input, size_t& offset, uint64_t& value)
+{
+    if (offset > input.size() || input.size() - offset < sizeof(uint64_t)) { return false; }
+    value = 0;
+    for (size_t i = 0; i < sizeof(uint64_t); ++i) { value = (value << 8) | input[offset + i]; }
+    offset += sizeof(uint64_t);
+    return true;
+}
+
+bool AppendU32(Metadata& out, uint32_t value)
+{
+    out.push_back(static_cast<uint8_t>((value >> 24) & 0xff));
+    out.push_back(static_cast<uint8_t>((value >> 16) & 0xff));
+    out.push_back(static_cast<uint8_t>((value >> 8) & 0xff));
+    out.push_back(static_cast<uint8_t>(value & 0xff));
+    return true;
+}
+
+bool ReadU32(const Metadata& input, size_t& offset, uint32_t& value)
+{
+    if (offset > input.size() || input.size() - offset < sizeof(uint32_t)) { return false; }
+    value = (static_cast<uint32_t>(input[offset]) << 24) |
+            (static_cast<uint32_t>(input[offset + 1]) << 16) |
+            (static_cast<uint32_t>(input[offset + 2]) << 8) |
+            static_cast<uint32_t>(input[offset + 3]);
+    offset += sizeof(uint32_t);
+    return true;
+}
+
+bool AppendU16(Metadata& out, uint16_t value)
+{
+    out.push_back(static_cast<uint8_t>((value >> 8) & 0xff));
+    out.push_back(static_cast<uint8_t>(value & 0xff));
+    return true;
+}
+
+bool ReadU16(const Metadata& input, size_t& offset, uint16_t& value)
+{
+    if (offset > input.size() || input.size() - offset < sizeof(uint16_t)) { return false; }
+    value = static_cast<uint16_t>((static_cast<uint16_t>(input[offset]) << 8) |
+                                  static_cast<uint16_t>(input[offset + 1]));
+    offset += sizeof(uint16_t);
+    return true;
+}
+
+bool AppendU8(Metadata& out, uint8_t value)
+{
+    out.push_back(value);
+    return true;
+}
+
+bool ReadU8(const Metadata& input, size_t& offset, uint8_t& value)
+{
+    if (offset >= input.size()) { return false; }
+    value = input[offset++];
+    return true;
+}
+
+bool AppendBytes(Metadata& out, const Metadata& value)
+{
+    if (value.size() > UINT32_MAX) { return false; }
+    AppendU32(out, static_cast<uint32_t>(value.size()));
+    out.insert(out.end(), value.begin(), value.end());
+    return true;
+}
+
+bool ReadBytes(const Metadata& input, size_t& offset, Metadata& value)
+{
+    uint32_t size = 0;
+    if (!ReadU32(input, offset, size) || offset > input.size() || input.size() - offset < size) {
+        return false;
+    }
+    value.assign(input.begin() + static_cast<std::ptrdiff_t>(offset),
+                 input.begin() + static_cast<std::ptrdiff_t>(offset + size));
+    offset += size;
+    return true;
+}
+
+bool AppendString(Metadata& out, const std::string& value)
+{
+    if (value.size() > UINT32_MAX) { return false; }
+    AppendU32(out, static_cast<uint32_t>(value.size()));
+    out.insert(out.end(), value.begin(), value.end());
+    return true;
+}
+
+bool ReadString(const Metadata& input, size_t& offset, std::string& value)
+{
+    uint32_t size = 0;
+    if (!ReadU32(input, offset, size) || offset > input.size() || input.size() - offset < size) {
+        return false;
+    }
+    value.assign(input.begin() + static_cast<std::ptrdiff_t>(offset),
+                 input.begin() + static_cast<std::ptrdiff_t>(offset + size));
+    offset += size;
+    return true;
+}
+
+}  // namespace transport::detail

--- a/ucm/transport/p2p/src/common/binary_codec.h
+++ b/ucm/transport/p2p/src/common/binary_codec.h
@@ -1,0 +1,52 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include "core/transport.h"
+
+namespace transport {
+
+namespace detail {
+
+uint64_t PtrToU64(const void* ptr);
+void* U64ToPtr(uint64_t value);
+
+bool AppendU64(Metadata& out, uint64_t value);
+bool ReadU64(const Metadata& input, size_t& offset, uint64_t& value);
+bool AppendU32(Metadata& out, uint32_t value);
+bool ReadU32(const Metadata& input, size_t& offset, uint32_t& value);
+bool AppendU16(Metadata& out, uint16_t value);
+bool ReadU16(const Metadata& input, size_t& offset, uint16_t& value);
+bool AppendU8(Metadata& out, uint8_t value);
+bool ReadU8(const Metadata& input, size_t& offset, uint8_t& value);
+bool AppendBytes(Metadata& out, const Metadata& value);
+bool ReadBytes(const Metadata& input, size_t& offset, Metadata& value);
+bool AppendString(Metadata& out, const std::string& value);
+bool ReadString(const Metadata& input, size_t& offset, std::string& value);
+
+}  // namespace detail
+}  // namespace transport

--- a/ucm/transport/p2p/src/control/control_channel.cpp
+++ b/ucm/transport/p2p/src/control/control_channel.cpp
@@ -1,0 +1,469 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "control/control_channel.h"
+#include <algorithm>
+#include <arpa/inet.h>
+#include <cerrno>
+#include <cstring>
+#include <mutex>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <thread>
+#include <unistd.h>
+#include <utility>
+#include "common/binary_codec.h"
+#include "logger/logger.h"
+
+namespace transport {
+namespace {
+
+using Socket = int;
+constexpr Socket kInvalidSocket = -1;
+
+struct ControlResponse {
+    Status status = Status::OK();
+    Metadata payload;
+};
+
+constexpr int kListenBacklog = 16;
+
+Status EncodeControlResponse(const ControlResponse& response, Metadata& out)
+{
+    out.clear();
+    const uint32_t status =
+        response.status.Success() ? 0 : (response.status == Status::InvalidParam() ? 1 : 2);
+    detail::AppendU32(out, status);
+    if (!detail::AppendBytes(out, response.payload)) { return Status::InvalidParam(); }
+    return Status::OK();
+}
+
+Status DecodeControlResponse(const Metadata& in, ControlResponse& response)
+{
+    size_t offset = 0;
+    uint32_t status = 0;
+    if (!detail::ReadU32(in, offset, status) || !detail::ReadBytes(in, offset, response.payload) ||
+        offset != in.size()) {
+        return Status::InvalidParam();
+    }
+    switch (status) {
+        case 0: response.status = Status::OK(); break;
+        case 1: response.status = Status::InvalidParam(); break;
+        case 2: response.status = Status::Error(); break;
+        default: return Status::InvalidParam();
+    }
+    return Status::OK();
+}
+
+Status SendAll(Socket socket, const void* data, size_t length)
+{
+    const auto* cursor = static_cast<const char*>(data);
+    while (length > 0) {
+        const auto chunk = static_cast<int>(std::min<size_t>(length, 64 * 1024));
+        const int sent = send(socket, cursor, chunk, 0);
+        if (sent <= 0) {
+            UC_ERROR("transport tcp send failed socket={} remaining={} errno={} error={}", socket,
+                     length, errno, std::strerror(errno));
+            return Status::Error();
+        }
+        cursor += sent;
+        length -= static_cast<size_t>(sent);
+    }
+    return Status::OK();
+}
+
+Status RecvAll(Socket socket, void* data, size_t length)
+{
+    auto* cursor = static_cast<char*>(data);
+    while (length > 0) {
+        const auto chunk = static_cast<int>(std::min<size_t>(length, 64 * 1024));
+        const int received = recv(socket, cursor, chunk, 0);
+        if (received == 0) {
+            UC_ERROR("transport tcp peer closed connection socket={} remaining={}", socket, length);
+            return Status::Error();
+        }
+        if (received < 0) {
+            UC_ERROR(
+                "transport tcp receive failed socket={} remaining={} result={} errno={} error={}",
+                socket, length, received, errno, std::strerror(errno));
+            return Status::Error();
+        }
+        cursor += received;
+        length -= static_cast<size_t>(received);
+    }
+    return Status::OK();
+}
+
+void CloseSocket(Socket socket)
+{
+    if (socket != kInvalidSocket) {
+        if (::shutdown(socket, SHUT_RDWR) != 0) {
+            UC_DEBUG("transport tcp shutdown socket={} failed", socket);
+        }
+        if (close(socket) != 0) { UC_DEBUG("transport tcp close socket={} failed", socket); }
+    }
+}
+
+Status SendFrame(Socket socket, const void* data, size_t length)
+{
+    if (socket == kInvalidSocket || (data == nullptr && length != 0) || length > UINT32_MAX) {
+        UC_ERROR("transport tcp send frame invalid socket={} data={} length={}", socket,
+                 static_cast<const void*>(data), length);
+        return Status::InvalidParam();
+    }
+    const uint32_t network_length = htonl(static_cast<uint32_t>(length));
+    auto status = SendAll(socket, &network_length, sizeof(network_length));
+    if (status != Status::OK() || length == 0) { return status; }
+    return SendAll(socket, data, length);
+}
+
+Status ReceiveFrame(Socket socket, Metadata& metadata, size_t max_length)
+{
+    if (socket == kInvalidSocket) {
+        UC_ERROR("transport tcp receive frame invalid socket={}", socket);
+        return Status::InvalidParam();
+    }
+    uint32_t network_length = 0;
+    auto status = RecvAll(socket, &network_length, sizeof(network_length));
+    if (status != Status::OK()) { return status; }
+    const auto length = ntohl(network_length);
+    if (length > max_length) {
+        UC_ERROR("transport tcp receive frame too large socket={} length={} limit={}", socket,
+                 length, max_length);
+        return Status::InvalidParam();
+    }
+    metadata.assign(length, 0);
+    return length == 0 ? Status::OK() : RecvAll(socket, metadata.data(), metadata.size());
+}
+
+}  // namespace
+
+ControlChannel::SocketHandle::SocketHandle() : socket_(kInvalidSocket) {}
+
+ControlChannel::SocketHandle::SocketHandle(int socket) : socket_(socket) {}
+
+ControlChannel::SocketHandle::~SocketHandle() { Reset(); }
+
+ControlChannel::SocketHandle::SocketHandle(SocketHandle&& other) noexcept : socket_(other.Release())
+{
+}
+
+ControlChannel::SocketHandle& ControlChannel::SocketHandle::operator=(SocketHandle&& other) noexcept
+{
+    if (this != &other) { Reset(other.Release()); }
+    return *this;
+}
+
+bool ControlChannel::SocketHandle::Valid() const { return socket_ != kInvalidSocket; }
+
+int ControlChannel::SocketHandle::Get() const { return socket_; }
+
+int ControlChannel::SocketHandle::Release()
+{
+    const auto socket = socket_;
+    socket_ = kInvalidSocket;
+    return socket;
+}
+
+void ControlChannel::SocketHandle::Reset(int socket)
+{
+    if (socket_ == socket) { return; }
+    CloseSocket(socket_);
+    socket_ = socket;
+}
+
+ControlChannel::ControlChannel() = default;
+
+ControlChannel::~ControlChannel() { Close(); }
+
+Status ControlChannel::Init(const Endpoint& endpoint, RequestHandler handler)
+{
+    UC_DEBUG("transport control init begin endpoint={}:{}", endpoint.host, endpoint.port);
+    Close();
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        request_handler_ = std::move(handler);
+    }
+    auto status = Listen(endpoint);
+    if (status != Status::OK()) {
+        UC_ERROR("transport control listen initialization failed endpoint={}:{} status={}",
+                 endpoint.host, endpoint.port, status.Underlying());
+        Close();
+        return status;
+    }
+    status = StartAccepting();
+    if (status != Status::OK()) {
+        UC_ERROR("transport control accept initialization failed endpoint={}:{} status={}",
+                 endpoint.host, endpoint.port, status.Underlying());
+        Close();
+    } else {
+        UC_DEBUG("transport control init completed endpoint={}:{}", endpoint.host, endpoint.port);
+    }
+    return status;
+}
+
+Status ControlChannel::Listen(const Endpoint& endpoint)
+{
+    if (endpoint.port == 0) {
+        UC_ERROR("transport tcp listen invalid endpoint={}:{}", endpoint.host, endpoint.port);
+        return Status::InvalidParam();
+    }
+    UC_DEBUG("transport tcp listen begin endpoint={}:{} backlog={}", endpoint.host, endpoint.port,
+             kListenBacklog);
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+    hints.ai_flags = AI_PASSIVE;
+
+    addrinfo* results = nullptr;
+    const auto port = std::to_string(endpoint.port);
+    const char* host = endpoint.host.empty() ? nullptr : endpoint.host.c_str();
+    if (getaddrinfo(host, port.c_str(), &hints, &results) != 0) {
+        UC_ERROR("transport tcp listen getaddrinfo failed endpoint={}:{}", endpoint.host,
+                 endpoint.port);
+        return Status::Error();
+    }
+
+    Status status = Status::Error();
+    for (auto* item = results; item != nullptr; item = item->ai_next) {
+        SocketHandle candidate(socket(item->ai_family, item->ai_socktype, item->ai_protocol));
+        if (!candidate.Valid()) { continue; }
+        int yes = 1;
+        if (setsockopt(candidate.Get(), SOL_SOCKET, SO_REUSEADDR,
+                       reinterpret_cast<const char*>(&yes), sizeof(yes)) != 0) {
+            continue;
+        }
+        if (bind(candidate.Get(), item->ai_addr, static_cast<int>(item->ai_addrlen)) == 0 &&
+            ::listen(candidate.Get(), kListenBacklog) == 0) {
+            const auto socket = candidate.Get();
+            listen_socket_.Reset(candidate.Release());
+            endpoint_ = endpoint;
+            status = Status::OK();
+            UC_DEBUG("transport tcp listen ok endpoint={}:{} socket={}", endpoint.host,
+                     endpoint.port, socket);
+            break;
+        }
+    }
+
+    freeaddrinfo(results);
+    if (status != Status::OK()) {
+        UC_ERROR("transport tcp listen failed endpoint={}:{}", endpoint.host, endpoint.port);
+    }
+    return status;
+}
+
+Status ControlChannel::AcceptSocket(SocketHandle& socket)
+{
+    if (!listen_socket_.Valid()) {
+        UC_ERROR("transport tcp accept failed: listen socket is invalid");
+        return Status::InvalidParam();
+    }
+
+    const auto accepted = ::accept(listen_socket_.Get(), nullptr, nullptr);
+    if (accepted == kInvalidSocket) {
+        if (stop_accept_.load(std::memory_order_relaxed)) {
+            UC_DEBUG("transport tcp accept stopped");
+            return Status::Error();
+        }
+        UC_ERROR("transport tcp accept failed");
+        return Status::Error();
+    }
+
+    socket.Reset(accepted);
+    UC_DEBUG("transport tcp accept ok socket={}", accepted);
+    return Status::OK();
+}
+
+Status ControlChannel::Connect(const Endpoint& endpoint)
+{
+    if (endpoint.host.empty() || endpoint.port == 0) {
+        UC_ERROR("transport tcp connect invalid endpoint={}:{}", endpoint.host, endpoint.port);
+        return Status::InvalidParam();
+    }
+    UC_DEBUG("transport tcp connect begin endpoint={}:{}", endpoint.host, endpoint.port);
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    addrinfo* results = nullptr;
+    const auto port = std::to_string(endpoint.port);
+    if (getaddrinfo(endpoint.host.c_str(), port.c_str(), &hints, &results) != 0) {
+        UC_ERROR("transport tcp connect getaddrinfo failed endpoint={}:{}", endpoint.host,
+                 endpoint.port);
+        return Status::Error();
+    }
+
+    Status status = Status::Error();
+    for (auto* item = results; item != nullptr; item = item->ai_next) {
+        SocketHandle candidate(socket(item->ai_family, item->ai_socktype, item->ai_protocol));
+        if (!candidate.Valid()) { continue; }
+        if (::connect(candidate.Get(), item->ai_addr, static_cast<int>(item->ai_addrlen)) == 0) {
+            const auto socket = candidate.Get();
+            socket_.Reset(candidate.Release());
+            status = Status::OK();
+            UC_DEBUG("transport tcp connect ok endpoint={}:{} socket={}", endpoint.host,
+                     endpoint.port, socket);
+            break;
+        }
+    }
+
+    freeaddrinfo(results);
+    if (status != Status::OK()) {
+        UC_ERROR("transport tcp connect failed endpoint={}:{}", endpoint.host, endpoint.port);
+    }
+    return status;
+}
+
+Status ControlChannel::Request(const Endpoint& endpoint, const Metadata& request,
+                               Metadata& response)
+{
+    UC_DEBUG("transport control request begin peer={}:{} bytes={}", endpoint.host, endpoint.port,
+             request.size());
+    ControlChannel channel;
+    auto status = channel.Connect(endpoint);
+    if (status != Status::OK()) {
+        UC_ERROR("transport control request connect failed peer={}:{} status={}", endpoint.host,
+                 endpoint.port, status.Underlying());
+        return status;
+    }
+
+    status = SendFrame(channel.socket_.Get(), request.data(), request.size());
+    if (status != Status::OK()) {
+        UC_ERROR("transport control request send failed peer={}:{} socket={} status={}",
+                 endpoint.host, endpoint.port, channel.socket_.Get(), status.Underlying());
+        return status;
+    }
+    UC_DEBUG("transport control request sent peer={}:{} socket={} bytes={}", endpoint.host,
+             endpoint.port, channel.socket_.Get(), request.size());
+
+    Metadata response_frame;
+    status = ReceiveFrame(channel.socket_.Get(), response_frame, max_receive_frame_size_);
+    if (status != Status::OK()) {
+        UC_ERROR("transport control response receive failed peer={}:{} socket={} status={}",
+                 endpoint.host, endpoint.port, channel.socket_.Get(), status.Underlying());
+        return status;
+    }
+    ControlResponse decoded_response;
+    status = DecodeControlResponse(response_frame, decoded_response);
+    if (status != Status::OK()) {
+        UC_ERROR("transport control response decode failed peer={}:{} socket={} bytes={} status={}",
+                 endpoint.host, endpoint.port, channel.socket_.Get(), response_frame.size(),
+                 status.Underlying());
+        return status;
+    }
+    if (decoded_response.status != Status::OK()) {
+        UC_ERROR("transport control peer rejected request peer={}:{} socket={} status={}",
+                 endpoint.host, endpoint.port, channel.socket_.Get(),
+                 decoded_response.status.Underlying());
+        return decoded_response.status;
+    }
+    response = std::move(decoded_response.payload);
+    UC_DEBUG("transport control request completed peer={}:{} socket={} response_bytes={}",
+             endpoint.host, endpoint.port, channel.socket_.Get(), response.size());
+    return Status::OK();
+}
+
+Status ControlChannel::StartAccepting()
+{
+    if (!listen_socket_.Valid()) {
+        UC_ERROR("transport tcp start accepting failed: listen socket is invalid");
+        return Status::InvalidParam();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!request_handler_) {
+            UC_ERROR("transport tcp start accepting failed: request handler is empty");
+            return Status::InvalidParam();
+        }
+        if (accept_thread_.joinable()) {
+            UC_DEBUG("transport tcp accept thread already running socket={}", listen_socket_.Get());
+            return Status::OK();
+        }
+        stop_accept_.store(false, std::memory_order_relaxed);
+    }
+
+    accept_thread_ = std::thread([this]() {
+        while (!stop_accept_.load(std::memory_order_relaxed)) {
+            SocketHandle accepted_socket;
+            const auto status = AcceptSocket(accepted_socket);
+            if (status != Status::OK()) { continue; }
+
+            Metadata request_frame;
+            const auto receive_status =
+                ReceiveFrame(accepted_socket.Get(), request_frame, max_receive_frame_size_);
+            if (receive_status != Status::OK()) {
+                UC_ERROR("transport control request receive failed socket={} status={}",
+                         accepted_socket.Get(), receive_status.Underlying());
+                continue;
+            }
+            UC_DEBUG("transport control request received socket={} bytes={}", accepted_socket.Get(),
+                     request_frame.size());
+
+            RequestHandler handler;
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                handler = request_handler_;
+            }
+            Metadata response;
+            const auto request_status =
+                handler ? handler(request_frame, response) : Status::InvalidParam();
+            if (request_status != Status::OK()) {
+                UC_ERROR("transport control request handler failed socket={} status={}",
+                         accepted_socket.Get(), request_status.Underlying());
+            } else {
+                UC_DEBUG("transport control request handled socket={} response_bytes={}",
+                         accepted_socket.Get(), response.size());
+            }
+            ControlResponse control_response{request_status, std::move(response)};
+            Metadata response_payload;
+            const auto encode_status = EncodeControlResponse(control_response, response_payload);
+            if (encode_status != Status::OK()) {
+                UC_ERROR("transport control response encode failed socket={} status={}",
+                         accepted_socket.Get(), encode_status.Underlying());
+                continue;
+            }
+            const auto send_status =
+                SendFrame(accepted_socket.Get(), response_payload.data(), response_payload.size());
+            if (send_status != Status::OK()) {
+                UC_ERROR("transport control response send failed socket={} bytes={} status={}",
+                         accepted_socket.Get(), response_payload.size(), send_status.Underlying());
+                continue;
+            }
+            UC_DEBUG("transport control response sent socket={} bytes={} status={}",
+                     accepted_socket.Get(), response_payload.size(), request_status.Underlying());
+        }
+    });
+    return Status::OK();
+}
+
+void ControlChannel::Close()
+{
+    UC_DEBUG("transport tcp close socket={} listen_socket={}", socket_.Get(), listen_socket_.Get());
+    stop_accept_.store(true, std::memory_order_relaxed);
+    listen_socket_.Reset();
+    if (accept_thread_.joinable()) { accept_thread_.join(); }
+    socket_.Reset();
+}
+
+}  // namespace transport

--- a/ucm/transport/p2p/src/control/control_protocol.cpp
+++ b/ucm/transport/p2p/src/control/control_protocol.cpp
@@ -1,0 +1,73 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "control/control_protocol.h"
+#include "common/binary_codec.h"
+
+namespace transport {
+
+Status EncodeControlRequest(const ControlRequest& request, Metadata& out)
+{
+    out.clear();
+    if (!detail::AppendU32(out, static_cast<uint32_t>(request.operation))) {
+        return Status::InvalidParam();
+    }
+    if (request.operation == ControlOperation::ExchangeMetadata) {
+        return detail::AppendString(out, request.manager_id) &&
+                       detail::AppendBytes(out, request.payload)
+                   ? Status::OK()
+                   : Status::InvalidParam();
+    }
+    if (!request.protocol.has_value()) { return Status::InvalidParam(); }
+    return detail::AppendU32(out, static_cast<uint32_t>(*request.protocol)) &&
+                   detail::AppendString(out, request.manager_id)
+               ? Status::OK()
+               : Status::InvalidParam();
+}
+
+Status DecodeControlRequest(const Metadata& in, ControlRequest& request)
+{
+    size_t offset = 0;
+    uint32_t raw_operation = 0;
+    if (!detail::ReadU32(in, offset, raw_operation) ||
+        raw_operation > static_cast<uint32_t>(ControlOperation::Disconnect)) {
+        return Status::InvalidParam();
+    }
+    request.operation = static_cast<ControlOperation>(raw_operation);
+    if (request.operation == ControlOperation::ExchangeMetadata) {
+        return detail::ReadString(in, offset, request.manager_id) &&
+                       detail::ReadBytes(in, offset, request.payload) && offset == in.size()
+                   ? Status::OK()
+                   : Status::InvalidParam();
+    }
+
+    uint32_t raw_protocol = 0;
+    if (!detail::ReadU32(in, offset, raw_protocol) ||
+        !detail::ReadString(in, offset, request.manager_id) || offset != in.size()) {
+        return Status::InvalidParam();
+    }
+    request.protocol = static_cast<TransportProtocol>(raw_protocol);
+    return Status::OK();
+}
+
+}  // namespace transport

--- a/ucm/transport/p2p/src/core/transport_manager.cpp
+++ b/ucm/transport/p2p/src/core/transport_manager.cpp
@@ -1,0 +1,750 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "core/transport_manager.h"
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+#include "common/binary_codec.h"
+#include "control/control_channel.h"
+#include "control/control_protocol.h"
+#ifdef UCM_P2P_HAS_HIXL
+#include "protocols/hixl/hixl_transport.h"
+#endif
+#include "logger/logger.h"
+
+namespace transport {
+namespace {
+
+struct TransportMetadataRecord {
+    TransportProtocol protocol;
+    Metadata metadata;
+};
+
+struct PeerAdvertisement {
+    std::vector<TransportMetadataRecord> records;
+};
+
+Status EncodePeerAdvertisement(const PeerAdvertisement& advertisement, Metadata& out)
+{
+    if (advertisement.records.size() > UINT32_MAX) { return Status::InvalidParam(); }
+
+    out.clear();
+    if (!detail::AppendU32(out, static_cast<uint32_t>(advertisement.records.size()))) {
+        return Status::InvalidParam();
+    }
+
+    for (const auto& record : advertisement.records) {
+        if (!detail::AppendU32(out, static_cast<uint32_t>(record.protocol)) ||
+            !detail::AppendBytes(out, record.metadata)) {
+            return Status::InvalidParam();
+        }
+    }
+    return Status::OK();
+}
+
+Status DecodePeerAdvertisement(const Metadata& in, PeerAdvertisement& advertisement)
+{
+    size_t offset = 0;
+    uint32_t count = 0;
+    if (!detail::ReadU32(in, offset, count)) { return Status::InvalidParam(); }
+
+    advertisement.records.clear();
+    advertisement.records.reserve(count);
+    for (uint32_t i = 0; i < count; ++i) {
+        TransportMetadataRecord record;
+        uint32_t protocol = 0;
+        if (!detail::ReadU32(in, offset, protocol) ||
+            !detail::ReadBytes(in, offset, record.metadata)) {
+            return Status::InvalidParam();
+        }
+        record.protocol = static_cast<TransportProtocol>(protocol);
+        advertisement.records.push_back(std::move(record));
+    }
+
+    return offset == in.size() ? Status::OK() : Status::InvalidParam();
+}
+
+bool TransportForDirect(OperationDirect direct, TransportProtocol& protocol)
+{
+    if (direct != OperationDirect::RemoteDeviceHost) { return false; }
+    protocol = TransportProtocol::Hixl;
+    return true;
+}
+
+}  // namespace
+
+TransportManager::TransportManager(ManagerID manager_id) : manager_id_(std::move(manager_id)) {}
+
+TransportManager::~TransportManager()
+{
+    if (Shutdown() != Status::OK()) {}
+}
+
+Status TransportManager::Init()
+{
+    UC_DEBUG("transport manager init begin manager={}", manager_id_);
+    if (ParseManagerID(manager_id_, local_endpoint_) != Status::OK()) {
+        UC_ERROR("transport manager init failed: invalid manager id={}", manager_id_);
+        return Status::InvalidParam();
+    }
+    if (control_) {
+        UC_DEBUG("transport manager init skipped: already initialized manager={}", manager_id_);
+        return Status::OK();
+    }
+    control_ = std::make_shared<ControlChannel>();
+    auto status =
+        control_->Init(LocalEndpoint(), [this](const Metadata& request, Metadata& response) {
+            return HandleControlRequest(request, response);
+        });
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager control init failed manager={} status={}", manager_id_,
+                 status.Underlying());
+        control_.reset();
+        return status;
+    }
+    UC_DEBUG("transport manager init completed manager={}", manager_id_);
+    return Status::OK();
+}
+
+Status TransportManager::InstallTransport(TransportProtocol protocol, const InitAttrs& options)
+{
+    if (protocol_map_.find(protocol) != protocol_map_.end()) {
+        UC_DEBUG("transport manager install skipped protocol={}: already installed",
+                 static_cast<uint32_t>(protocol));
+        return Status::OK();
+    }
+
+    auto transport = CreateTransport(protocol);
+    if (!transport) {
+        UC_ERROR("transport manager install failed: unsupported protocol={}",
+                 static_cast<uint32_t>(protocol));
+        return Status::Unsupported();
+    }
+    const auto status = transport->Init(options);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager install failed protocol={} status={}",
+                 static_cast<uint32_t>(protocol), status.Underlying());
+        return status;
+    }
+
+    protocol_map_[protocol] = transport.get();
+    transports_.push_back(InstalledTransport{protocol, std::move(transport)});
+    UC_DEBUG("transport manager installed protocol={}", static_cast<uint32_t>(protocol));
+    return Status::OK();
+}
+
+TransportPtr TransportManager::CreateTransport(TransportProtocol protocol) const
+{
+#ifdef UCM_P2P_HAS_HIXL
+    if (protocol == TransportProtocol::Hixl) { return std::make_shared<HixlTransport>(); }
+#else
+    (void)protocol;
+#endif
+    return nullptr;
+}
+
+Status TransportManager::Shutdown()
+{
+    UC_DEBUG("transport manager shutdown begin manager={}", manager_id_);
+    Status result = Status::OK();
+    std::vector<std::pair<TransportProtocol, ManagerID>> connections;
+    {
+        std::lock_guard<std::recursive_mutex> lock(peer_mutex_);
+        shutting_down_ = true;
+        connections.assign(connections_.begin(), connections_.end());
+    }
+    for (const auto& connection : connections) {
+        const auto status = CoordinateConnectionWithPeer(ControlOperation::Disconnect,
+                                                         connection.first, connection.second);
+        if (status != Status::OK() && result == Status::OK()) { result = status; }
+    }
+
+    if (control_) { control_->Close(); }
+
+    for (auto& item : transports_) {
+        const auto status = item.transport->Shutdown();
+        if (status != Status::OK()) {
+            UC_ERROR("transport manager transport shutdown failed protocol={} status={}",
+                     static_cast<uint32_t>(item.protocol), status.Underlying());
+            if (result == Status::OK()) { result = status; }
+        }
+    }
+    memories_.clear();
+    {
+        std::lock_guard<std::mutex> lock(transfers_mutex_);
+        transfers_.clear();
+        next_transfer_handle_ = 1;
+    }
+    {
+        std::lock_guard<std::recursive_mutex> lock(peer_mutex_);
+        connections_.clear();
+    }
+    protocol_map_.clear();
+    transports_.clear();
+    UC_DEBUG("transport manager shutdown completed manager={} status={}", manager_id_,
+             result.Underlying());
+    return result;
+}
+
+Status TransportManager::ExchangeMetadata(const ManagerID& manager_id)
+{
+    UC_DEBUG("transport manager metadata exchange begin local={} peer={}", manager_id_, manager_id);
+    Endpoint endpoint;
+    auto status = ParseManagerID(manager_id, endpoint);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager metadata exchange invalid peer={} status={}", manager_id,
+                 status.Underlying());
+        return status;
+    }
+
+    if (manager_id == LocalEndpoint().ToString()) {
+        UC_DEBUG("transport manager metadata exchange skipped local peer={}", manager_id);
+        return Status::OK();
+    }
+
+    Metadata local;
+    status = ExportLocalMetadata(manager_id, local);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager metadata export failed peer={} status={}", manager_id,
+                 status.Underlying());
+        return status;
+    }
+    Metadata remote;
+    Metadata request;
+    status = EncodeControlRequest(ControlRequest{ControlOperation::ExchangeMetadata, std::nullopt,
+                                                 manager_id_, std::move(local)},
+                                  request);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager metadata request encode failed peer={} status={}", manager_id,
+                 status.Underlying());
+        return status;
+    }
+    status = control_->Request(endpoint, request, remote);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager metadata request failed peer={} status={}", manager_id,
+                 status.Underlying());
+        return status;
+    }
+    status = ImportMetadata(remote, manager_id);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager metadata import failed peer={} status={}", manager_id,
+                 status.Underlying());
+        return status;
+    }
+    UC_DEBUG("transport manager metadata exchange completed local={} peer={}", manager_id_,
+             manager_id);
+    return status;
+}
+
+Status TransportManager::ExportLocalMetadata(const ManagerID& manager_id, Metadata& out)
+{
+    if (transports_.size() > UINT32_MAX) {
+        UC_ERROR("transport manager metadata export failed peer={}: transport count={}", manager_id,
+                 transports_.size());
+        return Status::InvalidParam();
+    }
+
+    PeerAdvertisement advertisement;
+    advertisement.records.reserve(transports_.size());
+    for (const auto& item : transports_) {
+        Metadata metadata;
+        const auto status = item.transport->ExportMetadata(manager_id, metadata);
+        if (status != Status::OK()) {
+            UC_ERROR("transport manager metadata export failed protocol={} peer={} status={}",
+                     static_cast<uint32_t>(item.protocol), manager_id, status.Underlying());
+            return status;
+        }
+        advertisement.records.push_back(
+            TransportMetadataRecord{item.protocol, std::move(metadata)});
+    }
+    const auto status = EncodePeerAdvertisement(advertisement, out);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager advertisement encode failed peer={} status={}", manager_id,
+                 status.Underlying());
+    }
+    return status;
+}
+
+Status TransportManager::ImportMetadata(const Metadata& metadata, const ManagerID& manager_id)
+{
+    Endpoint endpoint;
+    if (ParseManagerID(manager_id, endpoint) != Status::OK() ||
+        metadata.size() < sizeof(uint32_t)) {
+        UC_ERROR("transport manager metadata import invalid peer={} bytes={}", manager_id,
+                 metadata.size());
+        return Status::InvalidParam();
+    }
+
+    PeerAdvertisement advertisement;
+    const auto decode_status = DecodePeerAdvertisement(metadata, advertisement);
+    if (decode_status != Status::OK()) {
+        UC_ERROR("transport manager advertisement decode failed peer={} bytes={} status={}",
+                 manager_id, metadata.size(), decode_status.Underlying());
+        return decode_status;
+    }
+
+    std::lock_guard<std::recursive_mutex> lock(peer_mutex_);
+    for (const auto& record : advertisement.records) {
+        const auto it = protocol_map_.find(record.protocol);
+        if (it == protocol_map_.end()) {
+            UC_DEBUG("transport manager metadata ignored unsupported protocol={} peer={}",
+                     static_cast<uint32_t>(record.protocol), manager_id);
+            continue;
+        }
+
+        const auto status = it->second->ImportMetadata(manager_id, record.metadata);
+        if (status != Status::OK()) {
+            UC_ERROR("transport manager metadata import failed protocol={} peer={} status={}",
+                     static_cast<uint32_t>(record.protocol), manager_id, status.Underlying());
+            return status;
+        }
+    }
+
+    return Status::OK();
+}
+
+Status TransportManager::HandleMetadataExchange(const ManagerID& manager_id,
+                                                const Metadata& remote_metadata,
+                                                Metadata& local_metadata)
+{
+    UC_DEBUG("transport manager handling metadata exchange local={} peer={} request_bytes={}",
+             manager_id_, manager_id, remote_metadata.size());
+    const auto status = ImportMetadata(remote_metadata, manager_id);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager handling metadata import failed peer={} status={}", manager_id,
+                 status.Underlying());
+        return status;
+    }
+    const auto export_status = ExportLocalMetadata(manager_id, local_metadata);
+    if (export_status != Status::OK()) {
+        UC_ERROR("transport manager handling metadata export failed peer={} status={}", manager_id,
+                 export_status.Underlying());
+        return export_status;
+    }
+    UC_DEBUG("transport manager handled metadata exchange local={} peer={} response_bytes={}",
+             manager_id_, manager_id, local_metadata.size());
+    return Status::OK();
+}
+
+Status TransportManager::HandleControlRequest(const Metadata& request, Metadata& response)
+{
+    ControlRequest control_request{};
+    auto status = DecodeControlRequest(request, control_request);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager control request decode failed local={} bytes={} status={}",
+                 manager_id_, request.size(), status.Underlying());
+        return status;
+    }
+
+    UC_DEBUG(
+        "transport manager control request decoded local={} operation={} protocol={} peer={}",
+        manager_id_, ControlOperationName(control_request.operation),
+        control_request.protocol.has_value() ? static_cast<int32_t>(*control_request.protocol) : -1,
+        control_request.manager_id);
+
+    if (control_request.operation == ControlOperation::ExchangeMetadata) {
+        return HandleMetadataExchange(control_request.manager_id, control_request.payload,
+                                      response);
+    }
+    if (!control_request.protocol.has_value()) {
+        UC_ERROR("transport manager control request missing protocol local={} operation={} peer={}",
+                 manager_id_, ControlOperationName(control_request.operation),
+                 control_request.manager_id);
+        return Status::InvalidParam();
+    }
+
+    const auto apply_status = ApplyConnectionLocally(
+        control_request.operation, *control_request.protocol, control_request.manager_id);
+    if (apply_status != Status::OK()) {
+        UC_ERROR(
+            "transport manager control request apply failed operation={} protocol={} peer={} "
+            "status={}",
+            ControlOperationName(control_request.operation),
+            static_cast<uint32_t>(*control_request.protocol), control_request.manager_id,
+            apply_status.Underlying());
+        return apply_status;
+    }
+    UC_DEBUG("transport manager control request applied operation={} protocol={} peer={}",
+             ControlOperationName(control_request.operation),
+             static_cast<uint32_t>(*control_request.protocol), control_request.manager_id);
+    return Status::OK();
+}
+
+Status TransportManager::RegisterMemory(const MemoryRegion& memory, MemoryHandle& handle)
+{
+    handle = kInvalidMemoryHandle;
+    if (memory.addr == nullptr || memory.length == 0) {
+        UC_ERROR("transport manager register memory invalid addr={} length={}", memory.addr,
+                 memory.length);
+        return Status::InvalidParam();
+    }
+    const auto address = detail::PtrToU64(memory.addr);
+    if (memory.length > std::numeric_limits<uint64_t>::max() - address) {
+        UC_ERROR("transport manager register memory address overflow addr=0x{:x} length={}",
+                 address, memory.length);
+        return Status::InvalidParam();
+    }
+    if (transports_.empty()) {
+        UC_ERROR("transport manager register memory failed: no installed transports");
+        return Status::Error();
+    }
+
+    auto record = std::make_unique<MemoryRecord>();
+    record->region = memory;
+    for (const auto& item : transports_) {
+        MemoryHandle transport_handle = kInvalidMemoryHandle;
+        auto status = item.transport->RegisterMemory(memory, transport_handle);
+        if (status == Status::OK() && transport_handle == kInvalidMemoryHandle) {
+            status = Status::Error();
+        }
+        if (status != Status::OK()) {
+            UC_ERROR(
+                "transport manager register memory failed protocol={} status={} handle={} "
+                "addr=0x{:x} length={}",
+                static_cast<int>(item.protocol), status.Underlying(), transport_handle,
+                detail::PtrToU64(memory.addr), memory.length);
+            continue;
+        }
+        record->transport_handles.emplace(item.protocol, transport_handle);
+    }
+    if (record->transport_handles.empty()) {
+        UC_ERROR(
+            "transport manager register memory failed: no transport accepted addr=0x{:x} "
+            "length={}",
+            detail::PtrToU64(memory.addr), memory.length);
+        return Status::Error();
+    }
+
+    handle = reinterpret_cast<MemoryHandle>(record.get());
+    memories_.emplace(handle, std::move(record));
+    UC_DEBUG("transport manager registered memory handle={} addr=0x{:x} length={}", handle, address,
+             memory.length);
+    return Status::OK();
+}
+
+Status TransportManager::UnregisterMemory(MemoryHandle handle)
+{
+    if (handle == kInvalidMemoryHandle) {
+        UC_ERROR("transport manager unregister memory invalid handle={}", handle);
+        return Status::InvalidParam();
+    }
+
+    const auto it = memories_.find(handle);
+    if (it == memories_.end()) {
+        UC_ERROR("transport manager unregister memory unknown handle={}", handle);
+        return Status::Error();
+    }
+
+    for (const auto& item : it->second->transport_handles) {
+        const auto transport_it = protocol_map_.find(item.first);
+        if (transport_it == protocol_map_.end()) {
+            UC_ERROR("transport manager unregister memory failed protocol={} handle={}",
+                     static_cast<int>(item.first), item.second);
+            return Status::Error();
+        }
+        const auto status = transport_it->second->UnregisterMemory(item.second);
+        if (status != Status::OK()) {
+            UC_ERROR("transport manager unregister memory failed protocol={} status={} handle={}",
+                     static_cast<int>(item.first), status.Underlying(), item.second);
+            return Status::Error();
+        }
+    }
+    memories_.erase(it);
+    UC_DEBUG("transport manager unregistered memory handle={}", handle);
+    return Status::OK();
+}
+
+Status TransportManager::FindTransport(Operation& batch, Transport*& transport)
+{
+    if (batch.target_manager.empty()) {
+        UC_ERROR("transport manager select transport failed: target manager is empty");
+        return Status::InvalidParam();
+    }
+    Endpoint endpoint;
+    if (ParseManagerID(batch.target_manager, endpoint) != Status::OK()) {
+        UC_ERROR("transport manager select transport failed: invalid peer={}",
+                 batch.target_manager);
+        return Status::InvalidParam();
+    }
+
+    TransportProtocol protocol = TransportProtocol::Hixl;
+    if (!TransportForDirect(batch.direct, protocol)) {
+        UC_ERROR("transport manager select transport failed: unsupported direction={} peer={}",
+                 static_cast<uint32_t>(batch.direct), batch.target_manager);
+        return Status::Error();
+    }
+    const auto transport_it = protocol_map_.find(protocol);
+    if (transport_it == protocol_map_.end()) {
+        UC_ERROR("transport manager select transport failed: protocol={} not installed peer={}",
+                 static_cast<uint32_t>(protocol), batch.target_manager);
+        return Status::Error();
+    }
+    transport = transport_it->second;
+    return Status::OK();
+}
+
+Status TransportManager::Connect(TransportProtocol protocol, const ManagerID& manager_id)
+{
+    return CoordinateConnectionWithPeer(ControlOperation::Connect, protocol, manager_id);
+}
+
+Status TransportManager::Disconnect(TransportProtocol protocol, const ManagerID& manager_id)
+{
+    return CoordinateConnectionWithPeer(ControlOperation::Disconnect, protocol, manager_id);
+}
+
+Status TransportManager::ApplyConnectionLocally(ControlOperation operation,
+                                                TransportProtocol protocol,
+                                                const ManagerID& manager_id)
+{
+    UC_DEBUG("transport manager local {} begin protocol={} peer={}",
+             ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id);
+    std::lock_guard<std::recursive_mutex> lock(peer_mutex_);
+    if (shutting_down_ && operation == ControlOperation::Connect) { return Status::Error(); }
+    Endpoint endpoint;
+    if (ParseManagerID(manager_id, endpoint) != Status::OK()) {
+        UC_ERROR("transport manager local {} invalid peer={} protocol={}",
+                 ControlOperationName(operation), manager_id, static_cast<uint32_t>(protocol));
+        return Status::InvalidParam();
+    }
+    const auto it = protocol_map_.find(protocol);
+    if (it == protocol_map_.end()) {
+        UC_ERROR("transport manager local {} unavailable protocol={} peer={}",
+                 ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id);
+        return Status::InvalidParam();
+    }
+    const auto status = operation == ControlOperation::Connect ? it->second->Connect(manager_id)
+                                                               : it->second->Disconnect(manager_id);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager local {} failed protocol={} peer={} status={}",
+                 ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id,
+                 status.Underlying());
+        return status;
+    }
+
+    const auto connection = std::make_pair(protocol, manager_id);
+    if (operation == ControlOperation::Connect) {
+        connections_.insert(connection);
+    } else {
+        connections_.erase(connection);
+    }
+    UC_DEBUG("transport manager local {} completed protocol={} peer={}",
+             ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id);
+    return Status::OK();
+}
+
+Status TransportManager::CoordinateConnectionWithPeer(ControlOperation operation,
+                                                      TransportProtocol protocol,
+                                                      const ManagerID& manager_id)
+{
+    UC_DEBUG("transport manager coordinate {} begin protocol={} peer={}",
+             ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id);
+    Endpoint endpoint;
+    if (ParseManagerID(manager_id, endpoint) != Status::OK()) {
+        UC_ERROR("transport manager coordinate {} invalid peer={} protocol={}",
+                 ControlOperationName(operation), manager_id, static_cast<uint32_t>(protocol));
+        return Status::InvalidParam();
+    }
+    if (!control_) {
+        UC_ERROR(
+            "transport manager coordinate {} failed: control channel is unavailable peer={} "
+            "protocol={}",
+            ControlOperationName(operation), manager_id, static_cast<uint32_t>(protocol));
+        return Status::InvalidParam();
+    }
+    if (protocol_map_.find(protocol) == protocol_map_.end()) {
+        UC_ERROR("transport manager coordinate {} unavailable protocol={} peer={}",
+                 ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id);
+        return Status::InvalidParam();
+    }
+
+    Metadata request;
+    auto status =
+        EncodeControlRequest(ControlRequest{operation, protocol, manager_id_, {}}, request);
+    if (status != Status::OK()) {
+        UC_ERROR(
+            "transport manager coordinate {} request encode failed protocol={} peer={} status={}",
+            ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id,
+            status.Underlying());
+        return status;
+    }
+
+    const auto local_status = ApplyConnectionLocally(operation, protocol, manager_id);
+    if (operation == ControlOperation::Connect && local_status != Status::OK()) {
+        UC_ERROR("transport manager local connect failed protocol={} peer={} status={}",
+                 static_cast<uint32_t>(protocol), manager_id, local_status.Underlying());
+        return local_status;
+    }
+
+    Metadata ack;
+    UC_DEBUG(
+        "transport manager coordinate {} requesting peer ACK protocol={} peer={} local_status={}",
+        ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id,
+        local_status.Underlying());
+    const auto remote_status = control_->Request(endpoint, request, ack);
+    if (local_status != Status::OK() || remote_status != Status::OK()) {
+        UC_ERROR("transport manager coordinated {} failed protocol={} peer={} local={} remote={}",
+                 operation == ControlOperation::Connect ? "connect" : "disconnect",
+                 static_cast<uint32_t>(protocol), manager_id, local_status.Underlying(),
+                 remote_status.Underlying());
+        if (operation == ControlOperation::Connect && remote_status != Status::OK()) {
+            const auto rollback_status =
+                ApplyConnectionLocally(ControlOperation::Disconnect, protocol, manager_id);
+            UC_WARN("transport manager rolled back local connect protocol={} peer={} status={}",
+                    static_cast<uint32_t>(protocol), manager_id, rollback_status.Underlying());
+        }
+        return local_status != Status::OK() ? local_status : remote_status;
+    }
+    UC_DEBUG("transport manager coordinated {} success protocol={} peer={} ack_bytes={}",
+             ControlOperationName(operation), static_cast<uint32_t>(protocol), manager_id,
+             ack.size());
+    return Status::OK();
+}
+
+Status TransportManager::ExecuteSync(const Operation& batch)
+{
+    UC_DEBUG("transport manager sync transfer begin peer={} segments={}", batch.target_manager,
+             batch.ops.size());
+    Transport* transport = nullptr;
+    auto request = batch;
+    auto status = FindTransport(request, transport);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager sync transfer selection failed peer={} status={}",
+                 batch.target_manager, status.Underlying());
+        return status;
+    }
+    status = transport->ExecuteSync(request);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager sync transfer failed peer={} segments={} status={}",
+                 batch.target_manager, batch.ops.size(), status.Underlying());
+        return status;
+    }
+    UC_DEBUG("transport manager sync transfer completed peer={} segments={}", batch.target_manager,
+             batch.ops.size());
+    return Status::OK();
+}
+
+Status TransportManager::ExecuteAsync(const Operation& batch, TransferHandle& handle)
+{
+    handle = kInvalidTransferHandle;
+    Transport* transport = nullptr;
+    auto request = batch;
+    auto status = FindTransport(request, transport);
+    if (status != Status::OK()) {
+        UC_ERROR("transport manager async transfer selection failed peer={} status={}",
+                 batch.target_manager, status.Underlying());
+        return status;
+    }
+
+    TransferHandle transport_handle = kInvalidTransferHandle;
+    status = transport->ExecuteAsync(request, transport_handle);
+    if (status != Status::OK() || transport_handle == kInvalidTransferHandle) {
+        UC_ERROR(
+            "transport manager async transfer submit failed peer={} segments={} status={} "
+            "transport_handle={}",
+            batch.target_manager, batch.ops.size(), status.Underlying(), transport_handle);
+        return status == Status::OK() ? Status::Error() : status;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(transfers_mutex_);
+        handle = next_transfer_handle_++;
+        if (handle == kInvalidTransferHandle) { handle = next_transfer_handle_++; }
+        transfers_.emplace(handle, TransferRecord{transport, transport_handle});
+    }
+    UC_DEBUG(
+        "transport manager async transfer submitted peer={} segments={} handle={} "
+        "transport_handle={}",
+        batch.target_manager, batch.ops.size(), handle, transport_handle);
+    return Status::OK();
+}
+
+Status TransportManager::GetStatus(TransferHandle handle, TransferStatus& transfer_status)
+{
+    if (handle == kInvalidTransferHandle) {
+        UC_ERROR("transport manager transfer status invalid handle={}", handle);
+        return Status::InvalidParam();
+    }
+    TransferRecord record;
+    {
+        std::lock_guard<std::mutex> lock(transfers_mutex_);
+        const auto it = transfers_.find(handle);
+        if (it == transfers_.end() || it->second.transport == nullptr) {
+            UC_ERROR("transport manager transfer status unknown handle={}", handle);
+            return Status::Error();
+        }
+        record = it->second;
+    }
+    const auto status = record.transport->GetStatus(record.transport_handle, transfer_status);
+    if (status != Status::OK()) {
+        UC_ERROR(
+            "transport manager transfer status query failed handle={} transport_handle={} "
+            "status={}",
+            handle, record.transport_handle, status.Underlying());
+    } else if (transfer_status != TransferStatus::Waiting) {
+        UC_DEBUG("transport manager transfer completed handle={} transport_handle={} status={}",
+                 handle, record.transport_handle, static_cast<uint32_t>(transfer_status));
+    }
+    if (status != Status::OK() || transfer_status != TransferStatus::Waiting) {
+        std::lock_guard<std::mutex> lock(transfers_mutex_);
+        transfers_.erase(handle);
+    }
+    return status;
+}
+
+Endpoint TransportManager::LocalEndpoint() const { return local_endpoint_; }
+
+Status TransportManager::ParseManagerID(const ManagerID& manager_id, Endpoint& endpoint) const
+{
+    const auto separator = manager_id.rfind(':');
+    if (separator == std::string::npos || separator == 0 || separator + 1 >= manager_id.size()) {
+        UC_ERROR("transport manager invalid manager id={}", manager_id);
+        return Status::InvalidParam();
+    }
+
+    const auto host = manager_id.substr(0, separator);
+    const auto port_text = manager_id.substr(separator + 1);
+    try {
+        size_t parsed = 0;
+        const auto port = std::stoul(port_text, &parsed, 10);
+        if (parsed != port_text.size() || port == 0 ||
+            port > std::numeric_limits<uint16_t>::max()) {
+            UC_ERROR("transport manager invalid manager port manager={} port={}", manager_id,
+                     port_text);
+            return Status::InvalidParam();
+        }
+        endpoint = Endpoint{host, static_cast<uint16_t>(port)};
+        return Status::OK();
+    } catch (const std::exception& error) {
+        UC_ERROR("transport manager failed to parse manager id={} error={}", manager_id,
+                 error.what());
+        return Status::InvalidParam();
+    }
+}
+
+}  // namespace transport

--- a/ucm/transport/p2p/src/protocols/hixl/hixl_instance.cpp
+++ b/ucm/transport/p2p/src/protocols/hixl/hixl_instance.cpp
@@ -1,0 +1,340 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "protocols/hixl/hixl_instance.h"
+#include <acl/acl.h>
+#include <exception>
+#include <utility>
+#include "hixl/hixl.h"
+#include "logger/logger.h"
+
+namespace transport {
+namespace {
+
+std::vector<hixl::TransferOpDesc> BuildTransferOpDesc(const std::vector<Segment>& segments)
+{
+    std::vector<hixl::TransferOpDesc> descs;
+    descs.reserve(segments.size());
+    for (const auto& segment : segments) {
+        descs.push_back(hixl::TransferOpDesc{
+            reinterpret_cast<uintptr_t>(segment.local_addr),
+            static_cast<uintptr_t>(segment.remote_addr),
+            static_cast<size_t>(segment.length),
+        });
+    }
+    return descs;
+}
+
+}  // namespace
+
+HixlInstance::HixlInstance(Endpoint local_endpoint, int32_t device_id)
+    : local_endpoint_(std::move(local_endpoint)), device_id_(device_id)
+{
+}
+
+HixlInstance::~HixlInstance() { Finalize(); }
+
+Status HixlInstance::Initialize(const std::map<std::string, std::string>& options)
+{
+    std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (initialized_) {
+            UC_DEBUG("[Transport][HIXL] instance already initialized: engine={} device={}",
+                     local_endpoint_.ToString(), device_id_);
+            return Status::OK();
+        }
+        stopping_ = false;
+    }
+    if (worker_.joinable()) { worker_.join(); }
+
+    std::promise<Status> initialize_result;
+    auto initialize_future = initialize_result.get_future();
+    worker_ = std::thread(&HixlInstance::WorkerMain, this, options, std::move(initialize_result));
+    const auto status = initialize_future.get();
+    if (status != Status::OK() && worker_.joinable()) { worker_.join(); }
+    return status;
+}
+
+Status HixlInstance::Run(Task task)
+{
+    QueuedTask queued(std::move(task));
+    auto result = queued.get_future();
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!initialized_ || stopping_) {
+            UC_ERROR(
+                "[Transport][HIXL] reject worker task: engine={} device={} initialized={} "
+                "stopping={}",
+                local_endpoint_.ToString(), device_id_, initialized_, stopping_);
+            return Status::Error();
+        }
+        tasks_.push_back(std::move(queued));
+    }
+    cv_.notify_one();
+    try {
+        return result.get();
+    } catch (const std::exception& e) {
+        UC_ERROR("[Transport][HIXL] worker task failed: {}", e.what());
+    } catch (...) {
+        UC_ERROR("[Transport][HIXL] worker task failed with unknown exception");
+    }
+    return Status::Error();
+}
+
+void HixlInstance::Finalize()
+{
+    std::lock_guard<std::mutex> lifecycle_lock(lifecycle_mutex_);
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!worker_.joinable()) { return; }
+        stopping_ = true;
+    }
+    cv_.notify_one();
+    worker_.join();
+}
+
+void HixlInstance::WorkerMain(std::map<std::string, std::string> options,
+                              std::promise<Status> initialize_result)
+{
+    const auto set_device_status = aclrtSetDevice(device_id_);
+    if (set_device_status != ACL_ERROR_NONE) {
+        UC_ERROR("[Transport][HIXL] set device failed: aclrtSetDevice({}) returned {}", device_id_,
+                 static_cast<int>(set_device_status));
+        initialize_result.set_value(Status::Error());
+        return;
+    }
+
+    {
+        hixl::Hixl engine;
+        std::map<hixl::AscendString, hixl::AscendString> hixl_options;
+        for (const auto& item : options) {
+            hixl_options.emplace(item.first.c_str(), item.second.c_str());
+        }
+
+        const auto local_engine = local_endpoint_.ToString();
+        const auto init_status = engine.Initialize(local_engine.c_str(), hixl_options);
+        if (init_status != hixl::SUCCESS) {
+            UC_ERROR("[Transport][HIXL] init failed: Initialize(\"{}\") returned {}", local_engine,
+                     static_cast<int>(init_status));
+            initialize_result.set_value(Status::Error());
+        } else {
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                initialized_ = true;
+            }
+            initialize_result.set_value(Status::OK());
+            UC_DEBUG("[Transport][HIXL] instance initialized: engine={} device={}", local_engine,
+                     device_id_);
+            ProcessTasks(engine);
+            engine.Finalize();
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        initialized_ = false;
+    }
+    const auto reset_device_status = aclrtResetDevice(device_id_);
+    if (reset_device_status != ACL_ERROR_NONE) {
+        UC_WARN("[Transport][HIXL] reset device failed: aclrtResetDevice({}) returned {}",
+                device_id_, static_cast<int>(reset_device_status));
+    }
+}
+
+void HixlInstance::ProcessTasks(hixl::Hixl& engine)
+{
+    for (;;) {
+        QueuedTask queued;
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            cv_.wait(lock, [this] { return stopping_ || !tasks_.empty(); });
+            if (stopping_ && tasks_.empty()) { break; }
+            queued = std::move(tasks_.front());
+            tasks_.pop_front();
+        }
+        queued(engine);
+    }
+}
+
+Status HixlInstance::RegisterMemory(const MemoryRegion& memory, hixl::MemHandle& handle)
+{
+    hixl::MemHandle native_handle = nullptr;
+    const auto status = Run([&](hixl::Hixl& engine) {
+        hixl::MemDesc desc{};
+        desc.addr = reinterpret_cast<uintptr_t>(memory.addr);
+        desc.len = static_cast<size_t>(memory.length);
+        const auto type = memory.type == MemoryType::Device ? hixl::MEM_DEVICE : hixl::MEM_HOST;
+        const auto native_status = engine.RegisterMem(desc, type, native_handle);
+        if (native_status != hixl::SUCCESS) {
+            UC_ERROR(
+                "[Transport][HIXL] register memory failed: engine={} device={} "
+                "RegisterMem(addr=0x{:x}, length={}) returned {}",
+                local_endpoint_.ToString(), device_id_, reinterpret_cast<uintptr_t>(memory.addr),
+                memory.length, static_cast<int>(native_status));
+            return Status::Error();
+        }
+        UC_DEBUG(
+            "[Transport][HIXL] memory registered: engine={} device={} addr=0x{:x} length={} "
+            "handle={}",
+            local_endpoint_.ToString(), device_id_, reinterpret_cast<uintptr_t>(memory.addr),
+            memory.length, native_handle);
+        return Status::OK();
+    });
+    if (status == Status::OK()) { handle = native_handle; }
+    return status;
+}
+
+Status HixlInstance::UnregisterMemory(hixl::MemHandle handle)
+{
+    return Run([&](hixl::Hixl& engine) {
+        const auto native_status = engine.DeregisterMem(handle);
+        if (native_status != hixl::SUCCESS) {
+            UC_ERROR(
+                "[Transport][HIXL] unregister memory failed: engine={} DeregisterMem(handle={}) "
+                "returned {}",
+                local_endpoint_.ToString(), handle, static_cast<int>(native_status));
+            return Status::Error();
+        }
+        UC_DEBUG("[Transport][HIXL] memory unregistered: engine={} device={} handle={}",
+                 local_endpoint_.ToString(), device_id_, handle);
+        return Status::OK();
+    });
+}
+
+Status HixlInstance::Connect(const std::string& remote_engine, int32_t timeout_ms)
+{
+    return Run([&](hixl::Hixl& engine) {
+        const auto native_status = engine.Connect(remote_engine.c_str(), timeout_ms);
+        if (native_status != hixl::SUCCESS) {
+            UC_ERROR(
+                "[Transport][HIXL] connect failed: local_engine=\"{}\" remote_engine=\"{}\" "
+                "returned {}",
+                local_endpoint_.ToString(), remote_engine, static_cast<int>(native_status));
+            return Status::Error();
+        }
+        UC_DEBUG(
+            "[Transport][HIXL] connection established: local_engine={} device={} "
+            "remote_engine={}",
+            local_endpoint_.ToString(), device_id_, remote_engine);
+        return Status::OK();
+    });
+}
+
+Status HixlInstance::Disconnect(const std::string& remote_engine, int32_t timeout_ms)
+{
+    return Run([&](hixl::Hixl& engine) {
+        const auto native_status = engine.Disconnect(remote_engine.c_str(), timeout_ms);
+        if (native_status != hixl::SUCCESS) {
+            UC_ERROR(
+                "[Transport][HIXL] disconnect failed: local_engine={} device={} "
+                "remote_engine={} returned {}",
+                local_endpoint_.ToString(), device_id_, remote_engine,
+                static_cast<int>(native_status));
+            return Status::Error();
+        }
+        UC_DEBUG(
+            "[Transport][HIXL] connection disconnected: local_engine={} device={} "
+            "remote_engine={}",
+            local_endpoint_.ToString(), device_id_, remote_engine);
+        return Status::OK();
+    });
+}
+
+Status HixlInstance::TransferSync(const std::string& remote_engine, Opcode opcode,
+                                  const std::vector<Segment>& segments, int32_t timeout_ms)
+{
+    return Run([&](hixl::Hixl& engine) {
+        const auto descs = BuildTransferOpDesc(segments);
+        const auto operation = opcode == Opcode::Read ? hixl::READ : hixl::WRITE;
+        const auto native_status =
+            engine.TransferSync(remote_engine.c_str(), operation, descs, timeout_ms);
+        if (native_status != hixl::SUCCESS) {
+            UC_ERROR(
+                "[Transport][HIXL] operation failed: TransferSync(\"{}\", ops={}, timeout_ms={}) "
+                "returned {}",
+                remote_engine, descs.size(), timeout_ms, static_cast<int>(native_status));
+            return Status::Error();
+        }
+        UC_DEBUG(
+            "[Transport][HIXL] synchronous transfer completed: engine={} remote_engine={} "
+            "opcode={} segments={}",
+            local_endpoint_.ToString(), remote_engine, static_cast<int>(opcode), descs.size());
+        return Status::OK();
+    });
+}
+
+Status HixlInstance::TransferAsync(const std::string& remote_engine, Opcode opcode,
+                                   const std::vector<Segment>& segments, hixl::TransferReq& request)
+{
+    hixl::TransferReq native_request = nullptr;
+    const auto status = Run([&](hixl::Hixl& engine) {
+        const auto descs = BuildTransferOpDesc(segments);
+        hixl::TransferArgs args;
+        const auto operation = opcode == Opcode::Read ? hixl::READ : hixl::WRITE;
+        const auto native_status =
+            engine.TransferAsync(remote_engine.c_str(), operation, descs, args, native_request);
+        if (native_status != hixl::SUCCESS || native_request == nullptr) {
+            UC_ERROR(
+                "[Transport][HIXL] async operation failed: TransferAsync(\"{}\", ops={}) returned "
+                "{} request={}",
+                remote_engine, descs.size(), static_cast<int>(native_status), native_request);
+            return Status::Error();
+        }
+        UC_DEBUG(
+            "[Transport][HIXL] asynchronous transfer submitted: engine={} remote_engine={} "
+            "opcode={} segments={} request={}",
+            local_endpoint_.ToString(), remote_engine, static_cast<int>(opcode), descs.size(),
+            native_request);
+        return Status::OK();
+    });
+    if (status == Status::OK()) { request = native_request; }
+    return status;
+}
+
+Status HixlInstance::GetTransferStatus(hixl::TransferReq request, TransferStatus& status)
+{
+    status = TransferStatus::Failed;
+    return Run([&](hixl::Hixl& engine) {
+        hixl::TransferStatus native_transfer_status = hixl::TransferStatus::WAITING;
+        const auto native_status = engine.GetTransferStatus(request, native_transfer_status);
+        if (native_status != hixl::SUCCESS) {
+            UC_ERROR("[Transport][HIXL] get transfer status failed: req={} returned {}", request,
+                     static_cast<int>(native_status));
+            return Status::Error();
+        }
+        switch (native_transfer_status) {
+            case hixl::TransferStatus::WAITING: status = TransferStatus::Waiting; break;
+            case hixl::TransferStatus::COMPLETED: status = TransferStatus::Completed; break;
+            case hixl::TransferStatus::FAILED:
+            case hixl::TransferStatus::TIMEOUT: status = TransferStatus::Failed; break;
+        }
+        return Status::OK();
+    });
+}
+
+const Endpoint& HixlInstance::LocalEndpoint() const { return local_endpoint_; }
+
+int32_t HixlInstance::DeviceId() const { return device_id_; }
+
+}  // namespace transport

--- a/ucm/transport/p2p/src/protocols/hixl/hixl_instance.h
+++ b/ucm/transport/p2p/src/protocols/hixl/hixl_instance.h
@@ -1,0 +1,94 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <future>
+#include <map>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+#include "core/transport.h"
+#include "hixl/hixl_types.h"
+
+namespace hixl {
+class Hixl;
+}
+
+namespace transport {
+
+// Owns one HIXL engine and serializes its operations on a dedicated worker thread.
+class HixlInstance final {
+public:
+    HixlInstance(Endpoint local_endpoint, int32_t device_id);
+    ~HixlInstance();
+
+    HixlInstance(const HixlInstance&) = delete;
+    HixlInstance& operator=(const HixlInstance&) = delete;
+
+    Status Initialize(const std::map<std::string, std::string>& options);
+    void Finalize();
+
+    Status RegisterMemory(const MemoryRegion& memory, hixl::MemHandle& handle);
+    Status UnregisterMemory(hixl::MemHandle handle);
+    Status Connect(const std::string& remote_engine, int32_t timeout_ms);
+    Status Disconnect(const std::string& remote_engine, int32_t timeout_ms);
+    Status TransferSync(const std::string& remote_engine, Opcode opcode,
+                        const std::vector<Segment>& segments, int32_t timeout_ms);
+    Status TransferAsync(const std::string& remote_engine, Opcode opcode,
+                         const std::vector<Segment>& segments, hixl::TransferReq& request);
+    Status GetTransferStatus(hixl::TransferReq request, TransferStatus& status);
+
+    const Endpoint& LocalEndpoint() const;
+    int32_t DeviceId() const;
+
+private:
+    using Task = std::function<Status(hixl::Hixl&)>;
+    using QueuedTask = std::packaged_task<Status(hixl::Hixl&)>;
+
+    Status Run(Task task);
+    void WorkerMain(std::map<std::string, std::string> options,
+                    std::promise<Status> initialize_result);
+    void ProcessTasks(hixl::Hixl& engine);
+
+    Endpoint local_endpoint_;
+    int32_t device_id_ = -1;
+    std::thread worker_;
+
+    // Serializes Initialize and Finalize, including worker creation and join.
+    std::mutex lifecycle_mutex_;
+
+    // Protects tasks_, stopping_, and initialized_; cv_ coordinates state changes.
+    std::mutex mutex_;
+    std::condition_variable cv_;
+    std::deque<QueuedTask> tasks_;
+    bool stopping_ = false;
+    bool initialized_ = false;
+};
+
+}  // namespace transport

--- a/ucm/transport/p2p/src/protocols/hixl/hixl_transport.cpp
+++ b/ucm/transport/p2p/src/protocols/hixl/hixl_transport.cpp
@@ -1,0 +1,746 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "protocols/hixl/hixl_transport.h"
+#include <arpa/inet.h>
+#include <limits>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <string>
+#include <sys/socket.h>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+#include "common/binary_codec.h"
+#include "logger/logger.h"
+#include "protocols/hixl/hixl_instance.h"
+
+namespace transport {
+namespace {
+
+Status PickAvailablePort(const std::string& host, uint16_t& port)
+{
+    addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    addrinfo* results = nullptr;
+    if (getaddrinfo(host.c_str(), "0", &hints, &results) != 0) {
+        UC_ERROR("[Transport][HIXL] resolve host for available port failed: host={}", host);
+        return Status::Error();
+    }
+
+    Status status = Status::Error();
+    for (auto* item = results; item != nullptr; item = item->ai_next) {
+        const int candidate = socket(item->ai_family, item->ai_socktype, item->ai_protocol);
+        if (candidate < 0) { continue; }
+
+        if (bind(candidate, item->ai_addr, item->ai_addrlen) == 0) {
+            sockaddr_storage address{};
+            socklen_t address_length = sizeof(address);
+            if (getsockname(candidate, reinterpret_cast<sockaddr*>(&address), &address_length) ==
+                0) {
+                if (address.ss_family == AF_INET) {
+                    port = ntohs(reinterpret_cast<sockaddr_in*>(&address)->sin_port);
+                    status = port == 0 ? Status::Error() : Status::OK();
+                } else if (address.ss_family == AF_INET6) {
+                    port = ntohs(reinterpret_cast<sockaddr_in6*>(&address)->sin6_port);
+                    status = port == 0 ? Status::Error() : Status::OK();
+                }
+            }
+        }
+
+        close(candidate);
+        if (status == Status::OK()) { break; }
+    }
+
+    freeaddrinfo(results);
+    if (status != Status::OK()) {
+        UC_ERROR("[Transport][HIXL] no available port found: host={}", host);
+    }
+    return status;
+}
+
+Status EncodeMetadata(HixlRole role, const std::vector<HixlInstanceInfo>& instances, Metadata& out)
+{
+    if (instances.empty() || instances.size() > std::numeric_limits<uint32_t>::max()) {
+        UC_ERROR("[Transport][HIXL] encode metadata failed: instances={}", instances.size());
+        return Status::InvalidParam();
+    }
+
+    out.clear();
+    if (!detail::AppendU8(out, static_cast<uint8_t>(role)) ||
+        !detail::AppendU32(out, static_cast<uint32_t>(instances.size()))) {
+        UC_ERROR("[Transport][HIXL] encode metadata header failed: role={} instances={}",
+                 static_cast<uint32_t>(role), instances.size());
+        return Status::InvalidParam();
+    }
+    for (const auto& instance : instances) {
+        if (instance.device_id < 0 || !detail::AppendString(out, instance.endpoint.host) ||
+            !detail::AppendU16(out, instance.endpoint.port) ||
+            !detail::AppendU32(out, static_cast<uint32_t>(instance.device_id))) {
+            UC_ERROR("[Transport][HIXL] encode instance metadata failed: engine={} device={}",
+                     instance.endpoint.ToString(), instance.device_id);
+            return Status::InvalidParam();
+        }
+    }
+    return Status::OK();
+}
+
+Status DecodeMetadata(const Metadata& in, HixlRole& role, std::vector<HixlInstanceInfo>& instances)
+{
+    size_t offset = 0;
+    uint8_t raw_role = 0;
+    uint32_t count = 0;
+    if (!detail::ReadU8(in, offset, raw_role) ||
+        raw_role > static_cast<uint8_t>(HixlRole::Bidirectional) ||
+        !detail::ReadU32(in, offset, count) || count == 0) {
+        UC_ERROR("[Transport][HIXL] decode metadata header failed: bytes={}", in.size());
+        return Status::InvalidParam();
+    }
+    role = static_cast<HixlRole>(raw_role);
+
+    instances.clear();
+    instances.reserve(count);
+    for (uint32_t i = 0; i < count; ++i) {
+        HixlInstanceInfo instance;
+        uint32_t device_id = 0;
+        if (!detail::ReadString(in, offset, instance.endpoint.host) ||
+            !detail::ReadU16(in, offset, instance.endpoint.port) ||
+            !detail::ReadU32(in, offset, device_id) ||
+            device_id > static_cast<uint32_t>(std::numeric_limits<int32_t>::max())) {
+            UC_ERROR("[Transport][HIXL] decode instance metadata failed: index={} bytes={}", i,
+                     in.size());
+            return Status::InvalidParam();
+        }
+        instance.device_id = static_cast<int32_t>(device_id);
+        instances.push_back(std::move(instance));
+    }
+    if (offset != in.size()) {
+        UC_ERROR("[Transport][HIXL] decode metadata has trailing bytes: consumed={} total={}",
+                 offset, in.size());
+        return Status::InvalidParam();
+    }
+    return Status::OK();
+}
+
+}  // namespace
+
+HixlTransport::HixlTransport() = default;
+
+HixlTransport::~HixlTransport()
+{
+    if (Shutdown() != Status::OK()) {}
+}
+
+TransportProtocol HixlTransport::Protocol() const { return TransportProtocol::Hixl; }
+
+Status HixlTransport::Init(const InitAttrs& attrs)
+{
+    const auto* hixl_attrs = dynamic_cast<const HixlInitAttrs*>(&attrs);
+    if (hixl_attrs == nullptr) {
+        UC_ERROR("[Transport][HIXL] init failed: invalid attribute type");
+        return Status::InvalidParam();
+    }
+    return Init(*hixl_attrs);
+}
+
+Status HixlTransport::Init(const HixlInitAttrs& attrs)
+{
+    if (!instances_.empty()) {
+        UC_DEBUG("[Transport][HIXL] transport already initialized: instances={}",
+                 instances_.size());
+        return Status::OK();
+    }
+    if (attrs.instances.empty()) {
+        UC_ERROR("[Transport][HIXL] init failed: no instances configured");
+        return Status::InvalidParam();
+    }
+    if (attrs.role != HixlRole::Client && attrs.instances.size() > 1) {
+        UC_ERROR(
+            "[Transport][HIXL] only Client role supports multiple instances: role={} "
+            "instances={}",
+            static_cast<uint32_t>(attrs.role), attrs.instances.size());
+        return Status::InvalidParam();
+    }
+
+    for (size_t i = 0; i < attrs.instances.size(); ++i) {
+        const auto& instance_attrs = attrs.instances[i];
+        Endpoint local_endpoint;
+        local_endpoint.host = attrs.ip;
+        if (attrs.role == HixlRole::Client) {
+            local_endpoint.port = 0;
+        } else if (instance_attrs.port < 0) {
+            const auto status = PickAvailablePort(local_endpoint.host, local_endpoint.port);
+            if (status != Status::OK()) {
+                UC_ERROR("[Transport][HIXL] pick available port failed: host={}",
+                         local_endpoint.host);
+                return status;
+            }
+        } else if (instance_attrs.port > 0 &&
+                   instance_attrs.port <=
+                       static_cast<int32_t>(std::numeric_limits<uint16_t>::max())) {
+            local_endpoint.port = static_cast<uint16_t>(instance_attrs.port);
+        } else {
+            UC_ERROR("[Transport][HIXL] invalid port: port={}", instance_attrs.port);
+            return Status::InvalidParam();
+        }
+        UC_DEBUG("[Transport][HIXL] init instance={} role={} engine={} device={} options={}", i,
+                 static_cast<uint32_t>(attrs.role), local_endpoint.ToString(),
+                 instance_attrs.device_id, instance_attrs.options.size());
+
+        instances_.push_back(
+            std::make_unique<HixlInstance>(std::move(local_endpoint), instance_attrs.device_id));
+    }
+
+    connect_timeout_ms_ = attrs.connect_timeout_ms;
+    transfer_timeout_ms_ = attrs.transfer_timeout_ms;
+    role_ = attrs.role;
+
+    for (size_t i = 0; i < instances_.size(); ++i) {
+        const auto status = instances_[i]->Initialize(attrs.instances[i].options);
+        if (status != Status::OK()) {
+            UC_ERROR("[Transport][HIXL] instance init failed: instance={} device={} status={}", i,
+                     attrs.instances[i].device_id, status);
+            for (auto& instance : instances_) { instance->Finalize(); }
+            instances_.clear();
+            return status;
+        }
+    }
+    UC_DEBUG("[Transport][HIXL] init success role={} instances={}", static_cast<uint32_t>(role_),
+             instances_.size());
+    return Status::OK();
+}
+
+Status HixlTransport::Shutdown()
+{
+    std::unique_lock<std::shared_mutex> lock(lifecycle_mutex_);
+    Status result = Status::OK();
+    for (auto& item : peers_) {
+        auto& peer = item.second;
+        if (peer.local_index >= instances_.size() || !peer.connected) { continue; }
+        const auto status = DisconnectRoute(peer, true);
+        if (status != Status::OK() && result == Status::OK()) { result = status; }
+        peer.connected = false;
+    }
+
+    for (const auto& memory : memories_) {
+        for (const auto& handle : memory.second->native_handles) {
+            if (handle.first >= instances_.size() || handle.second == nullptr) { continue; }
+            const auto status = instances_[handle.first]->UnregisterMemory(handle.second);
+            if (status != Status::OK() && result == Status::OK()) { result = status; }
+        }
+    }
+
+    for (auto& instance : instances_) { instance->Finalize(); }
+    instances_.clear();
+    peers_.clear();
+    memories_.clear();
+    pending_transfers_.clear();
+    next_transfer_handle_ = 1;
+    return result;
+}
+
+Status HixlTransport::RegisterMemory(const MemoryRegion& memory, MemoryHandle& handle)
+{
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    handle = kInvalidMemoryHandle;
+    if (instances_.empty()) {
+        UC_ERROR("[Transport][HIXL] register memory failed: transport is not initialized");
+        return Status::Error();
+    }
+
+    std::unique_lock<std::shared_mutex> memory_lock(memories_mutex_);
+
+    auto record = std::make_unique<LocalMemoryRecord>();
+    record->region = memory;
+
+    for (size_t i = 0; i < instances_.size(); ++i) {
+        if (memory.type == MemoryType::Device && instances_[i]->DeviceId() != memory.device_id) {
+            continue;
+        }
+
+        hixl::MemHandle native_handle = nullptr;
+        const auto status = instances_[i]->RegisterMemory(memory, native_handle);
+        if (status != Status::OK() || native_handle == nullptr) {
+            for (const auto& item : record->native_handles) {
+                if (instances_[item.first]->UnregisterMemory(item.second) != Status::OK()) {
+                    UC_ERROR(
+                        "[Transport][HIXL] rollback memory registration failed: instance={} "
+                        "handle={}",
+                        item.first, item.second);
+                }
+            }
+            return status == Status::OK() ? Status::Error() : status;
+        }
+        record->native_handles.emplace(i, native_handle);
+    }
+
+    if (record->native_handles.empty()) {
+        UC_ERROR(
+            "[Transport][HIXL] register memory failed: no matching instance, type={} device={}",
+            static_cast<int>(memory.type), memory.device_id);
+        return Status::InvalidParam();
+    }
+    handle = reinterpret_cast<MemoryHandle>(record.get());
+    memories_.emplace(handle, std::move(record));
+    UC_DEBUG("[Transport][HIXL] memory registration completed: handle={} addr={} length={}", handle,
+             memory.addr, memory.length);
+    return Status::OK();
+}
+
+Status HixlTransport::UnregisterMemory(MemoryHandle handle)
+{
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    if (handle == kInvalidMemoryHandle) {
+        UC_ERROR("[Transport][HIXL] unregister memory failed: invalid handle");
+        return Status::InvalidParam();
+    }
+
+    std::unique_lock<std::shared_mutex> memory_lock(memories_mutex_);
+    const auto record_it = memories_.find(handle);
+    if (record_it == memories_.end()) {
+        UC_ERROR("[Transport][HIXL] unregister memory failed: unknown handle={}", handle);
+        return Status::Error();
+    }
+    auto& record = *record_it->second;
+    while (!record.native_handles.empty()) {
+        const auto item = *record.native_handles.begin();
+        if (item.first >= instances_.size() || item.second == nullptr) {
+            UC_ERROR("[Transport][HIXL] unregister memory failed: handle={} instance={} native={}",
+                     handle, item.first, item.second);
+            return Status::Error();
+        }
+        const auto status = instances_[item.first]->UnregisterMemory(item.second);
+        if (status != Status::OK()) { return status; }
+        record.native_handles.erase(item.first);
+    }
+    memories_.erase(record_it);
+    UC_DEBUG("[Transport][HIXL] memory unregistration completed: handle={}", handle);
+    return Status::OK();
+}
+
+Status HixlTransport::ExportMetadata(const ManagerID&, Metadata& out)
+{
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    std::vector<HixlInstanceInfo> metadata;
+    metadata.reserve(instances_.size());
+    for (const auto& instance : instances_) {
+        metadata.push_back(HixlInstanceInfo{instance->LocalEndpoint(), instance->DeviceId()});
+    }
+    return EncodeMetadata(role_, metadata, out);
+}
+
+Status HixlTransport::ImportMetadata(const ManagerID& manager_id, const Metadata& metadata)
+{
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    std::vector<HixlInstanceInfo> remote_instances;
+    HixlRole remote_role = HixlRole::Bidirectional;
+    const auto status = DecodeMetadata(metadata, remote_role, remote_instances);
+    if (status != Status::OK()) {
+        UC_ERROR("[Transport][HIXL] import metadata failed: peer={} status={}", manager_id, status);
+        return status;
+    }
+
+    {
+        std::unique_lock<std::shared_mutex> peer_lock(peers_mutex_);
+        const auto peer_it = peers_.find(manager_id);
+        if (peer_it != peers_.end()) {
+            // A second metadata exchange means the previous remote instance has stopped, even
+            // when the new instance uses the same endpoint and device identifiers.
+            if (peer_it->second.connected &&
+                DisconnectRoute(peer_it->second, true) != Status::OK()) {
+                UC_ERROR("[Transport][HIXL] cleanup stale route failed: peer={}", manager_id);
+            }
+            peers_.erase(peer_it);
+        }
+
+        Peer peer_state;
+        peer_state.role = remote_role;
+        peer_state.instances = std::move(remote_instances);
+        if (peer_state.instances.size() > 1) {
+            UC_DEBUG(
+                "[Transport][HIXL] import peer metadata with multiple remote instances: peer={} "
+                "remote_instances={}, use first instance for transfer route",
+                manager_id, peer_state.instances.size());
+        }
+        const auto route_status = BuildRouteLocked(manager_id, peer_state);
+        if (route_status != Status::OK()) { return route_status; }
+
+        peers_[manager_id] = std::move(peer_state);
+    }
+    return Status::OK();
+}
+
+Status HixlTransport::BuildRouteLocked(const ManagerID& manager_id, Peer& peer)
+{
+    peer.local_index = SIZE_MAX;
+    peer.connected = false;
+    if (instances_.empty() || peer.instances.empty()) {
+        UC_ERROR("[Transport][HIXL] build route failed: peer={} remote_instances={}", manager_id,
+                 peer.instances.size());
+        return Status::InvalidParam();
+    }
+
+    const auto& remote = peer.instances.front();
+    const bool initiates_connection = role_ != HixlRole::Server && peer.role != HixlRole::Client;
+    const auto local_count = instances_.size();
+    if (local_count == 1) {
+        if (initiates_connection && peer.instances.size() == 1 &&
+            instances_.front()->LocalEndpoint().host == remote.endpoint.host &&
+            instances_.front()->DeviceId() == remote.device_id) {
+            UC_ERROR(
+                "[Transport][HIXL] build route failed: local and remote single instances use "
+                "the same device, endpoint={} device={}",
+                remote.endpoint.ToString(), remote.device_id);
+            return Status::Error();
+        }
+        peer.local_index = 0;
+        UC_DEBUG(
+            "[Transport][HIXL] build route peer={} local_instance=0 local_engine={} "
+            "local_device={} remote_engine={} remote_device={}",
+            manager_id, instances_.front()->LocalEndpoint().ToString(),
+            instances_.front()->DeviceId(), remote.endpoint.ToString(), remote.device_id);
+        return Status::OK();
+    }
+
+    std::vector<size_t> load(local_count, 0);
+    for (const auto& item : peers_) {
+        if (item.first == manager_id) { continue; }
+        if (item.second.local_index < load.size()) { ++load[item.second.local_index]; }
+    }
+
+    std::vector<size_t> candidates;
+    size_t min_load = std::numeric_limits<size_t>::max();
+    for (size_t local_index = 0; local_index < local_count; ++local_index) {
+        if (initiates_connection &&
+            instances_[local_index]->LocalEndpoint().host == remote.endpoint.host &&
+            instances_[local_index]->DeviceId() == remote.device_id) {
+            continue;
+        }
+        if (load[local_index] < min_load) {
+            candidates.clear();
+            min_load = load[local_index];
+        }
+        if (load[local_index] == min_load) { candidates.push_back(local_index); }
+    }
+    if (candidates.empty()) {
+        UC_ERROR(
+            "[Transport][HIXL] build route failed: no valid local instance for endpoint={} "
+            "device={}",
+            remote.endpoint.ToString(), remote.device_id);
+        return Status::Error();
+    }
+
+    const auto local_index = candidates.front();
+    peer.local_index = local_index;
+    UC_DEBUG(
+        "[Transport][HIXL] build route peer={} local_instance={} local_engine={} "
+        "local_device={} remote_engine={} remote_device={}",
+        manager_id, local_index, instances_[local_index]->LocalEndpoint().ToString(),
+        instances_[local_index]->DeviceId(), remote.endpoint.ToString(), remote.device_id);
+    return Status::OK();
+}
+
+Status HixlTransport::DisconnectRoute(const Peer& peer, bool ignore_failure)
+{
+    if (peer.local_index >= instances_.size() || peer.instances.empty()) {
+        UC_ERROR(
+            "[Transport][HIXL] disconnect route failed: local_instance={} local_count={} "
+            "remote_count={}",
+            peer.local_index, instances_.size(), peer.instances.size());
+        return Status::Error();
+    }
+    if (role_ == HixlRole::Server || peer.role == HixlRole::Client) { return Status::OK(); }
+
+    const auto remote_engine = peer.instances.front().endpoint.ToString();
+    const auto status =
+        instances_[peer.local_index]->Disconnect(remote_engine, connect_timeout_ms_);
+    return ignore_failure ? Status::OK() : status;
+}
+
+Status HixlTransport::Connect(const ManagerID& manager_id)
+{
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    std::unique_lock<std::shared_mutex> peer_lock(peers_mutex_);
+    const auto peer_it = peers_.find(manager_id);
+    if (peer_it == peers_.end()) {
+        UC_ERROR("[Transport][HIXL] connect failed: unknown peer={}", manager_id);
+        return Status::Error();
+    }
+    auto& peer = peer_it->second;
+    if (peer.local_index == SIZE_MAX || peer.instances.empty()) {
+        UC_ERROR("[Transport][HIXL] connect failed: peer={} has no route", manager_id);
+        return Status::Error();
+    }
+    if (peer.connected) {
+        UC_DEBUG("[Transport][HIXL] connect skipped: peer={} already connected", manager_id);
+        return Status::OK();
+    }
+    if (peer.local_index >= instances_.size()) {
+        UC_ERROR("[Transport][HIXL] connect failed: peer={} local_instance={} local_count={}",
+                 manager_id, peer.local_index, instances_.size());
+        return Status::Error();
+    }
+
+    if (role_ == peer.role && role_ != HixlRole::Bidirectional) {
+        UC_ERROR("[Transport][HIXL] incompatible roles: local={} remote={} peer={}",
+                 static_cast<uint32_t>(role_), static_cast<uint32_t>(peer.role), manager_id);
+        return Status::InvalidParam();
+    }
+
+    const auto remote_engine = peer.instances.front().endpoint.ToString();
+    if (role_ != HixlRole::Server && peer.role != HixlRole::Client) {
+        const auto status =
+            instances_[peer.local_index]->Connect(remote_engine, connect_timeout_ms_);
+        if (status != Status::OK()) { return status; }
+    }
+
+    peer.connected = true;
+    UC_DEBUG("[Transport][HIXL] connect completed: peer={} local_instance={} remote_engine={}",
+             manager_id, peer.local_index, remote_engine);
+    return Status::OK();
+}
+
+Status HixlTransport::Disconnect(const ManagerID& manager_id)
+{
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    std::unique_lock<std::shared_mutex> peer_lock(peers_mutex_);
+    const auto peer_it = peers_.find(manager_id);
+    if (peer_it == peers_.end()) {
+        UC_ERROR("[Transport][HIXL] disconnect failed: unknown peer={}", manager_id);
+        return Status::Error();
+    }
+    auto& peer = peer_it->second;
+    if (!peer.connected) {
+        UC_DEBUG("[Transport][HIXL] disconnect skipped: peer={} is not connected", manager_id);
+        return Status::OK();
+    }
+    if (peer.local_index >= instances_.size() || peer.instances.empty()) {
+        UC_ERROR("[Transport][HIXL] disconnect failed: peer={} has invalid route", manager_id);
+        return Status::Error();
+    }
+
+    const auto status = DisconnectRoute(peer, false);
+    peer.connected = false;
+    if (status == Status::OK()) {
+        UC_DEBUG("[Transport][HIXL] disconnect completed: peer={}", manager_id);
+    }
+    return status;
+}
+
+Status HixlTransport::ValidateTransferLocked(const Operation& batch, size_t instance_index) const
+{
+    if (batch.target_manager.empty() || batch.ops.empty() || instance_index >= instances_.size()) {
+        UC_ERROR("[Transport][HIXL] invalid transfer: peer={} segments={} instance={} instances={}",
+                 batch.target_manager, batch.ops.size(), instance_index, instances_.size());
+        return Status::InvalidParam();
+    }
+    for (const auto& item : batch.ops) {
+        if (item.local_addr == nullptr || item.length == 0 || item.remote_addr == 0) {
+            UC_ERROR(
+                "[Transport][HIXL] invalid transfer segment: local_addr={} remote_addr={} "
+                "length={}",
+                item.local_addr, item.remote_addr, item.length);
+            return Status::InvalidParam();
+        }
+
+        const auto local_address = detail::PtrToU64(item.local_addr);
+        bool registered = false;
+        for (const auto& memory : memories_) {
+            const auto begin = detail::PtrToU64(memory.second->region.addr);
+            if (local_address < begin) { continue; }
+
+            const auto offset = local_address - begin;
+            if (offset <= memory.second->region.length &&
+                item.length <= memory.second->region.length - offset &&
+                memory.second->native_handles.find(instance_index) !=
+                    memory.second->native_handles.end()) {
+                registered = true;
+                break;
+            }
+        }
+        if (!registered) {
+            UC_ERROR(
+                "[Transport][HIXL] transfer memory is not registered: local_addr={} length={} "
+                "instance={}",
+                item.local_addr, item.length, instance_index);
+            return Status::InvalidParam();
+        }
+    }
+    return Status::OK();
+}
+
+Status HixlTransport::ExecuteSync(const Operation& batch)
+{
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    if (role_ == HixlRole::Server) {
+        UC_ERROR("[Transport][HIXL] server role cannot initiate synchronous transfer");
+        return Status::Unsupported();
+    }
+    size_t local_index = SIZE_MAX;
+    std::string remote_engine;
+    {
+        std::shared_lock<std::shared_mutex> peer_lock(peers_mutex_);
+        const auto peer_it = peers_.find(batch.target_manager);
+        if (peer_it == peers_.end()) {
+            UC_ERROR("[Transport][HIXL] synchronous transfer failed: unknown peer={}",
+                     batch.target_manager);
+            return Status::Error();
+        }
+        const auto& peer_state = peer_it->second;
+        if (peer_state.local_index >= instances_.size() || peer_state.instances.empty() ||
+            !peer_state.connected) {
+            UC_ERROR(
+                "[Transport][HIXL] synchronous transfer failed: peer={} connected={} "
+                "local_instance={} local_count={} remote_count={}",
+                batch.target_manager, peer_state.connected, peer_state.local_index,
+                instances_.size(), peer_state.instances.size());
+            return Status::Error();
+        }
+        local_index = peer_state.local_index;
+        remote_engine = peer_state.instances.front().endpoint.ToString();
+    }
+
+    {
+        std::shared_lock<std::shared_mutex> memory_lock(memories_mutex_);
+        const auto transfer_status = ValidateTransferLocked(batch, local_index);
+        if (transfer_status != Status::OK()) {
+            UC_ERROR("[Transport][HIXL] synchronous transfer validation failed: peer={} status={}",
+                     batch.target_manager, transfer_status);
+            return transfer_status;
+        }
+    }
+
+    UC_DEBUG("[Transport][HIXL] synchronous transfer started: peer={} opcode={} segments={}",
+             batch.target_manager, static_cast<int>(batch.opcode), batch.ops.size());
+    return instances_[local_index]->TransferSync(remote_engine, batch.opcode, batch.ops,
+                                                 transfer_timeout_ms_);
+}
+
+Status HixlTransport::ExecuteAsync(const Operation& batch, TransferHandle& handle)
+{
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    handle = kInvalidTransferHandle;
+    if (role_ == HixlRole::Server) {
+        UC_ERROR("[Transport][HIXL] server role cannot initiate asynchronous transfer");
+        return Status::Unsupported();
+    }
+    size_t local_index = SIZE_MAX;
+    std::string remote_engine;
+    {
+        std::shared_lock<std::shared_mutex> peer_lock(peers_mutex_);
+        const auto peer_it = peers_.find(batch.target_manager);
+        if (peer_it == peers_.end()) {
+            UC_ERROR("[Transport][HIXL] asynchronous transfer failed: unknown peer={}",
+                     batch.target_manager);
+            return Status::Error();
+        }
+        const auto& peer_state = peer_it->second;
+        if (peer_state.local_index >= instances_.size() || peer_state.instances.empty() ||
+            !peer_state.connected) {
+            UC_ERROR(
+                "[Transport][HIXL] asynchronous transfer failed: peer={} connected={} "
+                "local_instance={} local_count={} remote_count={}",
+                batch.target_manager, peer_state.connected, peer_state.local_index,
+                instances_.size(), peer_state.instances.size());
+            return Status::Error();
+        }
+        local_index = peer_state.local_index;
+        remote_engine = peer_state.instances.front().endpoint.ToString();
+    }
+
+    {
+        std::shared_lock<std::shared_mutex> memory_lock(memories_mutex_);
+        const auto transfer_status = ValidateTransferLocked(batch, local_index);
+        if (transfer_status != Status::OK()) {
+            UC_ERROR("[Transport][HIXL] asynchronous transfer validation failed: peer={} status={}",
+                     batch.target_manager, transfer_status);
+            return transfer_status;
+        }
+    }
+
+    hixl::TransferReq request = nullptr;
+    const auto status =
+        instances_[local_index]->TransferAsync(remote_engine, batch.opcode, batch.ops, request);
+    if (status != Status::OK()) {
+        UC_ERROR("[Transport][HIXL] asynchronous transfer submission failed: peer={} status={}",
+                 batch.target_manager, status);
+        return status;
+    }
+
+    {
+        std::lock_guard<std::mutex> pending_lock(pending_mutex_);
+        handle = next_transfer_handle_++;
+        if (handle == kInvalidTransferHandle) { handle = next_transfer_handle_++; }
+        pending_transfers_.emplace(handle, PendingTransfer{local_index, request});
+    }
+    UC_DEBUG(
+        "[Transport][HIXL] asynchronous transfer tracked: peer={} opcode={} segments={} "
+        "instance={} handle={} request={}",
+        batch.target_manager, static_cast<int>(batch.opcode), batch.ops.size(), local_index, handle,
+        request);
+    return Status::OK();
+}
+
+Status HixlTransport::GetStatus(TransferHandle handle, TransferStatus& status)
+{
+    status = TransferStatus::Failed;
+    if (handle == kInvalidTransferHandle) {
+        UC_ERROR("[Transport][HIXL] get status failed: invalid handle");
+        return Status::InvalidParam();
+    }
+    std::shared_lock<std::shared_mutex> lifecycle_lock(lifecycle_mutex_);
+    PendingTransfer pending;
+    {
+        std::lock_guard<std::mutex> pending_lock(pending_mutex_);
+        const auto it = pending_transfers_.find(handle);
+        if (it == pending_transfers_.end() || it->second.instance_index >= instances_.size()) {
+            UC_ERROR("[Transport][HIXL] get status failed: unknown handle={} instances={}", handle,
+                     instances_.size());
+            return Status::Error();
+        }
+        pending = it->second;
+    }
+
+    TransferStatus transfer_status = TransferStatus::Waiting;
+    const auto query_status =
+        instances_[pending.instance_index]->GetTransferStatus(pending.request, transfer_status);
+    if (query_status != Status::OK()) {
+        std::lock_guard<std::mutex> pending_lock(pending_mutex_);
+        pending_transfers_.erase(handle);
+        UC_ERROR("[Transport][HIXL] get status query failed: handle={} request={} status={}",
+                 handle, pending.request, query_status);
+        return query_status;
+    }
+    status = transfer_status;
+    if (status != TransferStatus::Waiting) {
+        std::lock_guard<std::mutex> pending_lock(pending_mutex_);
+        pending_transfers_.erase(handle);
+        UC_DEBUG("[Transport][HIXL] asynchronous transfer completed: handle={} status={}", handle,
+                 static_cast<int>(status));
+    }
+    return Status::OK();
+}
+
+}  // namespace transport


### PR DESCRIPTION
## Purpose

Introduce the P2P transport module, providing common transport interfaces, TCP control channels, transport lifecycle management, and HIXL-based data transfer.

## Modifications

### P2P transport interfaces

Impl the common P2P transport interfaces and initialization attributes.

Corresponding PR

- [p2p: add core transport interfaces #1042](https://github.com/ModelEngine-Group/unified-cache-management/pull/1042)
- [p2p: add transport manager #1054](https://github.com/ModelEngine-Group/unified-cache-management/pull/1054)

#### Transport interface

- Add protocol-independent connection management interfaces.
- Add memory registration and deregistration interfaces.
- Add asynchronous transfer submission and status query interfaces.
- Add transport metadata exchange interfaces.

#### TransportManager

- Manage transport backend initialization and lifecycle.
- Dispatch connection, memory, and transfer operations to the corresponding backend.
- Coordinate metadata exchange, connection, and disconnection with peers.

### TCP control and message channels

Impl the TCP channels used by the transport control plane.

Corresponding PR

- [control: add tcp control plane #1049](https://github.com/ModelEngine-Group/unified-cache-management/pull/1049)
- [tcp: add standalone tcp transport #1062](https://github.com/ModelEngine-Group/unified-cache-management/pull/1062)
- [Coordinate transport connection lifecycle #1164](https://github.com/ModelEngine-Group/unified-cache-management/pull/1164)

#### TCP message channel

- Add framed message transmission over TCP.
- Support request and response exchange between peers.

#### Control channel

- Support transport metadata exchange.
- Support peer connection coordination.
- Support peer disconnection coordination.

### HIXL transport

Impl the HIXL transport backend.

Corresponding PR

- [hixl: add hixl transport engine #1060](https://github.com/ModelEngine-Group/unified-cache-management/pull/1060)
- [hixl: add ACL runtime context guard #1069](https://github.com/ModelEngine-Group/unified-cache-management/pull/1069)
- [hixlTransport support multi-instance #1100](https://github.com/ModelEngine-Group/unified-cache-management/pull/1100)

#### HIXL instance

- Manage HIXL initialization and runtime context.
- Support connection and disconnection operations.
- Support memory registration and asynchronous transfer.

#### Multi-instance support

- Support multiple HIXL instances on different devices.
- Select local instances according to peer routes and instance load.
- Support Client, Server, and Bidirectional roles.