### PR TITLE
[Fix][vLLM] Use runtime device ID for UCM stores in data-parallel deployments

### DIFF
--- a/ucm/integration/vllm/device.py
+++ b/ucm/integration/vllm/device.py
@@ -704,3 +704,14 @@ def create_device() -> Optional[Device]:
         return NpuDevice()
 
     return None
+
+
+def get_current_device_id() -> int:
+    """Return the current process-visible accelerator device ordinal."""
+    if current_platform.is_cuda_alike():
+        return int(torch.cuda.current_device())
+
+    if current_platform.device_type == "npu":
+        return int(torch.npu.current_device())
+
+    raise RuntimeError("Unsupported device platform for UCM connector.")

--- a/ucm/integration/vllm/hla_connector.py
+++ b/ucm/integration/vllm/hla_connector.py
@@ -920,9 +920,7 @@ class UCMHybridLinearAttentionConnector(UCMDirectConnector, SupportsHMA):
 
         enable_affinity = _use_ucm_connector_cpu_affinity()
         worker_cores, store_cores = (
-            self.device.split_cores(self.device_id)
-            if enable_affinity
-            else (None, None)
+            self.device.split_cores(self.device_id) if enable_affinity else (None, None)
         )
 
         self.store = self._create_store(
@@ -1624,9 +1622,7 @@ class UCMHybridLinearAttentionLayerWiseConnector(UCMHybridLinearAttentionConnect
 
         enable_affinity = _use_ucm_connector_cpu_affinity()
         worker_cores, store_cores = (
-            self.device.split_cores(self.device_id)
-            if enable_affinity
-            else (None, None)
+            self.device.split_cores(self.device_id) if enable_affinity else (None, None)
         )
 
         self.store = self._create_store(

--- a/ucm/integration/vllm/hla_connector.py
+++ b/ucm/integration/vllm/hla_connector.py
@@ -855,7 +855,7 @@ class UCMHybridLinearAttentionConnector(UCMDirectConnector, SupportsHMA):
             config["storage_backends"] = backends
         config["unique_id"] = f"{self.unique_id}{unique_id_suffix}"
         if self._role == KVConnectorRole.WORKER:
-            config["device_id"] = self.local_rank
+            config["device_id"] = self.device_id
             tensor_size_list = _normalize_tensor_size_list(
                 tensor_size_list_override
                 if tensor_size_list_override is not None
@@ -920,7 +920,7 @@ class UCMHybridLinearAttentionConnector(UCMDirectConnector, SupportsHMA):
 
         enable_affinity = _use_ucm_connector_cpu_affinity()
         worker_cores, store_cores = (
-            self.device.split_cores(self.local_rank)
+            self.device.split_cores(self.device_id)
             if enable_affinity
             else (None, None)
         )
@@ -1624,7 +1624,7 @@ class UCMHybridLinearAttentionLayerWiseConnector(UCMHybridLinearAttentionConnect
 
         enable_affinity = _use_ucm_connector_cpu_affinity()
         worker_cores, store_cores = (
-            self.device.split_cores(self.local_rank)
+            self.device.split_cores(self.device_id)
             if enable_affinity
             else (None, None)
         )

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -711,7 +711,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         if self._role == KVConnectorRole.WORKER:
             if tensor_size_list is None:
                 raise RuntimeError(f"Worker FAWA {label} store needs tensor sizes.")
-            config["device_id"] = self.local_rank
+            config["device_id"] = self.device_id
             config["tensor_size_list"] = tensor_size_list
             # io_direct requires shard and block sizes to be 4KB aligned.
             aligned_size = 4096
@@ -753,7 +753,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
 
         enable_affinity = _use_ucm_connector_cpu_affinity()
         worker_cores, store_cores = (
-            self.device.split_cores(self.local_rank)
+            self.device.split_cores(self.device_id)
             if enable_affinity
             else (None, None)
         )

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -753,9 +753,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
 
         enable_affinity = _use_ucm_connector_cpu_affinity()
         worker_cores, store_cores = (
-            self.device.split_cores(self.device_id)
-            if enable_affinity
-            else (None, None)
+            self.device.split_cores(self.device_id) if enable_affinity else (None, None)
         )
 
         for group_id, group_spec in enumerate(self._kv_cache_config.kv_cache_groups):

--- a/ucm/integration/vllm/patch/apply_patch.py
+++ b/ucm/integration/vllm/patch/apply_patch.py
@@ -147,9 +147,6 @@ def apply_all_patches() -> None:
         from ucm.integration.vllm.patch.logger_patch import patch_logger
 
         if not ENABLE_UCM_PATCH:
-            logger.warning(
-                "UCM patching is disabled. Set ENABLE_UCM_PATCH=1 to enable it."
-            )
             return
 
         version = get_vllm_version()

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -36,7 +36,7 @@ from vllm.platforms import current_platform
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import KVConnectorOutput
 
-from ucm.integration.vllm.device import create_device
+from ucm.integration.vllm.device import create_device, get_current_device_id
 from ucm.integration.vllm.metrics import (
     UCM_HAS_PROM_METRICS,
     UCMConnectorStats,
@@ -1127,6 +1127,15 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self.local_rank = (
             -1 if role == KVConnectorRole.SCHEDULER else get_world_group().local_rank
         )
+        self.device_id = (
+            -1 if role == KVConnectorRole.SCHEDULER else get_current_device_id()
+        )
+        if role != KVConnectorRole.SCHEDULER:
+            logger.info(
+                "UCM worker device mapping: local_rank=%s, device_id=%s",
+                self.local_rank,
+                self.device_id,
+            )
         self.tp_rank = self._vllm_config.parallel_config.rank
         self.block_size = self._vllm_config.cache_config.block_size
         self.is_mla = self._vllm_config.model_config.is_deepseek_mla
@@ -1156,8 +1165,8 @@ class UCMDirectConnector(KVConnectorBase_V1):
         else:
             raise RuntimeError("Unsupported device platform for UCMDirectConnector.")
 
-        if self.local_rank >= 0:
-            self.device = torch_dev.device(f"{dev_name}:{self.local_rank}")
+        if self.device_id >= 0:
+            self.device = torch_dev.device(f"{dev_name}:{self.device_id}")
 
         self.store: UcmKVStoreBaseV1
         self.rope_store: Optional[UcmKVStoreBaseV1] = None
@@ -1327,7 +1336,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
             config["storage_backends"] = backends
         config["unique_id"] = f"{self.unique_id}"
         if self._role == KVConnectorRole.WORKER:
-            config["device_id"] = self.local_rank
+            config["device_id"] = self.device_id
             tensor_size_list = kv_cache_layout.tensor_size_list * self.blocks_per_chunk
             logical_shard_size = kv_cache_layout.shard_size * self.blocks_per_chunk
             logical_block_size = kv_cache_layout.block_size * self.blocks_per_chunk
@@ -1444,7 +1453,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
         enable_affinity = _use_ucm_connector_cpu_affinity()
         worker_cores, store_cores = (
-            self.device.split_cores(self.local_rank)
+            self.device.split_cores(self.device_id)
             if enable_affinity
             else (None, None)
         )
@@ -1570,7 +1579,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
             f"request_id: {request.request_id}, "
             f"total_blocks_num: {len(ucm_block_ids)}, "
             f"hit hbm: {hbm_hit_block_num * self.cp_world_size}, "
-            f"hit external: {external_hit_blocks * self.cp_world_size}"
+            f"hit external: {external_hit_blocks * self.cp_world_size}, "
             f"total tokens: {len(request.all_token_ids)}"
         )
 

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -1453,9 +1453,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
 
         enable_affinity = _use_ucm_connector_cpu_affinity()
         worker_cores, store_cores = (
-            self.device.split_cores(self.device_id)
-            if enable_affinity
-            else (None, None)
+            self.device.split_cores(self.device_id) if enable_affinity else (None, None)
         )
 
         self.store = self._create_store(


### PR DESCRIPTION
## Purpose
Fix incorrect device selection in single-node data-parallel deployments.

Recent vLLM versions may map a worker's logical local rank to a different
runtime device through assigned_physical_gpu_ids. As a result,
get_world_group().local_rank may no longer match the device ordinal expected
by torch or aclrtSetDevice().

For example, in a DP2TP4 deployment, a DP1 worker may have local_rank=0 while
actually running on device 4. Passing local_rank directly to the UCM store can
therefore bind the store to the wrong device.

This change separates the distributed local rank from the runtime device ID
and remains compatible with both assigned-device mapping and the previous
ASCEND_RT_VISIBLE_DEVICES isolation mechanism.
## Modifications 
- Add get_current_device_id() in device.py:
  - Use torch.cuda.current_device() for CUDA-like platforms.
  - Use torch.npu.current_device() for Ascend NPU.

- Keep local_rank as the vLLM/distributed logical rank.

- Introduce device_id as the current process-visible runtime device ordinal.

- Pass device_id instead of local_rank to UCM store configurations.

- Use device_id for device creation and CPU-affinity selection.

- Apply the same device-ID handling to:
  - UCMDirectConnector
  - UCMHybridLinearAttentionConnector
  - UCMHybridLinearAttentionLayerWiseConnector
  - UCMFAWAConnector

- Add a worker initialization log showing the local-rank-to-device-ID mapping.

- Update the connector test stub for the new device helper.
## Test
