### PR TITLE
[Fix] 信号 handler 修复：re-raise 防止死循环，启用 core dump

### DIFF
--- a/ucm/shared/infra/logger/cc/spdlog_logger.h
+++ b/ucm/shared/infra/logger/cc/spdlog_logger.h
@@ -27,7 +27,6 @@
 #include <atomic>
 #include <chrono>
 #include <csignal>
-#include <cstdlib>
 #include <mutex>
 #include <spdlog/spdlog.h>
 #include <string>
@@ -72,7 +71,20 @@ public:
         std::signal(SIGILL, &_signal_handler);
         std::signal(SIGINT, &_signal_handler);
     }
-    static void _signal_handler(int signum) { Logger::GetInstance().Flush(); }
+
+    static void _signal_handler(int signum)
+    {
+        // 只允许第一次进入时刷日志，防止 Flush 期间又来一个不同的致命信号导致重入
+        static std::atomic_flag flushed = ATOMIC_FLAG_INIT;
+        if (!flushed.test_and_set()) { Logger::GetInstance().Flush(); }
+
+        // 恢复默认动作后重新发给自己：
+        // SIGSEGV/SIGABRT/SIGFPE/SIGILL 的默认动作是 Term+Core，会生成 core dump；
+        // SIGINT 的默认动作是 Term，不产生 core dump。
+        // 是否 dump 由内核按信号种类决定，不需要代码区分。
+        std::signal(signum, SIG_DFL);
+        std::raise(signum);
+    }
 
     void Log(Level&& lv, SourceLocation&& loc, std::string&& msg);
     void LogFileOnly(Level&& lv, SourceLocation&& loc, std::string&& msg);

--- a/ucm/shared/infra/logger/cc/spdlog_logger.h
+++ b/ucm/shared/infra/logger/cc/spdlog_logger.h
@@ -74,14 +74,16 @@ public:
 
     static void _signal_handler(int signum)
     {
-        // 只允许第一次进入时刷日志，防止 Flush 期间又来一个不同的致命信号导致重入
+        // Only flush logs on first entry, to prevent reentrancy from a different
+        // fatal signal arriving during Flush
         static std::atomic_flag flushed = ATOMIC_FLAG_INIT;
         if (!flushed.test_and_set()) { Logger::GetInstance().Flush(); }
 
-        // 恢复默认动作后重新发给自己：
-        // SIGSEGV/SIGABRT/SIGFPE/SIGILL 的默认动作是 Term+Core，会生成 core dump；
-        // SIGINT 的默认动作是 Term，不产生 core dump。
-        // 是否 dump 由内核按信号种类决定，不需要代码区分。
+        // Restore the default action and re-raise to ourselves:
+        // SIGSEGV/SIGABRT/SIGFPE/SIGILL default to Term+Core, generating a core dump;
+        // SIGINT defaults to Term, no core dump.
+        // Whether to dump is decided by the kernel based on signal type, no need to
+        // handle it in code.
         std::signal(signum, SIG_DFL);
         std::raise(signum);
     }


### PR DESCRIPTION
## 背景

`spdlog_logger.h` 中的 `_signal_handler` 原实现只调用了 `Flush()` 就直接 return，对于 `SIGSEGV`/`SIGFPE`/`SIGILL` 这类硬件信号，从 handler 返回后会**重新执行出错的指令**，导致无限循环：

- 进程永远不会终止，**无法生成 core dump**
- 日志文件无限增长（实测 3 秒内涨到 8MB / 64 万行）

## 修复方案

在 `Flush()` 之后，恢复信号默认动作并重新发给自身：

```cpp
static void _signal_handler(int signum)
{
    static std::atomic_flag flushed = ATOMIC_FLAG_INIT;
    if (!flushed.test_and_set()) { Logger::GetInstance().Flush(); }
    std::signal(signum, SIG_DFL);
    std::raise(signum);
}
```

- `SIG_DFL` + `raise` 让内核按信号类型决定终止方式
- `SIGSEGV`/`SIGABRT`/`SIGFPE`/`SIGILL` → Term+Core，生成 core dump
- `SIGINT` → Term，不生成 core dump
- `atomic_flag` 防止 `Flush` 期间另一个不同信号导致重入

## 替代 #1256

本 PR 替代并关闭 #1256。#1256 对 `SIGINT` 使用了 `std::exit(128 + signum)`，导致 `waitpid` 返回 `WIFEXITED` 而非 `WIFSIGNALED`——虽然 shell 的 `$?` 都显示 130，但二者在进程层面是不同的：`WIFSIGNALED` 表示被信号杀死，`WIFEXITED` 表示主动退出。统一 re-raise 后所有信号都是 `WIFSIGNALED`，语义正确。

## 测试

通过 `fork/waitpid` 验证全部 5 个注册信号：

| 信号 | 编号 | 结果 |
|---|---|---|
| SIGSEGV | 11 | WIFSIGNALED, signal=11 |
| SIGABRT | 6 | WIFSIGNALED, signal=6 |
| SIGFPE | 8 | WIFSIGNALED, signal=8 |
| SIGILL | 4 | WIFSIGNALED, signal=4 |
| SIGINT | 2 | WIFSIGNALED, signal=2 |

- [x] 代码编译通过
- [x] 手动测试全部 5 个信号
