### PR TITLE
[Fix] fix Asu configs and implementation

### DIFF
--- a/docs/source/developer-guide/kv-test.md
+++ b/docs/source/developer-guide/kv-test.md
@@ -125,7 +125,7 @@ Options can use either `--option value` or `--option=value`.
 | `--help`, `-h` | Prints general or command-specific help. |
 | `--version` | Prints tool version. Does not accept positional arguments. |
 | `--check` | Enables consistency checking where supported. |
-| `--timeout <ms>` | Overrides `default_wait_timeout_ms` for this run. |
+| `--timeout <ms>` | Overrides `wait_timeout_ms` for this run. |
 | `--output <path>` | Overrides `output.path`. |
 | `--progress` | For `bench`, prints one progress line per measured second. |
 
@@ -175,7 +175,7 @@ Example:
 
 ```ini
 client_id=kv-test-client-0
-default_wait_timeout_ms=5000
+wait_timeout_ms=5000
 # Optional when libasu_client.so/libasu_transport.so are not discoverable.
 # asu.client_library_path=/path/to/libasu_client.so
 # asu.transport_library_path=/path/to/libasu_transport.so
@@ -222,7 +222,7 @@ These fields are parsed by the ASU client config parser:
 | `client_id` | Client identifier. |
 | `view_service_addrs` | View service addresses. |
 | `view.config_path` | File used by the default `ConfigFileViewServer`. |
-| `default_wait_timeout_ms` | Default wait timeout in milliseconds. |
+| `wait_timeout_ms` | Client wait and transport task timeout in milliseconds. |
 | `transport.asu_ids` | ASU ids. |
 | `transport.provider_type` | Transport provider used by `AsuTransportImpl`. Supported values are `AICPU`, `FAKE`, and `AIV`. The selected provider must also be enabled in CMake. The aliases `transport.provider_backend`, `transport.trans_provider_type`, and `transport.trans_provider_backend` are also accepted. |
 | `transport.device_id` | Local logical device id used to initialize the transport provider. |
@@ -264,7 +264,6 @@ These fields are parsed by `kv-test` itself:
 | `bench.batch_size` | Entries per batch operation. |
 | `output.path` | Base output directory. Empty value uses `.`. |
 | `output.realtime_file_max_bytes` | Maximum realtime CSV size before rolling. Default is 100 MiB. |
-| `connection.timeout_ms` | Also overrides ASU client default wait timeout. |
 
 Batch and sub-batch limits are left to Client and Transport. New kv-test configs
 should not include older `limits.batch_store_max`, `limits.batch_retrieve_max`,

--- a/examples/ucm_config_asu.yaml
+++ b/examples/ucm_config_asu.yaml
@@ -37,10 +37,9 @@ ucm_connectors:
       # asu_fake_backend_path: "./asu-fake-backend-store"
       # asu_fake_backend_latency_ms: 1
 
-      # ASU wait, operation timeout, and connection recovery.
-      asu_default_wait_timeout_ms: 5000
+      # ASU wait/task timeout and connection recovery.
+      asu_wait_timeout_ms: 5000
       asu_query_timeout_ms: 500
-      asu_timeout_ms: 5000
       asu_max_error_count: 2
       asu_client_max_inflight_tasks: 1024
       asu_transport_max_inflight_tasks: 1024

--- a/examples/ucm_config_asu.yaml
+++ b/examples/ucm_config_asu.yaml
@@ -44,6 +44,7 @@ ucm_connectors:
       asu_max_error_count: 2
       asu_client_max_inflight_tasks: 1024
       asu_transport_max_inflight_tasks: 1024
+      asu_sc: true
 
 enable_event_sync: true
 use_layerwise: false

--- a/examples/ucm_config_delegator.yaml
+++ b/examples/ucm_config_delegator.yaml
@@ -40,9 +40,8 @@ ucm_connectors:
       asu_fake_backend_path: "/mnt/test"
       asu_fake_backend_latency_ms: 1
 
-      # ASU wait, operation timeout, and connection recovery.
-      asu_default_wait_timeout_ms: 5000
-      asu_timeout_ms: 5000
+      # ASU wait/task timeout and connection recovery.
+      asu_wait_timeout_ms: 5000
       asu_max_error_count: 2
       asu_client_max_inflight_tasks: 1024
       asu_transport_max_inflight_tasks: 1024

--- a/examples/ucm_config_delegator.yaml
+++ b/examples/ucm_config_delegator.yaml
@@ -46,6 +46,7 @@ ucm_connectors:
       asu_max_error_count: 2
       asu_client_max_inflight_tasks: 1024
       asu_transport_max_inflight_tasks: 1024
+      asu_sc: true
 
 enable_event_sync: true
 use_layerwise: true

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -178,6 +178,7 @@ UC::ASU::TransportConfig BuildTransportConfig(const Config& config, std::size_t 
     const auto kvNsIndex = config.uniqueId.find("_fawa_wa") == std::string::npos ? 0 : 1;
     transportConfig.attrs["kv_ns_id"] = std::to_string(config.kvNsIds[kvNsIndex]);
     if (!config.localIp.empty()) { transportConfig.attrs["localIp"] = config.localIp; }
+    transportConfig.attrs["sc"] = config.sc ? "true" : "false";
 
     if (!config.asuIps.empty()) {
         UC::ASU::AsuEndpoint endpoint;
@@ -193,7 +194,6 @@ UC::ASU::TransportConfig BuildTransportConfig(const Config& config, std::size_t 
         transportConfig.attrs.try_emplace("dtype", "0");
         transportConfig.attrs.try_emplace("dspec", "0");
         transportConfig.attrs.try_emplace("lr", "false");
-        transportConfig.attrs["sc"] = "true";
         transportConfig.attrs["fake_backend.path"] = config.fakeBackendPath;
         transportConfig.attrs["fake_backend.latency_ms"] =
             std::to_string(config.fakeBackendLatencyMs);
@@ -410,6 +410,7 @@ private:
         inConfig.Get("asu_fake_backend_path", config.fakeBackendPath);
         inConfig.GetNumber("asu_fake_backend_latency_ms", config.fakeBackendLatencyMs);
         inConfig.GetNumber("asu_shared_provider", config.sharedProviderMode);
+        inConfig.Get("asu_sc", config.sc);
         ReadClientAttr(inConfig, "asu_router_type", "hash_table.type", config);
         ReadClientAttr(inConfig, "asu_ring_hash_virtual_node_count", "ring_hash.virtual_node_count",
                        config);

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -168,7 +168,7 @@ UC::ASU::TransportConfig BuildTransportConfig(const Config& config, std::size_t 
     transportConfig.asuId = static_cast<UC::ASU::AsuId>(config.asuIds[index]);
     transportConfig.asuName = config.asuNamePrefix + "-" + std::to_string(config.asuIds[index]);
     transportConfig.deviceId = config.deviceId;
-    transportConfig.timeoutMs = config.timeoutMs;
+    transportConfig.timeoutMs = config.waitTimeoutMs;
     transportConfig.maxErrorCount = static_cast<std::uint32_t>(config.maxErrorCount);
     transportConfig.maxInflightTasks = static_cast<std::uint32_t>(config.transportMaxInflightTasks);
     transportConfig.maxInflightBytes = config.maxInflightBytes;
@@ -215,8 +215,8 @@ UC::ASU::AsuClientConfig BuildAsuClientConfig(const Config& config)
     asuConfig.clientId = config.clientId;
     asuConfig.viewServiceAddrs = config.viewServiceAddrs;
     asuConfig.maxInflightTasks = static_cast<std::uint32_t>(config.clientMaxInflightTasks);
-    asuConfig.defaultWaitTimeoutMs = config.defaultWaitTimeoutMs;
-    asuConfig.timeoutMs = config.timeoutMs;
+    asuConfig.defaultWaitTimeoutMs = config.waitTimeoutMs;
+    asuConfig.timeoutMs = config.waitTimeoutMs;
     asuConfig.sharedProviderMode =
         static_cast<UC::ASU::SharedProviderMode>(config.sharedProviderMode);
     asuConfig.attrs = config.clientAttrs;
@@ -363,8 +363,8 @@ public:
     Status Wait(Detail::TaskHandle taskId) override
     {
         UC::ASU::TaskResult result;
-        auto status = client_->Wait(static_cast<UC::ASU::TaskId>(taskId),
-                                    config_.defaultWaitTimeoutMs, result);
+        auto status =
+            client_->Wait(static_cast<UC::ASU::TaskId>(taskId), config_.waitTimeoutMs, result);
         if (!status.ok()) {
             LogAsuStatus("wait task", status);
             return ConvertStatus(status);
@@ -392,8 +392,7 @@ private:
         inConfig.Get("asu_local_ip", config.localIp);
         inConfig.Get("asu_name_prefix", config.asuNamePrefix);
         inConfig.GetNumbers("kv_ns_ids", config.kvNsIds);
-        inConfig.GetNumber("asu_default_wait_timeout_ms", config.defaultWaitTimeoutMs);
-        inConfig.GetNumber("asu_timeout_ms", config.timeoutMs);
+        inConfig.GetNumber("asu_wait_timeout_ms", config.waitTimeoutMs);
         inConfig.GetNumber("asu_query_timeout_ms", config.queryTimeoutMs);
         inConfig.GetNumber("asu_max_error_count", config.maxErrorCount);
         inConfig.GetNumber("asu_client_max_inflight_tasks", config.clientMaxInflightTasks);
@@ -529,8 +528,8 @@ private:
             config.maxErrorCount > std::numeric_limits<std::uint32_t>::max()) {
             return Status::InvalidParam("asu_max_error_count must be in uint32 range and nonzero");
         }
-        if (config.timeoutMs == 0) {
-            return Status::InvalidParam("asu_timeout_ms must be greater than zero");
+        if (config.waitTimeoutMs == 0) {
+            return Status::InvalidParam("asu_wait_timeout_ms must be greater than zero");
         }
         if (config.queryTimeoutMs == 0) {
             return Status::InvalidParam("asu_query_timeout_ms must be greater than zero");

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -38,6 +38,7 @@ struct Config {
     std::string fakeBackendPath;
     std::uint64_t fakeBackendLatencyMs{1};
     ssize_t sharedProviderMode{0};
+    bool sc{false};
     std::unordered_map<std::string, std::string> clientAttrs;
 };
 

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -37,7 +37,7 @@ struct Config {
     std::string fakeBackendPath;
     std::uint64_t fakeBackendLatencyMs{1};
     ssize_t sharedProviderMode{0};
-    bool sc{false};
+    bool sc{true};
     std::unordered_map<std::string, std::string> clientAttrs;
 };
 

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -22,8 +22,7 @@ struct Config {
     std::string localIp;
     std::string asuNamePrefix{"asu"};
     std::vector<std::uint32_t> kvNsIds;
-    std::uint64_t defaultWaitTimeoutMs{100};
-    std::uint64_t timeoutMs{100};
+    std::uint64_t waitTimeoutMs{100};
     std::uint64_t queryTimeoutMs{500};
     std::uint64_t maxErrorCount{2};
     std::uint64_t clientMaxInflightTasks{1024};

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -237,9 +237,8 @@ UC::Detail::Dictionary MakeBaseConfig()
     config.SetNumber("tensor_size", std::size_t{64});
     config.SetNumber("shard_size", std::size_t{64});
     config.SetNumber("block_size", std::size_t{64});
-    config.SetNumber("asu_default_wait_timeout_ms", std::uint64_t{1000});
+    config.SetNumber("asu_wait_timeout_ms", std::uint64_t{1000});
     config.SetNumber("asu_query_timeout_ms", std::uint64_t{500});
-    config.SetNumber("asu_timeout_ms", std::uint64_t{1000});
     config.SetNumber("asu_client_max_inflight_tasks", std::uint64_t{16});
     config.SetNumber("asu_transport_max_inflight_tasks", std::uint64_t{16});
     config.Set("kv_ns_ids", std::vector<ssize_t>{100});
@@ -342,28 +341,32 @@ TEST(UCAsuStoreTest, ParsesKvNamespaces)
     }
 }
 
-TEST(UCAsuStoreTest, ParsesOperationTimeout)
+TEST(UCAsuStoreTest, PropagatesWaitTimeout)
 {
     UC::AsuStore::AsuStore store;
     auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_ids", std::vector<ssize_t>{1001});
-    config.SetNumber("asu_timeout_ms", std::uint64_t{321});
+    config.SetNumber("asu_wait_timeout_ms", std::uint64_t{321});
 
     ASSERT_TRUE(store.Setup(config).Success());
     ASSERT_FALSE(state->initConfigs.empty());
-    EXPECT_EQ(state->initConfigs.back().timeoutMs, 321);
+    EXPECT_EQ(state->initConfigs.back().waitTimeoutMs, 321);
+
+    auto asuClientConfig = UC::AsuStore::BuildAsuClientConfig(state->initConfigs.back());
+    EXPECT_EQ(asuClientConfig.defaultWaitTimeoutMs, 321);
+    EXPECT_EQ(asuClientConfig.timeoutMs, 321);
 
     auto transportConfig = UC::AsuStore::BuildTransportConfig(state->initConfigs.back(), 0);
     EXPECT_EQ(transportConfig.timeoutMs, 321);
 }
 
-TEST(UCAsuStoreTest, RejectsZeroOperationTimeout)
+TEST(UCAsuStoreTest, RejectsZeroWaitTimeout)
 {
     UC::AsuStore::AsuStore store;
     auto config = MakeBaseConfig();
     config.Set("asu_ids", std::vector<ssize_t>{1001});
-    config.SetNumber("asu_timeout_ms", std::uint64_t{0});
+    config.SetNumber("asu_wait_timeout_ms", std::uint64_t{0});
 
     EXPECT_TRUE(store.Setup(config).Failure());
 }
@@ -855,7 +858,7 @@ TEST(UCAsuStoreTest, ClientModeConfigPathSmoke)
         ASSERT_TRUE(configFile.is_open());
         configFile << "clientId=asu-store-test\n";
         configFile << "transport.asuIds=1001,1002\n";
-        configFile << "defaultWaitTimeoutMs=1000\n";
+        configFile << "wait_timeout_ms=1000\n";
     }
 
     UC::AsuStore::AsuStore store;

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -425,6 +425,22 @@ TEST(UCAsuStoreTest, PropagatesSeparateMaxInflightTasks)
     EXPECT_EQ(asuConfig.transportConfigs.front().maxInflightTasks, std::uint32_t{23});
 }
 
+TEST(UCAsuStoreTest, FakeProviderPreservesConfiguredSc)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeClient(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("asu_trans_provider_backend", std::string{"fake"});
+    config.Set("asu_sc", false);
+
+    ASSERT_TRUE(store.Setup(config).Success());
+    ASSERT_FALSE(state->initConfigs.empty());
+
+    const auto transportConfig = UC::AsuStore::BuildTransportConfig(state->initConfigs.back(), 0);
+    EXPECT_EQ(transportConfig.attrs.at("sc"), "false");
+}
+
 TEST(UCAsuStoreTest, RejectsMissingKvNamespaces)
 {
     UC::AsuStore::AsuStore store;

--- a/ucm/transport/kv/asu/client/src/client_config_parser.cpp
+++ b/ucm/transport/kv/asu/client/src/client_config_parser.cpp
@@ -77,10 +77,10 @@ Status LoadAsuClientConfig(const std::string& configPath, AsuClientConfig& confi
         } else if (key == "view.config_path" || key == "viewConfigPath" ||
                    key == "view_config_path") {
             config.attrs["view.config_path"] = value;
-        } else if (key == "defaultWaitTimeoutMs" || key == "default_wait_timeout_ms") {
-            config.defaultWaitTimeoutMs = ParseConfigUint64(value);
-        } else if (key == "timeoutMs" || key == "timeout_ms") {
-            config.timeoutMs = ParseConfigUint64(value);
+        } else if (key == "waitTimeoutMs" || key == "wait_timeout_ms") {
+            const auto waitTimeoutMs = ParseConfigUint64(value);
+            config.defaultWaitTimeoutMs = waitTimeoutMs;
+            config.timeoutMs = waitTimeoutMs;
         } else if (key == "asuSharedProvider" || key == "asu_shared_provider") {
             config.sharedProviderMode = static_cast<SharedProviderMode>(ParseConfigUint64(value));
         } else if (key == "router.type" || key == "routerType" || key == "hashTable.type" ||

--- a/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
@@ -896,6 +896,7 @@ TEST(AsuClientImplTest, Config_SeparatesClientAndTransportMaxInflightTasks)
         std::ofstream configFile{kConfigPath};
         ASSERT_TRUE(configFile.is_open());
         configFile << "client.maxInflightTasks=3\n";
+        configFile << "wait_timeout_ms=321\n";
         configFile << "transport.asuIds=10\n";
         configFile << "transport.maxInflightTasks=7\n";
     }
@@ -906,7 +907,10 @@ TEST(AsuClientImplTest, Config_SeparatesClientAndTransportMaxInflightTasks)
 
     ASSERT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(config.maxInflightTasks, std::uint32_t{3});
+    EXPECT_EQ(config.defaultWaitTimeoutMs, std::uint64_t{321});
+    EXPECT_EQ(config.timeoutMs, std::uint64_t{321});
     ASSERT_EQ(config.transportConfigs.size(), std::size_t{1});
+    EXPECT_EQ(config.transportConfigs.front().timeoutMs, std::uint64_t{321});
     EXPECT_EQ(config.transportConfigs.front().maxInflightTasks, std::uint32_t{7});
 }
 

--- a/ucm/transport/kv/asu/test/transport/fake_trans_provider_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/fake_trans_provider_test.cpp
@@ -1,9 +1,43 @@
 #include "fake_trans_provider.h"
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
 #include <gtest/gtest.h>
+#include <iomanip>
+#include <sstream>
 #include <unordered_set>
+#include "kv_protocol.h"
 
 namespace UC::ASU {
 namespace {
+
+std::string FakeBackendKeyFileName(const CacheKey& key)
+{
+    std::uint64_t hash = 1469598103934665603ULL;
+    for (auto byte : key) {
+        hash ^= std::to_integer<unsigned char>(byte);
+        hash *= 1099511628211ULL;
+    }
+
+    std::ostringstream stream;
+    stream << std::hex << std::setw(16) << std::setfill('0') << hash << ".bin";
+    return stream.str();
+}
+
+std::vector<std::uint32_t> BuildExistRequest(const std::vector<CacheKey>& keys, bool sc)
+{
+    std::vector<std::uint32_t> request(kSqeDwordCount + keys.size() * kKeyEntryDwordCount, 0);
+    request[0] = static_cast<std::uint32_t>(KvOpcode::Exist);
+    request[1] = 1;
+    request[10] = static_cast<std::uint32_t>(keys.size());
+    if (sc) { request[10] |= 1U << 16; }
+    for (std::size_t index = 0; index < keys.size(); ++index) {
+        std::memcpy(request.data() + kSqeDwordCount + index * kKeyEntryDwordCount,
+                    keys[index].data(), kCacheKeySizeBytes);
+    }
+    return request;
+}
 
 TEST(FakeTransProviderTest, RegisterMemoryReturnsUniqueHandlesAcrossCalls)
 {
@@ -40,6 +74,49 @@ TEST(FakeTransProviderTest, BindMemoryCreatesProviderLocalHandles)
     EXPECT_NE(handles[0], kInvalidMRHandle);
     EXPECT_NE(handles[1], kInvalidMRHandle);
     EXPECT_NE(handles[0], handles[1]);
+}
+
+TEST(FakeTransProviderTest, ExistHonorsSeekControl)
+{
+    const auto storePath =
+        std::filesystem::temp_directory_path() /
+        ("asu-fake-sc-test-" +
+         std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+    const auto asuPath = storePath / "asu-1";
+    std::filesystem::create_directories(asuPath);
+
+    CacheKey first{};
+    first[0] = std::byte{1};
+    CacheKey missing{};
+    missing[0] = std::byte{2};
+    CacheKey third{};
+    third[0] = std::byte{3};
+    std::ofstream{asuPath / FakeBackendKeyFileName(first)}.put('\0');
+    std::ofstream{asuPath / FakeBackendKeyFileName(third)}.put('\0');
+
+    FakeTransProviderConfig config;
+    config.storePath = storePath.string();
+    config.latencyMs = 0;
+    const std::vector<CacheKey> keys{first, missing, third};
+
+    auto request = BuildExistRequest(keys, false);
+    std::vector<std::uint32_t> completion;
+    auto status = CompleteFakeBackendRequestForTest(
+        config, request.data(), request.size() * sizeof(std::uint32_t), completion);
+    EXPECT_TRUE(status.ok()) << status.message;
+    ASSERT_GT(completion.size(), kCqeDwordCount);
+    EXPECT_EQ(completion[0] & 0xFFFF, 1U);
+
+    request = BuildExistRequest(keys, true);
+    status = CompleteFakeBackendRequestForTest(config, request.data(),
+                                               request.size() * sizeof(std::uint32_t), completion);
+    EXPECT_TRUE(status.ok()) << status.message;
+    ASSERT_GT(completion.size(), kCqeDwordCount);
+    EXPECT_EQ(completion[0] & 0xFFFF, 2U);
+    EXPECT_EQ(completion[kCqeDwordCount] & 0x7, 0x5U);
+
+    std::error_code errorCode;
+    std::filesystem::remove_all(storePath, errorCode);
 }
 
 }  // namespace

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
@@ -50,6 +50,7 @@ constexpr std::uint8_t kDeleteEntryOk = 0x0;
 constexpr std::uint8_t kDeleteEntryFailed = 0x1;
 constexpr std::uint8_t kExistEntryNotExist = 0x0;
 constexpr std::uint8_t kExistEntryExist = 0x1;
+constexpr std::uint32_t kExistSeekControlMask = 1U << 16;
 
 std::uint64_t ReadU64(std::uint32_t low, std::uint32_t high)
 {
@@ -342,12 +343,15 @@ Status CompleteExist(const FakeTransProviderConfig& config, AsuId asuId,
     const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
     std::vector<std::uint8_t> results(batchNumber, kExistEntryNotExist);
     std::uint16_t existingKeyNumber = 0;
+    const bool useSeekControl = (request[10] & kExistSeekControlMask) != 0;
 
     const auto keys = ReadKeyEntries(request, batchNumber);
     for (std::size_t index = 0; index < keys.size(); ++index) {
         if (ExistsKey(config, asuId, keys[index])) {
             results[index] = kExistEntryExist;
             ++existingKeyNumber;
+        } else if (!useSeekControl) {
+            break;
         }
     }
 
@@ -407,6 +411,15 @@ Status CompleteFakeBackendRequest(const FakeTransProviderConfig& config, const v
 }
 
 }  // namespace
+
+#ifdef ASU_BUILD_TESTS
+Status CompleteFakeBackendRequestForTest(const FakeTransProviderConfig& config,
+                                         const void* sendBuffer, std::uint64_t len,
+                                         std::vector<std::uint32_t>& completion)
+{
+    return CompleteFakeBackendRequest(config, sendBuffer, len, completion);
+}
+#endif
 
 FakeTransProviderConfig MakeFakeTransProviderConfig(const TransportConfig& config)
 {

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
@@ -82,4 +82,10 @@ private:
 
 FakeTransProviderConfig MakeFakeTransProviderConfig(const TransportConfig& config);
 
+#ifdef ASU_BUILD_TESTS
+Status CompleteFakeBackendRequestForTest(const FakeTransProviderConfig& config,
+                                         const void* sendBuffer, std::uint64_t len,
+                                         std::vector<std::uint32_t>& completion);
+#endif
+
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/kv_protocol.h
+++ b/ucm/transport/kv/asu/trans/src/kv_protocol.h
@@ -152,7 +152,7 @@ public:
     std::uint64_t response_buffer_addr{0};
     std::uint32_t response_mr_key{0};
     bool rflag{false};
-    bool sc{false};
+    bool sc{true};
     std::uint16_t batch_number{0};
     std::vector<CacheKey> keys;
 };

--- a/ucm/transport/kv/asu/trans/src/sqe_request.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.cpp
@@ -311,7 +311,7 @@ KvExistRequest BuildExistRequest(const BatchView<CacheKey>& keys,
     request.response_buffer_addr = flagBuffer.device_addr;
     request.response_mr_key = flagBuffer.tokenId;
     request.rflag = true;
-    request.sc = GetTransportConfigAttr<bool>(attrs, "sc");
+    request.sc = GetTransportConfigAttr<bool>(attrs, "sc", true);
     request.keys = CopyKeys(keys);
     request.batch_number = static_cast<std::uint16_t>(request.keys.size());
     return request;

--- a/ucm/transport/kv/kv-test/asu_kv_test.conf
+++ b/ucm/transport/kv/kv-test/asu_kv_test.conf
@@ -3,7 +3,7 @@
 
 # ASU client identity and wait behavior.
 client_id=kv-test-client-0
-default_wait_timeout_ms=5000
+wait_timeout_ms=5000
 # Optional runtime library overrides. If omitted, kv-test tries
 # KV_TEST_ASU_CLIENT_LIB/KV_TEST_ASU_TRANSPORT_LIB, dynamic linker search paths,
 # and the default build-tree sibling directory.

--- a/ucm/transport/kv/kv-test/asu_kv_test.conf
+++ b/ucm/transport/kv/kv-test/asu_kv_test.conf
@@ -33,6 +33,7 @@ transport.asu_ids=1
 transport.provider_type=AIV
 transport.device_id=0
 transport.localIp=127.0.0.1
+transport.sc=true
 
 # ASU endpoint list. Endpoint format:
 # protocol=<UB|ROCE|TCP>,local.comm_id=<ip-or-comm-id>,port=<port>

--- a/ucm/transport/kv/kv-test/scripts/fake_backend_common.sh
+++ b/ucm/transport/kv/kv-test/scripts/fake_backend_common.sh
@@ -79,7 +79,7 @@ write_fake_backend_config() {
 
     {
         echo "client_id=kv-test-fake-backend-script"
-        echo "default_wait_timeout_ms=5000"
+        echo "wait_timeout_ms=5000"
         echo
         echo "fake_backend.path=${store_path}"
         echo "fake_backend.latency_ms=1"

--- a/ucm/transport/kv/kv-test/src/kv_test_app.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_app.cpp
@@ -406,7 +406,7 @@ int KvTestApp::Run(int argc, char** argv)
                   << " command=config check config=" << options.configPath << '\n';
         std::cout << "config: key_prefix=" << config.keyPrefix << " count=" << config.count
                   << " value_size=" << config.valueSize
-                  << " timeout_ms=" << config.asuClientConfig.defaultWaitTimeoutMs
+                  << " wait_timeout_ms=" << config.asuClientConfig.defaultWaitTimeoutMs
                   << " output=" << config.output.path << '\n';
         return kExitSuccess;
     }

--- a/ucm/transport/kv/kv-test/src/kv_test_config_helpers.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_config_helpers.cpp
@@ -30,7 +30,6 @@ void PatchFakeBackendTransportConfig(UC::ASU::TransportConfig& config,
     config.attrs.try_emplace("dtype", "0");
     config.attrs.try_emplace("dspec", "0");
     config.attrs.try_emplace("lr", "false");
-    config.attrs["sc"] = "true";
     config.attrs["fake_backend.path"] = fakeConfig.storePath;
     config.attrs["fake_backend.latency_ms"] = std::to_string(fakeConfig.latencyMs);
     config.attrs["fake_backend.device_id"] = std::to_string(fakeBackendDeviceId);

--- a/ucm/transport/kv/kv-test/src/kv_test_config_loader.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_config_loader.cpp
@@ -220,11 +220,6 @@ Status KvTestConfigLoader::Load(const std::string& configPath, KvTestConfig& con
         GetStringAny(values, {"output.path"}, config.output.path);
         GetUint64Any(values, {"output.realtime_file_max_bytes"},
                      config.output.realtimeFileMaxBytes);
-
-        std::uint64_t timeoutMs{0};
-        if (GetUint64Any(values, {"connection.timeout_ms"}, timeoutMs)) {
-            config.asuClientConfig.defaultWaitTimeoutMs = timeoutMs;
-        }
     } catch (const std::exception& e) {
         return Status::Error(kExitInvalidArgument,
                              "invalid kv-test config value in " + configPath + ": " + e.what());
@@ -243,7 +238,13 @@ Status KvTestConfigLoader::MergeCommandOptions(const CommandOptions& options,
         if (options.command == CommandType::BENCH) { config.bench.ioSize = options.valueSize; }
     }
     if (options.batchSize != 0) { config.bench.batchSize = options.batchSize; }
-    if (options.timeoutMs != 0) { config.asuClientConfig.defaultWaitTimeoutMs = options.timeoutMs; }
+    if (options.timeoutMs != 0) {
+        config.asuClientConfig.defaultWaitTimeoutMs = options.timeoutMs;
+        config.asuClientConfig.timeoutMs = options.timeoutMs;
+        for (auto& transportConfig : config.asuClientConfig.transportConfigs) {
+            transportConfig.timeoutMs = options.timeoutMs;
+        }
+    }
     if (!options.outputPath.empty()) { config.output.path = options.outputPath; }
 
     if (options.benchOp != BenchOpType::UNKNOWN) { config.bench.op = options.benchOp; }

--- a/ucm/transport/kv/kv-test/test/kv_test_config_helpers_test.cpp
+++ b/ucm/transport/kv/kv-test/test/kv_test_config_helpers_test.cpp
@@ -26,6 +26,7 @@ TEST(KvTestConfigHelpersTest, FakeDefaultsDoNotModifyAivTransport)
     UC::ASU::TransportConfig fakeConfig;
     fakeConfig.asuId = 1;
     fakeConfig.providerType = UC::ASU::TransProviderType::FAKE;
+    fakeConfig.attrs["sc"] = "false";
     config.asuClientConfig.transportConfigs.emplace_back(std::move(fakeConfig));
 
     UC::ASU::TransportConfig aivConfig;
@@ -39,6 +40,7 @@ TEST(KvTestConfigHelpersTest, FakeDefaultsDoNotModifyAivTransport)
 
     const auto& patchedFake = config.asuClientConfig.transportConfigs[0];
     EXPECT_EQ(patchedFake.providerType, UC::ASU::TransProviderType::FAKE);
+    EXPECT_EQ(patchedFake.attrs.at("sc"), "false");
     EXPECT_EQ(patchedFake.attrs.at("fake_backend.path"), "./kv-test-fake-backend-store");
 
     const auto& unchangedAiv = config.asuClientConfig.transportConfigs[1];


### PR DESCRIPTION
## Purpose
This PR fixes a bug of fake backend and unifies some configurations.

## Modifications 
1. Seek-control(sc) now uses the value of config, rather than always uses default value.
2. Unify config `timeout_ms` and `default_wait_timeout_ms` with `wait_timeout_ms`.
3. Fake provider processes Exist with respect to `sc` config.

## Test
1. Unit tests are all passed.
4. Offline inference is passed.
5. kv-test exist now behaves correctly with different `sc` configs.
