### PR TITLE
fix: omit cache IO aggregation from FAWA config log

### DIFF
--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -740,6 +740,8 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         """Return a log-friendly store config without dumping large size lists."""
 
         summary = dict(config)
+        # CacheStore initialization logs the runtime IO aggregation configuration.
+        summary.pop("cache_io_aggregation", None)
         tensor_size_list = summary.pop("tensor_size_list", None)
         if tensor_size_list is not None:
             tensor_sizes = [int(size) for size in tensor_size_list]


### PR DESCRIPTION
## Problem

The FAWA connector config log includes `cache_io_aggregation` before CacheStore applies build-time capability gating. On unsupported builds, the connector can log `true` while CacheStore correctly logs `false`.

## Fix

Remove `cache_io_aggregation` from the FAWA connector config summary so the CacheStore log remains the source of truth for the effective value.

## Validation

- `git diff --check`