### PR TITLE
[Feat] Add posix aio model driven

### DIFF
--- a/toolkit/ucm_toolkit/tools/posix_aio/README.md
+++ b/toolkit/ucm_toolkit/tools/posix_aio/README.md
@@ -2,11 +2,16 @@
 
 调用仓库中的 `ucm/store/test/e2e/posixstore_aio_test.py`，通过 `UcmPipelineStore` 和 `posix_io_engine=aio` 做 dump/load 性能测试，用于评估 UCM POSIX AIO store 的磁盘读写带宽。
 
+支持两种用法：
+
+- **手动模式**（默认）：直接指定 `--shard-size` / `--shard-number` / `--block-number` 等。
+- **模型驱动模式**：传 `--model` 指向模型目录，自动读取 `config.json` 判定架构（GQA / MLA / DSA）并计算 `shard-size` / `shard-number` / `block-number`，再转发给同一脚本，实现自动化带宽测试。
+
 ← 返回 [UCM Toolkit 顶层文档](../../../README.md)
 
 ## 依赖
 
-当前 UCM Python 包及其 native 扩展可用，`numpy` 可导入。
+当前 UCM Python 包及其 native 扩展可用，`numpy` 可导入。模型驱动模式仅使用标准库（`json` / `math`），不依赖 `transformers` / `vllm`。
 
 ## 导入来源
 
@@ -22,6 +27,8 @@ UCM_TOOLKIT_POSIX_AIO_IMPORT=installed ucm-toolkit run posix-aio
 
 ## 示例
 
+### 手动模式
+
 ```bash
 ucm-toolkit run posix-aio
 
@@ -35,7 +42,32 @@ ucm-toolkit run posix-aio \
   --storage-backend ./build/data
 ```
 
+### 模型驱动模式
+
+```bash
+# MLA, layerwise
+ucm-toolkit run posix-aio --model /models/DeepSeek-V3 --tp 8 --input-len 4096 \
+  --worker-number 8 --layerwise --storage-backend /mnt/ssd/ucm
+
+# DSA (GLM-5.1 / DeepSeek-V3.2), 非 layerwise
+ucm-toolkit run posix-aio --model /models/GLM-5.1 --tp 8 --input-len 4096 \
+  --worker-number 8 --storage-backend /mnt/ssd/ucm
+
+# GQA, layerwise
+ucm-toolkit run posix-aio --model /models/Qwen3-32B --tp 8 --input-len 4096 \
+  --worker-number 8 --layerwise --storage-backend /mnt/ssd/ucm
+```
+
+不支持的架构会 warning 并退出：
+
+```bash
+ucm-toolkit run posix-aio --model /models/DeepSeek-V4-Pro --tp 8 --input-len 4096 --worker-number 8
+# → warning: architecture 'hybrid' not supported, only GQA and MLA family (MLA/DSA) are supported now
+```
+
 ## 参数
+
+### 手动模式参数
 
 | 参数 | 默认值 | 说明 |
 | --- | --- | --- |
@@ -47,9 +79,47 @@ ucm-toolkit run posix-aio \
 | `-l`, `--load-epoch-number` | `32` | load epoch number: number of load epochs. |
 | `-o`, `--storage-backend` | `./build/data` | storage backend: storage backend path; may be repeated. Passing this option replaces the default backend list with the provided values. |
 
+### 模型驱动模式参数
+
+传入 `--model` 即进入模型驱动模式。此时 `--shard-size` / `--shard-number` / `--block-number` 由模型 config 计算得出，会覆盖任何手动设置（并打印 warning）。`--storage-backend` / `--dump-epoch-number` / `--load-epoch-number` / `--worker-number` 仍透传给脚本。
+
+| 参数 | 默认值 | 说明 |
+| --- | --- | --- |
+| `--model` | — | 模型目录（含 `config.json`）或 `config.json` 文件路径；传入即进入模型驱动模式。 |
+| `--tp` | `1` | tensor parallel size；GQA 下用于按 rank 切分 `num_kv_heads`。 |
+| `--input-len` | `4096` | 请求输入长度；`block_number = ceil(input_len / block_size)`。 |
+| `--layerwise` | `False` | layerwise 模式：一个 shard = 一层；默认非 layerwise（一个 shard = 全部层）。 |
+| `--block-size` | `128` | vLLM paged block 的 token 数，用于 `input_len → block_number` 换算。 |
+| `--kv-dtype` | config 的 `torch_dtype`，无则 `bfloat16` | 覆盖 KV dtype：`bfloat16`/`bf16`、`float16`/`fp16`、`float32`/`fp32`、`float8_e4m3fn`/`fp8`、`float8_e5m2`、`int8`。 |
+
+### 支持的架构与计算公式
+
+检测逻辑参照 `docs/source/_static/calculator.js` 的 `detectArchitectureType`。设 `T` = 单层单 block 的 KV 字节数，`B` = `--block-size`，`elem` = dtype 字节数，`L` = `num_hidden_layers`：
+
+| 架构 | 判定字段 | 单层单 block 字节 `T` | TP 处理 |
+| --- | --- | --- | --- |
+| GQA（Qwen、MiniMax） | 有 `num_key_value_heads` | `2 * (num_kv_heads // tp) * head_dim * B * elem` | 每 rank 存自己的 KV，`num_kv_heads/tp` |
+| MLA（DeepSeek-V3/R1） | `kv_lora_rank` + `qk_rope_head_dim`，无 `index_head_dim` | `(kv_lora_rank + qk_rope_head_dim) * B * elem` | 不除 tp（latent 在 TP 间复制、仅 rank0 dump） |
+| DSA（DeepSeek-V3.2、GLM-5/5.1） | 上述 + `index_head_dim` | `(kv_lora_rank + qk_rope_head_dim + index_head_dim) * B * elem` | 不除 tp（同 MLA 族） |
+
+`head_dim` 推导：MLA→`kv_lora_rank + qk_rope_head_dim`；DSA→再加 `index_head_dim`；GQA→`config.head_dim`，否则 `hidden_size // num_attention_heads`。
+
+layerwise 与非 layerwise（对齐真实 UCM store 的 shard/block 切分）：
+
+| 模式 | `shard_size` | `shard_number` | 说明 |
+| --- | --- | --- | --- |
+| layerwise | `align_up(T, 4096)` | `L` | 一块 = L 个 shard，逐层 I/O，可与 forward 流水重叠 |
+| 非 layerwise | `align_up(L * T, 4096)` | `1` | 一块 = 1 个 shard，一次 I/O 传全部层 |
+
+`store_block_size = shard_size * shard_number`；`shard_size` 向上对齐到 4096，匹配真实 store 的 I/O 粒度并兼容 `io_direct`。
+
+不支持（warning 并退出 1）：Hybrid / DeepSeek V4（`compress_ratios` 等指标）、Mamba / 线性注意力（`linear_attention` / `model_type` 含 mamba）、未知架构。
+
 ## 资源估算
 
 ```text
 单 worker 数据量约为 shard-size * shard-number * block-number
 总数据量约为 worker-number * shard-size * shard-number * block-number
 ```
+
+模型驱动模式下，`shard-size` / `shard-number` / `block-number` 由上述公式计算，运行前会打印计算摘要（架构、层数、head_dim、dtype、shard_size、shard_number、store_block_size、block_number、单 worker 总数据量）。

--- a/toolkit/ucm_toolkit/tools/posix_aio/README.md
+++ b/toolkit/ucm_toolkit/tools/posix_aio/README.md
@@ -44,6 +44,9 @@ ucm-toolkit run posix-aio --model /models/GLM-5.1 --tp 8 --input-len 4096 \
 # GQA, layerwise
 ucm-toolkit run posix-aio --model /models/Qwen3-32B --tp 8 --input-len 4096 \
   --worker-number 8 --layerwise --storage-backend /mnt/ssd/ucm
+
+# 只打印 UCM Store IO Info（io size / io number），不跑脚本
+ucm-toolkit run posix-aio --model /models/Qwen3-32B --tp 8 --input-len 4096 --layerwise --dry-run
 ```
 
 不支持的架构会 warning 并退出：
@@ -79,6 +82,7 @@ ucm-toolkit run posix-aio --model /models/DeepSeek-V4-Pro --tp 8 --input-len 409
 | `--layerwise` | `False` | layerwise 模式：一个 shard = 一层；默认非 layerwise（一个 shard = 全部层）。 |
 | `--block-size` | `128` | vLLM paged block 的 token 数，用于 `input_len → block_number` 换算。 |
 | `--kv-dtype` | config 的 `torch_dtype`，无则 `bfloat16` | 覆盖 KV dtype：`bfloat16`/`bf16`、`float16`/`fp16`、`float32`/`fp32`、`float8_e4m3fn`/`fp8`、`float8_e5m2`、`int8`。 |
+| `--dry-run` | `False` | 只打印 `UCM Store IO Info` 摘要与转发命令，不启动脚本（用于核对 io size / io number）。 |
 
 ### 支持的架构与计算公式
 
@@ -94,12 +98,12 @@ ucm-toolkit run posix-aio --model /models/DeepSeek-V4-Pro --tp 8 --input-len 409
 
 layerwise 与非 layerwise（对齐真实 UCM store 的 shard/block 切分）：
 
-| 模式 | `shard_size` | `shard_number` | 说明 |
+| 模式 | shard size | shards per file | 说明 |
 | --- | --- | --- | --- |
-| layerwise | `align_up(T, 4096)` | `L` | 一块 = L 个 shard，逐层 I/O，可与 forward 流水重叠 |
-| 非 layerwise | `align_up(L * T, 4096)` | `1` | 一块 = 1 个 shard，一次 I/O 传全部层 |
+| layerwise | `align_up(T, 4096)` | `L` | 一个文件 = L 个 shard，逐层 I/O，可与 forward 流水重叠 |
+| 非 layerwise | `align_up(L * T, 4096)` | `1` | 一个文件 = 1 个 shard，一次 I/O 传全部层 |
 
-`store_block_size = shard_size * shard_number`；`shard_size` 向上对齐到 4096，匹配真实 store 的 I/O 粒度并兼容 `io_direct`。
+`file size = shard size * shards per file`；`shard size` 向上对齐到 4096，匹配真实 store 的 I/O 粒度并兼容 `io_direct`。一个 block 对应一个文件（`DataFilePath(blockId)`），故 `shards per file` 即一个文件里的 shard 数、`file size` 即该文件大小。
 
 不支持（warning 并退出 1）：Hybrid / DeepSeek V4（`compress_ratios` 等指标）、Mamba / 线性注意力（`linear_attention` / `model_type` 含 mamba）、未知架构。
 
@@ -110,4 +114,4 @@ layerwise 与非 layerwise（对齐真实 UCM store 的 shard/block 切分）：
 总数据量约为 worker-number * shard-size * shard-number * block-number
 ```
 
-模型驱动模式下，`shard-size` / `shard-number` / `block-number` 由上述公式计算，运行前会打印计算摘要（架构、层数、head_dim、dtype、shard_size、shard_number、store_block_size、block_number、单 worker 总数据量）。
+模型驱动模式下，`shard-size` / `shard-number` / `block-number` 由上述公式计算，运行前会打印 `UCM Store IO Info` 摘要：architecture（大写 GQA/MLA/DSA）、num_hidden_layers、head_dim、dtype、per_layer/block（bytes+KB+公式）、shard size（bytes+KB+公式）、shards per file、file size（bytes+KB+MB）、block_number、单 worker 总数据量。加 `--dry-run` 只打印摘要与转发命令、不真正跑脚本。

--- a/toolkit/ucm_toolkit/tools/posix_aio/README.md
+++ b/toolkit/ucm_toolkit/tools/posix_aio/README.md
@@ -13,18 +13,6 @@
 
 当前 UCM Python 包及其 native 扩展可用，`numpy` 可导入。模型驱动模式仅使用标准库（`json` / `math`），不依赖 `transformers` / `vllm`。
 
-## 导入来源
-
-`ucm-toolkit run posix-aio` 默认会优先使用当前 Python 环境中已经安装的 `ucm` 包；如果当前环境找不到安装版 `ucm`，才会把主仓源码根目录加入子进程 `PYTHONPATH`。当使用安装版 `ucm` 时，toolkit 会从子进程 `PYTHONPATH` 中移除主仓源码根目录，避免源码目录覆盖已安装包。如果需要显式切换导入来源，可以设置：
-
-```bash
-# 强制使用当前主仓源码中的 ucm 包
-UCM_TOOLKIT_POSIX_AIO_IMPORT=source ucm-toolkit run posix-aio
-
-# 强制使用当前 Python 环境中已安装的 ucm 包
-UCM_TOOLKIT_POSIX_AIO_IMPORT=installed ucm-toolkit run posix-aio
-```
-
 ## 示例
 
 ### 手动模式

--- a/toolkit/ucm_toolkit/tools/posix_aio/adapter.py
+++ b/toolkit/ucm_toolkit/tools/posix_aio/adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.machinery
+import math
 import os
 import sys
 from pathlib import Path
@@ -12,6 +13,12 @@ from ... import registry
 from ...errors import ScriptNotFoundError
 from ...registry import ToolAdapter
 from ...runner import run_command
+from .model_profile import (
+    ModelProfileError,
+    compute_io_profile,
+    detect_architecture,
+    load_config,
+)
 
 IMPORT_MODE_ENV = "UCM_TOOLKIT_POSIX_AIO_IMPORT"
 
@@ -116,6 +123,50 @@ class PosixAioTool(ToolAdapter):
             action="append",
             help="storage backend: storage backend path; may be repeated.",
         )
+        parser.add_argument(
+            "--model",
+            help=(
+                "model directory (or config.json) for model-driven mode. When set, "
+                "shard-size/shard-number/block-number are computed from the model "
+                "config and override any manually provided values."
+            ),
+        )
+        parser.add_argument(
+            "--tp",
+            type=int,
+            default=1,
+            help="tensor parallel size; divides num_kv_heads per rank for GQA.",
+        )
+        parser.add_argument(
+            "--input-len",
+            type=int,
+            default=4096,
+            help="request input length; block_number = ceil(input_len / block_size).",
+        )
+        parser.add_argument(
+            "--layerwise",
+            action="store_true",
+            help="layerwise mode: one shard = one layer. Default is non-layerwise (one shard = all layers).",
+        )
+        parser.add_argument(
+            "--block-size",
+            type=int,
+            default=128,
+            help="vLLM paged block size in tokens; used to derive block_number from input-len.",
+        )
+        parser.add_argument(
+            "--kv-dtype",
+            help=(
+                "override KV dtype: bfloat16/bf16, float16/fp16, float32/fp32, "
+                "float8_e4m3fn/fp8, float8_e5m2, int8. Default: config torch_dtype "
+                "or bfloat16."
+            ),
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="print the computed profile and the forwarded command without launching the script.",
+        )
 
     def _build_run_parser(self) -> argparse.ArgumentParser:
         parser = argparse.ArgumentParser(
@@ -145,14 +196,7 @@ class PosixAioTool(ToolAdapter):
                 forwarded.extend(["--storage-backend", path])
         return forwarded
 
-    def run(self, tool_args: list[str]) -> int:
-        """Run the POSIX AIO test script."""
-        parser = self._build_run_parser()
-        args = parser.parse_args(tool_args)
-        forwarded_args = self._forward_args(args)
-        script = registry.resolve_repo_path(self.script_path or "")
-        if not script.exists():
-            raise ScriptNotFoundError(str(script))
+    def _make_env(self) -> dict[str, str]:
         env = os.environ.copy()
         repo_root = registry.repo_root()
         import_mode = env.get(IMPORT_MODE_ENV, "auto").strip().lower()
@@ -164,7 +208,150 @@ class PosixAioTool(ToolAdapter):
             _drop_repo_root_from_pythonpath(env, repo_root)
         else:
             _prepend_pythonpath(env, repo_root)
+        return env
+
+    def _launch(self, forwarded_args: list[str]) -> int:
+        script = registry.resolve_repo_path(self.script_path or "")
+        if not script.exists():
+            raise ScriptNotFoundError(str(script))
+        env = self._make_env()
         return run_command([sys.executable, str(script), *forwarded_args], env=env)
+
+    def _build_model_driven_args(self, args: argparse.Namespace) -> list[str] | None:
+        """Compute shard/block sizing from the model config and return forwarded args.
+
+        Returns ``None`` (after printing a message) when the model is missing or
+        its architecture is unsupported; the caller turns that into exit code 1.
+        """
+        try:
+            cfg = load_config(args.model)
+        except FileNotFoundError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return None
+
+        arch = detect_architecture(cfg)
+        if arch not in ("gqa", "mla", "dsa"):
+            print(
+                f"warning: architecture '{arch}' not supported, only GQA and MLA "
+                f"family (MLA/DSA) are supported now",
+                file=sys.stderr,
+            )
+            return None
+
+        try:
+            profile = compute_io_profile(
+                cfg,
+                tp=args.tp,
+                block_size=args.block_size,
+                layerwise=args.layerwise,
+                kv_dtype=args.kv_dtype,
+            )
+        except ModelProfileError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return None
+
+        block_number = (
+            math.ceil(args.input_len / args.block_size) if args.block_size else 0
+        )
+
+        overridden = [
+            name
+            for name, value in (
+                ("shard-size", args.shard_size),
+                ("shard-number", args.shard_number),
+                ("block-number", args.block_number),
+            )
+            if value is not None
+        ]
+        if overridden:
+            print(
+                f"warning: model-driven mode overrides manually set: "
+                f"{', '.join(overridden)}",
+                file=sys.stderr,
+            )
+
+        self._print_summary(args, profile, block_number)
+
+        forwarded: list[str] = []
+        if args.worker_number is not None:
+            forwarded.extend(["--worker-number", str(args.worker_number)])
+        forwarded.extend(
+            [
+                "--shard-size",
+                str(profile["shard_size"]),
+                "--shard-number",
+                str(profile["shard_number"]),
+                "--block-number",
+                str(block_number),
+            ]
+        )
+        if args.dump_epoch_number is not None:
+            forwarded.extend(["--dump-epoch-number", str(args.dump_epoch_number)])
+        if args.load_epoch_number is not None:
+            forwarded.extend(["--load-epoch-number", str(args.load_epoch_number)])
+        if args.storage_backend is not None:
+            for path in args.storage_backend:
+                forwarded.extend(["--storage-backend", path])
+        return forwarded
+
+    @staticmethod
+    def _print_summary(
+        args: argparse.Namespace, profile: dict, block_number: int
+    ) -> None:
+        store_block = profile["store_block_size"]
+        total_bytes = store_block * block_number
+        kv_heads_line = ""
+        if profile["num_kv_heads_per_rank"] is not None:
+            kv_heads_line = (
+                f"  num_kv_heads/rank : {profile['num_kv_heads_per_rank']} "
+                f"(tp={profile['tensor_parallel']})\n"
+            )
+        print("posix-aio model-driven profile:")
+        print(f"  model             : {args.model}")
+        print(f"  architecture      : {profile['architecture']}")
+        print(f"  num_hidden_layers : {profile['num_hidden_layers']}")
+        print(f"  head_dim          : {profile['head_dim']}")
+        if kv_heads_line:
+            print(kv_heads_line, end="")
+        print(
+            f"  dtype             : {profile['dtype']} "
+            f"({profile['elem_size']} bytes/elem)"
+        )
+        print(f"  block_size(tokens): {profile['block_size_tokens']}")
+        print(f"  input_len         : {args.input_len}")
+        print(f"  layerwise         : {profile['layerwise']}")
+        print(f"  per_layer/block   : {profile['per_layer_block_bytes']} bytes")
+        print(f"  shard_size        : {profile['shard_size']} bytes (posix ioSize)")
+        print(f"  shard_number      : {profile['shard_number']} (shards per block)")
+        print(
+            f"  store_block_size  : {store_block} bytes "
+            f"(= shard_size * shard_number)"
+        )
+        print(
+            f"  block_number      : {block_number} "
+            f"(= ceil({args.input_len}/{profile['block_size_tokens']}))"
+        )
+        print(
+            f"  total data/worker : {total_bytes} bytes "
+            f"(~{total_bytes / 1024 ** 3:.3f} GiB)"
+        )
+
+    def run(self, tool_args: list[str]) -> int:
+        """Run the POSIX AIO test script."""
+        parser = self._build_run_parser()
+        args = parser.parse_args(tool_args)
+        if args.model:
+            forwarded = self._build_model_driven_args(args)
+            if forwarded is None:
+                return 1
+        else:
+            forwarded = self._forward_args(args)
+        if args.dry_run:
+            script = registry.resolve_repo_path(self.script_path or "")
+            cmd = [sys.executable, str(script), *forwarded]
+            print("[dry-run] would run: " + " ".join(cmd))
+            return 0
+        return self._launch(forwarded)
 
     def doctor(self, args: argparse.Namespace | None = None) -> int:
         """Inspect POSIX AIO script availability."""

--- a/toolkit/ucm_toolkit/tools/posix_aio/adapter.py
+++ b/toolkit/ucm_toolkit/tools/posix_aio/adapter.py
@@ -230,7 +230,7 @@ class PosixAioTool(ToolAdapter):
             return None
 
         arch = detect_architecture(cfg)
-        if arch not in ("gqa", "mla", "dsa"):
+        if arch not in ("GQA", "MLA", "DSA"):
             print(
                 f"warning: architecture '{arch}' not supported, only GQA and MLA "
                 f"family (MLA/DSA) are supported now",
@@ -306,7 +306,7 @@ class PosixAioTool(ToolAdapter):
                 f"  num_kv_heads/rank : {profile['num_kv_heads_per_rank']} "
                 f"(tp={profile['tensor_parallel']})\n"
             )
-        print("posix-aio model-driven profile:")
+        print("UCM Store IO Info:")
         print(f"  model             : {args.model}")
         print(f"  architecture      : {profile['architecture']}")
         print(f"  num_hidden_layers : {profile['num_hidden_layers']}")
@@ -320,12 +320,21 @@ class PosixAioTool(ToolAdapter):
         print(f"  block_size(tokens): {profile['block_size_tokens']}")
         print(f"  input_len         : {args.input_len}")
         print(f"  layerwise         : {profile['layerwise']}")
-        print(f"  per_layer/block   : {profile['per_layer_block_bytes']} bytes")
-        print(f"  shard_size        : {profile['shard_size']} bytes (posix ioSize)")
-        print(f"  shard_number      : {profile['shard_number']} (shards per block)")
+        plb = profile["per_layer_block_bytes"]
+        ss = profile["shard_size"]
         print(
-            f"  store_block_size  : {store_block} bytes "
-            f"(= shard_size * shard_number)"
+            f"  per_layer/block   : {plb} bytes ({plb / 1024:.2f} KB)"
+            f"  |  {profile['per_layer_formula']}"
+        )
+        print(
+            f"  shard size        : {ss} bytes ({ss / 1024:.2f} KB)"
+            f"  |  {profile['shard_size_formula']}"
+        )
+        print(f"  shards per file   : {profile['shard_number']}")
+        print(
+            f"  file size         : {store_block} bytes "
+            f"({store_block / 1024:.2f} KB / {store_block / 1024 / 1024:.2f} MB)"
+            f"  |  = shard size * shards per file"
         )
         print(
             f"  block_number      : {block_number} "

--- a/toolkit/ucm_toolkit/tools/posix_aio/model_profile.py
+++ b/toolkit/ucm_toolkit/tools/posix_aio/model_profile.py
@@ -141,10 +141,12 @@ def _is_hybrid(cfg: dict, text: dict, has) -> bool:
         return True
     if has("mixed_attention") or has("sparse_attention"):
         return True
-    if has("window_attention") or has("attention_window"):
-        return True
-    if has("sliding_window"):
-        return True
+    # A bare sliding_window / window_attention field marks a standard
+    # sliding-window attention model (e.g. Qwen2 / Mistral), whose KV cache is
+    # still computable with the GQA formula. calculator.js treats it as a hybrid
+    # indicator; we deliberately do not, so plain sliding-window GQA models are
+    # sized correctly. Genuine hybrids still trip on compress_ratios,
+    # linear_attention, layer_types, swa_*, or paired full/sliding layer lists.
     if has("swa_num_key_value_heads") or has("swa_num_attention_heads"):
         return True
     if has("swa_head_dim") or has("add_swa_attention_sink_bias"):

--- a/toolkit/ucm_toolkit/tools/posix_aio/model_profile.py
+++ b/toolkit/ucm_toolkit/tools/posix_aio/model_profile.py
@@ -26,7 +26,7 @@ from typing import Any
 
 ALIGNMENT = 4096
 
-SUPPORTED_ARCHITECTURES = ("mla", "dsa", "gqa")
+SUPPORTED_ARCHITECTURES = ("MLA", "DSA", "GQA")
 
 _DTYPE_BYTES: dict[str, int] = {
     "bfloat16": 2,
@@ -90,24 +90,24 @@ def detect_architecture(cfg: dict[str, Any]) -> str:
         return False
 
     if _is_hybrid(cfg, text, has):
-        return "hybrid"
+        return "HYBRID"
 
     model_type = str(cfg.get("model_type") or text.get("model_type") or "").lower()
     if "mamba" in model_type or "jamba" in model_type:
-        return "mamba"
+        return "MAMBA"
 
     kv_lora_rank = cfg.get("kv_lora_rank")
     qk_rope_head_dim = cfg.get("qk_rope_head_dim")
     index_head_dim = cfg.get("index_head_dim")
     if kv_lora_rank and qk_rope_head_dim and index_head_dim:
-        return "dsa"
+        return "DSA"
     if kv_lora_rank and qk_rope_head_dim and not index_head_dim:
-        return "mla"
+        return "MLA"
 
     if has("num_key_value_heads") or has("num_kv_heads") or has("num_attention_heads"):
-        return "gqa"
+        return "GQA"
 
-    return "unknown"
+    return "UNKNOWN"
 
 
 def _is_hybrid(cfg: dict, text: dict, has) -> bool:
@@ -222,7 +222,7 @@ def compute_io_profile(
     )
     num_attention_heads = _resolve(cfg, "num_attention_heads")
 
-    if arch in ("mla", "dsa"):
+    if arch in ("MLA", "DSA"):
         kv_lora_rank = _resolve(cfg, "kv_lora_rank")
         qk_rope_head_dim = _resolve(cfg, "qk_rope_head_dim")
         if kv_lora_rank is None or qk_rope_head_dim is None:
@@ -230,15 +230,24 @@ def compute_io_profile(
                 "kv_lora_rank and qk_rope_head_dim are required for MLA/DSA"
             )
         latent = int(kv_lora_rank) + int(qk_rope_head_dim)
-        if arch == "dsa":
+        if arch == "DSA":
             index_head_dim = _resolve(cfg, "index_head_dim")
             if index_head_dim is None:
                 raise ModelProfileError("index_head_dim is required for DSA")
             latent += int(index_head_dim)
+            per_layer_formula = (
+                f"(kv_lora_rank({kv_lora_rank})+qk_rope_head_dim({qk_rope_head_dim})"
+                f"+index_head_dim({index_head_dim})) * block_size({tokens_per_block}) * dtype({elem_size})"
+            )
+        else:
+            per_layer_formula = (
+                f"(kv_lora_rank({kv_lora_rank})+qk_rope_head_dim({qk_rope_head_dim}))"
+                f" * block_size({tokens_per_block}) * dtype({elem_size})"
+            )
         head_dim = latent
         per_layer_block_bytes = latent * tokens_per_block * elem_size
         num_kv_heads_per_rank: int | None = None
-    else:  # gqa
+    else:  # GQA
         if not num_kv_heads_full:
             raise ModelProfileError("num_key_value_heads is required for GQA")
         heads_per_rank = (
@@ -253,14 +262,23 @@ def compute_io_profile(
             if hidden_size is None:
                 raise ModelProfileError("cannot derive head_dim (missing head_dim/hidden_size)")
             head_dim = int(hidden_size) // int(num_attention_heads)
-        per_layer_block_bytes = 2 * heads_per_rank * int(head_dim) * tokens_per_block * elem_size
+        head_dim = int(head_dim)
+        per_layer_block_bytes = 2 * heads_per_rank * head_dim * tokens_per_block * elem_size
+        per_layer_formula = (
+            f"2 * num_kv_heads({heads_per_rank}) * head_dim({head_dim})"
+            f" * block_size({tokens_per_block}) * dtype({elem_size})"
+        )
 
     if layerwise:
         shard_size = align_up(per_layer_block_bytes, ALIGNMENT)
         shard_number = int(num_layers)
+        shard_size_formula = f"align_up(per_layer/block, {ALIGNMENT})"
     else:
         shard_size = align_up(int(num_layers) * per_layer_block_bytes, ALIGNMENT)
         shard_number = 1
+        shard_size_formula = (
+            f"align_up(num_layers({int(num_layers)}) * per_layer/block, {ALIGNMENT})"
+        )
     store_block_size = shard_size * shard_number
 
     return {
@@ -271,7 +289,9 @@ def compute_io_profile(
         "elem_size": elem_size,
         "dtype": effective_dtype,
         "per_layer_block_bytes": per_layer_block_bytes,
+        "per_layer_formula": per_layer_formula,
         "shard_size": shard_size,
+        "shard_size_formula": shard_size_formula,
         "shard_number": shard_number,
         "store_block_size": store_block_size,
         "block_size_tokens": tokens_per_block,

--- a/toolkit/ucm_toolkit/tools/posix_aio/model_profile.py
+++ b/toolkit/ucm_toolkit/tools/posix_aio/model_profile.py
@@ -68,9 +68,7 @@ def dtype_to_elem_size(dtype: str | None) -> int:
     if key in _DTYPE_BYTES:
         return _DTYPE_BYTES[key]
     supported = ", ".join(sorted(set(_DTYPE_BYTES)))
-    raise ModelProfileError(
-        f"unsupported dtype '{dtype}'; supported: {supported}"
-    )
+    raise ModelProfileError(f"unsupported dtype '{dtype}'; supported: {supported}")
 
 
 def detect_architecture(cfg: dict[str, Any]) -> str:
@@ -85,7 +83,13 @@ def detect_architecture(cfg: dict[str, Any]) -> str:
     def has(key: str, *, sources: tuple[dict, ...] = (cfg, text)) -> bool:
         for src in sources:
             value = src.get(key)
-            if value is not None and value is not False and value != "" and value != 0 and value != []:
+            if (
+                value is not None
+                and value is not False
+                and value != ""
+                and value != 0
+                and value != []
+            ):
                 return True
         return False
 
@@ -113,7 +117,9 @@ def detect_architecture(cfg: dict[str, Any]) -> str:
 def _is_hybrid(cfg: dict, text: dict, has) -> bool:
     """Return True if config exhibits hybrid / non-standard attention signals."""
     layer_types = text.get("layer_types") or cfg.get("layer_types")
-    if isinstance(layer_types, list) and any(t != "full_attention" for t in layer_types):
+    if isinstance(layer_types, list) and any(
+        t != "full_attention" for t in layer_types
+    ):
         return True
 
     attention_layers = cfg.get("attention_layers") or text.get("attention_layers")
@@ -211,7 +217,9 @@ def compute_io_profile(
     if not num_layers:
         raise ModelProfileError("num_hidden_layers is missing or zero")
 
-    effective_dtype = kv_dtype or _resolve(cfg, "torch_dtype") or _resolve(cfg, "dtype") or "bfloat16"
+    effective_dtype = (
+        kv_dtype or _resolve(cfg, "torch_dtype") or _resolve(cfg, "dtype") or "bfloat16"
+    )
     elem_size = dtype_to_elem_size(effective_dtype)
     tokens_per_block = block_size
 
@@ -251,19 +259,27 @@ def compute_io_profile(
         if not num_kv_heads_full:
             raise ModelProfileError("num_key_value_heads is required for GQA")
         heads_per_rank = (
-            max(1, int(num_kv_heads_full) // tp) if tp and tp > 0 else int(num_kv_heads_full)
+            max(1, int(num_kv_heads_full) // tp)
+            if tp and tp > 0
+            else int(num_kv_heads_full)
         )
         num_kv_heads_per_rank = heads_per_rank
         head_dim = _resolve(cfg, "head_dim")
         if head_dim is None:
             if not num_attention_heads:
-                raise ModelProfileError("cannot derive head_dim (missing head_dim/num_attention_heads)")
+                raise ModelProfileError(
+                    "cannot derive head_dim (missing head_dim/num_attention_heads)"
+                )
             hidden_size = _resolve(cfg, "hidden_size")
             if hidden_size is None:
-                raise ModelProfileError("cannot derive head_dim (missing head_dim/hidden_size)")
+                raise ModelProfileError(
+                    "cannot derive head_dim (missing head_dim/hidden_size)"
+                )
             head_dim = int(hidden_size) // int(num_attention_heads)
         head_dim = int(head_dim)
-        per_layer_block_bytes = 2 * heads_per_rank * head_dim * tokens_per_block * elem_size
+        per_layer_block_bytes = (
+            2 * heads_per_rank * head_dim * tokens_per_block * elem_size
+        )
         per_layer_formula = (
             f"2 * num_kv_heads({heads_per_rank}) * head_dim({head_dim})"
             f" * block_size({tokens_per_block}) * dtype({elem_size})"

--- a/toolkit/ucm_toolkit/tools/posix_aio/model_profile.py
+++ b/toolkit/ucm_toolkit/tools/posix_aio/model_profile.py
@@ -1,0 +1,278 @@
+"""Model-driven KV cache I/O sizing for the posix-aio tool (standard library only).
+
+Reads a HuggingFace ``config.json`` and computes the POSIX store I/O granularity
+(``shard_size`` / ``shard_number``) the UCM store would use for the model, in
+both layerwise and non-layerwise modes.
+
+Only GQA and the MLA family (plain MLA, and DSA = MLA + Lightning Indexer) are
+sized here. Hybrid (e.g. DeepSeek V4), Mamba / linear-attention, and unknown
+architectures are reported as unsupported so the adapter can warn and exit.
+
+The detection rules mirror ``docs/source/_static/calculator.js``
+(``detectArchitectureType``). The per-token formulas mirror the same source,
+with the TP handling adjusted to match the real UCM store:
+
+- MLA / DSA: the compressed latent is replicated across TP ranks and only
+  rank 0 dumps, so the stored block is the *full* latent (not divided by TP).
+- GQA: each TP rank stores its own KV, so ``num_kv_heads`` is divided by TP.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+ALIGNMENT = 4096
+
+SUPPORTED_ARCHITECTURES = ("mla", "dsa", "gqa")
+
+_DTYPE_BYTES: dict[str, int] = {
+    "bfloat16": 2,
+    "bf16": 2,
+    "half": 2,
+    "float16": 2,
+    "fp16": 2,
+    "float32": 4,
+    "fp32": 4,
+    "float": 4,
+    "float8_e4m3fn": 1,
+    "float8_e5m2": 1,
+    "float8": 1,
+    "fp8": 1,
+    "int8": 1,
+    "uint8": 1,
+}
+
+
+class ModelProfileError(ValueError):
+    """Raised when a model profile cannot be computed."""
+
+
+def load_config(model_dir: str | Path) -> dict[str, Any]:
+    """Load a model's ``config.json`` from a directory or file path."""
+    path = Path(model_dir)
+    config_path = path if path.is_file() else path / "config.json"
+    if not config_path.exists():
+        raise FileNotFoundError(f"config.json not found at {config_path}")
+    with config_path.open(encoding="utf-8") as handler:
+        return json.load(handler)
+
+
+def dtype_to_elem_size(dtype: str | None) -> int:
+    """Return the byte size of one element for a dtype string."""
+    if dtype is None or dtype == "":
+        return 2
+    key = str(dtype).strip().lower()
+    if key in _DTYPE_BYTES:
+        return _DTYPE_BYTES[key]
+    supported = ", ".join(sorted(set(_DTYPE_BYTES)))
+    raise ModelProfileError(
+        f"unsupported dtype '{dtype}'; supported: {supported}"
+    )
+
+
+def detect_architecture(cfg: dict[str, Any]) -> str:
+    """Classify a model config as mla/dsa/gqa/hybrid/mamba/unknown.
+
+    Detection mirrors ``calculator.js:detectArchitectureType``. The text_config
+    sub-dict (present in multimodal configs) is consulted for layer-level
+    indicators.
+    """
+    text = cfg.get("text_config") if isinstance(cfg.get("text_config"), dict) else {}
+
+    def has(key: str, *, sources: tuple[dict, ...] = (cfg, text)) -> bool:
+        for src in sources:
+            value = src.get(key)
+            if value is not None and value is not False and value != "" and value != 0 and value != []:
+                return True
+        return False
+
+    if _is_hybrid(cfg, text, has):
+        return "hybrid"
+
+    model_type = str(cfg.get("model_type") or text.get("model_type") or "").lower()
+    if "mamba" in model_type or "jamba" in model_type:
+        return "mamba"
+
+    kv_lora_rank = cfg.get("kv_lora_rank")
+    qk_rope_head_dim = cfg.get("qk_rope_head_dim")
+    index_head_dim = cfg.get("index_head_dim")
+    if kv_lora_rank and qk_rope_head_dim and index_head_dim:
+        return "dsa"
+    if kv_lora_rank and qk_rope_head_dim and not index_head_dim:
+        return "mla"
+
+    if has("num_key_value_heads") or has("num_kv_heads") or has("num_attention_heads"):
+        return "gqa"
+
+    return "unknown"
+
+
+def _is_hybrid(cfg: dict, text: dict, has) -> bool:
+    """Return True if config exhibits hybrid / non-standard attention signals."""
+    layer_types = text.get("layer_types") or cfg.get("layer_types")
+    if isinstance(layer_types, list) and any(t != "full_attention" for t in layer_types):
+        return True
+
+    attention_layers = cfg.get("attention_layers") or text.get("attention_layers")
+    if isinstance(attention_layers, dict):
+        return True
+    if isinstance(cfg.get("attention_type") or text.get("attention_type"), list):
+        return True
+    if isinstance(
+        cfg.get("layer_attention_type") or text.get("layer_attention_type"), list
+    ):
+        return True
+
+    attention_mode = cfg.get("attention_mode") or text.get("attention_mode")
+    if isinstance(attention_mode, str) and attention_mode.lower() in (
+        "sliding",
+        "linear",
+        "mixed",
+        "sparse",
+    ):
+        return True
+
+    if has("compress_ratios"):
+        return True
+    if has("hybrid_layer_pattern"):
+        return True
+    if has("mixed_attention") or has("sparse_attention"):
+        return True
+    if has("window_attention") or has("attention_window"):
+        return True
+    if has("sliding_window"):
+        return True
+    if has("swa_num_key_value_heads") or has("swa_num_attention_heads"):
+        return True
+    if has("swa_head_dim") or has("add_swa_attention_sink_bias"):
+        return True
+    if has("full_attention_layers") and (
+        has("sliding_attention_layers") or has("linear_attention_layers")
+    ):
+        return True
+    if has("linear_attention", sources=(text, cfg)) or has(
+        "linear_num_key_heads", sources=(text, cfg)
+    ):
+        return True
+    if has("linear_key_head_dim", sources=(text, cfg)):
+        return True
+    if has("global_head_dim", sources=(text, cfg)) or has(
+        "num_global_key_value_heads", sources=(text, cfg)
+    ):
+        return True
+    return False
+
+
+def align_up(value: int, alignment: int = ALIGNMENT) -> int:
+    """Round ``value`` up to the nearest multiple of ``alignment``."""
+    if value <= 0:
+        return 0
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+def _resolve(cfg: dict[str, Any], key: str) -> Any:
+    """Resolve a config field from the top level or text_config sub-dict."""
+    if key in cfg and cfg[key] is not None:
+        return cfg[key]
+    text = cfg.get("text_config")
+    if isinstance(text, dict):
+        value = text.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def compute_io_profile(
+    cfg: dict[str, Any],
+    *,
+    tp: int,
+    block_size: int,
+    layerwise: bool,
+    kv_dtype: str | None = None,
+) -> dict[str, Any]:
+    """Compute the POSIX store shard/block sizing for a supported model.
+
+    ``tp`` only affects GQA (``num_kv_heads`` is divided by TP per rank); MLA
+    and DSA store the full replicated latent and are TP-independent.
+    """
+    arch = detect_architecture(cfg)
+    if arch not in SUPPORTED_ARCHITECTURES:
+        raise ModelProfileError(
+            f"architecture '{arch}' is not supported; only GQA and MLA family "
+            f"(MLA/DSA) are supported"
+        )
+
+    num_layers = _resolve(cfg, "num_hidden_layers")
+    if not num_layers:
+        raise ModelProfileError("num_hidden_layers is missing or zero")
+
+    effective_dtype = kv_dtype or _resolve(cfg, "torch_dtype") or _resolve(cfg, "dtype") or "bfloat16"
+    elem_size = dtype_to_elem_size(effective_dtype)
+    tokens_per_block = block_size
+
+    num_kv_heads_full = (
+        _resolve(cfg, "num_key_value_heads")
+        or _resolve(cfg, "num_kv_heads")
+        or _resolve(cfg, "num_attention_heads")
+    )
+    num_attention_heads = _resolve(cfg, "num_attention_heads")
+
+    if arch in ("mla", "dsa"):
+        kv_lora_rank = _resolve(cfg, "kv_lora_rank")
+        qk_rope_head_dim = _resolve(cfg, "qk_rope_head_dim")
+        if kv_lora_rank is None or qk_rope_head_dim is None:
+            raise ModelProfileError(
+                "kv_lora_rank and qk_rope_head_dim are required for MLA/DSA"
+            )
+        latent = int(kv_lora_rank) + int(qk_rope_head_dim)
+        if arch == "dsa":
+            index_head_dim = _resolve(cfg, "index_head_dim")
+            if index_head_dim is None:
+                raise ModelProfileError("index_head_dim is required for DSA")
+            latent += int(index_head_dim)
+        head_dim = latent
+        per_layer_block_bytes = latent * tokens_per_block * elem_size
+        num_kv_heads_per_rank: int | None = None
+    else:  # gqa
+        if not num_kv_heads_full:
+            raise ModelProfileError("num_key_value_heads is required for GQA")
+        heads_per_rank = (
+            max(1, int(num_kv_heads_full) // tp) if tp and tp > 0 else int(num_kv_heads_full)
+        )
+        num_kv_heads_per_rank = heads_per_rank
+        head_dim = _resolve(cfg, "head_dim")
+        if head_dim is None:
+            if not num_attention_heads:
+                raise ModelProfileError("cannot derive head_dim (missing head_dim/num_attention_heads)")
+            hidden_size = _resolve(cfg, "hidden_size")
+            if hidden_size is None:
+                raise ModelProfileError("cannot derive head_dim (missing head_dim/hidden_size)")
+            head_dim = int(hidden_size) // int(num_attention_heads)
+        per_layer_block_bytes = 2 * heads_per_rank * int(head_dim) * tokens_per_block * elem_size
+
+    if layerwise:
+        shard_size = align_up(per_layer_block_bytes, ALIGNMENT)
+        shard_number = int(num_layers)
+    else:
+        shard_size = align_up(int(num_layers) * per_layer_block_bytes, ALIGNMENT)
+        shard_number = 1
+    store_block_size = shard_size * shard_number
+
+    return {
+        "architecture": arch,
+        "num_hidden_layers": int(num_layers),
+        "head_dim": int(head_dim),
+        "num_kv_heads_per_rank": num_kv_heads_per_rank,
+        "elem_size": elem_size,
+        "dtype": effective_dtype,
+        "per_layer_block_bytes": per_layer_block_bytes,
+        "shard_size": shard_size,
+        "shard_number": shard_number,
+        "store_block_size": store_block_size,
+        "block_size_tokens": tokens_per_block,
+        "tensor_parallel": int(tp) if tp and tp > 0 else 1,
+        "layerwise": bool(layerwise),
+    }


### PR DESCRIPTION
## Purpose

Add a model-driven mode to the `posix-aio` tool: pass `--model` to auto-detect architecture (GQA / MLA / DSA) and compute shard/block sizing from the model config, then forward to the existing `posixstore_aio_test.py` — automating POSIX AIO store bandwidth testing without manual IO sizing.

## Modifications

- **New `posix_aio/model_profile.py`**: loads `config.json`, detects GQA / MLA / DSA (mirroring `docs/source/_static/calculator.js`), and computes per-layer/block bytes, shard size (aligned to 4096), shards-per-file, and file size to match real store IO granularity. Hybrid / Mamba / linear-attention / unknown architectures warn and exit.
- **`posix_aio/adapter.py`**: adds `--model`, `--tp`, `--input-len`, `--layerwise`, `--block-size`, `--kv-dtype`, `--dry-run`; prints a `UCM Store IO Info` summary; model-driven values override manual settings (with warning); `--dry-run` prints summary + forwarded command without running.
- **`README.md`**: documents manual vs. model-driven modes, supported architectures + formulas, MLA/DSA/GQA examples, and `--dry-run`; drops the unclear "import source" section.

## Test

- `--dry-run` verified IO sizing for GQA (Qwen3), MLA (DeepSeek-V3), DSA (GLM-5.1) against expected formulas.
- Unsupported architecture (e.g. Hybrid) warns and exits with code 1.
- End-to-end dump/load run confirmed summary and bandwidth output.