### PR TITLE
[Fix][Test] toolkit/precheck: fix ucm import shadowed by source tree at runtime

### DIFF
--- a/toolkit/ucm_toolkit/tools/precheck/bandwidth.py
+++ b/toolkit/ucm_toolkit/tools/precheck/bandwidth.py
@@ -12,6 +12,7 @@ benchmark is Linux-only (posix mmap + the ucm ``.so``).
 
 from __future__ import annotations
 
+import importlib.machinery
 import multiprocessing
 import os
 import secrets
@@ -598,6 +599,15 @@ def _human_bytes(n: int) -> str:
     return f"{n}B"
 
 
+def _path_resolves_to_repo_root(path: str, repo_root: str) -> bool:
+    """Return whether a sys.path entry points at the ucm repo root."""
+    try:
+        candidate = os.path.realpath(path or os.getcwd())
+    except OSError:
+        return False
+    return candidate == repo_root
+
+
 def _read_aio_limits() -> Tuple[int, int]:
     """Read kernel aio limits from /proc/sys/fs/.
 
@@ -741,17 +751,67 @@ def check_bandwidth(cfg: PrecheckConfig) -> CheckResult:
         os.environ.setdefault(_k, _v)
 
     # Verify ucm is importable before spawning workers.
+    # The source-tree ucm/ (incomplete — missing compiled artifacts like
+    # ucmlogger) can shadow the installed package at site-packages when the
+    # repo root is on sys.path (CWD, PYTHONPATH, or an editable-install .pth).
+    # The ucm_patch.pth boot hook (installed with ucm) imports
+    # ucm.integration.* at Python startup; with the repo root on sys.path that
+    # boot import loads the INCOMPLETE source tree and leaves its submodules
+    # cached in sys.modules.  So: drop repo-root entries from sys.path AND
+    # purge any cached ucm.* submodules (only if ucm is still importable
+    # without the repo root), forcing a fresh import from site-packages.
+    # Workers (forked) inherit the fix.
+    _repo_root = os.path.realpath(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), *([".."] * 4))
+    )
+    _saved_path = sys.path[:]
+    _clean_path = [
+        p for p in sys.path if not _path_resolves_to_repo_root(p, _repo_root)
+    ]
+    if len(_clean_path) != len(sys.path) and (
+        importlib.machinery.PathFinder.find_spec("ucm", _clean_path) is not None
+    ):
+        sys.path[:] = _clean_path
+        for _m in [k for k in list(sys.modules) if k == "ucm" or k.startswith("ucm.")]:
+            del sys.modules[_m]
     try:
         import ucm  # noqa: F401
     except Exception as exc:
+        sys.path[:] = _saved_path  # restore for error handling
+        # Distinguish "ucm not installed" from "installed but import fails"
+        # (e.g. the source tree shadows site-packages, or a dependency like
+        # wrapt is missing).
+        ucm_installed = True
+        try:
+            from importlib.metadata import version as _pkg_version
+
+            _pkg_version("uc-manager")
+        except Exception:
+            ucm_installed = False
+        if ucm_installed:
+            detail = (
+                f"ucm is installed (site-packages) but import failed "
+                f"({type(exc).__name__}: {exc}); "
+                f"if running from the ucm source tree, the source ucm/ "
+                f"may shadow the installed package — try running from a "
+                f"different directory"
+            )
+            remediation = (
+                f"fix the import error ({exc}); "
+                f"common cause: source tree shadows installed package "
+                f"or missing dependency (pip install wrapt)"
+            )
+        else:
+            detail = f"ucm not installed ({type(exc).__name__}: {exc})"
+            remediation = "install ucm (with the built C++ posix store) to benchmark"
         return CheckResult(
             name="bandwidth",
             severity=WARN,
             status=STATUS_SKIP,
             value="-",
             threshold=f">= {cfg.bandwidth.threshold_gb} GB/s",
-            detail=f"skipped: ucm not importable ({type(exc).__name__}: {exc})",
-            remediation="install ucm (with the built C++ posix store) to benchmark",
+            detail=detail,
+            remediation=remediation,
             raw={"mount_path": cfg.mount_path},
         )
 
@@ -872,6 +932,7 @@ def check_bandwidth(cfg: PrecheckConfig) -> CheckResult:
     }
 
     if not metric_best:
+        sys.path[:] = _saved_path
         return CheckResult(
             name="bandwidth",
             severity=WARN,
@@ -908,6 +969,7 @@ def check_bandwidth(cfg: PrecheckConfig) -> CheckResult:
             "check the mount-point disk/NVMe throughput; try the aio engine, "
             "raise --workers, or confirm io_direct/O_DIRECT settings"
         )
+    sys.path[:] = _saved_path
     return CheckResult(
         name="bandwidth",
         severity=WARN,

--- a/toolkit/ucm_toolkit/tools/precheck/reporter.py
+++ b/toolkit/ucm_toolkit/tools/precheck/reporter.py
@@ -101,6 +101,8 @@ def render_text(results: List[CheckResult], color: bool = True) -> str:
         lines.append(f"{icon} {r.name.ljust(_NAME_WIDTH)} {r.value}".rstrip())
         if r.threshold:
             lines.append(_color(f"{'':8}threshold: {r.threshold}", _DIM, color))
+        if r.detail and r.status in (STATUS_WARN, STATUS_FAIL, STATUS_SKIP):
+            lines.append(_color(f"{'':8}{r.detail}", _DIM, color))
         if r.remediation and r.status in (STATUS_WARN, STATUS_FAIL, STATUS_SKIP):
             lines.append(_color(f"{'':8}fix: {r.remediation}", _YELLOW, color))
     lines.append(_color(_RULE, _DIM, color))


### PR DESCRIPTION
## Problem

`ucm-toolkit run precheck` skips the bandwidth benchmark with:

```
[SKIP] bandwidth  ucm is installed (site-packages) but import failed
        (ImportError: cannot import name 'ucmlogger' from
         'ucm.shared.infra' (/path/to/repo/ucm/shared/infra/__init__.py))
```

even though `uc-manager` is installed and working. The root cause is the
**`ucm_patch.pth` boot hook** (installed with uc-manager): it imports
`ucm.integration.*` at **Python interpreter startup**. When the ucm repo
root is on `sys.path` (CWD, `PYTHONPATH`, or an editable-install `.pth`),
that boot import loads the **incomplete source-tree `ucm`** package — which
lacks the compiled `ucmlogger` extension — and leaves its submodules
cached in `sys.modules`. Even after dropping repo-root entries from
`sys.path`, `import ucm` reuses the cached source-tree submodules and
still fails.

## Fix

Mirrors the toolkit's existing `posix-aio` adapter, extended:

- **`bandwidth.py`**: before `import ucm`, drop repo-root entries from
  `sys.path` **and purge any cached `ucm.*` submodules from
  `sys.modules`**, forcing a fresh import of the installed package from
  site-packages. Only applied when `ucm` is still importable without the
  repo root (i.e. the installed package exists). Forked workers inherit
  the fix.
- **`reporter.py`**: render the check `detail` line for
  WARN/FAIL/SKIP outcomes so the underlying import error is visible in
  the report instead of being swallowed.

## Validation

Verified on real hardware (Ascend 910B3, HDK 25.5.2, openEuler 5.10.0,
container image `quay.io/ascend/vllm-ascend:v0.23.0rc1`) with the repo
root placed on `PYTHONPATH` (reproducing the failing setup):

- Before: bandwidth SKIP with the `ucmlogger` import error.
- After: aio probe passes, and the full psync/aio matrix runs against the
  real `ucm` C++ posix store.

37 toolkit unit tests + 83 dev-mirror tests pass; `format.sh` (black,
isort, codespell) is green.