### PR TITLE
[Feat] Modify task datatype of AsuClient to spsc ring queue

### DIFF
--- a/examples/ucm_config_asu.yaml
+++ b/examples/ucm_config_asu.yaml
@@ -42,7 +42,8 @@ ucm_connectors:
       asu_query_timeout_ms: 500
       asu_timeout_ms: 5000
       asu_max_error_count: 2
-      asu_max_inflight_tasks: 1024
+      asu_client_max_inflight_tasks: 1024
+      asu_transport_max_inflight_tasks: 1024
 
 enable_event_sync: true
 use_layerwise: false

--- a/examples/ucm_config_delegator.yaml
+++ b/examples/ucm_config_delegator.yaml
@@ -44,7 +44,8 @@ ucm_connectors:
       asu_default_wait_timeout_ms: 5000
       asu_timeout_ms: 5000
       asu_max_error_count: 2
-      asu_max_inflight_tasks: 1024
+      asu_client_max_inflight_tasks: 1024
+      asu_transport_max_inflight_tasks: 1024
 
 enable_event_sync: true
 use_layerwise: true

--- a/ucm/shared/router/router.cc
+++ b/ucm/shared/router/router.cc
@@ -136,6 +136,7 @@ std::unordered_map<NodeId, std::vector<Router::EntryIndex>> Router::RouteKeys(
     const std::vector<CacheKey>& keys) const
 {
     std::unordered_map<NodeId, std::vector<EntryIndex>> routes;
+    routes.reserve(keys.size());
     for (EntryIndex index = 0; index < keys.size(); ++index) {
         auto nodeId = RouteKey(keys[index]);
         if (nodeId != kInvalidNodeId) { routes[nodeId].emplace_back(index); }

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -170,7 +170,7 @@ UC::ASU::TransportConfig BuildTransportConfig(const Config& config, std::size_t 
     transportConfig.deviceId = config.deviceId;
     transportConfig.timeoutMs = config.timeoutMs;
     transportConfig.maxErrorCount = static_cast<std::uint32_t>(config.maxErrorCount);
-    transportConfig.maxInflightTasks = static_cast<std::uint32_t>(config.maxInflightTasks);
+    transportConfig.maxInflightTasks = static_cast<std::uint32_t>(config.transportMaxInflightTasks);
     transportConfig.maxInflightBytes = config.maxInflightBytes;
     transportConfig.providerType = config.transProviderType;
 
@@ -214,6 +214,7 @@ UC::ASU::AsuClientConfig BuildAsuClientConfig(const Config& config)
     UC::ASU::AsuClientConfig asuConfig;
     asuConfig.clientId = config.clientId;
     asuConfig.viewServiceAddrs = config.viewServiceAddrs;
+    asuConfig.maxInflightTasks = static_cast<std::uint32_t>(config.clientMaxInflightTasks);
     asuConfig.defaultWaitTimeoutMs = config.defaultWaitTimeoutMs;
     asuConfig.timeoutMs = config.timeoutMs;
     asuConfig.sharedProviderMode =
@@ -395,7 +396,8 @@ private:
         inConfig.GetNumber("asu_timeout_ms", config.timeoutMs);
         inConfig.GetNumber("asu_query_timeout_ms", config.queryTimeoutMs);
         inConfig.GetNumber("asu_max_error_count", config.maxErrorCount);
-        inConfig.GetNumber("asu_max_inflight_tasks", config.maxInflightTasks);
+        inConfig.GetNumber("asu_client_max_inflight_tasks", config.clientMaxInflightTasks);
+        inConfig.GetNumber("asu_transport_max_inflight_tasks", config.transportMaxInflightTasks);
         inConfig.GetNumber("asu_max_inflight_bytes", config.maxInflightBytes);
         inConfig.GetNumber("shard_size", config.shardSize);
         inConfig.GetNumber("block_size", config.blockSize);
@@ -532,8 +534,11 @@ private:
         if (config.queryTimeoutMs == 0) {
             return Status::InvalidParam("asu_query_timeout_ms must be greater than zero");
         }
-        if (config.maxInflightTasks > std::numeric_limits<std::uint32_t>::max()) {
-            return Status::InvalidParam("asu_max_inflight_tasks exceeds uint32 range");
+        if (config.clientMaxInflightTasks > std::numeric_limits<std::uint32_t>::max()) {
+            return Status::InvalidParam("asu_client_max_inflight_tasks exceeds uint32 range");
+        }
+        if (config.transportMaxInflightTasks > std::numeric_limits<std::uint32_t>::max()) {
+            return Status::InvalidParam("asu_transport_max_inflight_tasks exceeds uint32 range");
         }
         // Scheduler config check done
         if (config.role == "scheduler") { return Status::OK(); }

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -26,7 +26,8 @@ struct Config {
     std::uint64_t timeoutMs{100};
     std::uint64_t queryTimeoutMs{500};
     std::uint64_t maxErrorCount{2};
-    std::uint64_t maxInflightTasks{1024};
+    std::uint64_t clientMaxInflightTasks{1024};
+    std::uint64_t transportMaxInflightTasks{1024};
     std::uint64_t maxInflightBytes{1ULL << 30};
     std::vector<std::size_t> tensorSizes;
     std::size_t shardSize{0};

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -240,7 +240,8 @@ UC::Detail::Dictionary MakeBaseConfig()
     config.SetNumber("asu_default_wait_timeout_ms", std::uint64_t{1000});
     config.SetNumber("asu_query_timeout_ms", std::uint64_t{500});
     config.SetNumber("asu_timeout_ms", std::uint64_t{1000});
-    config.SetNumber("asu_max_inflight_tasks", std::uint64_t{16});
+    config.SetNumber("asu_client_max_inflight_tasks", std::uint64_t{16});
+    config.SetNumber("asu_transport_max_inflight_tasks", std::uint64_t{16});
     config.Set("kv_ns_ids", std::vector<ssize_t>{100});
     return config;
 }
@@ -406,6 +407,24 @@ TEST(UCAsuStoreTest, PropagatesMaxErrorCountToTransport)
     EXPECT_EQ(transportConfig.maxErrorCount, std::uint32_t{7});
 }
 
+TEST(UCAsuStoreTest, PropagatesSeparateMaxInflightTasks)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeClient(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.SetNumber("asu_client_max_inflight_tasks", std::uint64_t{17});
+    config.SetNumber("asu_transport_max_inflight_tasks", std::uint64_t{23});
+
+    ASSERT_TRUE(store.Setup(config).Success());
+    ASSERT_FALSE(state->initConfigs.empty());
+
+    const auto asuConfig = UC::AsuStore::BuildAsuClientConfig(state->initConfigs.back());
+    EXPECT_EQ(asuConfig.maxInflightTasks, std::uint32_t{17});
+    ASSERT_EQ(asuConfig.transportConfigs.size(), std::size_t{1});
+    EXPECT_EQ(asuConfig.transportConfigs.front().maxInflightTasks, std::uint32_t{23});
+}
+
 TEST(UCAsuStoreTest, RejectsMissingKvNamespaces)
 {
     UC::AsuStore::AsuStore store;
@@ -498,7 +517,7 @@ TEST(UCAsuStoreTest, RejectsInvalidSharedProviderMode)
     EXPECT_TRUE(store.Setup(config).Failure());
 }
 
-TEST(UCAsuStoreTest, RejectsTransportIntegerOverflow)
+TEST(UCAsuStoreTest, RejectsAsuIntegerOverflow)
 {
     {
         UC::AsuStore::AsuStore store;
@@ -521,7 +540,16 @@ TEST(UCAsuStoreTest, RejectsTransportIntegerOverflow)
         UC::AsuStore::AsuStore store;
         auto config = MakeBaseConfig();
         config.Set("asu_ids", std::vector<ssize_t>{1001});
-        config.SetNumber("asu_max_inflight_tasks",
+        config.SetNumber("asu_client_max_inflight_tasks",
+                         std::uint64_t{std::numeric_limits<std::uint32_t>::max()} + 1);
+
+        EXPECT_TRUE(store.Setup(config).Failure());
+    }
+    {
+        UC::AsuStore::AsuStore store;
+        auto config = MakeBaseConfig();
+        config.Set("asu_ids", std::vector<ssize_t>{1001});
+        config.SetNumber("asu_transport_max_inflight_tasks",
                          std::uint64_t{std::numeric_limits<std::uint32_t>::max()} + 1);
 
         EXPECT_TRUE(store.Setup(config).Failure());

--- a/ucm/transport/kv/asu/client/include/asu_client/asu_client.h
+++ b/ucm/transport/kv/asu/client/include/asu_client/asu_client.h
@@ -40,6 +40,7 @@ struct AsuClientConfig {
 
     std::vector<TransportConfig> transportConfigs;
 
+    std::uint32_t maxInflightTasks{1024};
     std::uint64_t defaultWaitTimeoutMs{100};
     std::uint64_t timeoutMs{100};
     SharedProviderMode sharedProviderMode{SharedProviderMode::INDEPENDENT};

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -80,6 +80,13 @@ Status AsuClientImpl::Init(const AsuClientConfig& config)
         return Status::Error(StatusCode::INVALID_ARGUMENT,
                              "at least one transport config is required");
     }
+    const auto maxInflightTasks =
+        std::max_element(config.transportConfigs.begin(), config.transportConfigs.end(),
+                         [](const TransportConfig& lhs, const TransportConfig& rhs) {
+                             return lhs.maxInflightTasks < rhs.maxInflightTasks;
+                         });
+    const auto queueDepth =
+        std::max<std::size_t>(2, static_cast<std::size_t>(maxInflightTasks->maxInflightTasks));
 
     GlobalView view;
     auto status = viewServer_->GetGlobalView(view);
@@ -107,10 +114,8 @@ Status AsuClientImpl::Init(const AsuClientConfig& config)
         return status;
     }
 
-    {
-        std::lock_guard<std::mutex> lock{taskQueueMu_};
-        stopWorker_ = false;
-    }
+    taskQueue_.Setup(queueDepth + 1);
+    stopWorker_.store(false, std::memory_order_release);
     worker_ = std::thread(&AsuClientImpl::WorkerLoop, this);
     snapshot_ = std::move(nextSnapshot);
     initialized_ = true;
@@ -128,11 +133,14 @@ Status AsuClientImpl::Shutdown()
     JoinBackgroundRefresh();
 
     {
-        std::lock_guard<std::mutex> lock{taskQueueMu_};
-        stopWorker_ = true;
+        std::lock_guard<std::mutex> lock{producerMu_};
+        if (worker_.joinable()) {
+            taskQueue_.Push(ClientTaskPtr{});
+            worker_.join();
+        } else {
+            stopWorker_.store(true, std::memory_order_release);
+        }
     }
-    taskQueueCv_.notify_all();
-    if (worker_.joinable()) { worker_.join(); }
 
     std::shared_ptr<ViewSnapshot> snapshot;
     std::vector<std::shared_ptr<AsuTransport>> retiredTransports;
@@ -371,15 +379,18 @@ Status AsuClientImpl::SubmitAsync(AsuOpType opType, const std::vector<KVBuffer>&
     }
 
     {
-        std::lock_guard<std::mutex> lock{taskQueueMu_};
-        if (stopWorker_) {
+        std::lock_guard<std::mutex> lock{producerMu_};
+        if (stopWorker_.load(std::memory_order_acquire)) {
             (void)taskManager_.Remove(taskId);
             taskId = kInvalidTaskId;
             return NotInitialized();
         }
-        taskQueue_.emplace_back(std::move(rawCtx));
+        if (!taskQueue_.TryPush(std::move(rawCtx))) {
+            (void)taskManager_.Remove(taskId);
+            taskId = kInvalidTaskId;
+            return Status::Error(StatusCode::RESOURCE_BUSY, "client task queue is full");
+        }
     }
-    taskQueueCv_.notify_one();
     return Status::OK();
 }
 
@@ -415,35 +426,31 @@ Status AsuClientImpl::SubmitAsync(AsuOpType opType, const std::vector<CacheKey>&
     }
 
     {
-        std::lock_guard<std::mutex> lock{taskQueueMu_};
-        if (stopWorker_) {
+        std::lock_guard<std::mutex> lock{producerMu_};
+        if (stopWorker_.load(std::memory_order_acquire)) {
             (void)taskManager_.Remove(taskId);
             taskId = kInvalidTaskId;
             return NotInitialized();
         }
-        taskQueue_.emplace_back(std::move(rawCtx));
+        if (!taskQueue_.TryPush(std::move(rawCtx))) {
+            (void)taskManager_.Remove(taskId);
+            taskId = kInvalidTaskId;
+            return Status::Error(StatusCode::RESOURCE_BUSY, "client task queue is full");
+        }
     }
-    taskQueueCv_.notify_one();
     return Status::OK();
 }
 
 void AsuClientImpl::WorkerLoop()
 {
-    while (true) {
-        ClientTaskPtr ctx;
-        {
-            std::unique_lock<std::mutex> lock{taskQueueMu_};
-            taskQueueCv_.wait(lock, [this] { return stopWorker_ || !taskQueue_.empty(); });
-            if (taskQueue_.empty()) {
-                if (stopWorker_) { return; }
-                continue;
-            }
-            ctx = std::move(taskQueue_.front());
-            taskQueue_.pop_front();
+    taskQueue_.ConsumerLoop(stopWorker_, [this](ClientTaskPtr ctx) {
+        if (!ctx) {
+            stopWorker_.store(true, std::memory_order_release);
+            return;
         }
         auto status = taskManager_.Process(ctx);
         if (IsRefreshNeeded(status)) { RequestBackgroundRefresh(); }
-    }
+    });
 }
 
 Status AsuClientImpl::UnregisterRegions(const std::vector<MRHandle>& handles)

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -130,17 +130,12 @@ Status AsuClientImpl::Shutdown()
         initialized_ = false;
         waitTimeoutMs = config_.defaultWaitTimeoutMs;
     }
-    JoinBackgroundRefresh();
-
     {
         std::lock_guard<std::mutex> lock{producerMu_};
-        if (worker_.joinable()) {
-            taskQueue_.Push(ClientTaskPtr{});
-            worker_.join();
-        } else {
-            stopWorker_.store(true, std::memory_order_release);
-        }
+        stopWorker_.store(true, std::memory_order_release);
     }
+    JoinBackgroundRefresh();
+    if (worker_.joinable()) { worker_.join(); }
 
     std::shared_ptr<ViewSnapshot> snapshot;
     std::vector<std::shared_ptr<AsuTransport>> retiredTransports;
@@ -443,14 +438,14 @@ Status AsuClientImpl::SubmitAsync(AsuOpType opType, const std::vector<CacheKey>&
 
 void AsuClientImpl::WorkerLoop()
 {
-    taskQueue_.ConsumerLoop(stopWorker_, [this](ClientTaskPtr ctx) {
-        if (!ctx) {
-            stopWorker_.store(true, std::memory_order_release);
-            return;
-        }
+    auto processTask = [this](ClientTaskPtr ctx) {
         auto status = taskManager_.Process(ctx);
         if (IsRefreshNeeded(status)) { RequestBackgroundRefresh(); }
-    });
+    };
+    taskQueue_.ConsumerLoop(stopWorker_, processTask);
+
+    ClientTaskPtr ctx;
+    while (taskQueue_.TryPop(ctx)) { processTask(std::move(ctx)); }
 }
 
 Status AsuClientImpl::UnregisterRegions(const std::vector<MRHandle>& handles)

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -80,13 +80,8 @@ Status AsuClientImpl::Init(const AsuClientConfig& config)
         return Status::Error(StatusCode::INVALID_ARGUMENT,
                              "at least one transport config is required");
     }
-    const auto maxInflightTasks =
-        std::max_element(config.transportConfigs.begin(), config.transportConfigs.end(),
-                         [](const TransportConfig& lhs, const TransportConfig& rhs) {
-                             return lhs.maxInflightTasks < rhs.maxInflightTasks;
-                         });
     const auto queueDepth =
-        std::max<std::size_t>(2, static_cast<std::size_t>(maxInflightTasks->maxInflightTasks));
+        std::max<std::size_t>(2, static_cast<std::size_t>(config.maxInflightTasks));
 
     GlobalView view;
     auto status = viewServer_->GetGlobalView(view);

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.h
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.h
@@ -23,8 +23,7 @@
  * */
 #pragma once
 
-#include <condition_variable>
-#include <deque>
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -34,6 +33,7 @@
 #include "asu_client/asu_client.h"
 #include "asu_transport/types.h"
 #include "client_task_manager.h"
+#include "template/spsc_ring_queue.h"
 #include "view_server.h"
 
 namespace UC::Router {
@@ -147,11 +147,10 @@ private:
 
     // Tracks aggregate client tasks returned through public TaskId values.
     ClientTaskManager taskManager_;
-    // Protects the client worker queue and shutdown acceptance boundary.
-    std::mutex taskQueueMu_;
-    std::condition_variable taskQueueCv_;
-    std::deque<ClientTaskPtr> taskQueue_;
-    bool stopWorker_{true};
+    // Serializes producers and protects the shutdown acceptance boundary.
+    std::mutex producerMu_;
+    UC::SpscRingQueue<ClientTaskPtr> taskQueue_;
+    std::atomic_bool stopWorker_{true};
     std::thread worker_;
     // Creates ASU transports; tests inject fake transports through this hook.
     TransportFactory transportFactory_;

--- a/ucm/transport/kv/asu/client/src/client_config_parser.cpp
+++ b/ucm/transport/kv/asu/client/src/client_config_parser.cpp
@@ -153,6 +153,11 @@ Status LoadAsuClientConfig(const std::string& configPath, AsuClientConfig& confi
                     static_cast<std::uint32_t>(ParseConfigUint64(field.second));
                 continue;
             }
+            if (field.first == "maxInflightTasks" || field.first == "max_inflight_tasks") {
+                transportConfig.maxInflightTasks =
+                    static_cast<std::uint32_t>(ParseConfigUint64(field.second));
+                continue;
+            }
             transportConfig.attrs.emplace(field);
         }
 

--- a/ucm/transport/kv/asu/client/src/client_config_parser.cpp
+++ b/ucm/transport/kv/asu/client/src/client_config_parser.cpp
@@ -70,6 +70,8 @@ Status LoadAsuClientConfig(const std::string& configPath, AsuClientConfig& confi
         const auto value = TrimConfigValue(line.substr(pos + 1));
         if (key == "clientId" || key == "client_id") {
             config.clientId = value;
+        } else if (key == "client.maxInflightTasks" || key == "client.max_inflight_tasks") {
+            config.maxInflightTasks = static_cast<std::uint32_t>(ParseConfigUint64(value));
         } else if (key == "viewServiceAddrs" || key == "view_service_addrs") {
             config.viewServiceAddrs = SplitConfigValue(value, ',');
         } else if (key == "view.config_path" || key == "viewConfigPath" ||

--- a/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
@@ -1644,6 +1644,69 @@ TEST(AsuClientImplTest, Task_SubmitReturnsWhileWorkerDispatchIsBlocked)
     EXPECT_TRUE(client->Wait(taskId, 100, result).ok());
 }
 
+TEST(AsuClientImplTest, Task_SubmitReturnsResourceBusyWhenQueueIsFull)
+{
+    auto state = std::make_shared<TestState>();
+    state->blockStoreDispatch = true;
+    auto client = CreateAsuClient(MakeFactory(state));
+    auto config = MakeConfig({10});
+    config.transportConfigs.front().maxInflightTasks = 2;
+    ASSERT_TRUE(client->Init(config).ok());
+
+    std::vector<TaskId> taskIds;
+    TaskId taskId = kInvalidTaskId;
+    ASSERT_TRUE(client
+                    ->StoreAsync(
+                        {
+                            KVBuffer{MakeCacheKey("k05"), {}}
+    },
+                        taskId)
+                    .ok());
+    taskIds.emplace_back(taskId);
+
+    bool dispatchStarted = false;
+    {
+        std::unique_lock<std::mutex> lock{state->storeDispatchMu};
+        dispatchStarted = state->storeDispatchCv.wait_for(
+            lock, std::chrono::milliseconds(100), [&] { return state->storeDispatchStarted; });
+    }
+
+    std::vector<Status> queuedStatuses;
+    for (std::size_t index = 0; index < 2; ++index) {
+        taskId = kInvalidTaskId;
+        queuedStatuses.emplace_back(client->StoreAsync(
+            {
+                KVBuffer{MakeCacheKey("queued-" + std::to_string(index)), {}}
+        },
+            taskId));
+        if (queuedStatuses.back().ok()) { taskIds.emplace_back(taskId); }
+    }
+
+    taskId = 0;
+    const auto status = client->StoreAsync(
+        {
+            KVBuffer{MakeCacheKey("queue-full"), {}}
+    },
+        taskId);
+    EXPECT_EQ(status.code, StatusCode::RESOURCE_BUSY);
+    EXPECT_EQ(taskId, kInvalidTaskId);
+
+    {
+        std::lock_guard<std::mutex> lock{state->storeDispatchMu};
+        state->releaseStoreDispatch = true;
+    }
+    state->storeDispatchCv.notify_all();
+
+    ASSERT_TRUE(dispatchStarted);
+    ASSERT_EQ(queuedStatuses.size(), std::size_t{2});
+    EXPECT_TRUE(queuedStatuses[0].ok()) << queuedStatuses[0].message;
+    EXPECT_TRUE(queuedStatuses[1].ok()) << queuedStatuses[1].message;
+    for (const auto submittedTaskId : taskIds) {
+        TaskResult result;
+        EXPECT_TRUE(client->Wait(submittedTaskId, 100, result).ok());
+    }
+}
+
 TEST(AsuClientImplTest, Task_CheckUsesClientStateUntilCompletionCallback)
 {
     auto state = std::make_shared<TestState>();

--- a/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
@@ -18,6 +18,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include "client_config_parser.h"
 #include "router/router.h"
 
 namespace UC::ASU {
@@ -679,7 +680,7 @@ TEST(AsuClientImplTest, Lifecycle_ShutdownDrainsFullTaskQueue)
     state->blockStoreDispatch = true;
     auto client = CreateAsuClient(MakeFactory(state));
     auto config = MakeConfig({10});
-    config.transportConfigs.front().maxInflightTasks = 2;
+    config.maxInflightTasks = 2;
     ASSERT_TRUE(client->Init(config).ok());
 
     TaskId taskId = kInvalidTaskId;
@@ -886,6 +887,27 @@ TEST(AsuClientImplTest, Lifecycle_PublicInitLoadsClientConfigFile)
         EXPECT_EQ(state->initConfigs[asuId].asuQueryIoNum, std::size_t{14});
         EXPECT_EQ(state->initConfigs[asuId].maxErrorCount, std::uint32_t{5});
     }
+}
+
+TEST(AsuClientImplTest, Config_SeparatesClientAndTransportMaxInflightTasks)
+{
+    constexpr const char* kConfigPath = "asu_client_impl_max_inflight_tasks_test.conf";
+    {
+        std::ofstream configFile{kConfigPath};
+        ASSERT_TRUE(configFile.is_open());
+        configFile << "client.maxInflightTasks=3\n";
+        configFile << "transport.asuIds=10\n";
+        configFile << "transport.maxInflightTasks=7\n";
+    }
+
+    AsuClientConfig config;
+    const auto status = LoadAsuClientConfig(kConfigPath, config);
+    std::remove(kConfigPath);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(config.maxInflightTasks, std::uint32_t{3});
+    ASSERT_EQ(config.transportConfigs.size(), std::size_t{1});
+    EXPECT_EQ(config.transportConfigs.front().maxInflightTasks, std::uint32_t{7});
 }
 
 TEST(AsuClientImplTest, Lifecycle_PublicInitRejectsInvalidSharedProviderMode)
@@ -1698,7 +1720,7 @@ TEST(AsuClientImplTest, Task_SubmitReturnsResourceBusyWhenQueueIsFull)
     state->blockStoreDispatch = true;
     auto client = CreateAsuClient(MakeFactory(state));
     auto config = MakeConfig({10});
-    config.transportConfigs.front().maxInflightTasks = 2;
+    config.maxInflightTasks = 2;
     ASSERT_TRUE(client->Init(config).ok());
 
     std::vector<TaskId> taskIds;

--- a/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
@@ -417,7 +417,7 @@ public:
     Status GetGlobalView(GlobalView& view) override
     {
         std::lock_guard<std::mutex> lock{mutex_};
-        if (failFetchAt_ != 0 && fetchCount_ + 1 == failFetchAt_) {
+        if (failFetchFrom_ != 0 && fetchCount_ + 1 >= failFetchFrom_) {
             ++fetchCount_;
             return Status::Error(StatusCode::IO_ERROR, "fake view fetch failed");
         }
@@ -432,10 +432,10 @@ public:
         return Status::OK();
     }
 
-    void FailFetchAt(std::size_t fetchCount)
+    void FailFetchFrom(std::size_t fetchCount)
     {
         std::lock_guard<std::mutex> lock{mutex_};
-        failFetchAt_ = fetchCount;
+        failFetchFrom_ = fetchCount;
     }
     std::size_t FetchCount() const
     {
@@ -446,7 +446,7 @@ public:
 private:
     mutable std::mutex mutex_;
     std::size_t fetchCount_{0};
-    std::size_t failFetchAt_{0};
+    std::size_t failFetchFrom_{0};
     std::vector<std::vector<AsuId>> views_;
     std::vector<std::uint64_t> epochs_;
 };
@@ -1228,7 +1228,7 @@ TEST(AsuClientImplTest, BackgroundRefresh_QueryReturnsPartialFailedWhenViewFetch
             {10, 20}
     },
         std::vector<std::uint64_t>{1, 2});
-    viewServer->FailFetchAt(2);
+    viewServer->FailFetchFrom(2);
     auto config = MakeConfig({10, 20});
     auto client =
         std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));

--- a/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
@@ -673,6 +673,54 @@ TEST(AsuClientImplTest, Lifecycle_ShutdownClearsTasksAndRejectsFutureOperations)
     EXPECT_TRUE(client->Check(taskId));
 }
 
+TEST(AsuClientImplTest, Lifecycle_ShutdownDrainsFullTaskQueue)
+{
+    auto state = std::make_shared<TestState>();
+    state->blockStoreDispatch = true;
+    auto client = CreateAsuClient(MakeFactory(state));
+    auto config = MakeConfig({10});
+    config.transportConfigs.front().maxInflightTasks = 2;
+    ASSERT_TRUE(client->Init(config).ok());
+
+    TaskId taskId = kInvalidTaskId;
+    ASSERT_TRUE(client
+                    ->StoreAsync(
+                        {
+                            KVBuffer{MakeCacheKey("active"), {}}
+    },
+                        taskId)
+                    .ok());
+
+    {
+        std::unique_lock<std::mutex> lock{state->storeDispatchMu};
+        EXPECT_TRUE(state->storeDispatchCv.wait_for(lock, std::chrono::milliseconds(100),
+                                                    [&] { return state->storeDispatchStarted; }));
+    }
+
+    for (std::size_t index = 0; index < 2; ++index) {
+        EXPECT_TRUE(client
+                        ->StoreAsync(
+                            {
+                                KVBuffer{MakeCacheKey("queued-" + std::to_string(index)), {}}
+        },
+                            taskId)
+                        .ok());
+    }
+
+    auto shutdown = std::async(std::launch::async, [&] { return client->Shutdown(); });
+    EXPECT_EQ(shutdown.wait_for(std::chrono::milliseconds(20)), std::future_status::timeout);
+
+    {
+        std::lock_guard<std::mutex> lock{state->storeDispatchMu};
+        state->releaseStoreDispatch = true;
+    }
+    state->storeDispatchCv.notify_all();
+
+    ASSERT_EQ(shutdown.wait_for(std::chrono::milliseconds(200)), std::future_status::ready);
+    EXPECT_TRUE(shutdown.get().ok());
+    EXPECT_EQ(state->storeCalls.size(), std::size_t{3});
+}
+
 TEST(AsuClientImplTest, Input_EmptyQueryReturnsEmptyResult)
 {
     auto state = std::make_shared<TestState>();

--- a/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
@@ -61,10 +61,6 @@ struct TransportConfig {
     std::uint32_t maxInflightTasks{1024};
     std::uint64_t maxInflightBytes{1ULL << 30};
 
-    std::uint32_t maxQueryInflight{256};
-    std::uint32_t maxLoadInflight{512};
-    std::uint32_t maxStoreInflight{256};
-
     std::uint64_t timeoutMs{100};
     std::uint32_t maxErrorCount{2};
 

--- a/ucm/transport/kv/kv-test/CMakeLists.txt
+++ b/ucm/transport/kv/kv-test/CMakeLists.txt
@@ -15,6 +15,16 @@ add_executable(kv-test
     src/result_writer.cpp
 )
 
+target_compile_options(kv-test
+    PRIVATE
+        $<$<CONFIG:Release>:-O3>
+)
+
+target_link_options(kv-test
+    PRIVATE
+        $<$<CONFIG:Release>:-s>
+)
+
 target_include_directories(kv-test
     PRIVATE
         include

--- a/ucm/transport/kv/kv-test/CMakeLists.txt
+++ b/ucm/transport/kv/kv-test/CMakeLists.txt
@@ -53,4 +53,17 @@ if(BUILD_UNIT_TESTS)
     )
     target_link_libraries(kv-test-config.test PRIVATE gtest_main gtest)
     gtest_discover_tests(kv-test-config.test)
+
+    add_executable(kv-test-arg-parser.test
+        src/arg_parser.cpp
+        test/arg_parser_test.cpp
+    )
+    target_include_directories(kv-test-arg-parser.test
+        PRIVATE
+            include
+            ../asu/client/include
+            ../asu/trans/include
+    )
+    target_link_libraries(kv-test-arg-parser.test PRIVATE gtest_main gtest)
+    gtest_discover_tests(kv-test-arg-parser.test)
 endif()

--- a/ucm/transport/kv/kv-test/asu_kv_test.conf
+++ b/ucm/transport/kv/kv-test/asu_kv_test.conf
@@ -59,6 +59,8 @@ limits.memory_max_bytes=4294967296
 bench.io_size=4096
 bench.concurrency=1
 bench.duration_sec=10
+# Set to a positive value to run exactly this many io_size-byte logical IOs instead of timing.
+bench.io_count=0
 bench.warmup_sec=1
 bench.read_ratio=50
 bench.write_ratio=50

--- a/ucm/transport/kv/kv-test/include/kv_test/kv_test_types.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/kv_test_types.h
@@ -114,6 +114,7 @@ struct CommandOptions {
     std::string keysFile;
     std::string keyPrefix;
     std::uint64_t count{0};
+    std::uint64_t ioCount{0};
     std::uint64_t keyStart{0};
     std::uint64_t keyEnd{0};
     std::uint64_t seed{0};
@@ -140,6 +141,7 @@ struct BenchConfig {
     std::uint64_t ioSize{0};
     std::uint32_t concurrency{0};
     std::uint64_t durationSec{0};
+    std::uint64_t ioCount{0};
     std::uint64_t warmupSec{0};
     std::uint32_t readRatio{0};
     std::uint32_t writeRatio{0};

--- a/ucm/transport/kv/kv-test/scripts/fake_backend_common.sh
+++ b/ucm/transport/kv/kv-test/scripts/fake_backend_common.sh
@@ -104,6 +104,7 @@ write_fake_backend_config() {
         echo "bench.io_size=4096"
         echo "bench.concurrency=1"
         echo "bench.duration_sec=1"
+        echo "bench.io_count=0"
         echo "bench.warmup_sec=0"
         echo "bench.read_ratio=50"
         echo "bench.write_ratio=50"

--- a/ucm/transport/kv/kv-test/scripts/test_fake_backend_bench_count.sh
+++ b/ucm/transport/kv/kv-test/scripts/test_fake_backend_bench_count.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${SCRIPT_DIR}/fake_backend_common.sh"
+
+KV_TEST=$(find_kv_test_bin)
+WORK_DIR=$(make_temp_dir)
+echo "script artifacts: ${WORK_DIR}"
+
+CONFIG="${WORK_DIR}/kv-test.conf"
+STORE="${WORK_DIR}/store"
+OUTPUT="${WORK_DIR}/output"
+LOG="${WORK_DIR}/command.log"
+
+write_fake_backend_config "${CONFIG}" "${STORE}" "${OUTPUT}" "1"
+
+run_success "${LOG}" "${KV_TEST}" bench batch-store --configpath "${CONFIG}" \
+    --count 5 --batch-size 2 --concurrency 2 --warmup 0
+assert_contains "${LOG}" "entries=5"
+assert_contains "${LOG}" "bytes=20480"
+assert_contains "${LOG}" "operations=3"
+assert_contains "${LOG}" "io_count=5"
+
+print_success "fake_backend bench count passed"

--- a/ucm/transport/kv/kv-test/src/arg_parser.cpp
+++ b/ucm/transport/kv/kv-test/src/arg_parser.cpp
@@ -363,6 +363,17 @@ Status ArgParser::Parse(int argc, char** argv, CommandOptions& options) const
     }
     if (options.helpRequested && positionals.empty()) { return Status::Success(); }
 
+    auto status = SetCommand(positionals, options);
+    if (!status.Ok()) { return status; }
+
+    if (options.command == CommandType::BENCH && hasCount) {
+        if (options.count == 0) {
+            return Status::Error(kExitInvalidArgument, "bench --count must be greater than zero");
+        }
+        options.ioCount = options.count;
+        options.count = 0;
+    }
+
     const bool hasRangePart =
         !options.keyPrefix.empty() || options.keyStartSet || options.keyEndSet;
     if (hasRangePart && (options.keyPrefix.empty() || !options.keyStartSet || !options.keyEndSet)) {
@@ -382,9 +393,6 @@ Status ArgParser::Parse(int argc, char** argv, CommandOptions& options) const
                              "--key, --keys, --keys-file, --count, and prefix range are mutually "
                              "exclusive");
     }
-
-    auto status = SetCommand(positionals, options);
-    if (!status.Ok()) { return status; }
 
     if (options.helpRequested) { return Status::Success(); }
 

--- a/ucm/transport/kv/kv-test/src/bench_runner.cpp
+++ b/ucm/transport/kv/kv-test/src/bench_runner.cpp
@@ -383,8 +383,9 @@ Status BenchRunner::Run(const CommandOptions& options, const KvTestConfig& confi
     if (bench.concurrency == 0) {
         return Status::Error(kExitInvalidArgument, "bench concurrency must be greater than zero");
     }
-    if (bench.durationSec == 0) {
-        return Status::Error(kExitInvalidArgument, "bench duration must be greater than zero");
+    if (bench.durationSec == 0 && bench.ioCount == 0) {
+        return Status::Error(kExitInvalidArgument,
+                             "bench duration or IO count must be greater than zero");
     }
     if (bench.op == BenchOpType::MIX && bench.readRatio + bench.writeRatio == 0) {
         return Status::Error(kExitInvalidArgument,
@@ -407,6 +408,10 @@ Status BenchRunner::Run(const CommandOptions& options, const KvTestConfig& confi
 
     auto status = ValidateBenchBufferConfig(bench, poolEntryCount, config.memoryMaxBytes);
     if (!status.Ok()) { return status; }
+    if (bench.ioCount != 0 &&
+        bench.ioCount > std::numeric_limits<std::uint64_t>::max() / bench.ioSize) {
+        return Status::Error(kExitInvalidArgument, "bench total IO bytes overflow uint64");
+    }
 
     const std::string keyPrefix = config.keyPrefix.empty() ? "b" : config.keyPrefix;
     const bool useDeviceBuffers = UsesDevicePayloadBuffers(config);
@@ -435,9 +440,11 @@ Status BenchRunner::Run(const CommandOptions& options, const KvTestConfig& confi
     result.benchMetrics.warmupSec = bench.warmupSec;
     result.benchMetrics.durationSec = bench.durationSec;
 
-    auto runPhase = [&](std::uint64_t durationSec, bool collectStats) -> Status {
+    auto runPhase = [&](std::uint64_t durationSec, std::uint64_t ioCount,
+                        bool collectStats) -> Status {
         const auto phaseStart = Clock::now();
         const auto phaseEnd = phaseStart + std::chrono::seconds(durationSec);
+        std::uint64_t scheduledEntryCount = 0;
         std::uint64_t windowOperationCount = 0;
         std::uint64_t windowEntryCount = 0;
         std::uint64_t windowBytes = 0;
@@ -459,18 +466,26 @@ Status BenchRunner::Run(const CommandOptions& options, const KvTestConfig& confi
             if (options.progress) { PrintProgressSample(sample, operationsPerSec); }
         };
 
-        while (Clock::now() < phaseEnd) {
+        auto shouldContinue = [&]() {
+            return ioCount == 0 ? Clock::now() < phaseEnd : scheduledEntryCount < ioCount;
+        };
+
+        while (shouldContinue()) {
             std::vector<std::future<OperationOutcome>> futures;
             std::vector<OperationOutcome> inlineOutcomes;
             futures.reserve(bench.concurrency);
             inlineOutcomes.reserve(bench.concurrency);
-            for (std::uint32_t inFlight = 0;
-                 inFlight < bench.concurrency && Clock::now() < phaseEnd; ++inFlight) {
+            for (std::uint32_t inFlight = 0; inFlight < bench.concurrency && shouldContinue();
+                 ++inFlight) {
                 const auto begin =
                     static_cast<std::size_t>((operationIndex * entryCountPerOperation) % keyCount);
                 const auto available = keyCount - begin;
+                const auto remainingEntryCount =
+                    ioCount == 0 ? entryCountPerOperation : ioCount - scheduledEntryCount;
                 const auto currentEntryCount = static_cast<std::size_t>(
-                    std::min<std::uint64_t>(entryCountPerOperation, available));
+                    std::min({entryCountPerOperation, static_cast<std::uint64_t>(available),
+                              remainingEntryCount}));
+                scheduledEntryCount += currentEntryCount;
                 const auto currentOperationIndex = operationIndex++;
                 auto* bufferSlot = &bufferPool[inFlight];
 
@@ -580,7 +595,7 @@ Status BenchRunner::Run(const CommandOptions& options, const KvTestConfig& confi
     };
 
     if (bench.warmupSec != 0) {
-        status = runPhase(bench.warmupSec, false);
+        status = runPhase(bench.warmupSec, 0, false);
         if (!status.Ok()) {
             if (useDeviceBuffers) { (void)UnregisterBenchDeviceBuffers(clientRunner, bufferPool); }
             return status;
@@ -588,7 +603,7 @@ Status BenchRunner::Run(const CommandOptions& options, const KvTestConfig& confi
     }
 
     const auto measureStart = Clock::now();
-    status = runPhase(bench.durationSec, true);
+    status = runPhase(bench.durationSec, bench.ioCount, true);
     const auto measureEnd = Clock::now();
     auto cleanupStatus = useDeviceBuffers ? UnregisterBenchDeviceBuffers(clientRunner, bufferPool)
                                           : Status::Success();

--- a/ucm/transport/kv/kv-test/src/kv_test_app.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_app.cpp
@@ -63,6 +63,7 @@ CommandOptions BuildEffectiveOptions(const CommandOptions& options, const KvTest
     if (effective.benchOp == BenchOpType::UNKNOWN) { effective.benchOp = config.bench.op; }
     effective.concurrency = config.bench.concurrency;
     effective.durationSec = config.bench.durationSec;
+    effective.ioCount = config.bench.ioCount;
     effective.warmupSec = config.bench.warmupSec;
     effective.readRatio = config.bench.readRatio;
     effective.writeRatio = config.bench.writeRatio;
@@ -161,7 +162,7 @@ void PrintGeneralHelp()
         << "  --key <key>              Use one key.\n"
         << "  --keys <k1,k2,...>       Use a comma-separated key list.\n"
         << "  --keys-file <path>       Read comma-separated keys from a file.\n"
-        << "  --count <n>              Generate n keys from kv.key_prefix.\n"
+        << "  --count <n>              Generate n keys; for bench, run exactly n logical IOs.\n"
         << "  --prefix <p> --key-start <n> --key-end <n>\n"
         << "                           Generate keys in the closed interval [start, end].\n"
         << "  --seed <n>               Override kv.seed.\n"
@@ -173,7 +174,8 @@ void PrintGeneralHelp()
         << "\n"
         << "Bench options:\n"
         << "  --op <op>, --bench-op <op>, --io-size <bytes>, --concurrency <n>,\n"
-        << "  --duration <sec>, --warmup <sec>, --read-ratio <n>, --write-ratio <n>,\n"
+        << "  --duration <sec>, --count <n>, --warmup <sec>, --read-ratio <n>,\n"
+        << "  --write-ratio <n>,\n"
         << "  --progress               Print one benchmark progress line per second.\n\n"
         << "Examples:\n"
         << "  export KV_TEST_CONFIG=/abs/path/to/asu_kv_test.conf\n"
@@ -239,9 +241,12 @@ void PrintCommandHelp(CommandType command)
             break;
         case CommandType::BENCH:
             std::cout << "Usage: kv-test bench [store|retrieve|batch-store|batch-retrieve|mix] "
-                         "[--io-size <bytes>] [--concurrency <n>] [--duration <sec>]\n"
+                         "[--io-size <bytes>] [--concurrency <n>] "
+                         "[--duration <sec>] [--count <n>]\n"
                       << "       kv-test bench --op <op> [--batch-size <n>] [--warmup <sec>] "
-                         "[--read-ratio <n>] [--write-ratio <n>] [--progress]\n";
+                         "[--read-ratio <n>] [--write-ratio <n>] [--progress]\n"
+                      << "       A positive --count runs exactly that many io-size logical IOs "
+                         "and overrides duration.\n";
             break;
         case CommandType::UNKNOWN:
         default: PrintGeneralHelp(); break;
@@ -311,6 +316,7 @@ void PrintBenchSummary(const CommandOptions& options, const CommandResult& resul
               << std::setprecision(3) << metrics.elapsedSec
               << "\noperations=" << metrics.completedOperations
               << "\nentries=" << metrics.completedEntries << "\nbytes=" << metrics.completedBytes
+              << "\nio_count=" << options.ioCount
               << "\nbandwidth_mib_s=" << FormatMiBPerSec(metrics.avgBandwidthBytesPerSec)
               << "\niops=" << std::fixed << std::setprecision(2) << metrics.avgIops
               << "\nbatch_iops=" << metrics.avgBatchIops

--- a/ucm/transport/kv/kv-test/src/kv_test_config_loader.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_config_loader.cpp
@@ -211,6 +211,7 @@ Status KvTestConfigLoader::Load(const std::string& configPath, KvTestConfig& con
         GetUint64Any(values, {"bench.io_size"}, config.bench.ioSize);
         GetUint32Any(values, {"bench.concurrency"}, config.bench.concurrency);
         GetUint64Any(values, {"bench.duration_sec"}, config.bench.durationSec);
+        GetUint64Any(values, {"bench.io_count"}, config.bench.ioCount);
         GetUint64Any(values, {"bench.warmup_sec"}, config.bench.warmupSec);
         GetUint32Any(values, {"bench.read_ratio"}, config.bench.readRatio);
         GetUint32Any(values, {"bench.write_ratio"}, config.bench.writeRatio);
@@ -247,7 +248,11 @@ Status KvTestConfigLoader::MergeCommandOptions(const CommandOptions& options,
 
     if (options.benchOp != BenchOpType::UNKNOWN) { config.bench.op = options.benchOp; }
     if (options.concurrency != 0) { config.bench.concurrency = options.concurrency; }
-    if (options.durationSec != 0) { config.bench.durationSec = options.durationSec; }
+    if (options.durationSec != 0) {
+        config.bench.durationSec = options.durationSec;
+        config.bench.ioCount = 0;
+    }
+    if (options.ioCount != 0) { config.bench.ioCount = options.ioCount; }
     if (options.warmupSec != 0) { config.bench.warmupSec = options.warmupSec; }
     if (options.readRatio != 0) { config.bench.readRatio = options.readRatio; }
     if (options.writeRatio != 0) { config.bench.writeRatio = options.writeRatio; }

--- a/ucm/transport/kv/kv-test/src/result_writer.cpp
+++ b/ucm/transport/kv/kv-test/src/result_writer.cpp
@@ -216,6 +216,7 @@ Status ResultWriter::WriteSummary(const CommandOptions& options, const CommandRe
              << "batch_size: " << options.batchSize << '\n'
              << "concurrency: " << options.concurrency << '\n'
              << "duration_sec: " << options.durationSec << '\n'
+             << "io_count: " << options.ioCount << '\n'
              << "asu_status_code: " << asuStatusCode << '\n';
     if (!result.status.Ok()) { textFile << "error: " << result.status.message << '\n'; }
     if (!result.taskResult.status.message.empty()) {
@@ -248,7 +249,8 @@ Status ResultWriter::WriteSummary(const CommandOptions& options, const CommandRe
              << "    \"value_size\": " << options.valueSize << ",\n"
              << "    \"batch_size\": " << options.batchSize << ",\n"
              << "    \"concurrency\": " << options.concurrency << ",\n"
-             << "    \"duration_sec\": " << options.durationSec << "\n"
+             << "    \"duration_sec\": " << options.durationSec << ",\n"
+             << "    \"io_count\": " << options.ioCount << "\n"
              << "  },\n";
     if (options.command == CommandType::BENCH) {
         jsonFile << "  \"metrics\": {\n"
@@ -399,6 +401,7 @@ Status ResultWriter::WriteHtmlReport(const CommandOptions& options, const Comman
              << "<tr><th>Batch size</th><td>" << options.batchSize << "</td></tr>"
              << "<tr><th>Concurrency</th><td>" << options.concurrency << "</td></tr>"
              << "<tr><th>Duration sec</th><td>" << options.durationSec << "</td></tr>"
+             << "<tr><th>IO count</th><td>" << options.ioCount << "</td></tr>"
              << "</tbody></table></section>";
 
     if (options.command == CommandType::BENCH) {

--- a/ucm/transport/kv/kv-test/test/arg_parser_test.cpp
+++ b/ucm/transport/kv/kv-test/test/arg_parser_test.cpp
@@ -1,0 +1,49 @@
+#include "kv_test/arg_parser.h"
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+namespace UC::KVTest {
+namespace {
+
+Status ParseArguments(std::vector<std::string> arguments, CommandOptions& options)
+{
+    std::vector<char*> argv;
+    argv.reserve(arguments.size());
+    for (auto& argument : arguments) { argv.emplace_back(argument.data()); }
+    return ArgParser{}.Parse(static_cast<int>(argv.size()), argv.data(), options);
+}
+
+TEST(ArgParserTest, BenchCountSetsTotalIoCount)
+{
+    CommandOptions options;
+    auto status = ParseArguments({"kv-test", "bench", "batch-store", "--count", "100"}, options);
+
+    ASSERT_TRUE(status.Ok()) << status.message;
+    EXPECT_EQ(options.command, CommandType::BENCH);
+    EXPECT_EQ(options.ioCount, 100U);
+    EXPECT_EQ(options.count, 0U);
+}
+
+TEST(ArgParserTest, NonBenchCountKeepsKeyGenerationCount)
+{
+    CommandOptions options;
+    auto status = ParseArguments({"kv-test", "store", "--count", "100"}, options);
+
+    ASSERT_TRUE(status.Ok()) << status.message;
+    EXPECT_EQ(options.command, CommandType::STORE);
+    EXPECT_EQ(options.count, 100U);
+    EXPECT_EQ(options.ioCount, 0U);
+}
+
+TEST(ArgParserTest, BenchCountMustBePositive)
+{
+    CommandOptions options;
+    auto status = ParseArguments({"kv-test", "bench", "store", "--count", "0"}, options);
+
+    EXPECT_FALSE(status.Ok());
+    EXPECT_EQ(status.message, "bench --count must be greater than zero");
+}
+
+}  // namespace
+}  // namespace UC::KVTest


### PR DESCRIPTION
## Purpose
This PR optimizes data structure of AsuClient tasks.

## Modifications 
1. Replace deque with SpscRingQueue
2. Add some compiling options for kv-test
3. kv-test bench adds --count option to set IO number to certain value
4. Reserve space for router variables
5. Add config MaxInflightTasks for client/transport seperately

## Test
All unit tests are passed.
An offline inference is passed with fake/aiv provider.
Kv-test runs bench command normally with --count option.