### PR TITLE
feat:add shard-level thread pool for parallel H2H transfers && sglang integration

### DIFF
--- a/ucm/integration/sglang/ucm_connector.py
+++ b/ucm/integration/sglang/ucm_connector.py
@@ -21,6 +21,34 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _page_first_kv_split_buffers(mem_pool_host: "HostKVCache") -> List[torch.Tensor]:
+    """Return the K/V Host buffers for a regular MLA split layout."""
+    buffers = [mem_pool_host.k_buffer, mem_pool_host.v_buffer]
+    for name, buffer in zip(("k", "v"), buffers):
+        if not buffer.is_contiguous():
+            raise ValueError(
+                f"page_first_kv_split {name}_buffer must be contiguous"
+            )
+    return buffers
+
+
+def _page_first_kv_split_tensor_sizes(
+    mem_pool_host: "HostKVCache",
+) -> List[int]:
+    page_num = int(mem_pool_host.page_num)
+    if page_num <= 0:
+        raise ValueError(f"invalid page_num for page_first_kv_split: {page_num}")
+    sizes = []
+    for buffer in _page_first_kv_split_buffers(mem_pool_host):
+        nbytes = int(buffer.numel()) * int(buffer.element_size())
+        if nbytes % page_num != 0:
+            raise ValueError(
+                f"buffer bytes {nbytes} are not divisible by page_num {page_num}"
+            )
+        sizes.append(nbytes // page_num)
+    return sizes
+
+
 def _load_extra_config_from_yaml_env() -> Optional[Dict[str, Any]]:
     cfg_path = os.environ.get("UNIFIEDCACHE_CONFIG_FILE")
     if not cfg_path:
@@ -71,6 +99,8 @@ class UnifiedCacheStoreConfig:
         page_bytes = page_size * mem_pool_host.get_size_per_token()
         tensor_size = page_bytes if storage_config.is_mla_model else page_bytes // 2
         block_size = tensor_size * (1 if storage_config.is_mla_model else 2)
+        is_kv_split = mem_pool_host.layout == "page_first_kv_split"
+        use_cache_pipeline = storage_config.is_mla_model
 
         ucm_cfg = kvc.get("ucm_connector_config")
         name = kvc.get("ucm_connector_name")
@@ -85,12 +115,53 @@ class UnifiedCacheStoreConfig:
             )
 
         cfg = dict(ucm_cfg)
-        cfg["store_pipeline"] = "Posix"
-        cfg["storage_backends"] = [
-            path for path in cfg["storage_backends"].split(":") if path
-        ]
+        if use_cache_pipeline:
+            tensor_sizes = (
+                _page_first_kv_split_tensor_sizes(mem_pool_host)
+                if is_kv_split
+                else [page_bytes]
+            )
+            payload_size = sum(tensor_sizes)
+            io_direct = bool(cfg.get("io_direct", True))
+            block_size = (
+                (payload_size + 4095) // 4096 * 4096
+                if io_direct
+                else payload_size
+            )
+            cfg["store_pipeline"] = "Cache|Posix"
+            cfg.pop("tensor_size", None)
+            cfg["tensor_size_list"] = tensor_sizes
+            cfg["cache_use_host_buffer"] = True
+            cfg.setdefault("cache_h2h_worker_number", 4)
+            cfg.setdefault("cache_h2h_queue_depth", 1024)
+            cfg["cache_io_aggregation"] = False
+            cfg["cache_sdma_direct"] = False
+            cfg["use_gdr"] = False
+            cfg.pop("gpu_kv_buffer_addrs", None)
+            cfg.pop("gpu_kv_buffer_sizes", None)
+            safe_model_name = (
+                "-".join(storage_config.model_name.split("/"))
+                if storage_config.model_name
+                else "unknown-model"
+            )
+            if not cfg.get("unique_id"):
+                tensor_fingerprint = "-".join(str(size) for size in tensor_sizes)
+                cfg["unique_id"] = (
+                    f"sglang-{safe_model_name}-{mem_pool_host.layout}-"
+                    f"tp{storage_config.tp_size}-{tensor_fingerprint}"
+                )
+        else:
+            cfg["store_pipeline"] = "Posix"
+            cfg["tensor_size"] = tensor_size
+
+        storage_backends = cfg["storage_backends"]
+        if isinstance(storage_backends, str):
+            cfg["storage_backends"] = [
+                path for path in storage_backends.split(":") if path
+            ]
+        else:
+            cfg["storage_backends"] = list(storage_backends)
         cfg["device_id"] = get_world_group().local_rank
-        cfg["tensor_size"] = tensor_size
         cfg["shard_size"] = block_size
         cfg["block_size"] = block_size
         cfg["stream_number"] = 8
@@ -117,6 +188,26 @@ class SglangUcmConnector:
         self.cache_nums = 1 if self.is_mla else 2
         self.tp_rank = storage_config.tp_rank
         self.tp_size = storage_config.tp_size
+        self.is_kv_split = mem_pool_host.layout == "page_first_kv_split"
+        self.split_buffers = (
+            _page_first_kv_split_buffers(mem_pool_host)
+            if self.is_kv_split
+            else []
+        )
+        self.split_tensor_sizes = (
+            _page_first_kv_split_tensor_sizes(mem_pool_host)
+            if self.is_kv_split
+            else []
+        )
+        self.cache_tensor_sizes = (
+            self.split_tensor_sizes
+            if self.is_kv_split
+            else (
+                [self.page_size * mem_pool_host.get_size_per_token()]
+                if self.is_mla
+                else []
+            )
+        )
 
         self.config_suffix = self._build_config_suffix()
 
@@ -150,7 +241,13 @@ class SglangUcmConnector:
     def _build_config_suffix(self) -> str:
         model_name = "-".join(self.model.split("/")) if self.model else ""
         if self.is_mla:
-            return f"_{model_name}"
+            tensor_fingerprint = "-".join(
+                str(size) for size in self.cache_tensor_sizes
+            )
+            return (
+                f"_{model_name}_{self.mem_pool_host.layout}_p{self.page_size}_"
+                f"tp{self.tp_size}_{tensor_fingerprint}"
+            )
         return f"_{model_name}_{self.tp_rank}_{self.tp_size}"
 
     def _get_physical_key(self, logical_key: str) -> str:
@@ -168,6 +265,35 @@ class SglangUcmConnector:
             return [], [], []
 
         shard_index_list = [0] * len(encoded_keys)
+        if self.is_kv_split:
+            indices = host_indices.tolist()
+            if len(indices) % self.page_size != 0:
+                raise ValueError(
+                    "host_indices length must be a multiple of page_size"
+                )
+            if len(indices) // self.page_size != len(encoded_keys):
+                raise ValueError(
+                    "page count mismatch between keys and host_indices: "
+                    f"{len(encoded_keys)} != {len(indices) // self.page_size}"
+                )
+            ptr_list = []
+            for offset in range(0, len(indices), self.page_size):
+                first_token_index = int(indices[offset])
+                if first_token_index % self.page_size != 0:
+                    raise ValueError(
+                        "page_first_kv_split host index must start at a page boundary"
+                    )
+                page_index = first_token_index // self.page_size
+                ptr_list.append(
+                    [
+                        buffer.data_ptr() + page_index * tensor_size
+                        for buffer, tensor_size in zip(
+                            self.split_buffers, self.split_tensor_sizes
+                        )
+                    ]
+                )
+            return encoded_keys, shard_index_list, ptr_list
+
         ptr_list, _ = self.mem_pool_host.get_page_buffer_meta(host_indices)
 
         if not self.is_mla:

--- a/ucm/integration/sglang/unifiedcache_store.py
+++ b/ucm/integration/sglang/unifiedcache_store.py
@@ -43,9 +43,11 @@ class UnifiedCacheStore(HiCacheStorage):
 
     def register_mem_pool_host(self, mem_pool_host: HostKVCache):
         super().register_mem_pool_host(mem_pool_host)
-        if mem_pool_host.layout != "page_first":
+        supported_layouts = {"page_first", "page_first_kv_split", "page_first_direct"}
+        if mem_pool_host.layout not in supported_layouts:
             raise ValueError(
-                "UnifiedCacheStore currently requires --hicache-mem-layout page_first, "
+                "UnifiedCacheStore currently requires one of "
+                f"{sorted(supported_layouts)}, "
                 f"got {mem_pool_host.layout!r}."
             )
 

--- a/ucm/shared/test/case/trans/host_copy_executor_test.cc
+++ b/ucm/shared/test/case/trans/host_copy_executor_test.cc
@@ -1,0 +1,117 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "trans/host/host_copy_executor.h"
+#include <array>
+#include <atomic>
+#include <gtest/gtest.h>
+#include <list>
+#include <utility>
+
+namespace {
+
+using UC::Trans::HostCopyExecutor;
+
+TEST(HostCopyExecutorTest, GatherAndScatterVariableSegments)
+{
+    std::array<unsigned char, 2> first{1, 2};
+    std::array<unsigned char, 3> second{3, 4, 5};
+    std::array<unsigned char, 5> contiguous{};
+    std::vector<HostCopyExecutor::Segment> sources{{first.data(), first.size()},
+                                                   {second.data(), second.size()}};
+    size_t bytes = 0;
+    ASSERT_TRUE(HostCopyExecutor::Gather(sources, contiguous.data(), &bytes).Success());
+    EXPECT_EQ(bytes, contiguous.size());
+    EXPECT_EQ(contiguous, (std::array<unsigned char, 5>{1, 2, 3, 4, 5}));
+
+    first.fill(0);
+    second.fill(0);
+    ASSERT_TRUE(HostCopyExecutor::Scatter(contiguous.data(), sources, &bytes).Success());
+    EXPECT_EQ(first, (std::array<unsigned char, 2>{1, 2}));
+    EXPECT_EQ(second, (std::array<unsigned char, 3>{3, 4, 5}));
+}
+
+TEST(HostCopyExecutorTest, ReservationIsAtomicAndCompletionRunsOnce)
+{
+    HostCopyExecutor executor;
+    ASSERT_TRUE(executor.Setup(2, 2).Success());
+
+    auto reservationResult = executor.Reserve(2);
+    ASSERT_TRUE(reservationResult.HasValue());
+    EXPECT_FALSE(executor.Reserve(1).HasValue());
+    auto reservation = std::move(reservationResult).Value();
+
+    std::array<unsigned char, 4> source{1, 2, 3, 4};
+    std::array<unsigned char, 4> first{};
+    std::array<unsigned char, 4> second{};
+    std::atomic<size_t> completions{0};
+    std::list<HostCopyExecutor::Job> jobs;
+    for (auto* destination : {first.data(), second.data()}) {
+        HostCopyExecutor::Job job;
+        job.direction = HostCopyExecutor::Direction::SCATTER;
+        job.contiguous = source.data();
+        job.segments = {{destination, source.size()}};
+        job.completion = [&completions](const auto& result) {
+            if (result.status.Success()) { completions.fetch_add(1); }
+        };
+        jobs.push_back(std::move(job));
+    }
+    ASSERT_TRUE(reservation.Submit(jobs).Success());
+    executor.Synchronize();
+
+    EXPECT_EQ(completions.load(), 2U);
+    EXPECT_EQ(first, source);
+    EXPECT_EQ(second, source);
+    EXPECT_TRUE(executor.Reserve(2).HasValue());
+
+    std::atomic<bool> completionOnly{false};
+    ASSERT_TRUE(executor.PostCompletion([&completionOnly](const auto& result) {
+        completionOnly.store(result.status.Success());
+    }).Success());
+    executor.Synchronize();
+    EXPECT_TRUE(completionOnly.load());
+}
+
+TEST(HostCopyExecutorTest, PrerequisiteFailureSkipsCopy)
+{
+    HostCopyExecutor executor;
+    ASSERT_TRUE(executor.Setup(1, 1).Success());
+    std::array<unsigned char, 1> source{1};
+    std::array<unsigned char, 1> destination{0};
+    std::atomic<bool> failed{false};
+    std::list<HostCopyExecutor::Job> jobs;
+    HostCopyExecutor::Job job;
+    job.direction = HostCopyExecutor::Direction::SCATTER;
+    job.contiguous = source.data();
+    job.segments = {{destination.data(), destination.size()}};
+    job.prerequisite = [] { return UC::Status::Error("not ready"); };
+    job.completion = [&failed](const auto& result) { failed.store(result.status.Failure()); };
+    jobs.push_back(std::move(job));
+
+    ASSERT_TRUE(executor.Submit(jobs).Success());
+    executor.Synchronize();
+    EXPECT_TRUE(failed.load());
+    EXPECT_EQ(destination[0], 0);
+}
+
+}  // namespace

--- a/ucm/shared/trans/CMakeLists.txt
+++ b/ucm/shared/trans/CMakeLists.txt
@@ -10,6 +10,9 @@ endif()
 if(RUNTIME_ENVIRONMENT STREQUAL "simu")
     add_subdirectory(simu)
 endif()
+target_sources(trans PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/host/host_copy_executor.cc
+)
 if(NOT RUNTIME_ENVIRONMENT STREQUAL "cuda")
     target_sources(trans PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/cuda/gdr/gdr_mr_buffer.cc

--- a/ucm/shared/trans/host/host_copy_executor.cc
+++ b/ucm/shared/trans/host/host_copy_executor.cc
@@ -1,0 +1,249 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include "host_copy_executor.h"
+#include <chrono>
+#include <cstring>
+#include <exception>
+#include "logger/logger.h"
+
+namespace UC::Trans {
+
+HostCopyExecutor::Reservation::Reservation(HostCopyExecutor* executor, size_t count)
+    : executor_(executor), count_(count)
+{}
+
+HostCopyExecutor::Reservation::Reservation(Reservation&& other) noexcept
+    : executor_(other.executor_), count_(other.count_)
+{
+    other.executor_ = nullptr;
+    other.count_ = 0;
+}
+
+HostCopyExecutor::Reservation& HostCopyExecutor::Reservation::operator=(
+    Reservation&& other) noexcept
+{
+    if (this == &other) { return *this; }
+    Release();
+    executor_ = other.executor_;
+    count_ = other.count_;
+    other.executor_ = nullptr;
+    other.count_ = 0;
+    return *this;
+}
+
+HostCopyExecutor::Reservation::~Reservation() { Release(); }
+
+Status HostCopyExecutor::Reservation::Submit(std::list<Job>& jobs)
+{
+    if (executor_ == nullptr) { return Status::InvalidParam("invalid H2H reservation"); }
+    auto* executor = executor_;
+    const auto count = count_;
+    executor_ = nullptr;
+    count_ = 0;
+    return executor->SubmitReserved(count, jobs);
+}
+
+void HostCopyExecutor::Reservation::Release()
+{
+    if (executor_ != nullptr) { executor_->Release(count_); }
+    executor_ = nullptr;
+    count_ = 0;
+}
+
+HostCopyExecutor::~HostCopyExecutor() { Shutdown(); }
+
+Status HostCopyExecutor::Setup(size_t workerNumber, size_t queueDepth,
+                               const std::vector<ssize_t>& cpuAffinityCores)
+{
+    if (workerNumber == 0 || queueDepth == 0) {
+        return Status::InvalidParam("invalid H2H worker number({}) or queue depth({})",
+                                    workerNumber, queueDepth);
+    }
+    {
+        std::lock_guard<std::mutex> lock(stateMutex_);
+        if (accepting_ || queueDepth_ != 0) {
+            return Status::InvalidParam("HostCopyExecutor has already been set up");
+        }
+        queueDepth_ = queueDepth;
+    }
+    auto completionStarted =
+        completionPool_
+            .SetNWorker(1)
+            .SetWorkerFn([this](CompletionEvent& event, void* const&) { CompletionWorker(event); })
+            .SetCpuAffinity(cpuAffinityCores)
+            .Run();
+    auto copyStarted =
+        copyPool_
+            .SetNWorker(workerNumber)
+            .SetWorkerFn([this](Job& job, void* const&) { CopyWorker(job); })
+            .SetCpuAffinity(cpuAffinityCores)
+            .Run();
+    if (!completionStarted || !copyStarted) {
+        return Status::Error("failed to start host copy executor workers");
+    }
+    {
+        std::lock_guard<std::mutex> lock(stateMutex_);
+        accepting_ = true;
+    }
+    return Status::OK();
+}
+
+Expected<HostCopyExecutor::Reservation> HostCopyExecutor::Reserve(size_t number)
+{
+    std::lock_guard<std::mutex> lock(stateMutex_);
+    if (!accepting_) { return Status::Error("HostCopyExecutor is not accepting jobs"); }
+    if (number == 0) { return Status::InvalidParam("cannot reserve zero H2H jobs"); }
+    if (number > queueDepth_ || outstanding_ > queueDepth_ - number) {
+        return Status::Error("HostCopyExecutor queue full");
+    }
+    outstanding_ += number;
+    return Reservation(this, number);
+}
+
+Status HostCopyExecutor::Submit(std::list<Job>& jobs)
+{
+    auto reservation = Reserve(jobs.size());
+    if (!reservation) { return reservation.Error(); }
+    return reservation.Value().Submit(jobs);
+}
+
+Status HostCopyExecutor::PostCompletion(Completion completion)
+{
+    {
+        std::lock_guard<std::mutex> lock(stateMutex_);
+        if (!accepting_) { return Status::Error("HostCopyExecutor is not accepting jobs"); }
+        ++outstanding_;
+    }
+    completionPool_.Push(CompletionEvent{std::move(completion), Result{}});
+    return Status::OK();
+}
+
+Status HostCopyExecutor::SubmitReserved(size_t count, std::list<Job>& jobs)
+{
+    if (jobs.size() != count) {
+        Release(count);
+        return Status::InvalidParam("H2H job count({}, expect {})", jobs.size(), count);
+    }
+    copyPool_.Push(jobs);
+    return Status::OK();
+}
+
+void HostCopyExecutor::Release(size_t count)
+{
+    std::lock_guard<std::mutex> lock(stateMutex_);
+    if (count > outstanding_) {
+        UC_ERROR("Invalid HostCopyExecutor release count({}, outstanding {}).", count,
+                 outstanding_);
+        outstanding_ = 0;
+    } else {
+        outstanding_ -= count;
+    }
+    if (outstanding_ == 0) { idleCv_.notify_all(); }
+}
+
+void HostCopyExecutor::CopyWorker(Job& job)
+{
+    Result result;
+    try {
+        if (job.prerequisite) { result.status = job.prerequisite(); }
+        if (result.status.Success()) {
+            const auto start = std::chrono::steady_clock::now();
+            if (job.direction == Direction::GATHER) {
+                result.status = Gather(job.segments, job.contiguous, &result.bytes);
+            } else {
+                result.status = Scatter(job.contiguous, job.segments, &result.bytes);
+            }
+            result.durationMs =
+                std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start)
+                    .count();
+        }
+    } catch (const std::exception& e) {
+        result.status = Status::Error(e.what());
+    } catch (...) {
+        result.status = Status::Error("unknown exception in host copy worker");
+    }
+    completionPool_.Push(CompletionEvent{std::move(job.completion), std::move(result)});
+}
+
+void HostCopyExecutor::CompletionWorker(CompletionEvent& event)
+{
+    try {
+        if (event.completion) { event.completion(event.result); }
+    } catch (const std::exception& e) {
+        UC_ERROR("Host copy completion failed: {}.", e.what());
+    } catch (...) {
+        UC_ERROR("Host copy completion failed with unknown exception.");
+    }
+    Release(1);
+}
+
+Status HostCopyExecutor::Gather(const std::vector<Segment>& sources, void* destination,
+                                size_t* copiedBytes)
+{
+    if (destination == nullptr) { return Status::InvalidParam("invalid null host destination"); }
+    auto* dst = static_cast<std::byte*>(destination);
+    size_t offset = 0;
+    for (size_t i = 0; i < sources.size(); ++i) {
+        if (sources[i].address == nullptr) {
+            return Status::InvalidParam("invalid null host source({})", i);
+        }
+        std::memcpy(dst + offset, sources[i].address, sources[i].size);
+        offset += sources[i].size;
+    }
+    if (copiedBytes != nullptr) { *copiedBytes = offset; }
+    return Status::OK();
+}
+
+Status HostCopyExecutor::Scatter(const void* source,
+                                 const std::vector<Segment>& destinations,
+                                 size_t* copiedBytes)
+{
+    if (source == nullptr) { return Status::InvalidParam("invalid null host source"); }
+    const auto* src = static_cast<const std::byte*>(source);
+    size_t offset = 0;
+    for (size_t i = 0; i < destinations.size(); ++i) {
+        if (destinations[i].address == nullptr) {
+            return Status::InvalidParam("invalid null host destination({})", i);
+        }
+        std::memcpy(destinations[i].address, src + offset, destinations[i].size);
+        offset += destinations[i].size;
+    }
+    if (copiedBytes != nullptr) { *copiedBytes = offset; }
+    return Status::OK();
+}
+
+void HostCopyExecutor::Synchronize()
+{
+    std::unique_lock<std::mutex> lock(stateMutex_);
+    idleCv_.wait(lock, [this] { return outstanding_ == 0; });
+}
+
+void HostCopyExecutor::Shutdown()
+{
+    std::unique_lock<std::mutex> lock(stateMutex_);
+    accepting_ = false;
+    idleCv_.wait(lock, [this] { return outstanding_ == 0; });
+}
+
+}  // namespace UC::Trans

--- a/ucm/shared/trans/host/host_copy_executor.h
+++ b/ucm/shared/trans/host/host_copy_executor.h
@@ -1,0 +1,128 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2025 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef UNIFIEDCACHE_TRANS_HOST_COPY_EXECUTOR_H
+#define UNIFIEDCACHE_TRANS_HOST_COPY_EXECUTOR_H
+
+#include <condition_variable>
+#include <cstddef>
+#include <functional>
+#include <list>
+#include <mutex>
+#include <utility>
+#include <vector>
+#include "status/status.h"
+#include "thread/thread_pool.h"
+
+namespace UC::Trans {
+
+// A multi-worker executor, not a FIFO stream. Jobs and their callbacks may complete out of
+// submission order, while the segments within one job are always copied in the supplied order.
+class HostCopyExecutor {
+public:
+    enum class Direction { GATHER, SCATTER };
+
+    struct Segment {
+        void* address{nullptr};
+        size_t size{0};
+    };
+
+    struct Result {
+        Status status{Status::OK()};
+        size_t bytes{0};
+        double durationMs{0.0};
+    };
+
+    using Prerequisite = std::function<Status()>;
+    using Completion = std::function<void(const Result&)>;
+
+    struct Job {
+        Direction direction{Direction::GATHER};
+        void* contiguous{nullptr};
+        std::vector<Segment> segments;
+        Prerequisite prerequisite;
+        Completion completion;
+    };
+
+    class Reservation {
+        friend class HostCopyExecutor;
+
+    public:
+        Reservation() = default;
+        Reservation(const Reservation&) = delete;
+        Reservation& operator=(const Reservation&) = delete;
+        Reservation(Reservation&& other) noexcept;
+        Reservation& operator=(Reservation&& other) noexcept;
+        ~Reservation();
+
+        Status Submit(std::list<Job>& jobs);
+
+    private:
+        Reservation(HostCopyExecutor* executor, size_t count);
+        void Release();
+
+        HostCopyExecutor* executor_{nullptr};
+        size_t count_{0};
+    };
+
+    HostCopyExecutor() = default;
+    HostCopyExecutor(const HostCopyExecutor&) = delete;
+    HostCopyExecutor& operator=(const HostCopyExecutor&) = delete;
+    ~HostCopyExecutor();
+
+    Status Setup(size_t workerNumber, size_t queueDepth,
+                 const std::vector<ssize_t>& cpuAffinityCores = {});
+    Expected<Reservation> Reserve(size_t number);
+    Status Submit(std::list<Job>& jobs);
+    Status PostCompletion(Completion completion);
+    void Synchronize();
+
+    static Status Gather(const std::vector<Segment>& sources, void* destination,
+                         size_t* copiedBytes = nullptr);
+    static Status Scatter(const void* source, const std::vector<Segment>& destinations,
+                          size_t* copiedBytes = nullptr);
+
+private:
+    struct CompletionEvent {
+        Completion completion;
+        Result result;
+    };
+
+    Status SubmitReserved(size_t count, std::list<Job>& jobs);
+    void Release(size_t count);
+    void CopyWorker(Job& job);
+    void CompletionWorker(CompletionEvent& event);
+    void Shutdown();
+
+    size_t queueDepth_{0};
+    size_t outstanding_{0};
+    bool accepting_{false};
+    std::mutex stateMutex_;
+    std::condition_variable idleCv_;
+    ThreadPool<CompletionEvent> completionPool_;
+    ThreadPool<Job> copyPool_;
+};
+
+}  // namespace UC::Trans
+
+#endif

--- a/ucm/store/cache/cc/cache_store.cc
+++ b/ucm/store/cache/cc/cache_store.cc
@@ -54,7 +54,8 @@ public:
             UC_ERROR("Failed to check config params: {}.", s);
             return s;
         }
-        if (config.deviceId >= 0 && !config.gpuKvBufferAddrs.empty()) {
+        if (!config.cacheUseHostBuffer && config.deviceId >= 0 &&
+            !config.gpuKvBufferAddrs.empty()) {
             gpuKvBufferRegistrations_ = std::make_unique<Trans::GdrKVBufferConfig>();
             s = gpuKvBufferRegistrations_->Register(config.gpuKvBufferAddrs,
                                                     config.gpuKvBufferSizes);
@@ -168,6 +169,9 @@ private:
         config.Get("cache_io_aggregation", param.cacheIOAggregation);
         param.cacheIOAggregation = param.cacheIOAggregation && UCM_RUNTIME_ASCEND_IO_AGGREGATION;
         config.Get("cache_sdma_direct", param.cacheSdmaDirect);
+        config.Get("cache_use_host_buffer", param.cacheUseHostBuffer);
+        config.GetNumber("cache_h2h_worker_number", param.h2hWorkerNumber);
+        config.GetNumber("cache_h2h_queue_depth", param.h2hQueueDepth);
         config.GetNumber("local_rank_size", param.localRankSize);
         return param;
     }
@@ -191,6 +195,10 @@ private:
         if (config.deviceId < -1) {
             return Status::InvalidParam("invalid device({})", config.deviceId);
         }
+        if (config.cacheUseHostBuffer && config.deviceId < 0) {
+            return Status::InvalidParam(
+                "cache_use_host_buffer requires a non-negative device_id as cache owner id");
+        }
         if (config.uniqueId.empty()) { return Status::InvalidParam("invalid unique id"); }
         auto s =
             Trans::GdrKVBufferConfig::Validate(config.gpuKvBufferAddrs, config.gpuKvBufferSizes);
@@ -203,6 +211,18 @@ private:
         if (config.deviceId == -1) { return Status::OK(); }
         s = CheckSizeConfig(config);
         if (s.Failure()) { return s; }
+        if (config.cacheUseHostBuffer &&
+            (config.cacheIOAggregation || config.cacheSdmaDirect || config.useGdr ||
+             !config.gpuKvBufferAddrs.empty())) {
+            return Status::InvalidParam(
+                "cache_use_host_buffer is incompatible with cache_io_aggregation, "
+                "cache_sdma_direct, use_gdr, and gpu_kv_buffer_addrs");
+        }
+        if (config.cacheUseHostBuffer &&
+            (config.h2hWorkerNumber == 0 || config.h2hQueueDepth == 0)) {
+            return Status::InvalidParam("invalid H2H worker/queue configuration({},{})",
+                                        config.h2hWorkerNumber, config.h2hQueueDepth);
+        }
 #if !UCM_RUNTIME_ASCEND_SDMA_DIRECT
         if (config.cacheSdmaDirect) {
             return Status::InvalidParam("Cache SDMA Direct requires RUNTIME_ENVIRONMENT=ascend-a3");
@@ -272,6 +292,9 @@ private:
             UC_INFO("Set {}::StreamNumber to {}.", ns, config.EffectiveStreamNumber());
         }
         UC_INFO("Set {}::CacheSdmaDirect to {}.", ns, config.cacheSdmaDirect);
+        UC_INFO("Set {}::CacheUseHostBuffer to {}.", ns, config.cacheUseHostBuffer);
+        UC_INFO("Set {}::H2HWorkerNumber to {}.", ns, config.h2hWorkerNumber);
+        UC_INFO("Set {}::H2HQueueDepth to {}.", ns, config.h2hQueueDepth);
         UC_INFO("Set {}::LoadExclusiveBufferNumber to {}.", ns, config.loadExclusiveBufferNumber);
         UC_INFO("Set {}::GpuKvBufferNumber to {}.", ns, config.gpuKvBufferAddrs.size());
         UC_INFO("Set {}::UseGdr to {}.", ns, config.useGdr);

--- a/ucm/store/cache/cc/dump_queue.cc
+++ b/ucm/store/cache/cc/dump_queue.cc
@@ -24,7 +24,11 @@
 #include "dump_queue.h"
 #include <algorithm>
 #include <atomic>
+#include <cstddef>
+#include <cstring>
+#include <list>
 #include <memory>
+#include <numeric>
 #include "logger/logger.h"
 #include "metrics_api.h"
 #include "thread/cpu_affinity.h"
@@ -49,9 +53,31 @@ Status DumpQueue::Setup(const Config& config, TaskIdSet* failureSet, TransBuffer
     useGdr_ = config.useGdr;
     cacheIOAggregation_ = config.cacheIOAggregation;
     cacheSdmaDirect_ = config.cacheSdmaDirect;
+    useHostBuffer_ = config.cacheUseHostBuffer;
+    h2hQueueDepth_ = config.h2hQueueDepth;
     cpuAffinityCores_ = config.cpuAffinityCores;
     waiting_.Setup(config.waitingQueueDepth);
     dumping_.Setup(config.runningQueueDepth);
+    if (useHostBuffer_) {
+        auto completionStarted =
+            h2hCompletionPool_
+                .SetNWorker(1)
+                .SetWorkerFn([this](H2HDumpContextPtr& context, void* const&) {
+                    CompleteH2HDump(std::move(context));
+                })
+                .SetCpuAffinity(cpuAffinityCores_)
+                .Run();
+        auto copyStarted =
+            h2hCopyPool_
+                .SetNWorker(config.h2hWorkerNumber)
+                .SetWorkerFn(
+                    [this](H2HDumpJob& job, void* const&) { H2HDumpWorker(job); })
+                .SetCpuAffinity(cpuAffinityCores_)
+                .Run();
+        if (!completionStarted || !copyStarted) {
+            return Status::Error("failed to start CacheStore H2H dump workers");
+        }
+    }
     dumper_ = std::thread{&DumpQueue::BackendDumpStage, this};
     std::promise<Status> started;
     auto fut = started.get_future();
@@ -78,7 +104,9 @@ void DumpQueue::DispatchStage(std::promise<Status>& started)
     }
     CopyStream stream;
     auto s = Status::OK();
-    if (cacheIOAggregation_) {
+    if (useHostBuffer_) {
+        s = Status::OK();
+    } else if (cacheIOAggregation_) {
         s = stream.SetupIoAggregation(deviceId_, useGdr_);
     } else if (cacheSdmaDirect_) {
         s = stream.SetupSdmaDirect(deviceId_, useGdr_);
@@ -101,6 +129,16 @@ void DumpQueue::DispatchOneTask(CopyStream& stream, TaskPair&& pair)
     auto wait = NowTime::Now() - waiter->startTp;
     UC_DEBUG("Cache task({}) start running, wait {:.3f}ms.", task->id, wait * 1e3);
     UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_dump_queue_wait_duration_ms"), wait * 1e3);
+    if (useHostBuffer_) {
+        if (!failureSet_->Contains(task->id)) {
+            auto s = DispatchH2HDump(task, waiter);
+            if (s.Success()) { return; }
+            task->Fail(s);
+            failureSet_->Insert(task->id);
+        }
+        waiter->Done();
+        return;
+    }
     if (!failureSet_->Contains(task->id)) {
         auto s = DumpOneTask(stream, task);
         if (s.Failure()) [[unlikely]] {
@@ -206,6 +244,145 @@ Status DumpQueue::DumpOneTask(CopyStream& stream, TaskPtr task)
 Status DumpQueue::DeviceToHostAsync(CopyStream& stream, void** device, void* host)
 {
     return stream.DeviceToHostAsync(device, host, tensorSizes_);
+}
+
+bool DumpQueue::TryReserveH2HJobs(size_t number)
+{
+    auto outstanding = h2hOutstanding_.load(std::memory_order_relaxed);
+    for (;;) {
+        if (number > h2hQueueDepth_ || outstanding > h2hQueueDepth_ - number) { return false; }
+        if (h2hOutstanding_.compare_exchange_weak(outstanding, outstanding + number,
+                                                  std::memory_order_acq_rel,
+                                                  std::memory_order_relaxed)) {
+            return true;
+        }
+    }
+}
+
+Status DumpQueue::DispatchH2HDump(TaskPtr task, WaiterPtr waiter)
+{
+    if (task->desc.prerequisiteHandle != 0) {
+        return Status::InvalidParam(
+            "host-to-host dump does not accept a device prerequisite event");
+    }
+
+    auto context = std::make_shared<H2HDumpContext>();
+    context->task = task;
+    context->waiter = waiter;
+    context->backendTaskDesc.brief = "Cache2Backend";
+    context->bufferHandles.reserve(task->desc.size());
+    std::list<H2HDumpJob> jobs;
+
+    for (size_t shardIndex = 0; shardIndex < task->desc.size(); ++shardIndex) {
+        const auto& shard = task->desc[shardIndex];
+        auto handle = buffer_->Get(shard.owner, shard.index);
+        if (!handle.Owner()) { continue; }
+        const auto handleIndex = context->bufferHandles.size();
+        const auto ready = handle.Ready();
+        context->backendTaskDesc.push_back(
+            Detail::Shard{shard.owner, shard.index, {handle.Data()}});
+        context->bufferHandles.push_back(std::move(handle));
+        if (!ready) { jobs.push_back(H2HDumpJob{context, shardIndex, handleIndex}); }
+    }
+
+    UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_dump_shards_total"),
+                             static_cast<double>(task->desc.size()));
+    UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_dump_backend_shards_total"),
+                             static_cast<double>(context->backendTaskDesc.size()));
+    if (context->backendTaskDesc.empty()) {
+        waiter->Done();
+        return Status::OK();
+    }
+    if (jobs.empty()) {
+        h2hCompletionPool_.Push(std::move(context));
+        return Status::OK();
+    }
+    if (!TryReserveH2HJobs(jobs.size())) {
+        UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_dump_queue_full_total"), 1.0);
+        auto s = Status::Error("CacheStore H2H dump queue full");
+        for (const auto& job : jobs) {
+            context->bufferHandles[job.handleIndex].MarkFailed(s);
+        }
+        return s;
+    }
+    context->pending.store(jobs.size(), std::memory_order_release);
+    h2hCopyPool_.Push(jobs);
+    return Status::OK();
+}
+
+void DumpQueue::H2HDumpWorker(H2HDumpJob& job)
+{
+    const auto start = NowTime::Now();
+    auto& context = job.context;
+    auto& shard = context->task->desc[job.shardIndex];
+    auto& handle = context->bufferHandles[job.handleIndex];
+    auto s = HostToHostGather(shard, handle.Data());
+    if (s.Failure()) [[unlikely]] {
+        UC_ERROR("Failed({}) to do H2H gather for task({}).", s, context->task->id);
+        handle.MarkFailed(s);
+        context->task->Fail(s);
+        context->failed.store(true, std::memory_order_release);
+        UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_dump_errors_total"), 1.0);
+    } else {
+        const auto bytes = std::accumulate(tensorSizes_.begin(), tensorSizes_.end(), size_t(0));
+        UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_dump_bytes_total"),
+                                 static_cast<double>(bytes));
+        UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_dump_duration_ms"),
+                                 (NowTime::Now() - start) * 1e3);
+    }
+    if (context->pending.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+        h2hCompletionPool_.Push(std::move(context));
+    }
+    h2hOutstanding_.fetch_sub(1, std::memory_order_acq_rel);
+}
+
+void DumpQueue::CompleteH2HDump(H2HDumpContextPtr context)
+{
+    if (context->failed.load(std::memory_order_acquire)) {
+        auto error = context->task->FailureStatus();
+        for (auto& handle : context->bufferHandles) { handle.MarkFailed(error); }
+        failureSet_->Insert(context->task->id);
+        context->waiter->Done();
+        return;
+    }
+    for (auto& handle : context->bufferHandles) { handle.MarkReady(); }
+    auto res = backend_->Dump(std::move(context->backendTaskDesc));
+    if (!res) [[unlikely]] {
+        auto error = res.Error();
+        context->task->Fail(error);
+        failureSet_->Insert(context->task->id);
+        UC_ERROR("Failed({}) to submit H2H dump task({}) to backend.", error,
+                 context->task->id);
+        UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_backend_dump_submit_errors_total"),
+                                 1.0);
+        context->waiter->Done();
+        return;
+    }
+    DumpCtx dumpCtx;
+    dumpCtx.taskHandle = context->task->id;
+    dumpCtx.backendTaskHandle = res.Value();
+    dumpCtx.bufferHandles = std::move(context->bufferHandles);
+    dumping_.Push(std::move(dumpCtx));
+    context->waiter->Done();
+}
+
+Status DumpQueue::HostToHostGather(const Detail::Shard& shard, void* destination) const
+{
+    if (shard.addrs.size() != tensorSizes_.size()) {
+        return Status::InvalidParam("invalid host addr number({}, expect {})", shard.addrs.size(),
+                                    tensorSizes_.size());
+    }
+    if (destination == nullptr) { return Status::InvalidParam("invalid null host destination"); }
+    auto* dst = static_cast<std::byte*>(destination);
+    size_t offset = 0;
+    for (size_t i = 0; i < tensorSizes_.size(); ++i) {
+        if (shard.addrs[i] == nullptr) {
+            return Status::InvalidParam("invalid null host source({})", i);
+        }
+        std::memcpy(dst + offset, shard.addrs[i], tensorSizes_[i]);
+        offset += tensorSizes_[i];
+    }
+    return Status::OK();
 }
 
 void DumpQueue::BackendDumpStage()

--- a/ucm/store/cache/cc/dump_queue.cc
+++ b/ucm/store/cache/cc/dump_queue.cc
@@ -24,11 +24,8 @@
 #include "dump_queue.h"
 #include <algorithm>
 #include <atomic>
-#include <cstddef>
-#include <cstring>
 #include <list>
 #include <memory>
-#include <numeric>
 #include "logger/logger.h"
 #include "metrics_api.h"
 #include "thread/cpu_affinity.h"
@@ -39,6 +36,8 @@ DumpQueue::~DumpQueue()
 {
     stop_.store(true);
     if (dispatcher_.joinable()) { dispatcher_.join(); }
+    if (useHostBuffer_) { hostCopyExecutor_.Synchronize(); }
+    backendStop_.store(true);
     if (dumper_.joinable()) { dumper_.join(); }
 }
 
@@ -54,29 +53,13 @@ Status DumpQueue::Setup(const Config& config, TaskIdSet* failureSet, TransBuffer
     cacheIOAggregation_ = config.cacheIOAggregation;
     cacheSdmaDirect_ = config.cacheSdmaDirect;
     useHostBuffer_ = config.cacheUseHostBuffer;
-    h2hQueueDepth_ = config.h2hQueueDepth;
     cpuAffinityCores_ = config.cpuAffinityCores;
     waiting_.Setup(config.waitingQueueDepth);
     dumping_.Setup(config.runningQueueDepth);
     if (useHostBuffer_) {
-        auto completionStarted =
-            h2hCompletionPool_
-                .SetNWorker(1)
-                .SetWorkerFn([this](H2HDumpContextPtr& context, void* const&) {
-                    CompleteH2HDump(std::move(context));
-                })
-                .SetCpuAffinity(cpuAffinityCores_)
-                .Run();
-        auto copyStarted =
-            h2hCopyPool_
-                .SetNWorker(config.h2hWorkerNumber)
-                .SetWorkerFn(
-                    [this](H2HDumpJob& job, void* const&) { H2HDumpWorker(job); })
-                .SetCpuAffinity(cpuAffinityCores_)
-                .Run();
-        if (!completionStarted || !copyStarted) {
-            return Status::Error("failed to start CacheStore H2H dump workers");
-        }
+        auto s = hostCopyExecutor_.Setup(config.h2hWorkerNumber, config.h2hQueueDepth,
+                                         cpuAffinityCores_);
+        if (s.Failure()) { return s; }
     }
     dumper_ = std::thread{&DumpQueue::BackendDumpStage, this};
     std::promise<Status> started;
@@ -246,19 +229,6 @@ Status DumpQueue::DeviceToHostAsync(CopyStream& stream, void** device, void* hos
     return stream.DeviceToHostAsync(device, host, tensorSizes_);
 }
 
-bool DumpQueue::TryReserveH2HJobs(size_t number)
-{
-    auto outstanding = h2hOutstanding_.load(std::memory_order_relaxed);
-    for (;;) {
-        if (number > h2hQueueDepth_ || outstanding > h2hQueueDepth_ - number) { return false; }
-        if (h2hOutstanding_.compare_exchange_weak(outstanding, outstanding + number,
-                                                  std::memory_order_acq_rel,
-                                                  std::memory_order_relaxed)) {
-            return true;
-        }
-    }
-}
-
 Status DumpQueue::DispatchH2HDump(TaskPtr task, WaiterPtr waiter)
 {
     if (task->desc.prerequisiteHandle != 0) {
@@ -271,7 +241,11 @@ Status DumpQueue::DispatchH2HDump(TaskPtr task, WaiterPtr waiter)
     context->waiter = waiter;
     context->backendTaskDesc.brief = "Cache2Backend";
     context->bufferHandles.reserve(task->desc.size());
-    std::list<H2HDumpJob> jobs;
+    struct PendingCopy {
+        size_t shardIndex;
+        size_t handleIndex;
+    };
+    std::vector<PendingCopy> pendingCopies;
 
     for (size_t shardIndex = 0; shardIndex < task->desc.size(); ++shardIndex) {
         const auto& shard = task->desc[shardIndex];
@@ -282,7 +256,7 @@ Status DumpQueue::DispatchH2HDump(TaskPtr task, WaiterPtr waiter)
         context->backendTaskDesc.push_back(
             Detail::Shard{shard.owner, shard.index, {handle.Data()}});
         context->bufferHandles.push_back(std::move(handle));
-        if (!ready) { jobs.push_back(H2HDumpJob{context, shardIndex, handleIndex}); }
+        if (!ready) { pendingCopies.push_back({shardIndex, handleIndex}); }
     }
 
     UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_dump_shards_total"),
@@ -293,30 +267,59 @@ Status DumpQueue::DispatchH2HDump(TaskPtr task, WaiterPtr waiter)
         waiter->Done();
         return Status::OK();
     }
-    if (jobs.empty()) {
-        h2hCompletionPool_.Push(std::move(context));
-        return Status::OK();
+    if (pendingCopies.empty()) {
+        return hostCopyExecutor_.PostCompletion(
+            [this, context](const Trans::HostCopyExecutor::Result&) {
+                CompleteH2HDump(context);
+            });
     }
-    if (!TryReserveH2HJobs(jobs.size())) {
+    auto reservationResult = hostCopyExecutor_.Reserve(pendingCopies.size());
+    if (!reservationResult) {
         UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_dump_queue_full_total"), 1.0);
         auto s = Status::Error("CacheStore H2H dump queue full");
-        for (const auto& job : jobs) {
-            context->bufferHandles[job.handleIndex].MarkFailed(s);
+        for (const auto& copy : pendingCopies) {
+            context->bufferHandles[copy.handleIndex].MarkFailed(s);
         }
         return s;
     }
-    context->pending.store(jobs.size(), std::memory_order_release);
-    h2hCopyPool_.Push(jobs);
+    auto reservation = std::move(reservationResult).Value();
+    context->pending.store(pendingCopies.size(), std::memory_order_release);
+    std::list<Trans::HostCopyExecutor::Job> jobs;
+    for (const auto& copy : pendingCopies) {
+        auto& shard = context->task->desc[copy.shardIndex];
+        Trans::HostCopyExecutor::Job job;
+        job.direction = Trans::HostCopyExecutor::Direction::GATHER;
+        job.contiguous = context->bufferHandles[copy.handleIndex].Data();
+        job.segments = MakeH2HSegments(shard);
+        job.prerequisite = [this, context, shardIndex = copy.shardIndex] {
+            const auto& currentShard = context->task->desc[shardIndex];
+            if (currentShard.addrs.size() != tensorSizes_.size()) {
+                return Status::InvalidParam("invalid host addr number({}, expect {})",
+                                            currentShard.addrs.size(), tensorSizes_.size());
+            }
+            return Status::OK();
+        };
+        job.completion = [this, context, handleIndex = copy.handleIndex](
+                             const Trans::HostCopyExecutor::Result& result) {
+            CompleteH2HCopy(context, handleIndex, result);
+        };
+        jobs.push_back(std::move(job));
+    }
+    auto submitStatus = reservation.Submit(jobs);
+    if (submitStatus.Failure()) {
+        for (const auto& copy : pendingCopies) {
+            context->bufferHandles[copy.handleIndex].MarkFailed(submitStatus);
+        }
+        return submitStatus;
+    }
     return Status::OK();
 }
 
-void DumpQueue::H2HDumpWorker(H2HDumpJob& job)
+void DumpQueue::CompleteH2HCopy(const H2HDumpContextPtr& context, size_t handleIndex,
+                                const Trans::HostCopyExecutor::Result& result)
 {
-    const auto start = NowTime::Now();
-    auto& context = job.context;
-    auto& shard = context->task->desc[job.shardIndex];
-    auto& handle = context->bufferHandles[job.handleIndex];
-    auto s = HostToHostGather(shard, handle.Data());
+    auto& handle = context->bufferHandles[handleIndex];
+    auto s = result.status;
     if (s.Failure()) [[unlikely]] {
         UC_ERROR("Failed({}) to do H2H gather for task({}).", s, context->task->id);
         handle.MarkFailed(s);
@@ -324,16 +327,14 @@ void DumpQueue::H2HDumpWorker(H2HDumpJob& job)
         context->failed.store(true, std::memory_order_release);
         UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_dump_errors_total"), 1.0);
     } else {
-        const auto bytes = std::accumulate(tensorSizes_.begin(), tensorSizes_.end(), size_t(0));
         UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_dump_bytes_total"),
-                                 static_cast<double>(bytes));
+                                 static_cast<double>(result.bytes));
         UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_dump_duration_ms"),
-                                 (NowTime::Now() - start) * 1e3);
+                                 result.durationMs);
     }
     if (context->pending.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        h2hCompletionPool_.Push(std::move(context));
+        CompleteH2HDump(context);
     }
-    h2hOutstanding_.fetch_sub(1, std::memory_order_acq_rel);
 }
 
 void DumpQueue::CompleteH2HDump(H2HDumpContextPtr context)
@@ -366,23 +367,16 @@ void DumpQueue::CompleteH2HDump(H2HDumpContextPtr context)
     context->waiter->Done();
 }
 
-Status DumpQueue::HostToHostGather(const Detail::Shard& shard, void* destination) const
+std::vector<Trans::HostCopyExecutor::Segment> DumpQueue::MakeH2HSegments(
+    const Detail::Shard& shard) const
 {
-    if (shard.addrs.size() != tensorSizes_.size()) {
-        return Status::InvalidParam("invalid host addr number({}, expect {})", shard.addrs.size(),
-                                    tensorSizes_.size());
-    }
-    if (destination == nullptr) { return Status::InvalidParam("invalid null host destination"); }
-    auto* dst = static_cast<std::byte*>(destination);
-    size_t offset = 0;
+    std::vector<Trans::HostCopyExecutor::Segment> segments;
+    if (shard.addrs.size() != tensorSizes_.size()) { return segments; }
+    segments.reserve(tensorSizes_.size());
     for (size_t i = 0; i < tensorSizes_.size(); ++i) {
-        if (shard.addrs[i] == nullptr) {
-            return Status::InvalidParam("invalid null host source({})", i);
-        }
-        std::memcpy(dst + offset, shard.addrs[i], tensorSizes_[i]);
-        offset += tensorSizes_[i];
+        segments.push_back({shard.addrs[i], tensorSizes_[i]});
     }
-    return Status::OK();
+    return segments;
 }
 
 void DumpQueue::BackendDumpStage()
@@ -393,7 +387,7 @@ void DumpQueue::BackendDumpStage()
         auto s = CpuAffinity::SetCpuAffinity4CurrentThread(cpuAffinityCores_);
         if (s.Failure()) { UC_WARN("Failed({}) to set affinity.", s); }
     }
-    dumping_.ConsumerLoop(stop_, [this](auto&& task) {
+    dumping_.ConsumerLoop(backendStop_, [this](auto&& task) {
         if (task.backendTaskHandle > finishedBackendTaskHandle_) {
             auto tpWait = NowTime::Now();
             auto s = backend_->Wait(task.backendTaskHandle);

--- a/ucm/store/cache/cc/dump_queue.h
+++ b/ucm/store/cache/cc/dump_queue.h
@@ -33,7 +33,7 @@
 #include "template/hashset.h"
 #include "template/spsc_ring_queue.h"
 #include "thread/latch.h"
-#include "thread/thread_pool.h"
+#include "trans/host/host_copy_executor.h"
 #include "trans_buffer.h"
 #include "trans_task.h"
 #include "ucmstore_v1.h"
@@ -59,14 +59,10 @@ class DumpQueue {
         std::vector<TransBuffer::Handle> bufferHandles;
     };
     using H2HDumpContextPtr = std::shared_ptr<H2HDumpContext>;
-    struct H2HDumpJob {
-        H2HDumpContextPtr context;
-        size_t shardIndex{0};
-        size_t handleIndex{0};
-    };
 
 private:
     alignas(64) std::atomic_bool stop_{false};
+    alignas(64) std::atomic_bool backendStop_{false};
     Detail::TaskHandle finishedBackendTaskHandle_{0};
     TaskIdSet* failureSet_{nullptr};
     TransBuffer* buffer_{nullptr};
@@ -78,15 +74,12 @@ private:
     bool cacheIOAggregation_{false};
     bool cacheSdmaDirect_{false};
     bool useHostBuffer_{false};
-    size_t h2hQueueDepth_{0};
-    std::atomic<size_t> h2hOutstanding_{0};
     std::vector<ssize_t> cpuAffinityCores_{};
     SpscRingQueue<TaskPair> waiting_;
     SpscRingQueue<DumpCtx> dumping_;
     std::thread dispatcher_;
     std::thread dumper_;
-    ThreadPool<H2HDumpContextPtr> h2hCompletionPool_;
-    ThreadPool<H2HDumpJob> h2hCopyPool_;
+    Trans::HostCopyExecutor hostCopyExecutor_;
 
 public:
     ~DumpQueue();
@@ -99,10 +92,11 @@ private:
     Status DumpOneTask(CopyStream& stream, TaskPtr task);
     Status DeviceToHostAsync(CopyStream& stream, void** device, void* host);
     Status DispatchH2HDump(TaskPtr task, WaiterPtr waiter);
-    void H2HDumpWorker(H2HDumpJob& job);
+    void CompleteH2HCopy(const H2HDumpContextPtr& context, size_t handleIndex,
+                         const Trans::HostCopyExecutor::Result& result);
     void CompleteH2HDump(H2HDumpContextPtr context);
-    Status HostToHostGather(const Detail::Shard& shard, void* destination) const;
-    bool TryReserveH2HJobs(size_t number);
+    std::vector<Trans::HostCopyExecutor::Segment> MakeH2HSegments(
+        const Detail::Shard& shard) const;
     void BackendDumpStage();
 };
 

--- a/ucm/store/cache/cc/dump_queue.h
+++ b/ucm/store/cache/cc/dump_queue.h
@@ -24,13 +24,16 @@
 #ifndef UNIFIEDCACHE_CACHE_STORE_CC_DUMP_QUEUE_H
 #define UNIFIEDCACHE_CACHE_STORE_CC_DUMP_QUEUE_H
 
+#include <atomic>
 #include <future>
+#include <list>
 #include <string>
 #include <thread>
 #include "copy_stream.h"
 #include "template/hashset.h"
 #include "template/spsc_ring_queue.h"
 #include "thread/latch.h"
+#include "thread/thread_pool.h"
 #include "trans_buffer.h"
 #include "trans_task.h"
 #include "ucmstore_v1.h"
@@ -47,6 +50,20 @@ class DumpQueue {
         Detail::TaskHandle backendTaskHandle;
         std::vector<TransBuffer::Handle> bufferHandles;
     };
+    struct H2HDumpContext {
+        TaskPtr task;
+        WaiterPtr waiter;
+        std::atomic<size_t> pending{0};
+        std::atomic<bool> failed{false};
+        Detail::TaskDesc backendTaskDesc;
+        std::vector<TransBuffer::Handle> bufferHandles;
+    };
+    using H2HDumpContextPtr = std::shared_ptr<H2HDumpContext>;
+    struct H2HDumpJob {
+        H2HDumpContextPtr context;
+        size_t shardIndex{0};
+        size_t handleIndex{0};
+    };
 
 private:
     alignas(64) std::atomic_bool stop_{false};
@@ -60,11 +77,16 @@ private:
     bool useGdr_{false};
     bool cacheIOAggregation_{false};
     bool cacheSdmaDirect_{false};
+    bool useHostBuffer_{false};
+    size_t h2hQueueDepth_{0};
+    std::atomic<size_t> h2hOutstanding_{0};
     std::vector<ssize_t> cpuAffinityCores_{};
     SpscRingQueue<TaskPair> waiting_;
     SpscRingQueue<DumpCtx> dumping_;
     std::thread dispatcher_;
     std::thread dumper_;
+    ThreadPool<H2HDumpContextPtr> h2hCompletionPool_;
+    ThreadPool<H2HDumpJob> h2hCopyPool_;
 
 public:
     ~DumpQueue();
@@ -76,6 +98,11 @@ private:
     void DispatchOneTask(CopyStream& stream, TaskPair&& pair);
     Status DumpOneTask(CopyStream& stream, TaskPtr task);
     Status DeviceToHostAsync(CopyStream& stream, void** device, void* host);
+    Status DispatchH2HDump(TaskPtr task, WaiterPtr waiter);
+    void H2HDumpWorker(H2HDumpJob& job);
+    void CompleteH2HDump(H2HDumpContextPtr context);
+    Status HostToHostGather(const Detail::Shard& shard, void* destination) const;
+    bool TryReserveH2HJobs(size_t number);
     void BackendDumpStage();
 };
 

--- a/ucm/store/cache/cc/global_config.h
+++ b/ucm/store/cache/cc/global_config.h
@@ -63,6 +63,9 @@ struct Config {
     bool useGdr{false};
     bool cacheIOAggregation{false};
     bool cacheSdmaDirect{UCM_RUNTIME_ASCEND_SDMA_DIRECT};
+    bool cacheUseHostBuffer{false};
+    size_t h2hWorkerNumber{4};
+    size_t h2hQueueDepth{1024};
     size_t localRankSize{8};
 
     size_t EffectiveStreamNumber() const noexcept { return cacheSdmaDirect ? 1 : streamNumber; }

--- a/ucm/store/cache/cc/load_queue.cc
+++ b/ucm/store/cache/cc/load_queue.cc
@@ -22,6 +22,10 @@
  * SOFTWARE.
  * */
 #include "load_queue.h"
+#include <cstddef>
+#include <cstring>
+#include <list>
+#include <numeric>
 #include "logger/logger.h"
 #include "metrics_api.h"
 #include "thread/cpu_affinity.h"
@@ -47,12 +51,24 @@ Status LoadQueue::Setup(const Config& config, TaskIdSet* failureSet, TransBuffer
     useGdr_ = config.useGdr;
     cacheIOAggregation_ = config.cacheIOAggregation;
     cacheSdmaDirect_ = config.cacheSdmaDirect;
+    useHostBuffer_ = config.cacheUseHostBuffer;
+    h2hQueueDepth_ = config.h2hQueueDepth;
     cpuAffinityCores_ = config.cpuAffinityCores;
     localRankSize_ = config.localRankSize;
     waiting_.Setup(config.waitingQueueDepth);
     running_.Setup(config.runningQueueDepth);
     holder_.reserve(1024);
+    if (useHostBuffer_) {
+        auto started =
+            h2hCopyPool_
+                .SetNWorker(config.h2hWorkerNumber)
+                .SetWorkerFn([this](ShardTask& task, void* const&) { H2HLoadWorker(task); })
+                .SetCpuAffinity(cpuAffinityCores_)
+                .Run();
+        if (!started) { return Status::Error("failed to start CacheStore H2H load workers"); }
+    }
     dispatcher_ = std::thread{&LoadQueue::DispatchStage, this};
+    if (useHostBuffer_) { return Status::OK(); }
     std::promise<Status> started;
     auto fut = started.get_future();
     transfer_ = std::thread{&LoadQueue::TransferStage, this, std::ref(started)};
@@ -101,6 +117,10 @@ static std::vector<size_t> RearrangeIndex(size_t n, size_t iProc, size_t nProc)
 
 void LoadQueue::DispatchOneTask(TaskPair&& pair)
 {
+    if (useHostBuffer_) {
+        DispatchOneH2HTask(std::move(pair));
+        return;
+    }
     auto& task = pair.first;
     auto& waiter = pair.second;
     if (failureSet_->Contains(task->id)) {
@@ -162,13 +182,178 @@ void LoadQueue::DispatchOneTask(TaskPair&& pair)
                              static_cast<double>(nShard));
 }
 
+bool LoadQueue::TryReserveH2HJobs(size_t number)
+{
+    auto outstanding = h2hOutstanding_.load(std::memory_order_relaxed);
+    for (;;) {
+        if (number > h2hQueueDepth_ || outstanding > h2hQueueDepth_ - number) { return false; }
+        if (h2hOutstanding_.compare_exchange_weak(outstanding, outstanding + number,
+                                                  std::memory_order_acq_rel,
+                                                  std::memory_order_relaxed)) {
+            return true;
+        }
+    }
+}
+
+void LoadQueue::DispatchOneH2HTask(TaskPair&& pair)
+{
+    auto task = std::move(pair.first);
+    auto waiter = std::move(pair.second);
+    if (failureSet_->Contains(task->id)) {
+        waiter->Done();
+        return;
+    }
+    const auto nShard = task->desc.size();
+    if (nShard == 0) {
+        waiter->Done();
+        return;
+    }
+    if (!TryReserveH2HJobs(nShard)) {
+        auto s = Status::Error("CacheStore H2H load queue full");
+        task->Fail(s);
+        failureSet_->Insert(task->id);
+        RecordFailedShards(nShard);
+        UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_load_queue_full_total"), 1.0);
+        waiter->Done();
+        return;
+    }
+
+    auto context = std::make_shared<H2HLoadContext>();
+    context->task = task;
+    context->waiter = waiter;
+    context->pending.store(nShard, std::memory_order_release);
+    std::list<ShardTask> jobs;
+    size_t backendSubmitCount = 0;
+    const auto indexes = RearrangeIndex(nShard, deviceId_, localRankSize_);
+    for (size_t i = 0; i < nShard; ++i) {
+        auto& shard = task->desc[indexes[i]];
+        ShardTask shardTask;
+        shardTask.task = task;
+        shardTask.shard = shard;
+        shardTask.h2hContext = context;
+        shardTask.bufferHandle = buffer_->Get(shard.owner, shard.index, true, true);
+        shardTask.fromPosix = !shardTask.bufferHandle.Ready();
+        if (shardTask.bufferHandle.Owner() && !shardTask.bufferHandle.Ready()) {
+            if (context->failed.load(std::memory_order_acquire)) {
+                shardTask.bufferHandle.MarkFailed(task->FailureStatus());
+            } else {
+                Detail::TaskDesc backendTask{
+                    Detail::Shard{shard.owner, shard.index, {shardTask.bufferHandle.Data()}}
+                };
+                backendTask.brief = "Backend2Cache";
+                auto res = backend_->Load(std::move(backendTask));
+                if (!res) [[unlikely]] {
+                    auto error = res.Error();
+                    UC_ERROR("Failed({}) to submit H2H load task({}) to backend.", error,
+                             task->id);
+                    shardTask.bufferHandle.MarkFailed(error);
+                    task->Fail(error);
+                    context->failed.store(true, std::memory_order_release);
+                    failureSet_->Insert(task->id);
+                    UC::Metrics::UpdateStats(
+                        NAME_TO_METRIC_ID("cache_backend_load_submit_errors_total"), 1.0);
+                } else {
+                    shardTask.backendTaskHandle = res.Value();
+                    ++backendSubmitCount;
+                }
+            }
+        }
+        jobs.push_back(std::move(shardTask));
+    }
+    h2hCopyPool_.Push(jobs);
+
+    if (!context->failed.load(std::memory_order_acquire)) {
+        for (size_t i = 0; i < nShard; ++i) {
+            auto& shard = task->desc[indexes[i]];
+            if (shard.index + 1 != nShardPerBlock_) {
+                buffer_->Prealloc(shard.owner, shard.index + 1, true);
+            }
+        }
+    }
+    UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_load_backend_shards_total"),
+                             static_cast<double>(backendSubmitCount));
+    UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_load_shards_total"),
+                             static_cast<double>(nShard));
+}
+
+void LoadQueue::H2HLoadWorker(ShardTask& task)
+{
+    auto& context = task.h2hContext;
+    auto success = false;
+    auto s = Status::OK();
+    const auto start = NowTime::Now();
+
+    if (task.backendTaskHandle != 0 || !context->failed.load(std::memory_order_acquire)) {
+        auto tpBackendWait = NowTime::Now();
+        s = WaitBackendTaskReady(task);
+        UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_shard_backend_wait_ms"),
+                                 (NowTime::Now() - tpBackendWait) * 1e3);
+        if (s.Success() && !context->failed.load(std::memory_order_acquire)) {
+            s = HostToHostScatter(task.bufferHandle.Data(), task.shard);
+        }
+        success = s.Success() && !context->failed.load(std::memory_order_acquire);
+    }
+
+    if (!success) {
+        if (s.Success()) { s = context->task->FailureStatus(); }
+        context->task->Fail(s);
+        context->failed.store(true, std::memory_order_release);
+        failureSet_->Insert(context->task->id);
+        RecordFailedShards(1);
+        UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_load_errors_total"), 1.0);
+    } else {
+        const auto bytes = std::accumulate(tensorSizes_.begin(), tensorSizes_.end(), size_t(0));
+        UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_load_bytes_total"),
+                                 static_cast<double>(bytes));
+        UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_load_duration_ms"),
+                                 (NowTime::Now() - start) * 1e3);
+        if (task.fromPosix) {
+            UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_posix_load_success_shards_total"),
+                                     1.0);
+        } else {
+            UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_load_success_shards_total"), 1.0);
+        }
+    }
+    FinishH2HLoadShard(context, success);
+    h2hOutstanding_.fetch_sub(1, std::memory_order_acq_rel);
+}
+
+void LoadQueue::FinishH2HLoadShard(const H2HLoadContextPtr& context, bool success)
+{
+    if (!success) { context->failed.store(true, std::memory_order_release); }
+    if (context->pending.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+        context->waiter->Done();
+    }
+}
+
+Status LoadQueue::HostToHostScatter(void* source, const Detail::Shard& shard) const
+{
+    if (shard.addrs.size() != tensorSizes_.size()) {
+        return Status::InvalidParam("invalid host addr number({}, expect {})", shard.addrs.size(),
+                                    tensorSizes_.size());
+    }
+    if (source == nullptr) { return Status::InvalidParam("invalid null host source"); }
+    auto* src = static_cast<std::byte*>(source);
+    size_t offset = 0;
+    for (size_t i = 0; i < tensorSizes_.size(); ++i) {
+        if (shard.addrs[i] == nullptr) {
+            return Status::InvalidParam("invalid null host destination({})", i);
+        }
+        std::memcpy(shard.addrs[i], src + offset, tensorSizes_[i]);
+        offset += tensorSizes_[i];
+    }
+    return Status::OK();
+}
+
 void LoadQueue::TransferStage(std::promise<Status>& started)
 {
     auto nameStatus = CpuAffinity::SetCurrentThreadName("ucm_load_xfer");
     if (nameStatus.Failure()) { UC_WARN("Failed({}) to set UCM load transfer name.", nameStatus); }
     CopyStream stream;
     auto s = Status::OK();
-    if (cacheIOAggregation_) {
+    if (useHostBuffer_) {
+        s = Status::OK();
+    } else if (cacheIOAggregation_) {
         s = stream.SetupIoAggregation(deviceId_, useGdr_);
     } else if (cacheSdmaDirect_) {
         s = stream.SetupSdmaDirect(deviceId_, useGdr_);

--- a/ucm/store/cache/cc/load_queue.cc
+++ b/ucm/store/cache/cc/load_queue.cc
@@ -22,10 +22,7 @@
  * SOFTWARE.
  * */
 #include "load_queue.h"
-#include <cstddef>
-#include <cstring>
 #include <list>
-#include <numeric>
 #include "logger/logger.h"
 #include "metrics_api.h"
 #include "thread/cpu_affinity.h"
@@ -36,6 +33,7 @@ LoadQueue::~LoadQueue()
 {
     stop_.store(true);
     if (dispatcher_.joinable()) { dispatcher_.join(); }
+    if (useHostBuffer_) { hostCopyExecutor_.Synchronize(); }
     if (transfer_.joinable()) { transfer_.join(); }
 }
 
@@ -52,20 +50,15 @@ Status LoadQueue::Setup(const Config& config, TaskIdSet* failureSet, TransBuffer
     cacheIOAggregation_ = config.cacheIOAggregation;
     cacheSdmaDirect_ = config.cacheSdmaDirect;
     useHostBuffer_ = config.cacheUseHostBuffer;
-    h2hQueueDepth_ = config.h2hQueueDepth;
     cpuAffinityCores_ = config.cpuAffinityCores;
     localRankSize_ = config.localRankSize;
     waiting_.Setup(config.waitingQueueDepth);
     running_.Setup(config.runningQueueDepth);
     holder_.reserve(1024);
     if (useHostBuffer_) {
-        auto started =
-            h2hCopyPool_
-                .SetNWorker(config.h2hWorkerNumber)
-                .SetWorkerFn([this](ShardTask& task, void* const&) { H2HLoadWorker(task); })
-                .SetCpuAffinity(cpuAffinityCores_)
-                .Run();
-        if (!started) { return Status::Error("failed to start CacheStore H2H load workers"); }
+        auto s = hostCopyExecutor_.Setup(config.h2hWorkerNumber, config.h2hQueueDepth,
+                                         cpuAffinityCores_);
+        if (s.Failure()) { return s; }
     }
     dispatcher_ = std::thread{&LoadQueue::DispatchStage, this};
     if (useHostBuffer_) { return Status::OK(); }
@@ -182,19 +175,6 @@ void LoadQueue::DispatchOneTask(TaskPair&& pair)
                              static_cast<double>(nShard));
 }
 
-bool LoadQueue::TryReserveH2HJobs(size_t number)
-{
-    auto outstanding = h2hOutstanding_.load(std::memory_order_relaxed);
-    for (;;) {
-        if (number > h2hQueueDepth_ || outstanding > h2hQueueDepth_ - number) { return false; }
-        if (h2hOutstanding_.compare_exchange_weak(outstanding, outstanding + number,
-                                                  std::memory_order_acq_rel,
-                                                  std::memory_order_relaxed)) {
-            return true;
-        }
-    }
-}
-
 void LoadQueue::DispatchOneH2HTask(TaskPair&& pair)
 {
     auto task = std::move(pair.first);
@@ -208,7 +188,8 @@ void LoadQueue::DispatchOneH2HTask(TaskPair&& pair)
         waiter->Done();
         return;
     }
-    if (!TryReserveH2HJobs(nShard)) {
+    auto reservationResult = hostCopyExecutor_.Reserve(nShard);
+    if (!reservationResult) {
         auto s = Status::Error("CacheStore H2H load queue full");
         task->Fail(s);
         failureSet_->Insert(task->id);
@@ -217,28 +198,29 @@ void LoadQueue::DispatchOneH2HTask(TaskPair&& pair)
         waiter->Done();
         return;
     }
+    auto reservation = std::move(reservationResult).Value();
 
     auto context = std::make_shared<H2HLoadContext>();
     context->task = task;
     context->waiter = waiter;
     context->pending.store(nShard, std::memory_order_release);
-    std::list<ShardTask> jobs;
+    std::list<Trans::HostCopyExecutor::Job> jobs;
     size_t backendSubmitCount = 0;
     const auto indexes = RearrangeIndex(nShard, deviceId_, localRankSize_);
     for (size_t i = 0; i < nShard; ++i) {
         auto& shard = task->desc[indexes[i]];
-        ShardTask shardTask;
-        shardTask.task = task;
-        shardTask.shard = shard;
-        shardTask.h2hContext = context;
-        shardTask.bufferHandle = buffer_->Get(shard.owner, shard.index, true, true);
-        shardTask.fromPosix = !shardTask.bufferHandle.Ready();
-        if (shardTask.bufferHandle.Owner() && !shardTask.bufferHandle.Ready()) {
+        auto shardTask = std::make_shared<ShardTask>();
+        shardTask->task = task;
+        shardTask->shard = shard;
+        shardTask->h2hContext = context;
+        shardTask->bufferHandle = buffer_->Get(shard.owner, shard.index, true, true);
+        shardTask->fromPosix = !shardTask->bufferHandle.Ready();
+        if (shardTask->bufferHandle.Owner() && !shardTask->bufferHandle.Ready()) {
             if (context->failed.load(std::memory_order_acquire)) {
-                shardTask.bufferHandle.MarkFailed(task->FailureStatus());
+                shardTask->bufferHandle.MarkFailed(task->FailureStatus());
             } else {
                 Detail::TaskDesc backendTask{
-                    Detail::Shard{shard.owner, shard.index, {shardTask.bufferHandle.Data()}}
+                    Detail::Shard{shard.owner, shard.index, {shardTask->bufferHandle.Data()}}
                 };
                 backendTask.brief = "Backend2Cache";
                 auto res = backend_->Load(std::move(backendTask));
@@ -246,21 +228,51 @@ void LoadQueue::DispatchOneH2HTask(TaskPair&& pair)
                     auto error = res.Error();
                     UC_ERROR("Failed({}) to submit H2H load task({}) to backend.", error,
                              task->id);
-                    shardTask.bufferHandle.MarkFailed(error);
+                    shardTask->bufferHandle.MarkFailed(error);
                     task->Fail(error);
                     context->failed.store(true, std::memory_order_release);
                     failureSet_->Insert(task->id);
                     UC::Metrics::UpdateStats(
                         NAME_TO_METRIC_ID("cache_backend_load_submit_errors_total"), 1.0);
                 } else {
-                    shardTask.backendTaskHandle = res.Value();
+                    shardTask->backendTaskHandle = res.Value();
                     ++backendSubmitCount;
                 }
             }
         }
-        jobs.push_back(std::move(shardTask));
+        Trans::HostCopyExecutor::Job job;
+        job.direction = Trans::HostCopyExecutor::Direction::SCATTER;
+        job.contiguous = shardTask->bufferHandle.Data();
+        job.segments = MakeH2HSegments(shardTask->shard);
+        job.prerequisite = [this, shardTask] {
+            if (shardTask->shard.addrs.size() != tensorSizes_.size()) {
+                return Status::InvalidParam("invalid host addr number({}, expect {})",
+                                            shardTask->shard.addrs.size(), tensorSizes_.size());
+            }
+            if (shardTask->h2hContext->failed.load(std::memory_order_acquire) &&
+                shardTask->backendTaskHandle == 0) {
+                return shardTask->task->FailureStatus();
+            }
+            const auto start = NowTime::Now();
+            auto s = WaitBackendTaskReady(*shardTask);
+            UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_shard_backend_wait_ms"),
+                                     (NowTime::Now() - start) * 1e3);
+            return s;
+        };
+        job.completion = [this, shardTask](const Trans::HostCopyExecutor::Result& result) {
+            CompleteH2HLoad(shardTask, result);
+        };
+        jobs.push_back(std::move(job));
     }
-    h2hCopyPool_.Push(jobs);
+    auto submitStatus = reservation.Submit(jobs);
+    if (submitStatus.Failure()) {
+        task->Fail(submitStatus);
+        context->failed.store(true, std::memory_order_release);
+        failureSet_->Insert(task->id);
+        RecordFailedShards(nShard);
+        waiter->Done();
+        return;
+    }
 
     if (!context->failed.load(std::memory_order_acquire)) {
         for (size_t i = 0; i < nShard; ++i) {
@@ -276,23 +288,12 @@ void LoadQueue::DispatchOneH2HTask(TaskPair&& pair)
                              static_cast<double>(nShard));
 }
 
-void LoadQueue::H2HLoadWorker(ShardTask& task)
+void LoadQueue::CompleteH2HLoad(const std::shared_ptr<ShardTask>& task,
+                                const Trans::HostCopyExecutor::Result& result)
 {
-    auto& context = task.h2hContext;
-    auto success = false;
-    auto s = Status::OK();
-    const auto start = NowTime::Now();
-
-    if (task.backendTaskHandle != 0 || !context->failed.load(std::memory_order_acquire)) {
-        auto tpBackendWait = NowTime::Now();
-        s = WaitBackendTaskReady(task);
-        UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_shard_backend_wait_ms"),
-                                 (NowTime::Now() - tpBackendWait) * 1e3);
-        if (s.Success() && !context->failed.load(std::memory_order_acquire)) {
-            s = HostToHostScatter(task.bufferHandle.Data(), task.shard);
-        }
-        success = s.Success() && !context->failed.load(std::memory_order_acquire);
-    }
+    auto& context = task->h2hContext;
+    auto s = result.status;
+    auto success = s.Success() && !context->failed.load(std::memory_order_acquire);
 
     if (!success) {
         if (s.Success()) { s = context->task->FailureStatus(); }
@@ -302,12 +303,11 @@ void LoadQueue::H2HLoadWorker(ShardTask& task)
         RecordFailedShards(1);
         UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_load_errors_total"), 1.0);
     } else {
-        const auto bytes = std::accumulate(tensorSizes_.begin(), tensorSizes_.end(), size_t(0));
         UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_load_bytes_total"),
-                                 static_cast<double>(bytes));
+                                 static_cast<double>(result.bytes));
         UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_h2h_load_duration_ms"),
-                                 (NowTime::Now() - start) * 1e3);
-        if (task.fromPosix) {
+                                 result.durationMs);
+        if (task->fromPosix) {
             UC::Metrics::UpdateStats(NAME_TO_METRIC_ID("cache_posix_load_success_shards_total"),
                                      1.0);
         } else {
@@ -315,7 +315,6 @@ void LoadQueue::H2HLoadWorker(ShardTask& task)
         }
     }
     FinishH2HLoadShard(context, success);
-    h2hOutstanding_.fetch_sub(1, std::memory_order_acq_rel);
 }
 
 void LoadQueue::FinishH2HLoadShard(const H2HLoadContextPtr& context, bool success)
@@ -326,23 +325,16 @@ void LoadQueue::FinishH2HLoadShard(const H2HLoadContextPtr& context, bool succes
     }
 }
 
-Status LoadQueue::HostToHostScatter(void* source, const Detail::Shard& shard) const
+std::vector<Trans::HostCopyExecutor::Segment> LoadQueue::MakeH2HSegments(
+    const Detail::Shard& shard) const
 {
-    if (shard.addrs.size() != tensorSizes_.size()) {
-        return Status::InvalidParam("invalid host addr number({}, expect {})", shard.addrs.size(),
-                                    tensorSizes_.size());
-    }
-    if (source == nullptr) { return Status::InvalidParam("invalid null host source"); }
-    auto* src = static_cast<std::byte*>(source);
-    size_t offset = 0;
+    std::vector<Trans::HostCopyExecutor::Segment> segments;
+    if (shard.addrs.size() != tensorSizes_.size()) { return segments; }
+    segments.reserve(tensorSizes_.size());
     for (size_t i = 0; i < tensorSizes_.size(); ++i) {
-        if (shard.addrs[i] == nullptr) {
-            return Status::InvalidParam("invalid null host destination({})", i);
-        }
-        std::memcpy(shard.addrs[i], src + offset, tensorSizes_[i]);
-        offset += tensorSizes_[i];
+        segments.push_back({shard.addrs[i], tensorSizes_[i]});
     }
-    return Status::OK();
+    return segments;
 }
 
 void LoadQueue::TransferStage(std::promise<Status>& started)

--- a/ucm/store/cache/cc/load_queue.h
+++ b/ucm/store/cache/cc/load_queue.h
@@ -33,7 +33,7 @@
 #include "template/hashset.h"
 #include "template/spsc_ring_queue.h"
 #include "thread/latch.h"
-#include "thread/thread_pool.h"
+#include "trans/host/host_copy_executor.h"
 #include "trans_buffer.h"
 #include "trans_task.h"
 #include "ucmstore_v1.h"
@@ -75,8 +75,6 @@ private:
     bool cacheIOAggregation_{false};
     bool cacheSdmaDirect_{false};
     bool useHostBuffer_{false};
-    size_t h2hQueueDepth_{0};
-    std::atomic<size_t> h2hOutstanding_{0};
     std::vector<ssize_t> cpuAffinityCores_{};
     size_t localRankSize_{};
     SpscRingQueue<TaskPair> waiting_;
@@ -84,7 +82,7 @@ private:
     std::thread dispatcher_;
     std::thread transfer_;
     std::vector<ShardTask> holder_;
-    ThreadPool<ShardTask> h2hCopyPool_;
+    Trans::HostCopyExecutor hostCopyExecutor_;
 
 public:
     ~LoadQueue();
@@ -99,10 +97,11 @@ private:
     void TransferOneTask(CopyStream& stream, ShardTask&& task);
     Status WaitBackendTaskReady(ShardTask& task);
     Status HostToDeviceAsync(CopyStream& stream, void* host, void** device);
-    Status HostToHostScatter(void* source, const Detail::Shard& shard) const;
-    void H2HLoadWorker(ShardTask& task);
+    std::vector<Trans::HostCopyExecutor::Segment> MakeH2HSegments(
+        const Detail::Shard& shard) const;
+    void CompleteH2HLoad(const std::shared_ptr<ShardTask>& task,
+                         const Trans::HostCopyExecutor::Result& result);
     void FinishH2HLoadShard(const H2HLoadContextPtr& context, bool success);
-    bool TryReserveH2HJobs(size_t number);
     void RecordShardResults(const std::vector<ShardTask>& tasks, const ShardTask* extra,
                             bool success) const;
     void RecordFailedShards(size_t count) const;

--- a/ucm/store/cache/cc/load_queue.h
+++ b/ucm/store/cache/cc/load_queue.h
@@ -24,13 +24,16 @@
 #ifndef UNIFIEDCACHE_CACHE_STORE_CC_LOAD_QUEUE_H
 #define UNIFIEDCACHE_CACHE_STORE_CC_LOAD_QUEUE_H
 
+#include <atomic>
 #include <future>
+#include <list>
 #include <thread>
 #include <vector>
 #include "copy_stream.h"
 #include "template/hashset.h"
 #include "template/spsc_ring_queue.h"
 #include "thread/latch.h"
+#include "thread/thread_pool.h"
 #include "trans_buffer.h"
 #include "trans_task.h"
 #include "ucmstore_v1.h"
@@ -42,12 +45,20 @@ class LoadQueue {
     using WaiterPtr = std::shared_ptr<Latch>;
     using TaskPair = std::pair<TaskPtr, WaiterPtr>;
     using TaskIdSet = HashSet<Detail::TaskHandle>;
+    struct H2HLoadContext {
+        TaskPtr task;
+        WaiterPtr waiter;
+        std::atomic<size_t> pending{0};
+        std::atomic<bool> failed{false};
+    };
+    using H2HLoadContextPtr = std::shared_ptr<H2HLoadContext>;
     struct ShardTask {
         TaskPtr task;
         Detail::Shard shard;
         TransBuffer::Handle bufferHandle;
         Detail::TaskHandle backendTaskHandle;
         WaiterPtr waiter;
+        H2HLoadContextPtr h2hContext;
         bool fromPosix{false};
     };
 
@@ -63,6 +74,9 @@ private:
     bool useGdr_{false};
     bool cacheIOAggregation_{false};
     bool cacheSdmaDirect_{false};
+    bool useHostBuffer_{false};
+    size_t h2hQueueDepth_{0};
+    std::atomic<size_t> h2hOutstanding_{0};
     std::vector<ssize_t> cpuAffinityCores_{};
     size_t localRankSize_{};
     SpscRingQueue<TaskPair> waiting_;
@@ -70,6 +84,7 @@ private:
     std::thread dispatcher_;
     std::thread transfer_;
     std::vector<ShardTask> holder_;
+    ThreadPool<ShardTask> h2hCopyPool_;
 
 public:
     ~LoadQueue();
@@ -79,10 +94,15 @@ public:
 private:
     void DispatchStage();
     void DispatchOneTask(TaskPair&& pair);
+    void DispatchOneH2HTask(TaskPair&& pair);
     void TransferStage(std::promise<Status>& started);
     void TransferOneTask(CopyStream& stream, ShardTask&& task);
     Status WaitBackendTaskReady(ShardTask& task);
     Status HostToDeviceAsync(CopyStream& stream, void* host, void** device);
+    Status HostToHostScatter(void* source, const Detail::Shard& shard) const;
+    void H2HLoadWorker(ShardTask& task);
+    void FinishH2HLoadShard(const H2HLoadContextPtr& context, bool success);
+    bool TryReserveH2HJobs(size_t number);
     void RecordShardResults(const std::vector<ShardTask>& tasks, const ShardTask* extra,
                             bool success) const;
     void RecordFailedShards(size_t count) const;

--- a/ucm/store/cache/cc/load_queue.h
+++ b/ucm/store/cache/cc/load_queue.h
@@ -56,7 +56,7 @@ class LoadQueue {
         TaskPtr task;
         Detail::Shard shard;
         TransBuffer::Handle bufferHandle;
-        Detail::TaskHandle backendTaskHandle;
+        Detail::TaskHandle backendTaskHandle{0};
         WaiterPtr waiter;
         H2HLoadContextPtr h2hContext;
         bool fromPosix{false};

--- a/ucm/store/test/case/cache/cache_dump_queue_test.cc
+++ b/ucm/store/test/case/cache/cache_dump_queue_test.cc
@@ -22,6 +22,8 @@
  * SOFTWARE.
  * */
 #include <gtest/gtest.h>
+#include <array>
+#include <cstring>
 #include "cache/cc/dump_queue.h"
 #include "detail/data_generator.h"
 #include "detail/mock_store.h"
@@ -155,4 +157,71 @@ TEST_F(UCCacheDumpQueueTest, DumpBlockWhileBackendUnhealthy)
     waiter->Wait();
     ASSERT_TRUE(failureSet.Contains(task->id));
     EXPECT_EQ(task->FailureStatus(), UC::Status::StoreUnhealthy());
+}
+
+TEST_F(UCCacheDumpQueueTest, HostToHostGatherSupportsMultipleVariableSizeShards)
+{
+    using namespace UC::CacheStore;
+    using namespace testing;
+    constexpr size_t kSize = 16;
+    constexpr size_t vSize = 8;
+    std::array<uint8_t, kSize> k0{}, k1{};
+    std::array<uint8_t, vSize> v0{}, v1{};
+    k0.fill(0x11);
+    v0.fill(0x12);
+    k1.fill(0x21);
+    v1.fill(0x22);
+    UC::Latch backendFinished;
+    backendFinished.Up();
+
+    UC::Test::Detail::MockStore backend;
+    EXPECT_CALL(backend, Dump).WillOnce(Invoke([&](UC::Detail::TaskDesc desc) {
+        EXPECT_EQ(desc.size(), 2);
+        auto* page0 = static_cast<uint8_t*>(desc[0].addrs[0]);
+        auto* page1 = static_cast<uint8_t*>(desc[1].addrs[0]);
+        EXPECT_EQ(std::memcmp(page0, k0.data(), kSize), 0);
+        EXPECT_EQ(std::memcmp(page0 + kSize, v0.data(), vSize), 0);
+        EXPECT_EQ(std::memcmp(page1, k1.data(), kSize), 0);
+        EXPECT_EQ(std::memcmp(page1 + kSize, v1.data(), vSize), 0);
+        return NextId();
+    }));
+    EXPECT_CALL(backend, Wait).WillOnce(Invoke([&]() {
+        backendFinished.Done();
+        return UC::Status::OK();
+    }));
+
+    UC::HashSet<UC::Detail::TaskHandle> failureSet;
+    Config config;
+    config.storeBackend = &backend;
+    config.tensorSizes = {kSize, vSize};
+    config.shardSize = kSize + vSize;
+    config.blockSize = config.shardSize;
+    config.deviceId = 0;
+    config.bufferCapacity = config.shardSize * 1024;
+    config.uniqueId = rd.RandomString(10);
+    config.shareBufferEnable = true;
+    config.cacheUseHostBuffer = true;
+    config.cacheSdmaDirect = false;
+    config.h2hWorkerNumber = 2;
+    config.h2hQueueDepth = 8;
+
+    TransBuffer buffer;
+    DumpQueue dumpQ;
+    ASSERT_EQ(buffer.Setup(config), UC::Status::OK());
+    ASSERT_EQ(dumpQ.Setup(config, &failureSet, &buffer), UC::Status::OK());
+    auto block0 = UC::Test::Detail::TypesHelper::MakeBlockId(
+        "a1b2c3d4e5f6789012345678901234ab");
+    auto block1 = UC::Test::Detail::TypesHelper::MakeBlockId(
+        "b1b2c3d4e5f6789012345678901234ab");
+    UC::Detail::TaskDesc desc{
+        {block0, 0, {k0.data(), v0.data()}},
+        {block1, 0, {k1.data(), v1.data()}},
+    };
+    auto task = std::make_shared<TransTask>(TransTask::Type::DUMP, desc);
+    auto waiter = std::make_shared<UC::Latch>();
+    dumpQ.Submit(task, waiter);
+
+    ASSERT_TRUE(waiter->WaitForDuration(2000));
+    ASSERT_FALSE(failureSet.Contains(task->id));
+    ASSERT_TRUE(backendFinished.WaitForDuration(2000));
 }

--- a/ucm/store/test/case/cache/cache_load_queue_test.cc
+++ b/ucm/store/test/case/cache/cache_load_queue_test.cc
@@ -295,3 +295,79 @@ TEST_F(UCCacheLoadQueueTest, HostToHostScatterRunsShardsInParallel)
     for (auto byte : v0) { EXPECT_EQ(byte, value); }
     for (auto byte : v1) { EXPECT_EQ(byte, value); }
 }
+
+TEST_F(UCCacheLoadQueueTest, HostToHostConcurrentLoadWaitsBackendOnlyOnce)
+{
+    using namespace UC::CacheStore;
+    using namespace testing;
+    constexpr size_t tensorSize = 32;
+    constexpr uint8_t value = 0x6b;
+    std::promise<void> waitEntered;
+    std::promise<void> allowBackendReady;
+    auto allowBackendReadyFuture = allowBackendReady.get_future().share();
+
+    UC::Test::Detail::MockStore backend;
+    EXPECT_CALL(backend, Load)
+        .Times(1)
+        .WillOnce(Invoke([&](UC::Detail::TaskDesc desc) {
+            std::memset(desc[0].addrs[0], value, tensorSize);
+            return NextId();
+        }));
+    EXPECT_CALL(backend, Wait)
+        .Times(1)
+        .WillOnce(Invoke([&](UC::Detail::TaskHandle) {
+            waitEntered.set_value();
+            allowBackendReadyFuture.wait();
+            return UC::Status::OK();
+        }));
+
+    UC::HashSet<UC::Detail::TaskHandle> failureSet;
+    Config config;
+    config.storeBackend = &backend;
+    config.tensorSizes = {tensorSize};
+    config.shardSize = tensorSize;
+    config.blockSize = config.shardSize;
+    config.deviceId = 0;
+    config.bufferCapacity = config.shardSize * 1024;
+    config.uniqueId = rd.RandomString(10);
+    config.shareBufferEnable = true;
+    config.cacheUseHostBuffer = true;
+    config.cacheSdmaDirect = false;
+    config.h2hWorkerNumber = 2;
+    config.h2hQueueDepth = 8;
+
+    TransBuffer buffer;
+    LoadQueue loadQ;
+    ASSERT_EQ(buffer.Setup(config), UC::Status::OK());
+    ASSERT_EQ(loadQ.Setup(config, &failureSet, &buffer), UC::Status::OK());
+
+    std::array<uint8_t, tensorSize> dst0{}, dst1{};
+    auto blockId = UC::Test::Detail::TypesHelper::MakeBlockId(
+        "c1b2c3d4e5f6789012345678901234ab");
+    UC::Detail::TaskDesc desc0{
+        {blockId, 0, {dst0.data()}}
+    };
+    UC::Detail::TaskDesc desc1{
+        {blockId, 0, {dst1.data()}}
+    };
+    auto task0 = std::make_shared<TransTask>(TransTask::Type::LOAD, desc0);
+    auto task1 = std::make_shared<TransTask>(TransTask::Type::LOAD, desc1);
+    auto waiter0 = std::make_shared<UC::Latch>();
+    auto waiter1 = std::make_shared<UC::Latch>();
+
+    loadQ.Submit(task0, waiter0);
+    waitEntered.get_future().wait();
+    // Keep a non-owner reference alive so the second request must share the
+    // in-flight buffer instead of becoming a new backend-load owner.
+    auto observer = buffer.Get(blockId, 0, true, true);
+    ASSERT_FALSE(observer.Owner());
+    loadQ.Submit(task1, waiter1);
+    allowBackendReady.set_value();
+
+    ASSERT_TRUE(waiter0->WaitForDuration(2000));
+    ASSERT_TRUE(waiter1->WaitForDuration(2000));
+    ASSERT_FALSE(failureSet.Contains(task0->id));
+    ASSERT_FALSE(failureSet.Contains(task1->id));
+    for (auto byte : dst0) { EXPECT_EQ(byte, value); }
+    for (auto byte : dst1) { EXPECT_EQ(byte, value); }
+}

--- a/ucm/store/test/case/cache/cache_load_queue_test.cc
+++ b/ucm/store/test/case/cache/cache_load_queue_test.cc
@@ -22,6 +22,8 @@
  * SOFTWARE.
  * */
 #include <gtest/gtest.h>
+#include <array>
+#include <cstring>
 #include "cache/cc/load_queue.h"
 #include "detail/data_generator.h"
 #include "detail/mock_store.h"
@@ -225,4 +227,71 @@ TEST_F(UCCacheLoadQueueTest, LoadWhileBackendWaitFailed)
     ASSERT_EQ(observer.GetState(), TransBuffer::State::FAILED);
     ASSERT_EQ(observer.FailureStatus(), UC::Status::NotFound());
     ASSERT_EQ(task->FailureStatus(), UC::Status::NotFound());
+}
+
+TEST_F(UCCacheLoadQueueTest, HostToHostScatterRunsShardsInParallel)
+{
+    using namespace UC::CacheStore;
+    using namespace testing;
+    constexpr size_t kSize = 16;
+    constexpr size_t vSize = 8;
+    constexpr uint8_t value = 0x5a;
+    UC::Latch workersEntered;
+    workersEntered.Set(2);
+
+    UC::Test::Detail::MockStore backend;
+    EXPECT_CALL(backend, Load)
+        .Times(2)
+        .WillRepeatedly(Invoke([&](UC::Detail::TaskDesc desc) {
+            std::memset(desc[0].addrs[0], value, kSize + vSize);
+            return NextId();
+        }));
+    EXPECT_CALL(backend, Wait)
+        .Times(2)
+        .WillRepeatedly(Invoke([&](UC::Detail::TaskHandle) {
+            workersEntered.Done();
+            return workersEntered.WaitForDuration(1000) ? UC::Status::OK()
+                                                        : UC::Status::Timeout();
+        }));
+
+    UC::HashSet<UC::Detail::TaskHandle> failureSet;
+    Config config;
+    config.storeBackend = &backend;
+    config.tensorSizes = {kSize, vSize};
+    config.shardSize = kSize + vSize;
+    config.blockSize = config.shardSize;
+    config.deviceId = 0;
+    config.bufferCapacity = config.shardSize * 1024;
+    config.uniqueId = rd.RandomString(10);
+    config.shareBufferEnable = true;
+    config.cacheUseHostBuffer = true;
+    config.cacheSdmaDirect = false;
+    config.h2hWorkerNumber = 2;
+    config.h2hQueueDepth = 8;
+
+    TransBuffer buffer;
+    LoadQueue loadQ;
+    ASSERT_EQ(buffer.Setup(config), UC::Status::OK());
+    ASSERT_EQ(loadQ.Setup(config, &failureSet, &buffer), UC::Status::OK());
+
+    std::array<uint8_t, kSize> k0{}, k1{};
+    std::array<uint8_t, vSize> v0{}, v1{};
+    auto block0 = UC::Test::Detail::TypesHelper::MakeBlockId(
+        "a1b2c3d4e5f6789012345678901234ab");
+    auto block1 = UC::Test::Detail::TypesHelper::MakeBlockId(
+        "b1b2c3d4e5f6789012345678901234ab");
+    UC::Detail::TaskDesc desc{
+        {block0, 0, {k0.data(), v0.data()}},
+        {block1, 0, {k1.data(), v1.data()}},
+    };
+    auto task = std::make_shared<TransTask>(TransTask::Type::LOAD, desc);
+    auto waiter = std::make_shared<UC::Latch>();
+    loadQ.Submit(task, waiter);
+
+    ASSERT_TRUE(waiter->WaitForDuration(2000));
+    ASSERT_FALSE(failureSet.Contains(task->id));
+    for (auto byte : k0) { EXPECT_EQ(byte, value); }
+    for (auto byte : k1) { EXPECT_EQ(byte, value); }
+    for (auto byte : v0) { EXPECT_EQ(byte, value); }
+    for (auto byte : v1) { EXPECT_EQ(byte, value); }
 }


### PR DESCRIPTION
## Summary

  This PR adds shard-level Host-to-Host (H2H) thread pools to CacheStore and integrates the H2H path with SGLang HiCache.

  In the SGLang integration, one page corresponds to one CacheStore shard. Multiple pages can therefore be copied concurrently by different H2H workers.

  ## CacheStore H2H thread pools

  Added the following configuration options:

  ```yaml
  cache_use_host_buffer: true
  cache_h2h_worker_number: 4
  cache_h2h_queue_depth: 1024

  - cache_use_host_buffer enables Host-to-Host Cache transfers.
  - cache_h2h_worker_number configures the number of Load and Dump copy workers.
  - cache_h2h_queue_depth limits the number of queued and running H2H shard jobs.

  Host-buffer mode is incompatible with Device transfer paths, including:

  - cache_io_aggregation
  - cache_sdma_direct
  - use_gdr
  - gpu_kv_buffer_addrs

  ## Dump path

  Each non-ready Cache shard is submitted as an independent H2H job.

  Dump workers gather data from the SGLang Host tensors into the CacheStore shared buffer in parallel. After all shards of a request are ready, a dedicated completion worker:

  1. Marks the Cache handles as ready.
  2. Aggregates the shards into one backend task.
  3. Submits the task to the downstream PosixStore.
  4. Completes the request waiter.

  For a split K/V layout, K and V tensors within one page are copied sequentially by one worker, while different pages are copied concurrently.

  ## Load path

  Each Cache shard is submitted as an independent Load job.

  A Load worker:

  1. Waits for the corresponding backend Load task when required.
  2. Marks the Cache buffer as ready.
  3. Scatters the Cache payload into the target SGLang Host tensors.
  4. Updates the shared request completion counter.

  The request waiter is completed after all shards have reached a terminal state.

  Cache-hit shards can be scattered directly without another backend Load.

  ## Queue backpressure

  Load and Dump maintain separate atomic outstanding-shard counters.

  Queue capacity includes both queued and running jobs. Capacity is reserved for the entire request:

  - All shards are submitted when sufficient capacity is available.
  - The complete request fails when capacity is insufficient.
  - Partial request submission is not allowed.

  The queue depth is measured in shards/pages rather than requests.

  ## Failure handling

  The H2H path handles:

  - H2H queue exhaustion.
  - Invalid Host pointer counts.
  - Null source or destination addresses.
  - Gather and scatter failures.
  - Backend Load/Dump submission failures.
  - Backend Load wait failures.

  Incomplete Cache handles are marked as failed when a request cannot finish successfully. This prevents Cache entries from remaining permanently in the LOADING state.

  All submitted shard jobs participate in request completion, including failure paths.

  ## SGLang integration

  SGLang selects the storage pipeline according to the model type:

   Model type                             Pipeline
  ━━━━━━━━━━━━━━━━━━━━━━━━━
   Non-MLA models                         Posix
  ───────────────────────────────────
   MLA models                        Cache|Posix
  ───────────────────────────────────

  For MLA models, the connector automatically configures:

  store_pipeline: Cache|Posix
  cache_use_host_buffer: true
  cache_h2h_worker_number: 4
  cache_h2h_queue_depth: 1024
  cache_io_aggregation: false
  cache_sdma_direct: false
  use_gdr: false

  User-provided worker and queue-depth values take precedence.

  ## page_first_kv_split support

  For Ascend MLA, the connector obtains one K address and one V address for each page and configures:

  tensor_size_list = [K_page_bytes, V_page_bytes]

  The Dump payload layout is:

  Cache shard = K page | V page | optional alignment padding

  Load performs the reverse scatter operation.

  When Direct I/O is enabled, shard_size and block_size are aligned to 4096 bytes.

  The MLA cache identity includes the model, Host layout, page size, TP size, and tensor-size fingerprint to prevent incompatible layouts from sharing Cache data.

  ## Scope

  This PR supports the main MLA KV Cache.

  The following are outside the current scope:

  - Indexer Cache
  - V2 HostPoolGroup aggregation
  - Auxiliary KV pools
  - Parallel copies within a single shard
  - DMA-based asynchronous H2H

  Each H2H worker performs synchronous CPU memcpy, while different pages/shards run concurrently.

  ## Tests

  Added unit tests covering:

  - Parallel execution of multiple Load shards.
  - Multi-tensor K/V scatter.
  - Multi-shard Dump gather.
  - Variable tensor sizes.
  - Backend payload validation.