### PR TITLE
[Opt] Optimize ASU transport performance with configurable backoff and reduced polling latency

### DIFF
--- a/examples/ucm_config_asu.yaml
+++ b/examples/ucm_config_asu.yaml
@@ -44,6 +44,7 @@ ucm_connectors:
       asu_client_max_inflight_tasks: 1024
       asu_transport_max_inflight_tasks: 1024
       asu_sc: true
+      asu_completion_poll_spin_limit: 16
 
 enable_event_sync: true
 use_layerwise: false

--- a/ucm/shared/infra/template/spsc_ring_queue.h
+++ b/ucm/shared/infra/template/spsc_ring_queue.h
@@ -109,7 +109,7 @@ public:
                 std::this_thread::yield();
             } else {
                 if (stop.load(std::memory_order_acquire)) { break; }
-                std::this_thread::sleep_for(std::chrono::microseconds(100));
+                std::this_thread::sleep_for(std::chrono::microseconds(50));
                 spinCount = 0;
             }
         }

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -171,6 +171,8 @@ UC::ASU::TransportConfig BuildTransportConfig(const Config& config, std::size_t 
     transportConfig.timeoutMs = config.waitTimeoutMs;
     transportConfig.maxErrorCount = static_cast<std::uint32_t>(config.maxErrorCount);
     transportConfig.maxInflightTasks = static_cast<std::uint32_t>(config.transportMaxInflightTasks);
+    transportConfig.completionPollSpinLimit =
+        static_cast<std::size_t>(config.completionPollSpinLimit);
     transportConfig.maxInflightBytes = config.maxInflightBytes;
     transportConfig.providerType = config.transProviderType;
 
@@ -397,6 +399,7 @@ private:
         inConfig.GetNumber("asu_max_error_count", config.maxErrorCount);
         inConfig.GetNumber("asu_client_max_inflight_tasks", config.clientMaxInflightTasks);
         inConfig.GetNumber("asu_transport_max_inflight_tasks", config.transportMaxInflightTasks);
+        inConfig.GetNumber("asu_completion_poll_spin_limit", config.completionPollSpinLimit);
         inConfig.GetNumber("asu_max_inflight_bytes", config.maxInflightBytes);
         inConfig.GetNumber("shard_size", config.shardSize);
         inConfig.GetNumber("block_size", config.blockSize);
@@ -539,6 +542,11 @@ private:
         }
         if (config.transportMaxInflightTasks > std::numeric_limits<std::uint32_t>::max()) {
             return Status::InvalidParam("asu_transport_max_inflight_tasks exceeds uint32 range");
+        }
+        if (config.completionPollSpinLimit == 0 ||
+            config.completionPollSpinLimit > std::numeric_limits<std::size_t>::max()) {
+            return Status::InvalidParam(
+                "asu_completion_poll_spin_limit must be a positive size_t value");
         }
         // Scheduler config check done
         if (config.role == "scheduler") { return Status::OK(); }

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -27,6 +27,7 @@ struct Config {
     std::uint64_t maxErrorCount{2};
     std::uint64_t clientMaxInflightTasks{1024};
     std::uint64_t transportMaxInflightTasks{1024};
+    std::uint64_t completionPollSpinLimit{16};
     std::uint64_t maxInflightBytes{1ULL << 30};
     std::vector<std::size_t> tensorSizes;
     std::size_t shardSize{0};

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -418,6 +418,7 @@ TEST(UCAsuStoreTest, PropagatesSeparateMaxInflightTasks)
     config.Set("asu_ids", std::vector<ssize_t>{1001});
     config.SetNumber("asu_client_max_inflight_tasks", std::uint64_t{17});
     config.SetNumber("asu_transport_max_inflight_tasks", std::uint64_t{23});
+    config.SetNumber("asu_completion_poll_spin_limit", std::uint64_t{19});
 
     ASSERT_TRUE(store.Setup(config).Success());
     ASSERT_FALSE(state->initConfigs.empty());
@@ -426,6 +427,7 @@ TEST(UCAsuStoreTest, PropagatesSeparateMaxInflightTasks)
     EXPECT_EQ(asuConfig.maxInflightTasks, std::uint32_t{17});
     ASSERT_EQ(asuConfig.transportConfigs.size(), std::size_t{1});
     EXPECT_EQ(asuConfig.transportConfigs.front().maxInflightTasks, std::uint32_t{23});
+    EXPECT_EQ(asuConfig.transportConfigs.front().completionPollSpinLimit, std::size_t{19});
 }
 
 TEST(UCAsuStoreTest, FakeProviderPreservesConfiguredSc)

--- a/ucm/transport/kv/asu/client/src/client_config_parser.cpp
+++ b/ucm/transport/kv/asu/client/src/client_config_parser.cpp
@@ -138,6 +138,9 @@ Status LoadAsuClientConfig(const std::string& configPath, AsuClientConfig& confi
     for (auto& transportConfig : config.transportConfigs) {
         transportConfig.timeoutMs = config.timeoutMs;
         for (const auto& field : transportFields) {
+            if (ApplyTransportCompletionConfigField(transportConfig, field.first, field.second)) {
+                continue;
+            }
             if (ApplyTransportBufferConfigField(transportConfig, field.first, field.second)) {
                 continue;
             }

--- a/ucm/transport/kv/asu/common/config_parser_common.cpp
+++ b/ucm/transport/kv/asu/common/config_parser_common.cpp
@@ -164,6 +164,14 @@ bool ApplyTransportIoNumConfigField(TransportConfig& config, const std::string& 
     return true;
 }
 
+bool ApplyTransportCompletionConfigField(TransportConfig& config, const std::string& key,
+                                         const std::string& value)
+{
+    if (key != "completionPollSpinLimit" && key != "completion_poll_spin_limit") { return false; }
+    config.completionPollSpinLimit = static_cast<std::size_t>(ParseConfigUint64(value));
+    return true;
+}
+
 bool ApplyTransportProviderConfigField(TransportConfig& config, const std::string& key,
                                        const std::string& value)
 {

--- a/ucm/transport/kv/asu/common/config_parser_common.h
+++ b/ucm/transport/kv/asu/common/config_parser_common.h
@@ -40,6 +40,8 @@ bool ApplyTransportBufferConfigField(TransportConfig& config, const std::string&
                                      const std::string& value);
 bool ApplyTransportIoNumConfigField(TransportConfig& config, const std::string& key,
                                     const std::string& value);
+bool ApplyTransportCompletionConfigField(TransportConfig& config, const std::string& key,
+                                         const std::string& value);
 bool ApplyTransportProviderConfigField(TransportConfig& config, const std::string& key,
                                        const std::string& value);
 bool ApplyTransportDeviceConfigField(TransportConfig& config, const std::string& key,

--- a/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
@@ -858,6 +858,7 @@ TEST(AsuClientImplTest, Lifecycle_PublicInitLoadsClientConfigFile)
         configFile << "transport.device_id=6\n";
         configFile << "transport.provider_type=fake\n";
         configFile << "transport.max_error_count=5\n";
+        configFile << "transport.completion_poll_spin_limit=23\n";
         configFile << "asuInfo.20=protocol=roce,placement=device,port=6000,"
                    << "local.comm_id=192.168.1.20\n";
     }
@@ -886,6 +887,7 @@ TEST(AsuClientImplTest, Lifecycle_PublicInitLoadsClientConfigFile)
         EXPECT_EQ(state->initConfigs[asuId].asuDeleteIoNum, std::size_t{13});
         EXPECT_EQ(state->initConfigs[asuId].asuQueryIoNum, std::size_t{14});
         EXPECT_EQ(state->initConfigs[asuId].maxErrorCount, std::uint32_t{5});
+        EXPECT_EQ(state->initConfigs[asuId].completionPollSpinLimit, std::size_t{23});
     }
 }
 

--- a/ucm/transport/kv/asu/test/transport/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/sqe_request_test.cpp
@@ -64,6 +64,25 @@ TEST(TransportConfigParserTest, LoadsMaxErrorCount)
     EXPECT_EQ(config.maxErrorCount, std::uint32_t{7});
 }
 
+TEST(TransportConfigParserTest, LoadsCompletionPollSpinLimit)
+{
+    constexpr const char* kConfigPath = "asu_transport_completion_poll_spin_limit_test.conf";
+    {
+        std::ofstream configFile{kConfigPath};
+        ASSERT_TRUE(configFile.is_open());
+        configFile << "completion_poll_spin_limit=23\n"
+                   << "kernel_count=1\n"
+                   << "quiet_count=1\n";
+    }
+
+    TransportConfig config;
+    const auto status = LoadTransportConfig(kConfigPath, config);
+    std::remove(kConfigPath);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(config.completionPollSpinLimit, std::size_t{23});
+}
+
 CacheKey MakeCacheKey(std::string_view text)
 {
     CacheKey key{};

--- a/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
@@ -63,6 +63,7 @@ struct TransportConfig {
 
     std::uint64_t timeoutMs{100};
     std::uint32_t maxErrorCount{2};
+    std::size_t completionPollSpinLimit{16};
 
     bool enableDeviceDirect{true};
     bool enableHostFallback{false};

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -278,11 +278,31 @@ void AsuTransportImpl::WorkerLoop()
 
 void AsuTransportImpl::CompletionLoop()
 {
+    constexpr std::size_t kPollSpinLimit = 16;
+    std::size_t noCompletionRounds = 0;
+
     while (!stopCompletionWorker_.load(std::memory_order_acquire)) {
-        for (const auto& ctx : taskManager_.GetAll()) {
-            if (taskExecutor_->Poll(ctx)) { taskManager_.NotifyCompletion(ctx); }
+        const auto tasks = taskManager_.GetAll();
+        if (tasks.empty()) {
+            noCompletionRounds = 0;
+            std::this_thread::sleep_for(std::chrono::microseconds(50));
+            continue;
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+
+        bool completedTask = false;
+        for (const auto& ctx : tasks) {
+            if (taskExecutor_->Poll(ctx)) {
+                taskManager_.NotifyCompletion(ctx);
+                completedTask = true;
+            }
+        }
+
+        if (completedTask) {
+            noCompletionRounds = 0;
+        } else if (++noCompletionRounds >= kPollSpinLimit) {
+            noCompletionRounds = 0;
+            std::this_thread::yield();
+        }
     }
 }
 

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -73,6 +73,10 @@ Status AsuTransportImpl::Init(const TransportConfig& config,
     if (config_.maxErrorCount == 0) {
         return Status::Error(StatusCode::INVALID_ARGUMENT, "maxErrorCount must be greater than 0");
     }
+    if (config_.completionPollSpinLimit == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "completionPollSpinLimit must be greater than 0");
+    }
 
     if (!transProvider_) {
         UC_ERROR("AsuTransportImpl::Init: TransProvider is null");
@@ -278,7 +282,6 @@ void AsuTransportImpl::WorkerLoop()
 
 void AsuTransportImpl::CompletionLoop()
 {
-    constexpr std::size_t kPollSpinLimit = 16;
     std::size_t noCompletionRounds = 0;
 
     while (!stopCompletionWorker_.load(std::memory_order_acquire)) {
@@ -299,7 +302,7 @@ void AsuTransportImpl::CompletionLoop()
 
         if (completedTask) {
             noCompletionRounds = 0;
-        } else if (++noCompletionRounds >= kPollSpinLimit) {
+        } else if (++noCompletionRounds >= config_.completionPollSpinLimit) {
             noCompletionRounds = 0;
             std::this_thread::yield();
         }

--- a/ucm/transport/kv/asu/trans/src/transport_config_parser.cpp
+++ b/ucm/transport/kv/asu/trans/src/transport_config_parser.cpp
@@ -157,6 +157,8 @@ Status LoadTransportConfig(const std::string& configPath, TransportConfig& confi
             config.maxInflightTasks = static_cast<std::uint32_t>(ParseConfigUint64(value));
         } else if (key == "maxInflightBytes" || key == "max_inflight_bytes") {
             config.maxInflightBytes = ParseConfigUint64(value);
+        } else if (ApplyTransportCompletionConfigField(config, key, value)) {
+            continue;
         } else if (ApplyTransportBufferConfigField(config, key, value)) {
             continue;
         } else if (ApplyTransportIoNumConfigField(config, key, value)) {

--- a/ucm/transport/kv/kv-test/asu_kv_test.conf
+++ b/ucm/transport/kv/kv-test/asu_kv_test.conf
@@ -32,6 +32,8 @@ transport.asu_ids=1
 # Use FAKE for the local mock Send/CQE backend.
 transport.provider_type=AIV
 transport.device_id=0
+# Consecutive completion polling rounds without a completed task before yielding.
+transport.completion_poll_spin_limit=16
 transport.localIp=127.0.0.1
 transport.sc=true
 


### PR DESCRIPTION
## Purpose

Improve ASU completion polling responsiveness while reducing unnecessary idle wait time, and make completion polling backoff tunable for different latency and CPU-utilization requirements.

## Modifications

- Reduce ASU completion worker idle wait time from 1ms to 50μs when no transport task exists.
- Keep polling active transport tasks and yield after a configurable number of consecutive polling rounds without task completion.
- Add `completionPollSpinLimit` to `TransportConfig`, with a default value of 16.
- Support configuring the polling spin limit through:
  - `transport.completion_poll_spin_limit` in kv-test configuration.
  - `asu_completion_poll_spin_limit` in ASU YAML connector configuration.
- Propagate and validate the new setting through transport config parsing, ASU client config parsing, and AsuStore configuration.
- Reduce SPSC consumer idle sleep time from 100μs to 50μs.
- Add unit-test coverage for transport config parsing, client config propagation, and AsuStore config propagation.

## Test

- ASU unit tests are built successfully.
- Added configuration parsing and propagation unit-test coverage.
- A UCM offline inference is passed. (MLA/GQA+TP2)

