### PR TITLE
[Feat][Test] Refactor ASU buffer registration, unify QP config, and encapsulate task execution

### DIFF
--- a/ucm/transport/kv/asu/test/client/asu_client_e2e_metrics_test.cpp
+++ b/ucm/transport/kv/asu/test/client/asu_client_e2e_metrics_test.cpp
@@ -858,8 +858,13 @@ TEST(AsuClientE2EMetricsTest, DiskMembershipChangesRefreshAndContinueWorkload)
     QueryResult ignoredResult;
     auto status = QueryAndWait(*client, {MakeCacheKey("membership-refresh-add")}, ignoredResult);
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
-    ASSERT_TRUE(WaitUntil(
-        [&] { return viewServer->FetchCount() >= 2 && state->Snapshot().createdTransports >= 3; }));
+    const auto addProbeKeys = MakeProbeKeys(512);
+    ASSERT_TRUE(WaitUntil([&] {
+        state->ClearOperationCalls();
+        QueryResult result;
+        const auto retryStatus = QueryAndWait(*client, addProbeKeys, result);
+        return retryStatus.ok() && state->OperationCalls(3) > 0;
+    }));
 
     std::vector<std::vector<std::uint8_t>> addedPayloads;
     auto addedEntries = MakeStoreEntries("membership-added-key-", 96, 96, addedPayloads);
@@ -875,9 +880,10 @@ TEST(AsuClientE2EMetricsTest, DiskMembershipChangesRefreshAndContinueWorkload)
     status = QueryAndWait(*client, probeKeys, ignoredResult);
     EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
     ASSERT_TRUE(WaitUntil([&] {
+        state->ClearOperationCalls();
         QueryResult result;
-        auto retryStatus = QueryAndWait(*client, probeKeys, result);
-        return retryStatus.ok();
+        const auto retryStatus = QueryAndWait(*client, probeKeys, result);
+        return retryStatus.ok() && state->OperationCalls(2) == 0 && state->OperationCalls(3) > 0;
     }));
 
     state->ClearOperationCalls();

--- a/ucm/transport/kv/asu/test/transport/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/asu_submit_flow_test.cpp
@@ -127,9 +127,7 @@ public:
 void CreateTaskExecutor(AsuTransportImpl& transport)
 {
     transport.taskExecutor_ = std::make_unique<TransportTaskExecutor>(
-        transport.config_, transport.ioScheduler_, transport.transProvider_,
-        transport.sendBufferManager_, transport.flagBufferManager_, transport.protocolManager_,
-        transport.connManager_, transport.nextRequestCid_);
+        transport.config_, transport.transProvider_, transport.connManager_);
 }
 
 class AsuSubmitFlowBufferTest : public ::testing::Test {
@@ -158,6 +156,185 @@ protected:
 }  // namespace
 
 namespace {
+
+class AsuTransportBufferRegistrationTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite()
+    {
+        const auto ret = aclInit(nullptr);
+        if (ret != ACL_SUCCESS && ret != ACL_ERROR_REPEAT_INITIALIZE) {
+            FAIL() << "aclInit failed: " << ret;
+        }
+        ASSERT_EQ(aclrtSetDevice(0), ACL_SUCCESS);
+    }
+
+    static void TearDownTestSuite()
+    {
+        EXPECT_EQ(aclrtResetDevice(0), ACL_SUCCESS);
+        EXPECT_EQ(aclFinalize(), ACL_SUCCESS);
+    }
+};
+
+TEST_F(AsuTransportBufferRegistrationTest, InitRegistersAndShutdownUnregistersBothBuffers)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    AsuTransportImpl transport;
+
+    auto status = transport.Init(TransportConfig{}, provider);
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(provider->registerCount, 2);
+    EXPECT_EQ(provider->registerCallCount, 2);
+    EXPECT_EQ(provider->tokenLookupCount, 2);
+    ASSERT_NE(transport.taskExecutor_, nullptr);
+    EXPECT_NE(transport.taskExecutor_->sendBufferMrHandle_, kInvalidMRHandle);
+    EXPECT_NE(transport.taskExecutor_->flagBufferMrHandle_, kInvalidMRHandle);
+    EXPECT_EQ(transport.taskExecutor_->sendBufferManager_.GetTokenId(), 1);
+    EXPECT_EQ(transport.taskExecutor_->flagBufferManager_.GetTokenId(), 1);
+
+    status = transport.Shutdown();
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(provider->unregisterCount, 2);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, DestructorUnregistersBothBuffers)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+
+    {
+        AsuTransportImpl transport;
+        const auto status = transport.Init(TransportConfig{}, provider);
+        ASSERT_TRUE(status.ok()) << status.message;
+        EXPECT_EQ(provider->registerCount, 2);
+        EXPECT_EQ(provider->unregisterCount, 0);
+    }
+
+    EXPECT_EQ(provider->unregisterCount, 2);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, FirstRegistrationFailureDoesNotUnregister)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    provider->failRegisterAt = 1;
+    AsuTransportImpl transport;
+
+    const auto status = transport.Init(TransportConfig{}, provider);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("send buffer"), std::string::npos);
+    EXPECT_EQ(provider->registerCount, 1);
+    EXPECT_EQ(provider->registerCallCount, 1);
+    EXPECT_EQ(provider->tokenLookupCount, 0);
+    EXPECT_EQ(provider->unregisterCount, 0);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, FirstTokenLookupFailureCleansUpRegisteredBuffer)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    provider->failTokenLookupAt = 1;
+    AsuTransportImpl transport;
+
+    const auto status = transport.Init(TransportConfig{}, provider);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("send buffer"), std::string::npos);
+    EXPECT_EQ(provider->registerCount, 1);
+    EXPECT_EQ(provider->registerCallCount, 1);
+    EXPECT_EQ(provider->tokenLookupCount, 1);
+    EXPECT_EQ(provider->unregisterCount, 1);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, TokenLookupRollbackFailureIsRetriedDuringShutdown)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    provider->failTokenLookupAt = 1;
+    provider->failUnregisterAt = 1;
+    AsuTransportImpl transport;
+
+    const auto status = transport.Init(TransportConfig{}, provider);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("send buffer"), std::string::npos);
+    EXPECT_EQ(provider->registerCount, 1);
+    EXPECT_EQ(provider->tokenLookupCount, 1);
+    EXPECT_EQ(provider->unregisterCount, 2);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, SecondRegistrationFailureCleansUpFirstBuffer)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    provider->failRegisterAt = 2;
+    AsuTransportImpl transport;
+
+    const auto status = transport.Init(TransportConfig{}, provider);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("flag buffer"), std::string::npos);
+    EXPECT_EQ(provider->registerCount, 2);
+    EXPECT_EQ(provider->unregisterCount, 1);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, SecondTokenLookupFailureCleansUpBothBuffers)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    provider->failTokenLookupAt = 2;
+    AsuTransportImpl transport;
+
+    const auto status = transport.Init(TransportConfig{}, provider);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("flag buffer"), std::string::npos);
+    EXPECT_EQ(provider->registerCount, 2);
+    EXPECT_EQ(provider->tokenLookupCount, 2);
+    EXPECT_EQ(provider->unregisterCount, 2);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, FlagUnregistrationFailureIncludesCallerContext)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    AsuTransportImpl transport;
+
+    ASSERT_TRUE(transport.Init(TransportConfig{}, provider).ok());
+    provider->failUnregisterAt = 1;
+
+    const auto status = transport.Shutdown();
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("flag buffer"), std::string::npos);
+    EXPECT_EQ(provider->unregisterCount, 2);
+    ASSERT_NE(transport.taskExecutor_, nullptr);
+    EXPECT_NE(transport.taskExecutor_->flagBufferMrHandle_, kInvalidMRHandle);
+    EXPECT_EQ(transport.taskExecutor_->sendBufferMrHandle_, kInvalidMRHandle);
+
+    EXPECT_TRUE(transport.Shutdown().ok());
+    EXPECT_EQ(provider->unregisterCount, 3);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, SendUnregistrationFailureIncludesCallerContext)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    AsuTransportImpl transport;
+
+    ASSERT_TRUE(transport.Init(TransportConfig{}, provider).ok());
+    provider->failUnregisterAt = 2;
+
+    const auto status = transport.Shutdown();
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("send buffer"), std::string::npos);
+    EXPECT_EQ(provider->unregisterCount, 2);
+    ASSERT_NE(transport.taskExecutor_, nullptr);
+    EXPECT_EQ(transport.taskExecutor_->flagBufferMrHandle_, kInvalidMRHandle);
+    EXPECT_NE(transport.taskExecutor_->sendBufferMrHandle_, kInvalidMRHandle);
+
+    EXPECT_TRUE(transport.Shutdown().ok());
+    EXPECT_EQ(provider->unregisterCount, 3);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
 
 TEST(AsuSubmitFlowTest, SendSubBatchBuffersReadsSendCountsFromAttrs)
 {
@@ -265,12 +442,12 @@ TEST(AsuSubmitFlowTest, SendSubBatchBuffersReportsSendFailures)
 
 TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersUsesHostPinnedDeviceAddresses)
 {
-    ASSERT_TRUE(
-        transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST_PINNED, 4096, 1)
-            .ok());
-    ASSERT_TRUE(
-        transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST_PINNED, 128, 1)
-            .ok());
+    ASSERT_TRUE(transport_->taskExecutor_->sendBufferManager_
+                    .Init("test send buffer", MemoryType::HOST_PINNED, 4096, 1)
+                    .ok());
+    ASSERT_TRUE(transport_->taskExecutor_->flagBufferManager_
+                    .Init("test flag buffer", MemoryType::HOST_PINNED, 128, 1)
+                    .ok());
 
     transport_->connManager_ =
         std::make_unique<ConnectionManager>(*transport_->transProvider_, "", 5000);
@@ -282,8 +459,11 @@ TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersUsesHostPinnedDeviceAddr
     subBatchContext.channel = transport_->connManager_->SelectConnection();
     subBatchContext.entryStatus.assign(1, Status::OK());
     ASSERT_NE(subBatchContext.channel, nullptr);
-    ASSERT_TRUE(transport_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
-    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
     ASSERT_NE(subBatchContext.sendSge.local_addr, std::uint64_t{0});
     ASSERT_NE(subBatchContext.sendSge.device_addr, std::uint64_t{0});
     ASSERT_NE(subBatchContext.flagBuffer.local_addr, std::uint64_t{0});

--- a/ucm/transport/kv/asu/test/transport/buffer_manager_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/buffer_manager_test.cpp
@@ -390,103 +390,36 @@ TEST_F(BufferManagerTest, AllocateReturnsBusyWhenFull)
     mgr.Free(sge2.slot_index);
 }
 
-class StubTransProvider : public TransProvider {
-public:
-    uint32_t registerCount = 0;
-    uint32_t unregisterCount = 0;
-    uint32_t fakeTokenId = 42;
-    bool failRegister = false;
-    bool failGetToken = false;
-    MemType lastMemType = MemType::MEM_HOST;
-    uintptr_t lastAddr = 0;
-    uintptr_t lastLocalAddr = 0;
-    size_t lastSize = 0;
-
-    Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t, uint32_t,
-                            std::vector<ConnectionHandle>&) override
-    {
-        return Status::OK();
-    }
-    std::vector<Status> DeleteConnections(const std::vector<ConnectionHandle>&) override
-    {
-        return {};
-    }
-    std::vector<Status> Send(const std::vector<SendIoBatch>&, uint32_t, uint32_t) override
-    {
-        return {};
-    }
-    Status RegisterMemory(const std::vector<RegisterMemoryDesc>& descs,
-                          std::vector<MRHandle>& handles) override
-    {
-        registerCount++;
-        if (!descs.empty()) {
-            lastMemType = descs[0].memoryType;
-            lastAddr = descs[0].addr;
-            lastLocalAddr = descs[0].localAddr;
-            lastSize = descs[0].size;
-        }
-        if (failRegister) {
-            return Status::Error(StatusCode::INTERNAL_ERROR, "stub register failed");
-        }
-        handles.push_back(reinterpret_cast<MRHandle>(static_cast<uintptr_t>(registerCount)));
-        return Status::OK();
-    }
-    std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& descs) override
-    {
-        unregisterCount += static_cast<uint32_t>(descs.size());
-        return std::vector<Status>(descs.size(), Status::OK());
-    }
-    Status AllocThread(uint32_t, const std::vector<uint32_t>&, std::vector<ThreadHandle>&) override
-    {
-        return Status::OK();
-    }
-    std::vector<Status> FreeThread(const std::vector<ThreadHandle>&) override { return {}; }
-    Status GetMemTokenId(MRHandle, uint32_t& tokenId) override
-    {
-        if (failGetToken) {
-            return Status::Error(StatusCode::INTERNAL_ERROR, "stub get token failed");
-        }
-        tokenId = fakeTokenId;
-        return Status::OK();
-    }
-};
-
-TEST_F(BufferManagerTest, InitWithProviderRegistersMemory)
+TEST_F(BufferManagerTest, HostMemoryExposesRegistrationDescription)
 {
-    StubTransProvider provider;
-
     BufferManager mgr;
-    auto status = mgr.Init("test_rdma", MemoryType::HOST, 1024, 10, &provider);
+    auto status = mgr.Init("test_host", MemoryType::HOST, 1024, 10);
     ASSERT_TRUE(status.ok()) << status.message;
-    ASSERT_EQ(provider.registerCount, 1);
-    ASSERT_EQ(provider.lastMemType, TransProvider::MemType::MEM_HOST);
-    ASSERT_NE(provider.lastAddr, 0);
-    ASSERT_EQ(provider.lastLocalAddr, provider.lastAddr);
-    ASSERT_EQ(provider.lastSize, 1024 * 10);
-    ASSERT_EQ(mgr.GetTokenId(), 42);
 
-    ScatterGatherEntry sge;
-    ASSERT_TRUE(mgr.Allocate(64, sge).ok());
-    ASSERT_EQ(sge.local_addr, sge.device_addr);
+    TransProvider::RegisterMemoryDesc desc;
+    status = mgr.GetRegisterMemoryDesc(desc);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(desc.memoryType, TransProvider::MemType::MEM_HOST);
+    ASSERT_NE(desc.addr, 0);
+    ASSERT_EQ(desc.localAddr, desc.addr);
+    ASSERT_EQ(desc.size, 1024 * 10);
 }
 
-TEST_F(BufferManagerTest, HostPinnedRegistersDeviceAddress)
+TEST_F(BufferManagerTest, HostPinnedMemoryExposesDeviceRegistrationDescription)
 {
-    StubTransProvider provider;
-
     BufferManager mgr;
-    auto status = mgr.Init("test_rdma_pinned", MemoryType::HOST_PINNED, 4096, 1, &provider);
+    auto status = mgr.Init("test_pinned", MemoryType::HOST_PINNED, 4096, 1);
     ASSERT_TRUE(status.ok()) << status.message;
-    ASSERT_EQ(provider.registerCount, 1);
-    ASSERT_EQ(provider.lastMemType, TransProvider::MemType::MEM_DEVICE);
 
     ScatterGatherEntry sge;
     ASSERT_TRUE(mgr.Allocate(64, sge).ok());
-    ASSERT_NE(sge.local_addr, 0);
-    ASSERT_NE(sge.device_addr, 0);
-    ASSERT_EQ(sge.local_addr % 4096, 0);
-    ASSERT_EQ(provider.lastAddr, sge.device_addr);
-    ASSERT_EQ(provider.lastLocalAddr, sge.local_addr);
+    TransProvider::RegisterMemoryDesc desc;
+    status = mgr.GetRegisterMemoryDesc(desc);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(desc.memoryType, TransProvider::MemType::MEM_DEVICE);
+    ASSERT_EQ(desc.addr, sge.device_addr);
+    ASSERT_EQ(desc.localAddr, sge.local_addr);
+    ASSERT_EQ(desc.size, 4096);
 
     // The CPU writes through local_addr while HCOMM and remote RDMA use device_addr.
     // ACL simulators may map both roles to the same numeric address.
@@ -494,14 +427,13 @@ TEST_F(BufferManagerTest, HostPinnedRegistersDeviceAddress)
     ASSERT_EQ(*reinterpret_cast<unsigned char*>(sge.local_addr), 0x5A);
 }
 
-TEST_F(BufferManagerTest, InitWithProviderAllocateReturnsTokenId)
+TEST_F(BufferManagerTest, SetTokenIdIsReflectedInAllocatedSge)
 {
-    StubTransProvider provider;
-    provider.fakeTokenId = 99;
-
     BufferManager mgr;
-    auto status = mgr.Init("test_rdma", MemoryType::HOST, 1024, 10, &provider);
+    auto status = mgr.Init("test_token", MemoryType::HOST, 1024, 10);
     ASSERT_TRUE(status.ok()) << status.message;
+    mgr.SetTokenId(99);
+    ASSERT_EQ(mgr.GetTokenId(), 99);
 
     ScatterGatherEntry sge;
     status = mgr.Allocate(64, sge);
@@ -511,40 +443,13 @@ TEST_F(BufferManagerTest, InitWithProviderAllocateReturnsTokenId)
     mgr.Free(sge.slot_index);
 }
 
-TEST_F(BufferManagerTest, DestroyWithProviderUnregistersMemory)
+TEST_F(BufferManagerTest, RegistrationDescriptionRequiresInitialization)
 {
-    StubTransProvider provider;
-    {
-        BufferManager mgr;
-        auto status = mgr.Init("test_rdma", MemoryType::HOST, 1024, 10, &provider);
-        ASSERT_TRUE(status.ok()) << status.message;
-        ASSERT_EQ(provider.unregisterCount, 0);
-    }
-    ASSERT_EQ(provider.unregisterCount, 1);
-}
-
-TEST_F(BufferManagerTest, InitWithProviderRegisterFails)
-{
-    StubTransProvider provider;
-    provider.failRegister = true;
-
     BufferManager mgr;
-    auto status = mgr.Init("test_rdma", MemoryType::HOST, 1024, 10, &provider);
+    TransProvider::RegisterMemoryDesc desc;
+    const auto status = mgr.GetRegisterMemoryDesc(desc);
     ASSERT_FALSE(status.ok());
-    ASSERT_EQ(status.code, StatusCode::INTERNAL_ERROR);
-    ASSERT_EQ(provider.unregisterCount, 0);
-}
-
-TEST_F(BufferManagerTest, InitWithProviderGetTokenFailsCleansUp)
-{
-    StubTransProvider provider;
-    provider.failGetToken = true;
-
-    BufferManager mgr;
-    auto status = mgr.Init("test_rdma", MemoryType::HOST, 1024, 10, &provider);
-    ASSERT_FALSE(status.ok());
-    ASSERT_EQ(status.code, StatusCode::INTERNAL_ERROR);
-    ASSERT_EQ(provider.unregisterCount, 1);
+    ASSERT_EQ(status.code, StatusCode::NOT_INITIALIZED);
 }
 
 }  // namespace

--- a/ucm/transport/kv/asu/test/transport/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/sqe_request_test.cpp
@@ -113,9 +113,7 @@ public:
 void CreateTaskExecutor(AsuTransportImpl& transport)
 {
     transport.taskExecutor_ = std::make_unique<TransportTaskExecutor>(
-        transport.config_, transport.ioScheduler_, transport.transProvider_,
-        transport.sendBufferManager_, transport.flagBufferManager_, transport.protocolManager_,
-        transport.connManager_, transport.nextRequestCid_);
+        transport.config_, transport.transProvider_, transport.connManager_);
 }
 
 constexpr std::size_t kFlagBufferHeaderSize = 16;
@@ -183,18 +181,22 @@ protected:
         transport_ = std::make_unique<AsuTransportImpl>();
         transport_->SetTransProvider(std::make_unique<StubTransProvider>());
         transport_->config_.attrs = DefaultAttrs();
-        transport_->nextRequestCid_.store(1, std::memory_order_relaxed);
-        auto* provider = transport_->transProvider_.get();
-        auto status =
-            transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST_PINNED,
-                                                kFlagBufferSlotSize, kFlagBufferSlotNum, provider);
-        ASSERT_TRUE(status.ok()) << status.message;
-        status = transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST_PINNED,
-                                                     kTestSendBufferSlotSize,
-                                                     kTestSendBufferSlotNum, provider);
-        ASSERT_TRUE(status.ok()) << status.message;
-        transport_->protocolManager_ = std::make_unique<ProtocolManager>();
         CreateTaskExecutor(*transport_);
+        auto status = transport_->taskExecutor_->flagBufferManager_.Init(
+            "test flag buffer", MemoryType::HOST_PINNED, kFlagBufferSlotSize, kFlagBufferSlotNum);
+        ASSERT_TRUE(status.ok()) << status.message;
+        status = transport_->taskExecutor_->sendBufferManager_.Init(
+            "test send buffer", MemoryType::HOST_PINNED, kTestSendBufferSlotSize,
+            kTestSendBufferSlotNum);
+        ASSERT_TRUE(status.ok()) << status.message;
+        status = transport_->taskExecutor_->RegisterBufferMemory(
+            transport_->taskExecutor_->sendBufferManager_,
+            transport_->taskExecutor_->sendBufferMrHandle_);
+        ASSERT_TRUE(status.ok()) << status.message;
+        status = transport_->taskExecutor_->RegisterBufferMemory(
+            transport_->taskExecutor_->flagBufferManager_,
+            transport_->taskExecutor_->flagBufferMrHandle_);
+        ASSERT_TRUE(status.ok()) << status.message;
     }
 
     std::unique_ptr<AsuTransportImpl> transport_;
@@ -232,7 +234,7 @@ TEST_F(SqeRequestTest, SubmitBatchStoreAllocatesFlagBufferAndBuildsRequest)
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
     TransportSubBatchContext subBatchContext;
-    transport_->nextRequestCid_.store(41, std::memory_order_relaxed);
+    transport_->taskExecutor_->nextRequestCid_.store(41, std::memory_order_relaxed);
     const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
         AsuOpType::BATCH_STORE, subBatch, subBatchContext);
 
@@ -291,18 +293,24 @@ TEST_F(SqeRequestTest, SubmitBatchStorePacksSqeIntoDeviceSendBuffer)
     AsuTransportImpl deviceTransport;
     deviceTransport.SetTransProvider(std::make_unique<StubTransProvider>());
     deviceTransport.config_.attrs = DefaultAttrs();
-    deviceTransport.nextRequestCid_.store(41, std::memory_order_relaxed);
-    auto* provider = deviceTransport.transProvider_.get();
-    ASSERT_TRUE(deviceTransport.flagBufferManager_
-                    .Init("test flag buffer", MemoryType::HOST_PINNED, kFlagBufferSlotSize,
-                          kFlagBufferSlotNum, provider)
-                    .ok());
-    ASSERT_TRUE(deviceTransport.sendBufferManager_
-                    .Init("test send buffer", MemoryType::ASCEND_DEVICE, kTestSendBufferSlotSize,
-                          kTestSendBufferSlotNum, provider)
-                    .ok());
-    deviceTransport.protocolManager_ = std::make_unique<ProtocolManager>();
     CreateTaskExecutor(deviceTransport);
+    ASSERT_TRUE(deviceTransport.taskExecutor_->flagBufferManager_
+                    .Init("test flag buffer", MemoryType::HOST_PINNED, kFlagBufferSlotSize,
+                          kFlagBufferSlotNum)
+                    .ok());
+    ASSERT_TRUE(deviceTransport.taskExecutor_->sendBufferManager_
+                    .Init("test send buffer", MemoryType::ASCEND_DEVICE, kTestSendBufferSlotSize,
+                          kTestSendBufferSlotNum)
+                    .ok());
+    ASSERT_TRUE(deviceTransport.taskExecutor_
+                    ->RegisterBufferMemory(deviceTransport.taskExecutor_->sendBufferManager_,
+                                           deviceTransport.taskExecutor_->sendBufferMrHandle_)
+                    .ok());
+    ASSERT_TRUE(deviceTransport.taskExecutor_
+                    ->RegisterBufferMemory(deviceTransport.taskExecutor_->flagBufferManager_,
+                                           deviceTransport.taskExecutor_->flagBufferMrHandle_)
+                    .ok());
+    deviceTransport.taskExecutor_->nextRequestCid_.store(41, std::memory_order_relaxed);
 
     auto entries = MakeEntries(3);
     SetMrKeys(entries, 0x12340000);
@@ -322,8 +330,9 @@ TEST_F(SqeRequestTest, SubmitBatchStorePacksSqeIntoDeviceSendBuffer)
                           reinterpret_cast<void*>(subBatchContext.sendSge.device_addr),
                           packed.size(), ACL_MEMCPY_DEVICE_TO_HOST),
               ACL_SUCCESS);
-    EXPECT_TRUE(
-        deviceTransport.protocolManager_->VerifyPackedBuffer(packed.data(), packed.size()).ok());
+    EXPECT_TRUE(deviceTransport.taskExecutor_->protocolManager_
+                    .VerifyPackedBuffer(packed.data(), packed.size())
+                    .ok());
 }
 
 TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
@@ -336,7 +345,7 @@ TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
         BatchView<KVBuffer>{entries.data(), entries.size()}
     };
     TransportSubBatchContext subBatchContext;
-    transport_->nextRequestCid_.store(9, std::memory_order_relaxed);
+    transport_->taskExecutor_->nextRequestCid_.store(9, std::memory_order_relaxed);
     const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
         AsuOpType::BATCH_LOAD, subBatch, subBatchContext);
 
@@ -401,7 +410,7 @@ TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)
         BatchView<CacheKey>{keys.data(), keys.size()}
     };
     TransportSubBatchContext subBatchContext;
-    transport_->nextRequestCid_.store(55, std::memory_order_relaxed);
+    transport_->taskExecutor_->nextRequestCid_.store(55, std::memory_order_relaxed);
 
     const auto status = transport_->taskExecutor_->SubmitKeySubBatchRequest(
         AsuOpType::DELETE, subBatch, subBatchContext);
@@ -426,7 +435,7 @@ TEST_F(SqeRequestTest, SubmitExistReadsScAttribute)
         BatchView<CacheKey>{keys.data(), keys.size()}
     };
     TransportSubBatchContext subBatchContext;
-    transport_->nextRequestCid_.store(13, std::memory_order_relaxed);
+    transport_->taskExecutor_->nextRequestCid_.store(13, std::memory_order_relaxed);
 
     const auto status = transport_->taskExecutor_->SubmitKeySubBatchRequest(
         AsuOpType::QUERY, subBatch, subBatchContext);
@@ -445,7 +454,7 @@ TEST_F(SqeRequestTest, SubmitExistDisablesSeekControlWhenScDisabled)
     auto attrs = DefaultAttrs();
     attrs["sc"] = "false";
     transport_->config_.attrs = attrs;
-    transport_->nextRequestCid_.store(13, std::memory_order_relaxed);
+    transport_->taskExecutor_->nextRequestCid_.store(13, std::memory_order_relaxed);
 
     std::vector<CacheKey> keys = {MakeCacheKey("k0")};
     IoScheduler::ScheduledKeyBatch subBatch{
@@ -471,13 +480,12 @@ TEST_F(SqeRequestTest, AllocationFailureMarksWholeSubBatchFailed)
     AsuTransportImpl uninitializedFlagTransport;
     uninitializedFlagTransport.SetTransProvider(std::make_unique<StubTransProvider>());
     uninitializedFlagTransport.config_.attrs = DefaultAttrs();
-    uninitializedFlagTransport.nextRequestCid_.store(3, std::memory_order_relaxed);
-    ASSERT_TRUE(uninitializedFlagTransport.sendBufferManager_
+    CreateTaskExecutor(uninitializedFlagTransport);
+    ASSERT_TRUE(uninitializedFlagTransport.taskExecutor_->sendBufferManager_
                     .Init("test send buffer", MemoryType::HOST, kTestSendBufferSlotSize,
                           kTestSendBufferSlotNum)
                     .ok());
-    uninitializedFlagTransport.protocolManager_ = std::make_unique<ProtocolManager>();
-    CreateTaskExecutor(uninitializedFlagTransport);
+    uninitializedFlagTransport.taskExecutor_->nextRequestCid_.store(3, std::memory_order_relaxed);
     const auto status = uninitializedFlagTransport.taskExecutor_->BuildEntrySubBatchRequest(
         AsuOpType::BATCH_STORE, subBatch, subBatchContext);
 
@@ -495,7 +503,7 @@ TEST_F(SqeRequestTest, AllocationFailureMarksWholeSubBatchFailed)
 TEST_F(SqeRequestTest, SubmitKeepAliveBuildsFlagBackedRequest)
 {
     TransportSubBatchContext subBatchContext;
-    transport_->nextRequestCid_.store(77, std::memory_order_relaxed);
+    transport_->taskExecutor_->nextRequestCid_.store(77, std::memory_order_relaxed);
 
     const auto status = transport_->taskExecutor_->SubmitKeepAliveRequest(subBatchContext);
 

--- a/ucm/transport/kv/asu/test/transport/transport_task_completion_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/transport_task_completion_test.cpp
@@ -85,9 +85,7 @@ public:
 void CreateTaskExecutor(AsuTransportImpl& transport)
 {
     transport.taskExecutor_ = std::make_unique<TransportTaskExecutor>(
-        transport.config_, transport.ioScheduler_, transport.transProvider_,
-        transport.sendBufferManager_, transport.flagBufferManager_, transport.protocolManager_,
-        transport.connManager_, transport.nextRequestCid_);
+        transport.config_, transport.transProvider_, transport.connManager_);
 }
 
 class TransportTaskCompletionTest : public ::testing::Test {
@@ -108,16 +106,21 @@ protected:
     {
         transport_ = std::make_unique<AsuTransportImpl>();
         transport_->SetTransProvider(std::make_unique<StubTransProvider>());
-        auto* provider = transport_->transProvider_.get();
-        auto status =
-            transport_->sendBufferManager_.Init("test send buffer", MemoryType::HOST,
-                                                kTestBufferSlotSize, kTestBufferSlotNum, provider);
-        ASSERT_TRUE(status.ok()) << status.message;
-        status =
-            transport_->flagBufferManager_.Init("test flag buffer", MemoryType::HOST,
-                                                kTestBufferSlotSize, kTestBufferSlotNum, provider);
-        ASSERT_TRUE(status.ok()) << status.message;
         CreateTaskExecutor(*transport_);
+        auto status = transport_->taskExecutor_->sendBufferManager_.Init(
+            "test send buffer", MemoryType::HOST, kTestBufferSlotSize, kTestBufferSlotNum);
+        ASSERT_TRUE(status.ok()) << status.message;
+        status = transport_->taskExecutor_->flagBufferManager_.Init(
+            "test flag buffer", MemoryType::HOST, kTestBufferSlotSize, kTestBufferSlotNum);
+        ASSERT_TRUE(status.ok()) << status.message;
+        status = transport_->taskExecutor_->RegisterBufferMemory(
+            transport_->taskExecutor_->sendBufferManager_,
+            transport_->taskExecutor_->sendBufferMrHandle_);
+        ASSERT_TRUE(status.ok()) << status.message;
+        status = transport_->taskExecutor_->RegisterBufferMemory(
+            transport_->taskExecutor_->flagBufferManager_,
+            transport_->taskExecutor_->flagBufferMrHandle_);
+        ASSERT_TRUE(status.ok()) << status.message;
     }
 
     std::unique_ptr<AsuTransportImpl> transport_;
@@ -177,8 +180,11 @@ TEST_F(TransportTaskCompletionTest, CompleteSubBatchCompletesPendingSubBatch)
 TEST_F(TransportTaskCompletionTest, ReleaseSubBatchResourcesClearsAllocatedSlots)
 {
     TransportSubBatchContext subBatchContext;
-    ASSERT_TRUE(transport_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
-    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
 
     transport_->taskExecutor_->ReleaseSubBatchResources(subBatchContext);
 
@@ -192,18 +198,25 @@ TEST_F(TransportTaskCompletionTest, PollTaskCompletionsReadsDeviceFlagBuffer)
 {
     AsuTransportImpl deviceTransport;
     deviceTransport.SetTransProvider(std::make_unique<StubTransProvider>());
-    auto* provider = deviceTransport.transProvider_.get();
-    ASSERT_TRUE(deviceTransport.sendBufferManager_
-                    .Init("test send buffer", MemoryType::HOST, kTestBufferSlotSize,
-                          kTestBufferSlotNum, provider)
-                    .ok());
-    ASSERT_TRUE(deviceTransport.flagBufferManager_
-                    .Init("test flag buffer", MemoryType::ASCEND_DEVICE, kTestBufferSlotSize,
-                          kTestBufferSlotNum, provider)
-                    .ok());
-    deviceTransport.protocolManager_ = std::make_unique<ProtocolManager>();
-    deviceTransport.connManager_ = std::make_unique<ConnectionManager>(*provider, "", 5000, 2);
     CreateTaskExecutor(deviceTransport);
+    ASSERT_TRUE(
+        deviceTransport.taskExecutor_->sendBufferManager_
+            .Init("test send buffer", MemoryType::HOST, kTestBufferSlotSize, kTestBufferSlotNum)
+            .ok());
+    ASSERT_TRUE(deviceTransport.taskExecutor_->flagBufferManager_
+                    .Init("test flag buffer", MemoryType::ASCEND_DEVICE, kTestBufferSlotSize,
+                          kTestBufferSlotNum)
+                    .ok());
+    ASSERT_TRUE(deviceTransport.taskExecutor_
+                    ->RegisterBufferMemory(deviceTransport.taskExecutor_->sendBufferManager_,
+                                           deviceTransport.taskExecutor_->sendBufferMrHandle_)
+                    .ok());
+    ASSERT_TRUE(deviceTransport.taskExecutor_
+                    ->RegisterBufferMemory(deviceTransport.taskExecutor_->flagBufferManager_,
+                                           deviceTransport.taskExecutor_->flagBufferMrHandle_)
+                    .ok());
+    auto* provider = deviceTransport.transProvider_.get();
+    deviceTransport.connManager_ = std::make_unique<ConnectionManager>(*provider, "", 5000, 2);
     ASSERT_TRUE(deviceTransport.connManager_->AddGroup(AsuEndpoint{}, 1).ok());
     auto channel = deviceTransport.connManager_->SelectConnection();
     ASSERT_NE(channel, nullptr);
@@ -221,7 +234,7 @@ TEST_F(TransportTaskCompletionTest, PollTaskCompletionsReadsDeviceFlagBuffer)
     subBatchContext.entryStatus.assign(2, Status::OK());
     subBatchContext.channel = channel;
     ASSERT_TRUE(
-        deviceTransport.flagBufferManager_
+        deviceTransport.taskExecutor_->flagBufferManager_
             .Allocate((kCqeDwordCount + 1) * sizeof(std::uint32_t), subBatchContext.flagBuffer)
             .ok());
     ASSERT_EQ(subBatchContext.flagBuffer.memory_type, MemoryType::ASCEND_DEVICE);
@@ -250,7 +263,6 @@ TEST_F(TransportTaskCompletionTest, PollTaskCompletionsReadsDeviceFlagBuffer)
 TEST_F(TransportTaskCompletionTest, FailureCqeAccumulatesWithoutSuccessReset)
 {
     auto* provider = transport_->transProvider_.get();
-    transport_->protocolManager_ = std::make_unique<ProtocolManager>();
     transport_->connManager_ = std::make_unique<ConnectionManager>(*provider, "", 5000, 3);
     ASSERT_TRUE(transport_->connManager_->AddGroup(AsuEndpoint{}, 1).ok());
     auto channel = transport_->connManager_->SelectConnection();
@@ -268,7 +280,7 @@ TEST_F(TransportTaskCompletionTest, FailureCqeAccumulatesWithoutSuccessReset)
     subBatchContext.entryStatus.assign(1, Status::OK());
     subBatchContext.channel = channel;
     ASSERT_TRUE(
-        transport_->flagBufferManager_
+        transport_->taskExecutor_->flagBufferManager_
             .Allocate((kCqeDwordCount + 1) * sizeof(std::uint32_t), subBatchContext.flagBuffer)
             .ok());
 
@@ -301,8 +313,11 @@ TEST_F(TransportTaskCompletionTest, PollTaskCompletionsTimesOutAndReleasesResour
     subBatchContext.opType = AsuOpType::BATCH_STORE;
     subBatchContext.entryStatus.assign(2, Status::OK());
     subBatchContext.channel = channel;
-    ASSERT_TRUE(transport_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
-    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
 
     std::size_t callbackCount = 0;
     TaskResult callbackResult;
@@ -357,8 +372,11 @@ TEST_F(TransportTaskCompletionTest, ReleaseSubBatchResourcesPreservesSubBatchSta
     TransportSubBatchContext subBatchContext;
     subBatchContext.state = TransportSubBatchState::COMPLETED;
     subBatchContext.status = Status::Error(StatusCode::IO_ERROR, "send failed");
-    ASSERT_TRUE(transport_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
-    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
 
     transport_->taskExecutor_->ReleaseSubBatchResources(subBatchContext);
 
@@ -370,7 +388,9 @@ TEST_F(TransportTaskCompletionTest, ReleaseSubBatchResourcesClearsSlotsAfterFree
 {
     TransportSubBatchContext subBatchContext;
     subBatchContext.sendSge.slot_index = kTestBufferSlotNum;
-    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
 
     transport_->taskExecutor_->ReleaseSubBatchResources(subBatchContext);
 
@@ -625,7 +645,6 @@ TEST_F(TransportTaskCompletionTest, ShutdownCallbackCannotSubmitNewTask)
 
 TEST_F(TransportTaskCompletionTest, ShutdownDrainsInflightTaskBeforeCanceling)
 {
-    transport_->protocolManager_ = std::make_unique<ProtocolManager>();
     auto ctx = std::make_unique<TransportTask>();
     ctx->entryStatus.assign(1, Status::OK());
     ctx->subBatchContexts->resize(1);
@@ -634,7 +653,9 @@ TEST_F(TransportTaskCompletionTest, ShutdownDrainsInflightTaskBeforeCanceling)
     subBatchContext.cid = 123;
     subBatchContext.opType = AsuOpType::BATCH_STORE;
     subBatchContext.entryStatus.assign(1, Status::OK());
-    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
     auto* cqe = reinterpret_cast<std::uint32_t*>(subBatchContext.flagBuffer.local_addr);
     cqe[3] = subBatchContext.cid;
 
@@ -667,8 +688,11 @@ TEST_F(TransportTaskCompletionTest, CancelReleasesResourcesBeforeInvokingCallbac
     auto ctx = std::make_unique<TransportTask>();
     ctx->subBatchContexts->resize(1);
     auto& subBatchContext = (*ctx->subBatchContexts)[0];
-    ASSERT_TRUE(transport_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
-    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
     auto* rawCtx = ctx.get();
     ctx->onComplete = [&](TaskResult result) {
         ++callbackCount;
@@ -697,8 +721,11 @@ TEST_F(TransportTaskCompletionTest, ShutdownReleasesResourcesBeforeInvokingCallb
     ctx->subBatchContexts->resize(1);
     auto& subBatchContext = (*ctx->subBatchContexts)[0];
     subBatchContext.entryStatus = {Status::OK()};
-    ASSERT_TRUE(transport_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
-    ASSERT_TRUE(transport_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
     auto* rawCtx = ctx.get();
     ctx->onComplete = [&](TaskResult result) {
         ++callbackCount;

--- a/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
@@ -56,9 +56,7 @@ struct TransportConfig {
 
     TransProviderType providerType{TransProviderType::AICPU};
 
-    std::uint32_t queryQpNum{1};
-    std::uint32_t loadQpNum{4};
-    std::uint32_t storeQpNum{2};
+    std::uint32_t qpNum{1};
 
     std::uint32_t maxInflightTasks{1024};
     std::uint64_t maxInflightBytes{1ULL << 30};

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -93,7 +93,7 @@ Status AsuTransportImpl::Init(const TransportConfig& config,
     connManager_ = std::make_unique<ConnectionManager>(*transProvider_, localIp, timeout,
                                                        config_.maxErrorCount);
 
-    std::uint32_t qp_num = config_.queryQpNum + config_.loadQpNum + config_.storeQpNum;
+    const std::uint32_t qp_num = config_.qpNum;
     UC_DEBUG("AsuTransportImpl::Init endpoints={} qp_num={}", config_.endpoints.size(), qp_num);
     for (const auto& ep : config_.endpoints) {
         auto s = connManager_->AddGroup(ep, qp_num);
@@ -137,40 +137,20 @@ Status AsuTransportImpl::Init(const TransportConfig& config,
             config_.asuBatchStoreIoNum, config_.asuBatchLoadIoNum, config_.asuDeleteIoNum,
             config_.asuQueryIoNum);
 
-    ioScheduler_ = IoScheduler(config_);
     connManager_->StartRecoverLoop();
 
-    auto status = sendBufferManager_.Init("asu send buffer", MemoryType::HOST_PINNED,
-                                          config_.sendBufferSlotSize, config_.sendBufferSlotNum,
-                                          transProvider_.get());
+    taskExecutor_ = std::make_unique<TransportTaskExecutor>(config_, transProvider_, connManager_);
+    auto status = taskExecutor_->Init();
     if (!status.ok()) {
         const auto shutdownStatus = Shutdown();
         if (!shutdownStatus.ok()) {
             UC_WARN(
-                "AsuTransportImpl::Init cleanup failed after send buffer initialization "
+                "AsuTransportImpl::Init cleanup failed after task executor initialization "
                 "failure: code={} message={}",
                 static_cast<int>(shutdownStatus.code), shutdownStatus.message);
         }
         return status;
     }
-
-    status = flagBufferManager_.Init("asu flag buffer", MemoryType::HOST_PINNED,
-                                     config_.flagBufferSlotSize, config_.flagBufferSlotNum,
-                                     transProvider_.get());
-    if (!status.ok()) {
-        const auto shutdownStatus = Shutdown();
-        if (!shutdownStatus.ok()) {
-            UC_WARN(
-                "AsuTransportImpl::Init cleanup failed after flag buffer initialization "
-                "failure: code={} message={}",
-                static_cast<int>(shutdownStatus.code), shutdownStatus.message);
-        }
-        return status;
-    }
-    protocolManager_ = std::make_unique<ProtocolManager>();
-    taskExecutor_ = std::make_unique<TransportTaskExecutor>(
-        config_, ioScheduler_, transProvider_, sendBufferManager_, flagBufferManager_,
-        protocolManager_, connManager_, nextRequestCid_);
     auto queueDepth = std::max<std::size_t>(2, static_cast<std::size_t>(config_.maxInflightTasks));
     executeQueue_.Setup(queueDepth + 1);
     stopWorker_.store(false, std::memory_order_release);
@@ -216,9 +196,14 @@ Status AsuTransportImpl::Shutdown()
     for (const auto& ctx : taskManager_.GetAll()) {
         if (ctx != nullptr) { (void)taskManager_.Remove(ctx->taskId); }
     }
-    taskExecutor_.reset();
-    flagBufferManager_.Shutdown();
-    sendBufferManager_.Shutdown();
+    if (taskExecutor_) {
+        const auto status = taskExecutor_->Shutdown();
+        if (!status.ok()) {
+            if (finalStatus.ok()) { finalStatus = status; }
+        } else {
+            taskExecutor_.reset();
+        }
+    }
 
     if (connManager_) {
         auto status = connManager_->Shutdown();

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
@@ -32,10 +32,7 @@
 #include <vector>
 #include "asu_transport/asu_transport.h"
 #include "asu_transport/trans_provider.h"
-#include "buffer_manager.h"
 #include "connection_manager.h"
-#include "io_scheduler.h"
-#include "kv_protocol.h"
 #include "template/spsc_ring_queue.h"
 #include "transport_task_executor.h"
 #include "transport_task_manager.h"
@@ -67,14 +64,8 @@ private:
     void SetTransProvider(std::shared_ptr<TransProvider> provider);
 
     TransportConfig config_;
-    IoScheduler ioScheduler_;
     std::shared_ptr<TransProvider> transProvider_;
-    BufferManager sendBufferManager_;
-    BufferManager flagBufferManager_;
-    std::unique_ptr<ProtocolManager> protocolManager_;
-
     std::unique_ptr<ConnectionManager> connManager_;
-    std::atomic<std::uint16_t> nextRequestCid_{1};
 
     std::unique_ptr<TransportTaskExecutor> taskExecutor_;
     TransportTaskManager taskManager_;

--- a/ucm/transport/kv/asu/trans/src/buffer_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/buffer_manager.cpp
@@ -98,17 +98,6 @@ BufferManager::~BufferManager() { Shutdown(); }
 
 void BufferManager::Shutdown()
 {
-    if (provider_ && mrHandle_) {
-        std::vector<TransProvider::UnregisterMemoryDesc> descs{{mrHandle_}};
-        const auto statuses = provider_->UnregisterMemory(descs);
-        for (const auto& status : statuses) {
-            if (!status.ok()) {
-                UC_WARN("Failed to unregister {} buffer memory: {}.", name_, status.message);
-            }
-        }
-    }
-    provider_ = nullptr;
-    mrHandle_ = kInvalidMRHandle;
     tokenId_ = 0;
     region_.Reset();
     slot_capacity_ = 0;
@@ -117,7 +106,7 @@ void BufferManager::Shutdown()
 }
 
 Status BufferManager::Init(std::string name, MemoryType type, std::size_t slot_capacity,
-                           std::size_t slot_num, TransProvider* provider)
+                           std::size_t slot_num)
 {
     if (region_) {
         return Status::Error(StatusCode::INVALID_ARGUMENT, name + " already initialized");
@@ -154,43 +143,16 @@ Status BufferManager::Init(std::string name, MemoryType type, std::size_t slot_c
     }
 
     index_pool_.Setup(static_cast<IndexPool::Index>(slot_num));
-
-    if (provider) {
-        provider_ = provider;
-        auto regStatus = RegisterMemory();
-        if (!regStatus.ok()) {
-            provider_ = nullptr;
-            region_.Reset();
-            return regStatus;
-        }
-    }
+    tokenId_ = 0;
 
     return Status::OK();
 }
 
-Status BufferManager::RegisterMemory()
+Status BufferManager::GetRegisterMemoryDesc(TransProvider::RegisterMemoryDesc& desc) const
 {
-    std::size_t total = slot_stride_ * slot_num_;
-    std::vector<TransProvider::RegisterMemoryDesc> descs{
-        {region_.providerMemType, reinterpret_cast<uintptr_t>(region_.deviceAddr), total,
-         reinterpret_cast<uintptr_t>(region_.localAddr)}
-    };
-    std::vector<MRHandle> mrHandles;
-    auto regStatus = provider_->RegisterMemory(descs, mrHandles);
-    if (!regStatus.ok() || mrHandles.empty()) {
-        return Status::Error(StatusCode::INTERNAL_ERROR,
-                             name_ + ": failed to register memory: " + regStatus.message);
-    }
-
-    auto tokenStatus = provider_->GetMemTokenId(mrHandles[0], tokenId_);
-    if (!tokenStatus.ok()) {
-        std::vector<TransProvider::UnregisterMemoryDesc> unregDescs{{mrHandles[0]}};
-        provider_->UnregisterMemory(unregDescs);
-        return Status::Error(StatusCode::INTERNAL_ERROR,
-                             name_ + ": failed to get token id: " + tokenStatus.message);
-    }
-
-    mrHandle_ = mrHandles[0];
+    if (!region_) { return Status::Error(StatusCode::NOT_INITIALIZED, name_ + " not initialized"); }
+    desc = {region_.providerMemType, reinterpret_cast<uintptr_t>(region_.deviceAddr),
+            slot_stride_ * slot_num_, reinterpret_cast<uintptr_t>(region_.localAddr)};
     return Status::OK();
 }
 

--- a/ucm/transport/kv/asu/trans/src/buffer_manager.h
+++ b/ucm/transport/kv/asu/trans/src/buffer_manager.h
@@ -53,8 +53,7 @@ public:
     BufferManager(const BufferManager&) = delete;
     BufferManager& operator=(const BufferManager&) = delete;
 
-    Status Init(std::string name, MemoryType type, std::size_t slot_capacity, std::size_t slot_num,
-                TransProvider* provider = nullptr);
+    Status Init(std::string name, MemoryType type, std::size_t slot_capacity, std::size_t slot_num);
     void Shutdown();
 
     Status Allocate(std::size_t size, ScatterGatherEntry& sge);
@@ -63,6 +62,8 @@ public:
     bool IsValidPointer(const void* ptr) const;
 
     std::uint32_t GetTokenId() const { return tokenId_; }
+    void SetTokenId(std::uint32_t tokenId) { tokenId_ = tokenId; }
+    Status GetRegisterMemoryDesc(TransProvider::RegisterMemoryDesc& desc) const;
 
 private:
     struct BufferRegion {
@@ -77,7 +78,6 @@ private:
         TransProvider::MemType providerMemType{TransProvider::MemType::MEM_HOST};
     };
 
-    Status RegisterMemory();
     std::string name_;
     std::size_t slot_capacity_{0};
     std::size_t slot_stride_{0};
@@ -87,8 +87,6 @@ private:
     BufferRegion region_;
     IndexPool index_pool_;
 
-    TransProvider* provider_{nullptr};
-    MRHandle mrHandle_{kInvalidMRHandle};
     std::uint32_t tokenId_{0};
 };
 

--- a/ucm/transport/kv/asu/trans/src/sqe_request.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.cpp
@@ -391,7 +391,7 @@ Status TransportTaskExecutor::BuildEntrySubBatchRequest(
 
     auto request = BuildSqeRequest(opcode, source, config_.attrs, subBatchContext.cid,
                                    subBatchContext.flagBuffer, subBatchContext);
-    return PackSubBatchRequest(*protocolManager_, sendBufferManager_, opcode, *request,
+    return PackSubBatchRequest(protocolManager_, sendBufferManager_, opcode, *request,
                                subBatchContext);
 }
 
@@ -409,7 +409,7 @@ Status TransportTaskExecutor::SubmitKeySubBatchRequest(
 
     auto request = BuildSqeRequest(opcode, source, config_.attrs, subBatchContext.cid,
                                    subBatchContext.flagBuffer, subBatchContext);
-    return PackSubBatchRequest(*protocolManager_, sendBufferManager_, opcode, *request,
+    return PackSubBatchRequest(protocolManager_, sendBufferManager_, opcode, *request,
                                subBatchContext);
 }
 
@@ -426,7 +426,7 @@ Status TransportTaskExecutor::SubmitKeepAliveRequest(TransportSubBatchContext& s
 
     auto request = BuildSqeRequest(opcode, source, config_.attrs, subBatchContext.cid,
                                    subBatchContext.flagBuffer, subBatchContext);
-    return PackSubBatchRequest(*protocolManager_, sendBufferManager_, opcode, *request,
+    return PackSubBatchRequest(protocolManager_, sendBufferManager_, opcode, *request,
                                subBatchContext);
 }
 

--- a/ucm/transport/kv/asu/trans/src/transport_task_executor.cpp
+++ b/ucm/transport/kv/asu/trans/src/transport_task_executor.cpp
@@ -56,20 +56,150 @@ Status CopyDeviceToHost(const ScatterGatherEntry& sge, void* host, std::size_t s
 }  // namespace
 
 TransportTaskExecutor::TransportTaskExecutor(
-    const TransportConfig& config, IoScheduler& ioScheduler,
-    const std::shared_ptr<TransProvider>& transProvider, BufferManager& sendBufferManager,
-    BufferManager& flagBufferManager, const std::unique_ptr<ProtocolManager>& protocolManager,
-    const std::unique_ptr<ConnectionManager>& connectionManager,
-    std::atomic<std::uint16_t>& nextRequestCid)
+    const TransportConfig& config, const std::shared_ptr<TransProvider>& transProvider,
+    const std::unique_ptr<ConnectionManager>& connectionManager)
     : config_(config),
-      ioScheduler_(ioScheduler),
+      ioScheduler_(config),
       transProvider_(transProvider),
-      sendBufferManager_(sendBufferManager),
-      flagBufferManager_(flagBufferManager),
-      protocolManager_(protocolManager),
-      connManager_(connectionManager),
-      nextRequestCid_(nextRequestCid)
+      connManager_(connectionManager)
 {
+}
+
+TransportTaskExecutor::~TransportTaskExecutor()
+{
+    const auto status = Shutdown();
+    if (!status.ok()) {
+        UC_WARN("TransportTaskExecutor destructor cleanup failed: code={} message={}",
+                static_cast<int>(status.code), status.message);
+    }
+}
+
+Status TransportTaskExecutor::Init()
+{
+    auto status = sendBufferManager_.Init("asu send buffer", MemoryType::HOST_PINNED,
+                                          config_.sendBufferSlotSize, config_.sendBufferSlotNum);
+    if (!status.ok()) {
+        (void)Shutdown();
+        return status;
+    }
+
+    status = flagBufferManager_.Init("asu flag buffer", MemoryType::HOST_PINNED,
+                                     config_.flagBufferSlotSize, config_.flagBufferSlotNum);
+    if (!status.ok()) {
+        (void)Shutdown();
+        return status;
+    }
+
+    status = RegisterBufferMemory(sendBufferManager_, sendBufferMrHandle_);
+    if (!status.ok()) {
+        const auto registerStatus =
+            Status::Error(status.code, "failed to register send buffer: " + status.message);
+        const auto shutdownStatus = Shutdown();
+        if (!shutdownStatus.ok()) {
+            UC_WARN(
+                "TransportTaskExecutor::Init cleanup failed after send buffer registration "
+                "failure: code={} message={}",
+                static_cast<int>(shutdownStatus.code), shutdownStatus.message);
+        }
+        return registerStatus;
+    }
+
+    status = RegisterBufferMemory(flagBufferManager_, flagBufferMrHandle_);
+    if (!status.ok()) {
+        const auto registerStatus =
+            Status::Error(status.code, "failed to register flag buffer: " + status.message);
+        const auto shutdownStatus = Shutdown();
+        if (!shutdownStatus.ok()) {
+            UC_WARN(
+                "TransportTaskExecutor::Init cleanup failed after flag buffer registration "
+                "failure: code={} message={}",
+                static_cast<int>(shutdownStatus.code), shutdownStatus.message);
+        }
+        return registerStatus;
+    }
+    return Status::OK();
+}
+
+Status TransportTaskExecutor::Shutdown()
+{
+    Status finalStatus = Status::OK();
+    auto status = UnregisterBufferMemory(flagBufferMrHandle_);
+    if (!status.ok()) {
+        UC_WARN("Failed to unregister flag buffer: code={} message={}",
+                static_cast<int>(status.code), status.message);
+        finalStatus =
+            Status::Error(status.code, "failed to unregister flag buffer: " + status.message);
+    }
+
+    status = UnregisterBufferMemory(sendBufferMrHandle_);
+    if (!status.ok()) {
+        UC_WARN("Failed to unregister send buffer: code={} message={}",
+                static_cast<int>(status.code), status.message);
+        if (finalStatus.ok()) {
+            finalStatus =
+                Status::Error(status.code, "failed to unregister send buffer: " + status.message);
+        }
+    }
+
+    if (flagBufferMrHandle_ == kInvalidMRHandle) { flagBufferManager_.Shutdown(); }
+    if (sendBufferMrHandle_ == kInvalidMRHandle) { sendBufferManager_.Shutdown(); }
+    return finalStatus;
+}
+
+Status TransportTaskExecutor::RegisterBufferMemory(BufferManager& bufferManager, MRHandle& mrHandle)
+{
+    if (!transProvider_) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "TransProvider is null");
+    }
+
+    TransProvider::RegisterMemoryDesc desc;
+    auto status = bufferManager.GetRegisterMemoryDesc(desc);
+    if (!status.ok()) { return status; }
+
+    std::vector<MRHandle> mrHandles;
+    status = transProvider_->RegisterMemory({desc}, mrHandles);
+    if (!status.ok()) {
+        return Status::Error(StatusCode::INTERNAL_ERROR,
+                             "provider memory registration failed: " + status.message);
+    }
+    if (mrHandles.empty() || mrHandles[0] == kInvalidMRHandle) {
+        return Status::Error(StatusCode::INTERNAL_ERROR, "provider returned no valid MR handle");
+    }
+
+    mrHandle = mrHandles[0];
+    std::uint32_t tokenId = 0;
+    status = transProvider_->GetMemTokenId(mrHandle, tokenId);
+    if (!status.ok()) {
+        const auto unregisterStatus = UnregisterBufferMemory(mrHandle);
+        if (!unregisterStatus.ok()) {
+            UC_WARN("Failed to unregister memory after token lookup failure: {}",
+                    unregisterStatus.message);
+        }
+        return Status::Error(StatusCode::INTERNAL_ERROR,
+                             "memory token lookup failed: " + status.message);
+    }
+
+    bufferManager.SetTokenId(tokenId);
+    return Status::OK();
+}
+
+Status TransportTaskExecutor::UnregisterBufferMemory(MRHandle& mrHandle)
+{
+    if (mrHandle == kInvalidMRHandle) { return Status::OK(); }
+    if (!transProvider_) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "TransProvider is null");
+    }
+
+    const auto statuses =
+        transProvider_->UnregisterMemory({TransProvider::UnregisterMemoryDesc{mrHandle}});
+    for (const auto& status : statuses) {
+        if (!status.ok()) {
+            return Status::Error(status.code,
+                                 "provider memory unregistration failed: " + status.message);
+        }
+    }
+    mrHandle = kInvalidMRHandle;
+    return Status::OK();
 }
 
 void TransportTaskExecutor::ReleaseSubBatchResources(TransportSubBatchContext& subBatchContext)
@@ -292,7 +422,7 @@ bool TransportTaskExecutor::Poll(const TransportTaskPtr& task)
                 }
 
                 if (const auto status =
-                        protocolManager_->PollResponseCid(responseData, completedCid);
+                        protocolManager_.PollResponseCid(responseData, completedCid);
                     !status.ok()) {
                     continue;
                 }
@@ -317,7 +447,7 @@ bool TransportTaskExecutor::Poll(const TransportTaskPtr& task)
                 KvResponse response;
                 const auto batchNumber =
                     static_cast<std::uint16_t>(subBatchContext.entryStatus.size());
-                if (const auto status = protocolManager_->UnpackResponse(
+                if (const auto status = protocolManager_.UnpackResponse(
                         responseData, ToKvOpcode(subBatchContext.opType), batchNumber, response);
                     !status.ok()) {
                     completeWithError(status);

--- a/ucm/transport/kv/asu/trans/src/transport_task_executor.h
+++ b/ucm/transport/kv/asu/trans/src/transport_task_executor.h
@@ -55,18 +55,21 @@ inline KvOpcode ToKvOpcode(AsuOpType opType)
 // Task lookup, waiting, and callback delivery remain TransportTaskManager concerns.
 class TransportTaskExecutor {
 public:
-    TransportTaskExecutor(const TransportConfig& config, IoScheduler& ioScheduler,
+    TransportTaskExecutor(const TransportConfig& config,
                           const std::shared_ptr<TransProvider>& transProvider,
-                          BufferManager& sendBufferManager, BufferManager& flagBufferManager,
-                          const std::unique_ptr<ProtocolManager>& protocolManager,
-                          const std::unique_ptr<ConnectionManager>& connectionManager,
-                          std::atomic<std::uint16_t>& nextRequestCid);
+                          const std::unique_ptr<ConnectionManager>& connectionManager);
+    ~TransportTaskExecutor();
+
+    Status Init();
+    Status Shutdown();
 
     bool Execute(const TransportTaskPtr& task);
     bool Poll(const TransportTaskPtr& task);
     bool Cancel(const TransportTaskPtr& task);
 
 private:
+    Status RegisterBufferMemory(BufferManager& bufferManager, MRHandle& mrHandle);
+    Status UnregisterBufferMemory(MRHandle& mrHandle);
     std::uint16_t AllocateRequestCid();
 
     Status PrepareTaskSubBatches(const TransportTask& task,
@@ -93,13 +96,15 @@ private:
     void ReleaseAllSubBatchResources(std::vector<TransportSubBatchContext>& subBatchContexts);
 
     const TransportConfig& config_;
-    IoScheduler& ioScheduler_;
+    IoScheduler ioScheduler_;
     const std::shared_ptr<TransProvider>& transProvider_;
-    BufferManager& sendBufferManager_;
-    BufferManager& flagBufferManager_;
-    const std::unique_ptr<ProtocolManager>& protocolManager_;
+    BufferManager sendBufferManager_;
+    BufferManager flagBufferManager_;
+    MRHandle sendBufferMrHandle_{kInvalidMRHandle};
+    MRHandle flagBufferMrHandle_{kInvalidMRHandle};
+    ProtocolManager protocolManager_;
     const std::unique_ptr<ConnectionManager>& connManager_;
-    std::atomic<std::uint16_t>& nextRequestCid_;
+    std::atomic<std::uint16_t> nextRequestCid_{1};
 };
 
 }  // namespace UC::ASU


### PR DESCRIPTION
## Purpose

Refactor ASU transport resource ownership to separate buffer allocation from provider-specific memory registration, simplify QP configuration, and encapsulate task data-path state in `TransportTaskExecutor`.

## Modifications

- Make `BufferManager` provider-agnostic: it now manages buffer allocation, slots, registration descriptions, and SGE token IDs only; send/flag buffer registration and MR-handle lifecycle move to `AsuTransportImpl`.
- Add failure-safe cleanup for buffer registration and token lookup, and unregister send/flag buffer regions during transport shutdown.
- Replace `queryQpNum`, `loadQpNum`, and `storeQpNum` with `TransportConfig::qpNum`, defaulting to `1` for endpoint connection-group creation.
- Move task-only state—`IoScheduler`, `ProtocolManager`, SQE/response handling, and request CID allocation—into `TransportTaskExecutor`.

## Compatibility Notes

- Migrate callers of `queryQpNum`, `loadQpNum`, and `storeQpNum` to `TransportConfig::qpNum`.
- The default QP count per endpoint is now `1`.

## Test

- `bash format.sh` passed (`codespell`, `black`, `isort`, `actionlint`)
- `clang-format 20.1.3 --dry-run --Werror` passed
- ASU target built successfully; ASU unit tests passed (371/371)
- `UCM offline/online inference` tests and `kv-test` build/run passed