### PR TITLE
[Opt] Dramstore register kvcache && Fix test bugs on ascend

### DIFF
--- a/ucm/store/dram/CMakeLists.txt
+++ b/ucm/store/dram/CMakeLists.txt
@@ -1,5 +1,4 @@
-if(NOT (RUNTIME_ENVIRONMENT STREQUAL "ascend"
-        OR RUNTIME_ENVIRONMENT STREQUAL "simu"))
+if(NOT (UCM_RUNTIME_ASCEND_FAMILY OR RUNTIME_ENVIRONMENT STREQUAL "simu"))
     return()
 endif()
 
@@ -16,7 +15,7 @@ set(UCM_DRAM_STORE_CC_SOURCE_FILES
     ${DRAM_SOURCE_DIR}/node_scheduler.cc
     ${DRAM_SOURCE_DIR}/task_manager.cc
 )
-if(RUNTIME_ENVIRONMENT STREQUAL "ascend")
+if(UCM_RUNTIME_ASCEND_FAMILY)
     list(APPEND UCM_DRAM_STORE_CC_SOURCE_FILES
         ${DRAM_SOURCE_DIR}/transport_manager_backend.cc)
 endif()
@@ -26,7 +25,7 @@ set_target_properties(dramstore PROPERTIES
     BUILD_WITH_INSTALL_RPATH ON
     INSTALL_RPATH "$ORIGIN;$ORIGIN/../../transport/p2p"
 )
-if(RUNTIME_ENVIRONMENT STREQUAL "ascend")
+if(UCM_RUNTIME_ASCEND_FAMILY)
     target_compile_definitions(dramstore PRIVATE UC_DRAM_ASCEND_BACKEND)
 endif()
 target_include_directories(dramstore PUBLIC
@@ -45,7 +44,7 @@ target_link_libraries(dramstore
         router
         buffer_pool
 )
-if(RUNTIME_ENVIRONMENT STREQUAL "ascend")
+if(UCM_RUNTIME_ASCEND_FAMILY)
     target_link_libraries(dramstore PUBLIC ucm_p2p_transport)
 endif()
 file(RELATIVE_PATH DRAM_INSTALL_REL_PATH ${UCM_ROOT_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
@@ -56,6 +55,7 @@ install(TARGETS dramstore
 
 set(DRAMPOOL_SOURCE_DIR ${DRAM_SOURCE_DIR}/drampool)
 set(DRAMPOOL_SOURCE_FILES
+    ${DRAM_SOURCE_DIR}/kv_protocol.cc
     ${DRAMPOOL_SOURCE_DIR}/completion_poller.cc
     ${DRAMPOOL_SOURCE_DIR}/drampool_daemon.cc
     ${DRAMPOOL_SOURCE_DIR}/drampool_launch_config.cc
@@ -70,6 +70,8 @@ target_include_directories(drampool_core
     PUBLIC
         ${DRAMPOOL_SOURCE_DIR}
         ${DRAM_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/ucm/shared
+        ${CMAKE_SOURCE_DIR}/ucm/store/detail
 )
 target_link_libraries(drampool_core
     PUBLIC
@@ -80,8 +82,10 @@ target_link_libraries(drampool_core
         buffer_pool
         ucm_p2p_transport
         trans
-        dramstore
 )
 add_executable(drampool ${DRAMPOOL_SOURCE_DIR}/main.cc)
 target_link_libraries(drampool PRIVATE drampool_core)
+set_target_properties(drampool PROPERTIES
+    INSTALL_RPATH "$ORIGIN/../ucm/transport/p2p"
+)
 install(TARGETS drampool RUNTIME DESTINATION bin COMPONENT ucm)

--- a/ucm/store/dram/cc/config.cc
+++ b/ucm/store/dram/cc/config.cc
@@ -159,27 +159,17 @@ Expected<DramConfig> DramConfig::Parse(const Detail::Dictionary& dictionary)
             return Status::InvalidParam("unsupported router_type({})", routerType);
         }
 
-        std::size_t deviceId = 0;
-        status = OptionalSize(dictionary, "device_id", &deviceId);
-        if (status.Failure() || deviceId > 65) {
-            return status.Failure() ? status : Status::InvalidParam("device_id is out of range");
+        ssize_t deviceId = result.deviceId;
+        dictionary.GetNumber("device_id", deviceId);
+        if (deviceId < std::numeric_limits<std::int32_t>::min() || deviceId > 65) {
+            return Status::InvalidParam("device_id is out of range");
         }
         result.deviceId = static_cast<std::int32_t>(deviceId);
-        result.nodeScheduler.deviceId = result.deviceId;
-
-        if (dictionary.Contains("role")) {
-            std::string roleStr;
-            dictionary.Get("role", roleStr);
-            if (roleStr == "scheduler") {
-                result.role = Role::SCHEDULER;
-            } else if (roleStr != "worker") {
-                return Status::InvalidParam("unsupported role({})", roleStr);
-            }
-        }
+        result.nodeScheduler.deviceId = result.RuntimeDeviceId();
 
         std::size_t hixlListenPort = result.hixlListenPort;
         status = OptionalSize(dictionary, "hixl_listen_port", &hixlListenPort);
-        const auto hixlPortOffset = result.role == Role::WORKER ? 1U : 0U;
+        const auto hixlPortOffset = result.GetRole() == Role::SCHEDULER ? 0U : 1U;
         if (status.Failure() || hixlListenPort == 0 ||
             hixlListenPort > std::numeric_limits<std::uint16_t>::max() - hixlPortOffset) {
             return status.Failure() ? status
@@ -195,7 +185,7 @@ Expected<DramConfig> DramConfig::Parse(const Detail::Dictionary& dictionary)
         status = ParseControlEndpoint(result.localTransportManagerId, "local_transport_manager_id",
                                       &managerHost, &managerPort);
         if (status.Failure()) { return status; }
-        if (result.role == Role::WORKER) {
+        if (result.GetRole() == Role::WORKER) {
             const auto offset = static_cast<std::uint32_t>(result.deviceId) + 1;
             if (result.localControlPort > std::numeric_limits<std::uint16_t>::max() - offset ||
                 managerPort > std::numeric_limits<std::uint16_t>::max() - offset) {
@@ -289,6 +279,17 @@ Expected<DramConfig> DramConfig::Parse(const Detail::Dictionary& dictionary)
         }
         result.tensorSizes.assign(tensorSizes.begin(), tensorSizes.end());
 
+        std::vector<std::size_t> gpuKvBufferAddrs;
+        if (dictionary.Contains("gpu_kv_buffer_addrs")) {
+            status = NumberList(dictionary, "gpu_kv_buffer_addrs", &gpuKvBufferAddrs);
+            if (status.Failure()) { return status; }
+        }
+        result.gpuKvBufferAddrs.assign(gpuKvBufferAddrs.begin(), gpuKvBufferAddrs.end());
+        if (dictionary.Contains("gpu_kv_buffer_sizes")) {
+            status = NumberList(dictionary, "gpu_kv_buffer_sizes", &result.gpuKvBufferSizes);
+            if (status.Failure()) { return status; }
+        }
+
         status = result.Validate();
         if (status.Failure()) { return status; }
         return result;
@@ -337,8 +338,18 @@ Status DramConfig::Validate() const
     if (nodeScheduler.reconnectInterval.count() <= 0) {
         return Status::InvalidParam("DramStore reconnect interval must be positive");
     }
-    if (role != Role::SCHEDULER && tensorSizes.empty()) {
+    if (GetRole() == Role::WORKER && tensorSizes.empty()) {
         return Status::InvalidParam("tensor_size_list must not be empty");
+    }
+    if (gpuKvBufferAddrs.size() != gpuKvBufferSizes.size()) {
+        return Status::InvalidParam(
+            "gpu_kv_buffer_addrs({}) and gpu_kv_buffer_sizes({}) must have the same size",
+            gpuKvBufferAddrs.size(), gpuKvBufferSizes.size());
+    }
+    for (std::size_t index = 0; index < gpuKvBufferAddrs.size(); ++index) {
+        if (gpuKvBufferAddrs[index] == 0 || gpuKvBufferSizes[index] == 0) {
+            return Status::InvalidParam("invalid GPU KV buffer at index({})", index);
+        }
     }
     return Status::OK();
 }

--- a/ucm/store/dram/cc/config.h
+++ b/ucm/store/dram/cc/config.h
@@ -45,8 +45,9 @@ struct DramConfig {
     std::uint16_t localControlPort{0};
     std::string localHost;
     std::string localTransportManagerId;
-    std::int32_t deviceId{0};
-    Role role{Role::WORKER};
+    // Scheduler currently omits device_id and defaults to -1; an explicit scheduler deviceId must
+    // be negative.
+    std::int32_t deviceId{-1};
     std::uint16_t hixlListenPort{36666};
     bool enableHixlCs{false};
     UC::Router::RouterType routerType{UC::Router::RouterType::RING_HASH_FULL_SPREAD};
@@ -57,6 +58,15 @@ struct DramConfig {
     std::size_t replySlotCount{0};
     std::uint32_t replySlotSize{0};
     std::vector<std::uint64_t> tensorSizes;
+    std::vector<std::uintptr_t> gpuKvBufferAddrs;
+    std::vector<std::size_t> gpuKvBufferSizes;
+
+    Role GetRole() const noexcept { return deviceId < 0 ? Role::SCHEDULER : Role::WORKER; }
+    // Scheduler uses device 0 for the runtime resources required by DramStore.
+    std::int32_t RuntimeDeviceId() const noexcept
+    {
+        return GetRole() == Role::SCHEDULER ? 0 : deviceId;
+    }
 
     static Expected<DramConfig> Parse(const Detail::Dictionary& dictionary);
     Status Validate() const;

--- a/ucm/store/dram/cc/dram_store.cc
+++ b/ucm/store/dram/cc/dram_store.cc
@@ -73,6 +73,7 @@ public:
     Status Wait(Detail::TaskHandle taskId) override;
 
 private:
+    Status RegisterKvBuffers(const DramConfig& config);
     Expected<Detail::TaskHandle> SubmitTransfer(OpType op, Detail::TaskDesc task);
     Status Start();
 
@@ -90,12 +91,13 @@ private:
 
     Status Compose()
     {
+        const auto runtimeDeviceId = config_->RuntimeDeviceId();
         UC::Trans::Device device;
         const auto initStatus = device.Init();
         if (initStatus.Failure() && initStatus != Status::DuplicateKey()) {
             return Status::Error("aclInit failed: " + initStatus.ToString());
         }
-        const auto setupStatus = device.Setup(config_->deviceId);
+        const auto setupStatus = device.Setup(runtimeDeviceId);
         if (setupStatus.Failure()) {
             return Status::Error("aclrtSetDevice failed: " + setupStatus.ToString());
         }
@@ -109,7 +111,7 @@ private:
             config_->localControlPort,
             config_->localTransportManagerId,
             config_->localHost,
-            config_->deviceId,
+            runtimeDeviceId,
             config_->hixlListenPort,
             config_->enableHixlCs,
             1000,
@@ -121,7 +123,7 @@ private:
         transportBackend_ = std::move(createdBackend).Value();
 
         auto createdReplies = ReplyService::Create(ReplyService::Options{
-            config_->deviceId, config_->replySlotSize, config_->replySlotCount,
+            runtimeDeviceId, config_->replySlotSize, config_->replySlotCount,
             std::chrono::microseconds{50}, [this](NodeId nodeId, NodeEvent event) {
                 nodeScheduler_->Publish(nodeId, std::move(event));
             }});
@@ -177,7 +179,11 @@ private:
                                                    ? nodeScheduler_->Post(request)
                                                    : Status::Error("NodeScheduler is unavailable");
                                     }});
-        return config_->role == Role::SCHEDULER ? Start() : Status::OK();
+        if (config_->GetRole() == Role::WORKER) {
+            const auto registerStatus = RegisterKvBuffers(*config_);
+            if (registerStatus.Failure()) { return registerStatus; }
+        }
+        return Start();
 #else
         return Status::Unsupported();
 #endif
@@ -232,10 +238,45 @@ Status DramStore::Setup(const Detail::Dictionary& config)
     UC_INFO(
         "DramStore setup succeeded, role={} device_id={} nodes={} max_io_entries={} "
         "max_batch_entries={} max_inflight_per_node={} reply_slots={}",
-        config_->role == Role::SCHEDULER ? "scheduler" : "worker", config_->deviceId,
+        config_->GetRole() == Role::SCHEDULER ? "scheduler" : "worker", config_->deviceId,
         config_->nodeScheduler.nodes.size(), config_->maxIoEntries,
         config_->nodeScheduler.limits.maxBatchEntries,
         config_->nodeScheduler.limits.maxInflightRequests, config_->replySlotCount);
+    return Status::OK();
+}
+
+Status DramStore::RegisterKvBuffers(const DramConfig& config)
+{
+    if (config.gpuKvBufferAddrs.empty()) { return Status::OK(); }
+    if (!transportBackend_) { return Status::Error("DramStore transport backend is unavailable"); }
+
+    const auto firstHandle = memoryHandles_.size();
+    memoryHandles_.reserve(firstHandle + config.gpuKvBufferAddrs.size());
+
+    for (std::size_t index = 0; index < config.gpuKvBufferAddrs.size(); ++index) {
+        auto registered = transportBackend_->RegisterMemory(
+            reinterpret_cast<void*>(config.gpuKvBufferAddrs[index]), config.gpuKvBufferSizes[index],
+            MemoryRegionType::DEVICE);
+        if (registered) {
+            memoryHandles_.push_back(std::move(registered).Value());
+            continue;
+        }
+
+        auto result = registered.Error();
+        while (memoryHandles_.size() > firstHandle) {
+            const auto cleanup = transportBackend_->UnregisterMemory(memoryHandles_.back());
+            if (cleanup.Failure()) {
+                result = cleanup;
+                break;
+            }
+            memoryHandles_.pop_back();
+        }
+        UC_ERROR("DramStore GPU KV buffer registration failed, failed_index={} count={} status={}",
+                 index, config.gpuKvBufferAddrs.size(), result);
+        return result;
+    }
+
+    UC_INFO("DramStore GPU KV buffers registered, count={}", config.gpuKvBufferAddrs.size());
     return Status::OK();
 }
 
@@ -262,7 +303,7 @@ Status DramStore::Start()
         return status;
     }
     UC_INFO("DramStore started, role={} nodes={}",
-            config_->role == Role::SCHEDULER ? "scheduler" : "worker",
+            config_->GetRole() == Role::SCHEDULER ? "scheduler" : "worker",
             config_->nodeScheduler.nodes.size());
     return Status::OK();
 }

--- a/ucm/store/dram/cc/reply_service.h
+++ b/ucm/store/dram/cc/reply_service.h
@@ -68,6 +68,8 @@ public:
     Status Start();
     void Shutdown();
 
+    // Acquire and Release may invoke device-runtime operations. The calling thread must have
+    // initialized the device context configured by Options::deviceId.
     Expected<ReplySlot> Acquire(const RequestToken& token, OpType op, std::size_t entryCount);
     Status Release(const RequestToken& token, const ReplySlot& slot) noexcept;
 

--- a/ucm/store/pipeline/connector.py
+++ b/ucm/store/pipeline/connector.py
@@ -362,6 +362,13 @@ def _yuanrong_posix_pipeline_builder(
     _stack_yuanrong_store(config, pipeline)
 
 
+def _dram_pipeline_builder(
+    config: Dict[str, object], pipeline: ucmpipelinestore.PipelineStore
+):
+    store_dir = Path(__file__).resolve().parent.parent
+    pipeline.Stack("Dram", str(store_dir / "dram/libdramstore.so"), config)
+
+
 UcmPipelineStoreBuilder.register("Cache|Ds3fs", _cache_ds3fs_pipeline_builder)
 UcmPipelineStoreBuilder.register("Cache|Empty", _cache_empty_pipeline_builder)
 UcmPipelineStoreBuilder.register("Cache|Posix", _cache_posix_pipeline_builder)
@@ -376,3 +383,4 @@ UcmPipelineStoreBuilder.register("Mooncake", _mooncake_pipeline_builder)
 UcmPipelineStoreBuilder.register("Mooncake|Posix", _mooncake_posix_pipeline_builder)
 UcmPipelineStoreBuilder.register("YuanRong", _yuanrong_pipeline_builder)
 UcmPipelineStoreBuilder.register("YuanRong|Posix", _yuanrong_posix_pipeline_builder)
+UcmPipelineStoreBuilder.register("Dram", _dram_pipeline_builder)

--- a/ucm/store/test/case/dram/dram_config_test.cc
+++ b/ucm/store/test/case/dram/dram_config_test.cc
@@ -30,7 +30,7 @@
 namespace UC::Dram {
 namespace {
 
-Detail::Dictionary BaseConfig(bool includeTensorSizes = true)
+Detail::Dictionary BaseConfig(bool includeTensorSizes = true, bool includeDeviceId = true)
 {
     Detail::Dictionary config;
     config.Set("local_control_endpoint", std::string{"127.0.0.1:6000"});
@@ -40,6 +40,7 @@ Detail::Dictionary BaseConfig(bool includeTensorSizes = true)
                std::vector<std::string>{"127.0.0.1:7000", "127.0.0.1:9000"});
     config.Set("node_transport_manager_ids",
                std::vector<std::string>{"127.0.0.1:7100", "127.0.0.1:9100"});
+    if (includeDeviceId) { config.SetNumber("device_id", 0); }
     if (includeTensorSizes) { config.Set("tensor_size_list", std::vector<ssize_t>{4096}); }
     return config;
 }
@@ -107,6 +108,34 @@ TEST(UCDramConfigTest, ParsesFixedReconnectInterval)
 
 TEST(UCDramConfigTest, RequiresTensorSizes) { EXPECT_FALSE(DramConfig::Parse(BaseConfig(false))); }
 
+TEST(UCDramConfigTest, ParsesGpuKvBuffers)
+{
+    auto input = BaseConfig();
+    input.Set("gpu_kv_buffer_addrs", std::vector<ssize_t>{4096, 8192});
+    input.Set("gpu_kv_buffer_sizes", std::vector<ssize_t>{1024, 2048});
+    auto parsed = DramConfig::Parse(input);
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ(parsed.Value().gpuKvBufferAddrs, (std::vector<std::uintptr_t>{4096, 8192}));
+    EXPECT_EQ(parsed.Value().gpuKvBufferSizes, (std::vector<std::size_t>{1024, 2048}));
+}
+
+TEST(UCDramConfigTest, RejectsInvalidGpuKvBuffers)
+{
+    auto mismatched = BaseConfig();
+    mismatched.Set("gpu_kv_buffer_addrs", std::vector<ssize_t>{4096});
+    EXPECT_FALSE(DramConfig::Parse(mismatched));
+
+    auto zeroAddress = BaseConfig();
+    zeroAddress.Set("gpu_kv_buffer_addrs", std::vector<ssize_t>{0});
+    zeroAddress.Set("gpu_kv_buffer_sizes", std::vector<ssize_t>{1024});
+    EXPECT_FALSE(DramConfig::Parse(zeroAddress));
+
+    auto zeroSize = BaseConfig();
+    zeroSize.Set("gpu_kv_buffer_addrs", std::vector<ssize_t>{4096});
+    zeroSize.Set("gpu_kv_buffer_sizes", std::vector<ssize_t>{0});
+    EXPECT_FALSE(DramConfig::Parse(zeroSize));
+}
+
 TEST(UCDramConfigTest, ParsesRouterTypeIntoStrongConfiguration)
 {
     auto input = BaseConfig();
@@ -153,7 +182,7 @@ TEST(UCDramConfigTest, RejectsInvalidSchedulerBoundaries)
 TEST(UCDramConfigTest, ParsesControlEndpointsAndStoresManagerIds)
 {
     auto input = BaseConfig();
-    input.Set("role", std::string{"scheduler"});
+    input.SetNumber("device_id", -1);
     input.Set("local_control_endpoint", std::string{"127.0.0.1:06000"});
     auto parsed = DramConfig::Parse(input);
     ASSERT_TRUE(parsed);
@@ -172,12 +201,14 @@ TEST(UCDramConfigTest, ParsesControlEndpointsAndStoresManagerIds)
 TEST(UCDramConfigTest, UsesConfiguredPortsForScheduler)
 {
     auto input = BaseConfig();
-    input.Set("role", std::string{"scheduler"});
-    input.SetNumber("device_id", 3);
+    input.SetNumber("device_id", -1);
     input.SetNumber("hixl_listen_port", 36666);
     input.Set("enable_hixl_cs", true);
     auto parsed = DramConfig::Parse(input);
     ASSERT_TRUE(parsed);
+    EXPECT_EQ(parsed.Value().GetRole(), Role::SCHEDULER);
+    EXPECT_EQ(parsed.Value().deviceId, -1);
+    EXPECT_EQ(parsed.Value().nodeScheduler.deviceId, 0);
     EXPECT_EQ(parsed.Value().localControlPort, std::uint16_t{6000});
     EXPECT_EQ(parsed.Value().localTransportManagerId, "127.0.0.1:6100");
     EXPECT_EQ(parsed.Value().hixlListenPort, std::uint16_t{36666});
@@ -187,29 +218,46 @@ TEST(UCDramConfigTest, UsesConfiguredPortsForScheduler)
 TEST(UCDramConfigTest, OffsetsWorkerPortsByDeviceId)
 {
     auto input = BaseConfig();
-    input.Set("role", std::string{"worker"});
     input.SetNumber("device_id", 3);
     auto parsed = DramConfig::Parse(input);
     ASSERT_TRUE(parsed);
+    EXPECT_EQ(parsed.Value().GetRole(), Role::WORKER);
     EXPECT_EQ(parsed.Value().localControlPort, std::uint16_t{6004});
     EXPECT_EQ(parsed.Value().localTransportManagerId, "127.0.0.1:6104");
     EXPECT_EQ(parsed.Value().hixlListenPort, std::uint16_t{36667});
 }
 
-TEST(UCDramConfigTest, RejectsInvalidRoleAndWorkerPortOverflow)
+TEST(UCDramConfigTest, RejectsInvalidDeviceIdAndWorkerPortOverflow)
 {
-    auto invalidRole = BaseConfig();
-    invalidRole.Set("role", std::string{"server"});
-    EXPECT_FALSE(DramConfig::Parse(invalidRole));
+    auto invalidDeviceId = BaseConfig();
+    invalidDeviceId.SetNumber("device_id", 66);
+    EXPECT_FALSE(DramConfig::Parse(invalidDeviceId));
 
     auto overflow = BaseConfig();
-    overflow.Set("role", std::string{"worker"});
+    overflow.SetNumber("device_id", 0);
     overflow.Set("local_control_endpoint", std::string{"127.0.0.1:65535"});
     EXPECT_FALSE(DramConfig::Parse(overflow));
 
     auto hixlOverflow = BaseConfig();
     hixlOverflow.SetNumber("hixl_listen_port", 65535);
     EXPECT_FALSE(DramConfig::Parse(hixlOverflow));
+}
+
+TEST(UCDramConfigTest, SchedulerDoesNotRequireWorkerTensorSizes)
+{
+    auto input = BaseConfig(false);
+    input.SetNumber("device_id", -2);
+    auto parsed = DramConfig::Parse(input);
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ(parsed.Value().GetRole(), Role::SCHEDULER);
+}
+
+TEST(UCDramConfigTest, DefaultsToSchedulerWhenDeviceIdIsOmitted)
+{
+    auto parsed = DramConfig::Parse(BaseConfig(false, false));
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ(parsed.Value().deviceId, -1);
+    EXPECT_EQ(parsed.Value().GetRole(), Role::SCHEDULER);
 }
 
 }  // namespace

--- a/ucm/store/test/case/dram/dram_reply_service_polling_test.cc
+++ b/ucm/store/test/case/dram/dram_reply_service_polling_test.cc
@@ -218,6 +218,8 @@ TEST(UCDramReplyServicePollingTest, AllowsShutdownWithAbandonedLease)
 
 TEST(UCDramReplyServicePollingTest, EventPublisherExceptionIsFatal)
 {
+    const auto deathTestStyle = GTEST_FLAG_GET(death_test_style);
+    GTEST_FLAG_SET(death_test_style, "threadsafe");
     EXPECT_DEATH(
         {
             std::promise<void> publishAttempted;
@@ -246,6 +248,7 @@ TEST(UCDramReplyServicePollingTest, EventPublisherExceptionIsFatal)
             }
         },
         "");
+    GTEST_FLAG_SET(death_test_style, deathTestStyle);
 }
 
 }  // namespace

--- a/ucm/store/test/case/dram/dram_reply_service_test.cc
+++ b/ucm/store/test/case/dram/dram_reply_service_test.cc
@@ -156,6 +156,11 @@ TEST_F(UCDramReplyServiceTest, SupportsConcurrentLeases)
     owners.reserve(kOwnerCount);
     for (std::size_t owner = 0; owner < kOwnerCount; ++owner) {
         owners.emplace_back([&, owner] {
+            Trans::Device device;
+            if (device.Setup(0).Failure()) {
+                failed.store(true, std::memory_order_relaxed);
+                return;
+            }
             for (std::size_t iteration = 0; iteration < kIterations; ++iteration) {
                 const auto token = Token(owner + 1, owner * kIterations + iteration + 1);
                 auto slot = service->Acquire(token, OpType::LOOKUP, 1);


### PR DESCRIPTION
## Purpose
Enable Dramstore to register kvcache buffer in worker and improve ascend compatibility for build & test.
## Modifications 
- Pass vllm `KVConnectorRole`  into store config
- Register kvcache during Dramstore `Setup`
- Add Dram pipelinestrore registration
- fix drampool rpath
- fix concurrent bugs for ascend memory usage
## Test
passed.
