### PR TITLE
Support Cache|Posix H2H pipeline for SGLang MLA models

### DIFF
--- a/ucm/integration/sglang/ucm_connector.py
+++ b/ucm/integration/sglang/ucm_connector.py
@@ -100,6 +100,7 @@ class UnifiedCacheStoreConfig:
         tensor_size = page_bytes if storage_config.is_mla_model else page_bytes // 2
         block_size = tensor_size * (1 if storage_config.is_mla_model else 2)
         is_kv_split = mem_pool_host.layout == "page_first_kv_split"
+        use_cache_pipeline = storage_config.is_mla_model
 
         ucm_cfg = kvc.get("ucm_connector_config")
         name = kvc.get("ucm_connector_name")
@@ -114,8 +115,12 @@ class UnifiedCacheStoreConfig:
             )
 
         cfg = dict(ucm_cfg)
-        if is_kv_split:
-            tensor_sizes = _page_first_kv_split_tensor_sizes(mem_pool_host)
+        if use_cache_pipeline:
+            tensor_sizes = (
+                _page_first_kv_split_tensor_sizes(mem_pool_host)
+                if is_kv_split
+                else [page_bytes]
+            )
             payload_size = sum(tensor_sizes)
             io_direct = bool(cfg.get("io_direct", False))
             block_size = (
@@ -127,7 +132,7 @@ class UnifiedCacheStoreConfig:
             cfg.pop("tensor_size", None)
             cfg["tensor_size_list"] = tensor_sizes
             cfg["cache_use_host_buffer"] = True
-            # Host pointers must never enter the Ascend SDMA or GDR paths.
+            # Host pointers must never enter device SDMA or GDR paths.
             cfg["cache_sdma_direct"] = False
             cfg["use_gdr"] = False
             cfg.pop("gpu_kv_buffer_addrs", None)
@@ -140,7 +145,7 @@ class UnifiedCacheStoreConfig:
             if not cfg.get("unique_id"):
                 tensor_fingerprint = "-".join(str(size) for size in tensor_sizes)
                 cfg["unique_id"] = (
-                    f"sglang-{safe_model_name}-page-first-kv-split-"
+                    f"sglang-{safe_model_name}-{mem_pool_host.layout}-"
                     f"tp{storage_config.tp_size}-{tensor_fingerprint}"
                 )
         else:
@@ -192,6 +197,15 @@ class SglangUcmConnector:
             if self.is_kv_split
             else []
         )
+        self.cache_tensor_sizes = (
+            self.split_tensor_sizes
+            if self.is_kv_split
+            else (
+                [self.page_size * mem_pool_host.get_size_per_token()]
+                if self.is_mla
+                else []
+            )
+        )
 
         self.config_suffix = self._build_config_suffix()
 
@@ -224,16 +238,14 @@ class SglangUcmConnector:
 
     def _build_config_suffix(self) -> str:
         model_name = "-".join(self.model.split("/")) if self.model else ""
-        if self.is_kv_split:
+        if self.is_mla:
             tensor_fingerprint = "-".join(
-                str(size) for size in self.split_tensor_sizes
+                str(size) for size in self.cache_tensor_sizes
             )
             return (
-                f"_{model_name}_page_first_kv_split_p{self.page_size}_"
+                f"_{model_name}_{self.mem_pool_host.layout}_p{self.page_size}_"
                 f"tp{self.tp_size}_{tensor_fingerprint}"
             )
-        if self.is_mla:
-            return f"_{model_name}"
         return f"_{model_name}_{self.tp_rank}_{self.tp_size}"
 
     def _get_physical_key(self, logical_key: str) -> str:

--- a/ucm/integration/sglang/ucm_connector.py
+++ b/ucm/integration/sglang/ucm_connector.py
@@ -21,6 +21,34 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _page_first_kv_split_buffers(mem_pool_host: "HostKVCache") -> List[torch.Tensor]:
+    """Return the K/V Host buffers for a regular MLA split layout."""
+    buffers = [mem_pool_host.k_buffer, mem_pool_host.v_buffer]
+    for name, buffer in zip(("k", "v"), buffers):
+        if not buffer.is_contiguous():
+            raise ValueError(
+                f"page_first_kv_split {name}_buffer must be contiguous"
+            )
+    return buffers
+
+
+def _page_first_kv_split_tensor_sizes(
+    mem_pool_host: "HostKVCache",
+) -> List[int]:
+    page_num = int(mem_pool_host.page_num)
+    if page_num <= 0:
+        raise ValueError(f"invalid page_num for page_first_kv_split: {page_num}")
+    sizes = []
+    for buffer in _page_first_kv_split_buffers(mem_pool_host):
+        nbytes = int(buffer.numel()) * int(buffer.element_size())
+        if nbytes % page_num != 0:
+            raise ValueError(
+                f"buffer bytes {nbytes} are not divisible by page_num {page_num}"
+            )
+        sizes.append(nbytes // page_num)
+    return sizes
+
+
 def _load_extra_config_from_yaml_env() -> Optional[Dict[str, Any]]:
     cfg_path = os.environ.get("UNIFIEDCACHE_CONFIG_FILE")
     if not cfg_path:
@@ -71,6 +99,7 @@ class UnifiedCacheStoreConfig:
         page_bytes = page_size * mem_pool_host.get_size_per_token()
         tensor_size = page_bytes if storage_config.is_mla_model else page_bytes // 2
         block_size = tensor_size * (1 if storage_config.is_mla_model else 2)
+        is_kv_split = mem_pool_host.layout == "page_first_kv_split"
 
         ucm_cfg = kvc.get("ucm_connector_config")
         name = kvc.get("ucm_connector_name")
@@ -85,12 +114,47 @@ class UnifiedCacheStoreConfig:
             )
 
         cfg = dict(ucm_cfg)
-        cfg["store_pipeline"] = "Posix"
-        cfg["storage_backends"] = [
-            path for path in cfg["storage_backends"].split(":") if path
-        ]
+        if is_kv_split:
+            tensor_sizes = _page_first_kv_split_tensor_sizes(mem_pool_host)
+            payload_size = sum(tensor_sizes)
+            io_direct = bool(cfg.get("io_direct", False))
+            block_size = (
+                (payload_size + 4095) // 4096 * 4096
+                if io_direct
+                else payload_size
+            )
+            cfg["store_pipeline"] = "Cache|Posix"
+            cfg.pop("tensor_size", None)
+            cfg["tensor_size_list"] = tensor_sizes
+            cfg["cache_use_host_buffer"] = True
+            # Host pointers must never enter the Ascend SDMA or GDR paths.
+            cfg["cache_sdma_direct"] = False
+            cfg["use_gdr"] = False
+            cfg.pop("gpu_kv_buffer_addrs", None)
+            cfg.pop("gpu_kv_buffer_sizes", None)
+            safe_model_name = (
+                "-".join(storage_config.model_name.split("/"))
+                if storage_config.model_name
+                else "unknown-model"
+            )
+            if not cfg.get("unique_id"):
+                tensor_fingerprint = "-".join(str(size) for size in tensor_sizes)
+                cfg["unique_id"] = (
+                    f"sglang-{safe_model_name}-page-first-kv-split-"
+                    f"tp{storage_config.tp_size}-{tensor_fingerprint}"
+                )
+        else:
+            cfg["store_pipeline"] = "Posix"
+            cfg["tensor_size"] = tensor_size
+
+        storage_backends = cfg["storage_backends"]
+        if isinstance(storage_backends, str):
+            cfg["storage_backends"] = [
+                path for path in storage_backends.split(":") if path
+            ]
+        else:
+            cfg["storage_backends"] = list(storage_backends)
         cfg["device_id"] = get_world_group().local_rank
-        cfg["tensor_size"] = tensor_size
         cfg["shard_size"] = block_size
         cfg["block_size"] = block_size
         cfg["stream_number"] = 8
@@ -117,6 +181,17 @@ class SglangUcmConnector:
         self.cache_nums = 1 if self.is_mla else 2
         self.tp_rank = storage_config.tp_rank
         self.tp_size = storage_config.tp_size
+        self.is_kv_split = mem_pool_host.layout == "page_first_kv_split"
+        self.split_buffers = (
+            _page_first_kv_split_buffers(mem_pool_host)
+            if self.is_kv_split
+            else []
+        )
+        self.split_tensor_sizes = (
+            _page_first_kv_split_tensor_sizes(mem_pool_host)
+            if self.is_kv_split
+            else []
+        )
 
         self.config_suffix = self._build_config_suffix()
 
@@ -149,6 +224,14 @@ class SglangUcmConnector:
 
     def _build_config_suffix(self) -> str:
         model_name = "-".join(self.model.split("/")) if self.model else ""
+        if self.is_kv_split:
+            tensor_fingerprint = "-".join(
+                str(size) for size in self.split_tensor_sizes
+            )
+            return (
+                f"_{model_name}_page_first_kv_split_p{self.page_size}_"
+                f"tp{self.tp_size}_{tensor_fingerprint}"
+            )
         if self.is_mla:
             return f"_{model_name}"
         return f"_{model_name}_{self.tp_rank}_{self.tp_size}"
@@ -168,6 +251,35 @@ class SglangUcmConnector:
             return [], [], []
 
         shard_index_list = [0] * len(encoded_keys)
+        if self.is_kv_split:
+            indices = host_indices.tolist()
+            if len(indices) % self.page_size != 0:
+                raise ValueError(
+                    "host_indices length must be a multiple of page_size"
+                )
+            if len(indices) // self.page_size != len(encoded_keys):
+                raise ValueError(
+                    "page count mismatch between keys and host_indices: "
+                    f"{len(encoded_keys)} != {len(indices) // self.page_size}"
+                )
+            ptr_list = []
+            for offset in range(0, len(indices), self.page_size):
+                first_token_index = int(indices[offset])
+                if first_token_index % self.page_size != 0:
+                    raise ValueError(
+                        "page_first_kv_split host index must start at a page boundary"
+                    )
+                page_index = first_token_index // self.page_size
+                ptr_list.append(
+                    [
+                        buffer.data_ptr() + page_index * tensor_size
+                        for buffer, tensor_size in zip(
+                            self.split_buffers, self.split_tensor_sizes
+                        )
+                    ]
+                )
+            return encoded_keys, shard_index_list, ptr_list
+
         ptr_list, _ = self.mem_pool_host.get_page_buffer_meta(host_indices)
 
         if not self.is_mla:

--- a/ucm/integration/sglang/unifiedcache_store.py
+++ b/ucm/integration/sglang/unifiedcache_store.py
@@ -43,9 +43,11 @@ class UnifiedCacheStore(HiCacheStorage):
 
     def register_mem_pool_host(self, mem_pool_host: HostKVCache):
         super().register_mem_pool_host(mem_pool_host)
-        if mem_pool_host.layout != "page_first":
+        supported_layouts = {"page_first", "page_first_kv_split", "page_first_direct"}
+        if mem_pool_host.layout not in supported_layouts:
             raise ValueError(
-                "UnifiedCacheStore currently requires --hicache-mem-layout page_first, "
+                "UnifiedCacheStore currently requires one of "
+                f"{sorted(supported_layouts)}, "
                 f"got {mem_pool_host.layout!r}."
             )
 

--- a/ucm/store/cache/cc/cache_store.cc
+++ b/ucm/store/cache/cc/cache_store.cc
@@ -49,7 +49,8 @@ public:
             UC_ERROR("Failed to check config params: {}.", s);
             return s;
         }
-        if (config.deviceId >= 0 && !config.gpuKvBufferAddrs.empty()) {
+        if (!config.cacheUseHostBuffer && config.deviceId >= 0 &&
+            !config.gpuKvBufferAddrs.empty()) {
             gpuKvBufferRegistrations_ = std::make_unique<Trans::GdrKVBufferConfig>();
             s = gpuKvBufferRegistrations_->Register(config.gpuKvBufferAddrs,
                                                     config.gpuKvBufferSizes);
@@ -161,6 +162,7 @@ private:
         config.GetNumbers("gpu_kv_buffer_sizes", param.gpuKvBufferSizes);
         config.Get("use_gdr", param.useGdr);
         config.Get("cache_sdma_direct", param.cacheSdmaDirect);
+        config.Get("cache_use_host_buffer", param.cacheUseHostBuffer);
         config.GetNumber("local_rank_size", param.localRankSize);
         return param;
     }
@@ -184,6 +186,10 @@ private:
         if (config.deviceId < -1) {
             return Status::InvalidParam("invalid device({})", config.deviceId);
         }
+        if (config.cacheUseHostBuffer && config.deviceId < 0) {
+            return Status::InvalidParam(
+                "cache_use_host_buffer requires a non-negative device_id as cache owner id");
+        }
         if (config.uniqueId.empty()) { return Status::InvalidParam("invalid unique id"); }
         auto s =
             Trans::GdrKVBufferConfig::Validate(config.gpuKvBufferAddrs, config.gpuKvBufferSizes);
@@ -196,6 +202,12 @@ private:
         if (config.deviceId == -1) { return Status::OK(); }
         s = CheckSizeConfig(config);
         if (s.Failure()) { return s; }
+        if (config.cacheUseHostBuffer &&
+            (config.cacheSdmaDirect || config.useGdr || !config.gpuKvBufferAddrs.empty())) {
+            return Status::InvalidParam(
+                "cache_use_host_buffer is incompatible with cache_sdma_direct, use_gdr, "
+                "and gpu_kv_buffer_addrs");
+        }
 #if !UCM_RUNTIME_ASCEND_SDMA_DIRECT
         if (config.cacheSdmaDirect) {
             return Status::InvalidParam("Cache SDMA Direct requires RUNTIME_ENVIRONMENT=ascend-a3");
@@ -253,6 +265,7 @@ private:
             UC_INFO("Set {}::StreamNumber to {}.", ns, config.EffectiveStreamNumber());
         }
         UC_INFO("Set {}::CacheSdmaDirect to {}.", ns, config.cacheSdmaDirect);
+        UC_INFO("Set {}::CacheUseHostBuffer to {}.", ns, config.cacheUseHostBuffer);
         UC_INFO("Set {}::LoadExclusiveBufferNumber to {}.", ns, config.loadExclusiveBufferNumber);
         UC_INFO("Set {}::GpuKvBufferNumber to {}.", ns, config.gpuKvBufferAddrs.size());
         UC_INFO("Set {}::UseGdr to {}.", ns, config.useGdr);

--- a/ucm/store/cache/cc/dump_queue.cc
+++ b/ucm/store/cache/cc/dump_queue.cc
@@ -24,6 +24,8 @@
 #include "dump_queue.h"
 #include <algorithm>
 #include <atomic>
+#include <cstddef>
+#include <cstring>
 #include <memory>
 #include "logger/logger.h"
 #include "metrics_api.h"
@@ -48,6 +50,7 @@ Status DumpQueue::Setup(const Config& config, TaskIdSet* failureSet, TransBuffer
     streamNumber_ = config.EffectiveStreamNumber();
     useGdr_ = config.useGdr;
     cacheSdmaDirect_ = config.cacheSdmaDirect;
+    useHostBuffer_ = config.cacheUseHostBuffer;
     cpuAffinityCores_ = config.cpuAffinityCores;
     waiting_.Setup(config.waitingQueueDepth);
     dumping_.Setup(config.runningQueueDepth);
@@ -76,8 +79,9 @@ void DumpQueue::DispatchStage(std::promise<Status>& started)
         UC_WARN("Failed({}) to set UCM dump dispatcher name.", nameStatus);
     }
     CopyStream stream;
-    auto s = cacheSdmaDirect_ ? stream.SetupSdmaDirect(deviceId_, useGdr_)
-                              : stream.Setup(deviceId_, streamNumber_, useGdr_);
+    auto s = useHostBuffer_ ? Status::OK()
+                            : (cacheSdmaDirect_ ? stream.SetupSdmaDirect(deviceId_, useGdr_)
+                                                : stream.Setup(deviceId_, streamNumber_, useGdr_));
     started.set_value(s);
     if (s.Failure()) [[unlikely]] { return; }
     if (!cpuAffinityCores_.empty()) {
@@ -115,6 +119,10 @@ Status DumpQueue::DumpOneTask(CopyStream& stream, TaskPtr task)
     dumpCtx.taskHandle = task->id;
     std::shared_ptr<std::atomic<double>> eventReadyTp;
     if (task->desc.prerequisiteHandle != 0) {
+        if (useHostBuffer_) {
+            return Status::InvalidParam(
+                "host-to-host dump does not accept a device prerequisite event");
+        }
         auto s = stream.WaitEvent(reinterpret_cast<void*>(task->desc.prerequisiteHandle));
         if (s.Failure()) [[unlikely]] {
             UC_ERROR("Failed({}) to wait prerequisite event for dump task({}).", s, task->id);
@@ -134,9 +142,11 @@ Status DumpQueue::DumpOneTask(CopyStream& stream, TaskPtr task)
         if (!handle.Owner()) { continue; }
         if (!handle.Ready()) {
             auto* host = cacheSdmaDirect_ ? handle.DeviceData() : handle.Data();
-            auto s = DeviceToHostAsync(stream, shard.addrs.data(), host);
+            auto s = useHostBuffer_ ? HostToHostGather(shard, host)
+                                    : DeviceToHostAsync(stream, shard.addrs.data(), host);
             if (s.Failure()) [[unlikely]] {
-                UC_ERROR("Failed({}) to do D2H for task({}).", s, task->id);
+                UC_ERROR("Failed({}) to do {} gather for task({}).", s,
+                         useHostBuffer_ ? "H2H" : "D2H", task->id);
                 UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_d2h_errors_total"), 1.0);
                 return s;
             }
@@ -152,7 +162,7 @@ Status DumpQueue::DumpOneTask(CopyStream& stream, TaskPtr task)
                              static_cast<double>(backendTaskDesc.size()));
     if (backendTaskDesc.empty()) { return Status::OK(); }
     auto tpSyncStart = NowTime::Now();
-    auto s = stream.Synchronize();
+    auto s = useHostBuffer_ ? Status::OK() : stream.Synchronize();
     if (s.Failure()) [[unlikely]] {
         UC_ERROR("Failed({}) to sync on stream for task({}).", s, task->id);
         UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_d2h_errors_total"), 1.0);
@@ -199,6 +209,25 @@ Status DumpQueue::DumpOneTask(CopyStream& stream, TaskPtr task)
 Status DumpQueue::DeviceToHostAsync(CopyStream& stream, void** device, void* host)
 {
     return stream.DeviceToHostAsync(device, host, tensorSizes_);
+}
+
+Status DumpQueue::HostToHostGather(const Detail::Shard& shard, void* destination)
+{
+    if (shard.addrs.size() != tensorSizes_.size()) {
+        return Status::InvalidParam("invalid host addr number({}, expect {})", shard.addrs.size(),
+                                    tensorSizes_.size());
+    }
+    if (destination == nullptr) { return Status::InvalidParam("invalid null host destination"); }
+    auto* dst = static_cast<std::byte*>(destination);
+    size_t offset = 0;
+    for (size_t i = 0; i < tensorSizes_.size(); ++i) {
+        if (shard.addrs[i] == nullptr) {
+            return Status::InvalidParam("invalid null host source({})", i);
+        }
+        std::memcpy(dst + offset, shard.addrs[i], tensorSizes_[i]);
+        offset += tensorSizes_[i];
+    }
+    return Status::OK();
 }
 
 void DumpQueue::BackendDumpStage()

--- a/ucm/store/cache/cc/dump_queue.h
+++ b/ucm/store/cache/cc/dump_queue.h
@@ -59,6 +59,7 @@ private:
     size_t streamNumber_{1};
     bool useGdr_{false};
     bool cacheSdmaDirect_{false};
+    bool useHostBuffer_{false};
     std::vector<ssize_t> cpuAffinityCores_{};
     SpscRingQueue<TaskPair> waiting_;
     SpscRingQueue<DumpCtx> dumping_;
@@ -75,6 +76,7 @@ private:
     void DispatchOneTask(CopyStream& stream, TaskPair&& pair);
     Status DumpOneTask(CopyStream& stream, TaskPtr task);
     Status DeviceToHostAsync(CopyStream& stream, void** device, void* host);
+    Status HostToHostGather(const Detail::Shard& shard, void* destination);
     void BackendDumpStage();
 };
 

--- a/ucm/store/cache/cc/global_config.h
+++ b/ucm/store/cache/cc/global_config.h
@@ -58,6 +58,7 @@ struct Config {
     std::vector<size_t> gpuKvBufferSizes{};
     bool useGdr{false};
     bool cacheSdmaDirect{UCM_RUNTIME_ASCEND_SDMA_DIRECT};
+    bool cacheUseHostBuffer{false};
     size_t localRankSize{8};
 
     size_t EffectiveStreamNumber() const noexcept { return cacheSdmaDirect ? 1 : streamNumber; }

--- a/ucm/store/cache/cc/load_queue.cc
+++ b/ucm/store/cache/cc/load_queue.cc
@@ -22,6 +22,8 @@
  * SOFTWARE.
  * */
 #include "load_queue.h"
+#include <cstddef>
+#include <cstring>
 #include "logger/logger.h"
 #include "metrics_api.h"
 #include "thread/cpu_affinity.h"
@@ -45,6 +47,7 @@ Status LoadQueue::Setup(const Config& config, TaskIdSet* failureSet, TransBuffer
     streamNumber_ = config.EffectiveStreamNumber();
     useGdr_ = config.useGdr;
     cacheSdmaDirect_ = config.cacheSdmaDirect;
+    useHostBuffer_ = config.cacheUseHostBuffer;
     cpuAffinityCores_ = config.cpuAffinityCores;
     localRankSize_ = config.localRankSize;
     waiting_.Setup(config.waitingQueueDepth);
@@ -159,8 +162,9 @@ void LoadQueue::TransferStage(std::promise<Status>& started)
     auto nameStatus = CpuAffinity::SetCurrentThreadName("ucm_load_xfer");
     if (nameStatus.Failure()) { UC_WARN("Failed({}) to set UCM load transfer name.", nameStatus); }
     CopyStream stream;
-    auto s = cacheSdmaDirect_ ? stream.SetupSdmaDirect(deviceId_, useGdr_)
-                              : stream.Setup(deviceId_, streamNumber_, useGdr_);
+    auto s = useHostBuffer_ ? Status::OK()
+                            : (cacheSdmaDirect_ ? stream.SetupSdmaDirect(deviceId_, useGdr_)
+                                                : stream.Setup(deviceId_, streamNumber_, useGdr_));
     started.set_value(s);
     if (s.Failure()) [[unlikely]] { return; }
     if (!cpuAffinityCores_.empty()) {
@@ -197,16 +201,22 @@ void LoadQueue::TransferOneTask(CopyStream& stream, ShardTask&& task)
                                  (tpBackendReady - tpBackendWait) * 1e3);
 
         auto* host = cacheSdmaDirect_ ? task.bufferHandle.DeviceData() : task.bufferHandle.Data();
-        s = HostToDeviceAsync(stream, host, task.shard.addrs.data());
+        s = useHostBuffer_ ? HostToHostScatter(host, task.shard)
+                           : HostToDeviceAsync(stream, host, task.shard.addrs.data());
         auto tpH2dSubmitted = NowTime::Now();
         if (s.Failure()) [[unlikely]] {
-            UC_ERROR("Failed({}) to do H2D for task({}).", s, taskHandle);
+            UC_ERROR("Failed({}) to do {} scatter for task({}).", s,
+                     useHostBuffer_ ? "H2H" : "H2D", taskHandle);
             UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2d_errors_total"), 1.0);
             RecordShardResults(holder_, &task, false);
             break;
         }
         UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2d_submit_ms"),
                                  (tpH2dSubmitted - tpBackendReady) * 1e3);
+        if (useHostBuffer_) {
+            RecordShardResults({}, &task, true);
+            break;
+        }
         if (!waiter) {
             holder_.push_back(std::move(task));
             return;
@@ -257,6 +267,25 @@ Status LoadQueue::WaitBackendTaskReady(ShardTask& task)
 Status LoadQueue::HostToDeviceAsync(CopyStream& stream, void* host, void** device)
 {
     return stream.HostToDeviceAsync(host, device, tensorSizes_);
+}
+
+Status LoadQueue::HostToHostScatter(void* source, const Detail::Shard& shard)
+{
+    if (shard.addrs.size() != tensorSizes_.size()) {
+        return Status::InvalidParam("invalid host addr number({}, expect {})", shard.addrs.size(),
+                                    tensorSizes_.size());
+    }
+    if (source == nullptr) { return Status::InvalidParam("invalid null host source"); }
+    auto* src = static_cast<std::byte*>(source);
+    size_t offset = 0;
+    for (size_t i = 0; i < tensorSizes_.size(); ++i) {
+        if (shard.addrs[i] == nullptr) {
+            return Status::InvalidParam("invalid null host destination({})", i);
+        }
+        std::memcpy(shard.addrs[i], src + offset, tensorSizes_[i]);
+        offset += tensorSizes_[i];
+    }
+    return Status::OK();
 }
 
 void LoadQueue::RecordShardResults(const std::vector<ShardTask>& tasks, const ShardTask* extra,

--- a/ucm/store/cache/cc/load_queue.h
+++ b/ucm/store/cache/cc/load_queue.h
@@ -61,6 +61,7 @@ private:
     size_t streamNumber_{1};
     bool useGdr_{false};
     bool cacheSdmaDirect_{false};
+    bool useHostBuffer_{false};
     std::vector<ssize_t> cpuAffinityCores_{};
     size_t localRankSize_{};
     SpscRingQueue<TaskPair> waiting_;
@@ -81,6 +82,7 @@ private:
     void TransferOneTask(CopyStream& stream, ShardTask&& task);
     Status WaitBackendTaskReady(ShardTask& task);
     Status HostToDeviceAsync(CopyStream& stream, void* host, void** device);
+    Status HostToHostScatter(void* source, const Detail::Shard& shard);
     void RecordShardResults(const std::vector<ShardTask>& tasks, const ShardTask* extra,
                             bool success) const;
     void RecordFailedShards(size_t count) const;

--- a/ucm/store/test/case/cache/cache_dump_queue_test.cc
+++ b/ucm/store/test/case/cache/cache_dump_queue_test.cc
@@ -22,6 +22,8 @@
  * SOFTWARE.
  * */
 #include <gtest/gtest.h>
+#include <array>
+#include <cstring>
 #include "cache/cc/dump_queue.h"
 #include "detail/data_generator.h"
 #include "detail/mock_store.h"
@@ -152,4 +154,54 @@ TEST_F(UCCacheDumpQueueTest, DumpBlockWhileBackendUnhealthy)
     waiter->Wait();
     ASSERT_TRUE(failureSet.Contains(task->id));
     EXPECT_EQ(task->FailureStatus(), UC::Status::StoreUnhealthy());
+}
+
+TEST_F(UCCacheDumpQueueTest, HostToHostGatherSupportsVariableTensorSizes)
+{
+    using namespace UC::CacheStore;
+    using namespace testing;
+    constexpr size_t kSize = 16;
+    constexpr size_t vSize = 8;
+    std::array<uint8_t, kSize> k{};
+    std::array<uint8_t, vSize> v{};
+    for (size_t i = 0; i < k.size(); ++i) { k[i] = static_cast<uint8_t>(i + 1); }
+    for (size_t i = 0; i < v.size(); ++i) { v[i] = static_cast<uint8_t>(i + 33); }
+
+    UC::Test::Detail::MockStore backend;
+    EXPECT_CALL(backend, Dump).WillOnce(Invoke([&](UC::Detail::TaskDesc desc) {
+        EXPECT_EQ(desc.size(), 1);
+        auto* data = static_cast<uint8_t*>(desc[0].addrs[0]);
+        EXPECT_EQ(std::memcmp(data, k.data(), k.size()), 0);
+        EXPECT_EQ(std::memcmp(data + k.size(), v.data(), v.size()), 0);
+        return NextId();
+    }));
+    EXPECT_CALL(backend, Wait).WillOnce(Return(UC::Status::OK()));
+
+    UC::HashSet<UC::Detail::TaskHandle> failureSet;
+    Config config;
+    config.storeBackend = &backend;
+    config.tensorSizes = {kSize, vSize};
+    config.shardSize = kSize + vSize;
+    config.blockSize = config.shardSize;
+    config.deviceId = 0;
+    config.bufferCapacity = config.shardSize * 1024;
+    config.uniqueId = rd.RandomString(10);
+    config.shareBufferEnable = true;
+    config.cacheUseHostBuffer = true;
+    config.cacheSdmaDirect = false;
+
+    TransBuffer buffer;
+    DumpQueue dumpQ;
+    ASSERT_EQ(buffer.Setup(config), UC::Status::OK());
+    ASSERT_EQ(dumpQ.Setup(config, &failureSet, &buffer), UC::Status::OK());
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId(
+        "a1b2c3d4e5f6789012345678901234ab");
+    UC::Detail::TaskDesc desc{
+        {blockId, 0, {k.data(), v.data()}}
+    };
+    auto task = std::make_shared<TransTask>(TransTask::Type::DUMP, desc);
+    auto waiter = std::make_shared<UC::Latch>();
+    dumpQ.Submit(task, waiter);
+    waiter->Wait();
+    ASSERT_FALSE(failureSet.Contains(task->id));
 }

--- a/ucm/store/test/case/cache/cache_load_queue_test.cc
+++ b/ucm/store/test/case/cache/cache_load_queue_test.cc
@@ -22,6 +22,8 @@
  * SOFTWARE.
  * */
 #include <gtest/gtest.h>
+#include <array>
+#include <cstring>
 #include "cache/cc/load_queue.h"
 #include "detail/data_generator.h"
 #include "detail/mock_store.h"
@@ -225,4 +227,56 @@ TEST_F(UCCacheLoadQueueTest, LoadWhileBackendWaitFailed)
     ASSERT_EQ(observer.GetState(), TransBuffer::State::FAILED);
     ASSERT_EQ(observer.FailureStatus(), UC::Status::NotFound());
     ASSERT_EQ(task->FailureStatus(), UC::Status::NotFound());
+}
+
+TEST_F(UCCacheLoadQueueTest, HostToHostScatterSupportsVariableTensorSizes)
+{
+    using namespace UC::CacheStore;
+    using namespace testing;
+    constexpr size_t kSize = 16;
+    constexpr size_t vSize = 8;
+    std::array<uint8_t, kSize + vSize> expected{};
+    for (size_t i = 0; i < expected.size(); ++i) {
+        expected[i] = static_cast<uint8_t>(i + 1);
+    }
+
+    UC::Test::Detail::MockStore backend;
+    EXPECT_CALL(backend, Load).WillOnce(Invoke([&](UC::Detail::TaskDesc desc) {
+        EXPECT_EQ(desc.size(), 1);
+        std::memcpy(desc[0].addrs[0], expected.data(), expected.size());
+        return NextId();
+    }));
+    EXPECT_CALL(backend, Wait).WillOnce(Return(UC::Status::OK()));
+
+    UC::HashSet<UC::Detail::TaskHandle> failureSet;
+    Config config;
+    config.storeBackend = &backend;
+    config.tensorSizes = {kSize, vSize};
+    config.shardSize = expected.size();
+    config.blockSize = config.shardSize;
+    config.deviceId = 0;
+    config.bufferCapacity = config.shardSize * 1024;
+    config.uniqueId = rd.RandomString(10);
+    config.shareBufferEnable = true;
+    config.cacheUseHostBuffer = true;
+    config.cacheSdmaDirect = false;
+
+    TransBuffer buffer;
+    LoadQueue loadQ;
+    ASSERT_EQ(buffer.Setup(config), UC::Status::OK());
+    ASSERT_EQ(loadQ.Setup(config, &failureSet, &buffer), UC::Status::OK());
+    std::array<uint8_t, kSize> k{};
+    std::array<uint8_t, vSize> v{};
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId(
+        "a1b2c3d4e5f6789012345678901234ab");
+    UC::Detail::TaskDesc desc{
+        {blockId, 0, {k.data(), v.data()}}
+    };
+    auto task = std::make_shared<TransTask>(TransTask::Type::LOAD, desc);
+    auto waiter = std::make_shared<UC::Latch>();
+    loadQ.Submit(task, waiter);
+    waiter->Wait();
+    ASSERT_FALSE(failureSet.Contains(task->id));
+    EXPECT_EQ(std::memcmp(k.data(), expected.data(), k.size()), 0);
+    EXPECT_EQ(std::memcmp(v.data(), expected.data() + k.size(), v.size()), 0);
 }


### PR DESCRIPTION
 ## Purpose

  Enable SGLang MLA models to use the UCM `Cache|Posix` pipeline through
  Host-to-Host transfers.

  SGLang HiCache passes Host KV addresses to external storage, while CacheStore
  previously treated all addresses as device pointers and always performed
  D2H/H2D transfers.

  This PR adds a Host-buffer mode to CacheStore and automatically selects
  `Cache|Posix` for MLA models.

  Supported scenarios:

  - Ascend MLA with `page_first_kv_split`
  - CUDA MLA with `page_first`
  - Primary MLA KV cache only; Indexer and auxiliary KV pools are out of scope

  Non-MLA models continue to use the Posix-only pipeline.

  ## Modifications

  ### CacheStore H2H support

  - Add the `cache_use_host_buffer` configuration.
  - Gather one or multiple Host tensors into a contiguous CacheStore shard on dump.
  - Scatter a CacheStore shard back to Host tensors on load.
  - Support tensors with different sizes through `tensor_size_list`.
  - Skip device streams and D2H/H2D synchronization in Host-buffer mode.
  - Reject incompatible options:
    - `cache_sdma_direct`
    - `use_gdr`
    - `gpu_kv_buffer_addrs`
  - Preserve the existing device transfer path by default.

  Data path:

  ```text
  Dump:
  SGLang Host KV -> CacheStore H2H gather -> PosixStore

  Load:
  PosixStore -> CacheStore H2H scatter -> SGLang Host KV

  ### SGLang integration

  - Automatically select the pipeline using is_mla_model:

   Model type    Pipeline
  ━━━━━━━━━━━━
   MLA           Cache|Posix
  ─────────────────  
   Non-MLA       Posix

  - Support page_first, page_first_direct, and page_first_kv_split.
  - Calculate per-page tensor sizes from the actual Host tensors.
  - Support separate, variable-sized K/V buffers for page_first_kv_split.
  - Use a single Host tensor per page for regular CUDA MLA layouts.
  - Align shard_size to 4 KiB when io_direct=true.
  - Generate layout- and tensor-size-aware cache identifiers.
  - Disable SDMA/GDR paths when passing Host pointers.

  Non-MLA behavior remains unchanged. On Ascend, the direct Posix path should use:

  io_direct: false
  posix_io_engine: psync

  Direct I/O for Ascend non-MLA Host pools is outside the scope of this PR.

  ## Test

  Added CacheStore unit tests covering:

  - H2H gather and scatter
  - Multiple tensors with different sizes
  - Tensor ordering and data integrity