### PR TITLE
[Bugfix] Reinitialize logger backends after fork

### DIFF
--- a/test/test_logger.py
+++ b/test/test_logger.py
@@ -1,6 +1,7 @@
 import ast
 import importlib.util
 import logging
+import os
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -82,3 +83,24 @@ def test_default_rate_limit_window_is_ten_seconds():
 
     assert "kDefaultRateLimitWindowMs = 10000" in header
     assert "default: 10000 = 10s" in logger_doc
+
+
+def test_after_fork_child_clears_once_caches(monkeypatch):
+    callbacks = {}
+    monkeypatch.setattr(
+        os,
+        "register_at_fork",
+        lambda **kwargs: callbacks.update(kwargs),
+        raising=False,
+    )
+    module, _ = _load_logger_module(monkeypatch)
+    logger = module.init_logger("fork-cache-test")
+
+    module._print_info_once(logger, "cached before fork")
+    assert module._print_info_once.cache_info().currsize == 1
+
+    callbacks["after_in_child"]()
+
+    assert module._print_debug_once.cache_info().currsize == 0
+    assert module._print_info_once.cache_info().currsize == 0
+    assert module._print_warning_once.cache_info().currsize == 0

--- a/ucm/logger.py
+++ b/ucm/logger.py
@@ -152,6 +152,16 @@ def _print_warning_once(logger: logging.Logger, msg: str, *args) -> None:
     logger.warning(msg, *args, stacklevel=3)
 
 
+def _after_fork_child() -> None:
+    _print_debug_once.cache_clear()
+    _print_info_once.cache_clear()
+    _print_warning_once.cache_clear()
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_after_fork_child)
+
+
 _RATE_LIMIT_EXTRA = {"ucm_rate_limit": True}
 
 

--- a/ucm/shared/infra/logger/cc/spdlog_logger.cc
+++ b/ucm/shared/infra/logger/cc/spdlog_logger.cc
@@ -24,7 +24,6 @@
 
 #include <algorithm>
 #include <cerrno>
-#include <charconv>
 #include <chrono>
 #include <memory>
 #include <mutex>
@@ -38,7 +37,6 @@
 #include <spdlog/spdlog.h>
 #include <string>
 #include <string_view>
-#include <sys/syscall.h>
 #include <unistd.h>
 #include <unordered_set>
 #include <vector>
@@ -119,23 +117,6 @@ private:
     bool color_enabled_;
 };
 
-class ForkSafeThreadIdFlag final : public spdlog::custom_flag_formatter {
-public:
-    void format(const spdlog::details::log_msg&, const std::tm&,
-                spdlog::memory_buf_t& dest) override
-    {
-        char buffer[32];
-        const auto [end, error] =
-            std::to_chars(buffer, buffer + sizeof(buffer), syscall(SYS_gettid));
-        if (error == std::errc{}) { dest.append(buffer, end); }
-    }
-
-    std::unique_ptr<spdlog::custom_flag_formatter> clone() const override
-    {
-        return std::make_unique<ForkSafeThreadIdFlag>();
-    }
-};
-
 bool EnvFlag(const char* name, bool default_value)
 {
     auto value = spdlog::details::os::getenv(name);
@@ -144,14 +125,9 @@ bool EnvFlag(const char* name, bool default_value)
     return value != "false" && value != "0" && value != "off";
 }
 
-void ConfigureLogger(const std::shared_ptr<spdlog::logger>& logger, bool forked_child)
+void ConfigureLogger(const std::shared_ptr<spdlog::logger>& logger)
 {
-    auto formatter = std::make_unique<spdlog::pattern_formatter>();
-    // Calendar conversion may retain a libc lock held by a vanished parent thread.
-    formatter->add_flag<ForkSafeThreadIdFlag>('t').set_pattern(
-        forked_child ? "[%E.%f][%n][%^%L%$] %v [%P,%t][%s:%#,%!]"
-                     : "[%Y-%m-%d %H:%M:%S.%f][%n][%^%L%$] %v [%P,%t][%s:%#,%!]");
-    logger->set_formatter(std::move(formatter));
+    logger->set_pattern("[%Y-%m-%d %H:%M:%S.%f][%n][%^%L%$] %v [%P,%t][%s:%#,%!]");
     auto level_str = spdlog::details::os::getenv("UCM_LOG_LEVEL");
     if (level_str.empty()) { level_str = spdlog::details::os::getenv("UC_LOGGER_LEVEL"); }
     if (!level_str.empty()) {
@@ -205,6 +181,21 @@ struct Logger::Backend {
         return SourceLocation{file_ptr, func_ptr, line};
     }
 
+    void Log(Level lv, const SourceLocation& loc, std::string&& msg)
+    {
+        auto level = SpdLevels[fmt::underlying(lv)];
+        logger_->log(spdlog::source_loc{loc.file, loc.line, loc.func}, level, std::move(msg));
+    }
+
+    void LogFileOnly(Level lv, const SourceLocation& loc, std::string&& msg)
+    {
+        auto capture_logger = MakeCaptureLogger();
+        if (!capture_logger) { return; }
+        auto level = SpdLevels[fmt::underlying(lv)];
+        capture_logger->log(spdlog::source_loc{loc.file, loc.line, loc.func}, level,
+                            std::move(msg));
+    }
+
     std::shared_ptr<spdlog::logger> MakeCaptureLogger()
     {
         if (!file_enabled_) { return nullptr; }
@@ -221,7 +212,7 @@ struct Logger::Backend {
             } else {
                 file_logger_ = std::make_shared<spdlog::logger>("VLLM", file_sink);
             }
-            ConfigureLogger(file_logger_, forked_child_);
+            ConfigureLogger(file_logger_);
             file_logger_->set_level(logger_->level());
             if (!thread_pool_) { file_logger_->flush_on(spdlog::level::trace); }
             if (!forked_child_) {
@@ -337,7 +328,7 @@ private:
             logger_ =
                 std::make_shared<spdlog::logger>("UC", std::make_shared<ForkSafeStdoutSink>());
         }
-        ConfigureLogger(logger_, forked_child_);
+        ConfigureLogger(logger_);
         if (!thread_pool_) { logger_->flush_on(spdlog::level::trace); }
     }
 
@@ -388,25 +379,40 @@ Logger::Backend* Logger::GetBackend()
     }
 }
 
-SourceLocation Logger::InternSourceLocation(std::string&& file, std::string&& func, int line)
+void Logger::Log(Level lv, const SourceLocation& loc, std::string&& msg)
 {
-    return GetBackend()->InternSourceLocation(std::move(file), std::move(func), line);
+    GetBackend()->Log(lv, loc, std::move(msg));
 }
 
-void Logger::Log(Level&& lv, SourceLocation&& loc, std::string&& msg)
+void Logger::LogDynamic(Level lv, std::string&& file, std::string&& func, int line,
+                        std::string&& msg)
 {
     Backend* backend = GetBackend();
-    auto level = SpdLevels[fmt::underlying(lv)];
-    backend->logger_->log(spdlog::source_loc{loc.file, loc.line, loc.func}, level, std::move(msg));
+    SourceLocation loc = backend->InternSourceLocation(std::move(file), std::move(func), line);
+    backend->Log(lv, loc, std::move(msg));
 }
 
-void Logger::LogFileOnly(Level&& lv, SourceLocation&& loc, std::string&& msg)
+void Logger::LogRateLimit(Level lv, const SourceLocation& loc, std::string&& msg)
 {
     Backend* backend = GetBackend();
-    auto logger = backend->MakeCaptureLogger();
-    if (!logger) { return; }
-    auto level = SpdLevels[fmt::underlying(lv)];
-    logger->log(spdlog::source_loc{loc.file, loc.line, loc.func}, level, std::move(msg));
+    if (backend->FilterCallSite(loc.file, loc.line)) { backend->Log(lv, loc, std::move(msg)); }
+}
+
+void Logger::LogRateLimitDynamic(Level lv, std::string&& file, std::string&& func, int line,
+                                 std::string&& msg)
+{
+    Backend* backend = GetBackend();
+    if (!backend->FilterCallSite(file.c_str(), line)) { return; }
+    SourceLocation loc = backend->InternSourceLocation(std::move(file), std::move(func), line);
+    backend->Log(lv, loc, std::move(msg));
+}
+
+void Logger::LogFileOnlyDynamic(Level lv, std::string&& file, std::string&& func, int line,
+                                std::string&& msg)
+{
+    Backend* backend = GetBackend();
+    SourceLocation loc = backend->InternSourceLocation(std::move(file), std::move(func), line);
+    backend->LogFileOnly(lv, loc, std::move(msg));
 }
 
 void Logger::Setup(const std::string& path, int max_files, int max_size)
@@ -427,11 +433,6 @@ bool Logger::IsEnabledFor(Level lv)
 {
     auto level = SpdLevels[fmt::underlying(lv)];
     return GetBackend()->logger_->should_log(level);
-}
-
-bool Logger::FilterCallSite(const char* file, int line)
-{
-    return GetBackend()->FilterCallSite(file, line);
 }
 
 void Logger::LoadRateLimitConfig()

--- a/ucm/shared/infra/logger/cc/spdlog_logger.cc
+++ b/ucm/shared/infra/logger/cc/spdlog_logger.cc
@@ -23,226 +23,415 @@
  * */
 
 #include <algorithm>
+#include <cerrno>
+#include <charconv>
 #include <chrono>
+#include <memory>
 #include <mutex>
 #include <spdlog/async.h>
 #include <spdlog/cfg/helpers.h>
 #include <spdlog/details/os.h>
-#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/details/periodic_worker.h>
+#include <spdlog/details/thread_pool.h>
+#include <spdlog/pattern_formatter.h>
+#include <spdlog/sinks/base_sink.h>
 #include <spdlog/spdlog.h>
+#include <string>
+#include <string_view>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <unordered_set>
+#include <vector>
 #include "compress_rotate_file_sink.h"
 #include "logger.h"
+
 namespace UC::Logger {
+namespace {
 constexpr uint32_t kRateLimitCountBits = 2;
 constexpr uint64_t kRateLimitCountMask = (1u << kRateLimitCountBits) - 1u;
 constexpr size_t kHashMixMagic = 0x9e3779b97f4a7c15ULL;
 constexpr size_t kHashShiftLeft = 12;
 constexpr size_t kHashShiftRight = 4;
-static spdlog::level::level_enum SpdLevels[] = {spdlog::level::debug, spdlog::level::info,
-                                                spdlog::level::warn, spdlog::level::err,
-                                                spdlog::level::critical};
+constexpr size_t kAsyncQueueSize = 8192;
+constexpr size_t kAsyncWorkerCount = 1;
 
-/* The async logger formats messages on a background thread after the caller
- * has returned, but spdlog::source_loc only stores raw char pointers; intern
- * file/function names so those pointers stay valid for the process lifetime. */
-const char* InternSourceString(std::string&& s)
-{
-    static std::mutex mtx;
-    static std::unordered_set<std::string> pool;
-    std::lock_guard<std::mutex> lg(mtx);
-    return pool.insert(std::move(s)).first->c_str();
-}
+spdlog::level::level_enum SpdLevels[] = {spdlog::level::debug, spdlog::level::info,
+                                         spdlog::level::warn, spdlog::level::err,
+                                         spdlog::level::critical};
 
-void Logger::Log(Level&& lv, SourceLocation&& loc, std::string&& msg)
-{
-    auto level = SpdLevels[fmt::underlying(lv)];
-    auto logger = this->Make();
-    logger->log(spdlog::source_loc{loc.file, loc.line, loc.func}, level, std::move(msg));
-}
+class ForkSafeStdoutSink final : public spdlog::sinks::base_sink<std::mutex> {
+public:
+    ForkSafeStdoutSink() : color_enabled_(isatty(STDOUT_FILENO) != 0) {}
 
-void Logger::LogFileOnly(Level&& lv, SourceLocation&& loc, std::string&& msg)
-{
-    auto level = SpdLevels[fmt::underlying(lv)];
-    auto logger = this->MakeCapture();
-    if (!logger) { return; }
-    logger->log(spdlog::source_loc{loc.file, loc.line, loc.func}, level, std::move(msg));
-}
+protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override
+    {
+        spdlog::memory_buf_t formatted;
+        formatter_->format(msg, formatted);
 
-inline uint64_t GetCurrentTimeMs()
-{
-    auto now = std::chrono::steady_clock::now();
-    auto ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
-    return ms.time_since_epoch().count();
-}
-
-bool Logger::FilterCallSite(const char* file, int line)
-{
-    if (!rate_limit_enabled_) { return true; }
-
-    uint64_t now = GetCurrentTimeMs();
-    const std::string_view fv(file);
-    std::hash<std::string_view> h;
-    size_t x = h(fv);
-    x ^= static_cast<size_t>(line) + kHashMixMagic + (x << kHashShiftLeft) + (x >> kHashShiftRight);
-    const uint64_t full_hash = static_cast<uint64_t>(x);
-    const size_t slot_idx = static_cast<size_t>(full_hash % HASH_SLOT_NUM);
-    // key_tag=0 is reserved for empty; so shift by +1.
-    const uint64_t key_tag = full_hash + 1u;
-
-    auto& slot = hash_slots_[slot_idx];
-    std::atomic<uint64_t>* rate_state = nullptr;
-
-    // 1) Lookup: find an existing chain entry with the same key.
-    for (size_t i = 0; i < HASH_CHAIN_LEN; ++i) {
-        uint64_t stored = slot.chain_entries[i].key_hash.load(std::memory_order_relaxed);
-        if (stored == key_tag) {
-            rate_state = &slot.chain_entries[i].rate_limit_state;
-            break;
+        if (!color_enabled_ || msg.color_range_end <= msg.color_range_start ||
+            msg.color_range_end > formatted.size()) {
+            WriteAll(formatted.data(), formatted.size());
+            return;
         }
+
+        const std::string_view color = ColorFor(msg.level);
+        WriteAll(formatted.data(), msg.color_range_start);
+        WriteAll(color.data(), color.size());
+        WriteAll(formatted.data() + msg.color_range_start,
+                 msg.color_range_end - msg.color_range_start);
+        constexpr std::string_view reset = "\033[m";
+        WriteAll(reset.data(), reset.size());
+        WriteAll(formatted.data() + msg.color_range_end, formatted.size() - msg.color_range_end);
     }
 
-    // 2) Insert: if key not found, try to claim an empty entry.
-    if (rate_state == nullptr) {
-        for (size_t i = 0; i < HASH_CHAIN_LEN; ++i) {
-            uint64_t expected_empty = 0;
-            if (slot.chain_entries[i].key_hash.compare_exchange_strong(expected_empty, key_tag,
-                                                                       std::memory_order_relaxed,
-                                                                       std::memory_order_relaxed)) {
-                rate_state = &slot.chain_entries[i].rate_limit_state;
+    void flush_() override {}
+
+private:
+    static void WriteAll(const char* data, size_t size)
+    {
+        size_t offset = 0;
+        while (offset < size) {
+            const ssize_t written = write(STDOUT_FILENO, data + offset, size - offset);
+            if (written > 0) {
+                offset += static_cast<size_t>(written);
+            } else if (written < 0 && errno == EINTR) {
+                continue;
+            } else {
                 break;
             }
         }
     }
 
-    // 3) Evict: if the chain is full, overwrite a deterministic entry.
-    if (rate_state == nullptr) {
-        const size_t evict_idx = static_cast<size_t>(key_tag % HASH_CHAIN_LEN);
-        rate_state = &slot.chain_entries[evict_idx].rate_limit_state;
-        slot.chain_entries[evict_idx].key_hash.store(key_tag, std::memory_order_relaxed);
-        slot.chain_entries[evict_idx].rate_limit_state.store(0, std::memory_order_relaxed);
-    }
-
-    uint64_t s = rate_state->load(std::memory_order_relaxed);
-    const uint64_t window_start = s >> kRateLimitCountBits;
-    const uint32_t count = static_cast<uint32_t>(s & kRateLimitCountMask);
-
-    if (s == 0 || now - window_start > rate_limit_window_ms_) {
-        const uint64_t desired = (now << kRateLimitCountBits) | 1u;
-        if (rate_state->compare_exchange_strong(s, desired, std::memory_order_relaxed,
-                                                std::memory_order_relaxed)) {
-            return true;
+    static std::string_view ColorFor(spdlog::level::level_enum level)
+    {
+        switch (level) {
+            case spdlog::level::trace: return "\033[37m";
+            case spdlog::level::debug: return "\033[36m";
+            case spdlog::level::info: return "\033[32m";
+            case spdlog::level::warn: return "\033[33m\033[1m";
+            case spdlog::level::err: return "\033[31m\033[1m";
+            case spdlog::level::critical: return "\033[1m\033[41m";
+            default: return "";
         }
-        return false;
     }
 
-    if (count >= rate_limit_max_logs_) { return false; }
-    const uint64_t desired =
-        (window_start << kRateLimitCountBits) | static_cast<uint64_t>(count + 1u);
-    if (rate_state->compare_exchange_strong(s, desired, std::memory_order_relaxed,
-                                            std::memory_order_relaxed)) {
-        return true;
-    }
-    return false;
-}
+    bool color_enabled_;
+};
 
-static bool EnvFlag(const char* name, bool defaultValue)
+class ForkSafeThreadIdFlag final : public spdlog::custom_flag_formatter {
+public:
+    void format(const spdlog::details::log_msg&, const std::tm&,
+                spdlog::memory_buf_t& dest) override
+    {
+        char buffer[32];
+        const auto [end, error] =
+            std::to_chars(buffer, buffer + sizeof(buffer), syscall(SYS_gettid));
+        if (error == std::errc{}) { dest.append(buffer, end); }
+    }
+
+    std::unique_ptr<spdlog::custom_flag_formatter> clone() const override
+    {
+        return std::make_unique<ForkSafeThreadIdFlag>();
+    }
+};
+
+bool EnvFlag(const char* name, bool default_value)
 {
     auto value = spdlog::details::os::getenv(name);
-    if (value.empty()) { return defaultValue; }
+    if (value.empty()) { return default_value; }
     std::transform(value.begin(), value.end(), value.begin(), ::tolower);
     return value != "false" && value != "0" && value != "off";
 }
 
-std::shared_ptr<spdlog::logger> Logger::Make()
+void ConfigureLogger(const std::shared_ptr<spdlog::logger>& logger, bool forked_child)
 {
-    if (this->logger_) { return this->logger_; }
-    std::lock_guard<std::mutex> lg(this->mutex_);
-    if (this->logger_) { return this->logger_; }
-    std::string pid = std::to_string(getpid());
-    std::string log_path = this->path_ + "/ucm-" + pid + ".log";
-    const std::string name = "UC";
-    try {
-        if (!spdlog::thread_pool()) { spdlog::init_thread_pool(8192, 1); }
-        auto tp = spdlog::thread_pool();
+    auto formatter = std::make_unique<spdlog::pattern_formatter>();
+    // Calendar conversion may retain a libc lock held by a vanished parent thread.
+    formatter->add_flag<ForkSafeThreadIdFlag>('t').set_pattern(
+        forked_child ? "[%E.%f][%n][%^%L%$] %v [%P,%t][%s:%#,%!]"
+                     : "[%Y-%m-%d %H:%M:%S.%f][%n][%^%L%$] %v [%P,%t][%s:%#,%!]");
+    logger->set_formatter(std::move(formatter));
+    auto level_str = spdlog::details::os::getenv("UCM_LOG_LEVEL");
+    if (level_str.empty()) { level_str = spdlog::details::os::getenv("UC_LOGGER_LEVEL"); }
+    if (!level_str.empty()) {
+        auto level = spdlog::level::from_str(level_str);
+        if (level != spdlog::level::off || level_str == "off") { logger->set_level(level); }
+    }
+    logger->flush_on(spdlog::level::warn);
+}
 
-        auto console_sink = std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
-        std::vector<spdlog::sink_ptr> sinks;
-        sinks.push_back(console_sink);
+uint64_t GetCurrentTimeMs()
+{
+    auto now = std::chrono::steady_clock::now();
+    auto ms = std::chrono::time_point_cast<std::chrono::milliseconds>(now);
+    return ms.time_since_epoch().count();
+}
+}  // namespace
 
-        this->file_enabled_ = EnvFlag("UCM_LOG_TO_FILE", true);
-        if (this->file_enabled_) {
+struct Logger::Backend {
+    Backend(int32_t process_id, const std::string& path, int max_files, int max_size,
+            bool rate_limit_enabled, uint64_t rate_limit_window_ms, uint32_t rate_limit_max_logs,
+            bool forked_child)
+        : pid(process_id),
+          path_(path),
+          max_files_(max_files),
+          max_size_(max_size),
+          rate_limit_enabled_(rate_limit_enabled),
+          rate_limit_window_ms_(rate_limit_window_ms),
+          rate_limit_max_logs_(rate_limit_max_logs),
+          forked_child_(forked_child)
+    {
+        MakeMainLogger();
+        if (thread_pool_) {
+            flusher_ = std::make_unique<spdlog::details::periodic_worker>([this] { Flush(); },
+                                                                          std::chrono::seconds(1));
+        }
+    }
+
+    void RegisterMainLogger()
+    {
+        try {
+            spdlog::register_logger(logger_);
+        } catch (...) {
+        }
+    }
+
+    SourceLocation InternSourceLocation(std::string&& file, std::string&& func, int line)
+    {
+        std::lock_guard<std::mutex> lock(source_mutex_);
+        const char* file_ptr = source_pool_.insert(std::move(file)).first->c_str();
+        const char* func_ptr = source_pool_.insert(std::move(func)).first->c_str();
+        return SourceLocation{file_ptr, func_ptr, line};
+    }
+
+    std::shared_ptr<spdlog::logger> MakeCaptureLogger()
+    {
+        if (!file_enabled_) { return nullptr; }
+        std::lock_guard<std::mutex> lock(capture_mutex_);
+        if (file_logger_) { return file_logger_; }
+
+        std::string log_path = path_ + "/vllm-" + std::to_string(pid) + ".log";
+        try {
             auto file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
-                log_path, this->max_size_, this->max_files_);
-            sinks.push_back(file_sink);
+                log_path, max_size_, max_files_);
+            if (thread_pool_) {
+                file_logger_ = std::make_shared<spdlog::async_logger>(
+                    "VLLM", file_sink, thread_pool_, spdlog::async_overflow_policy::overrun_oldest);
+            } else {
+                file_logger_ = std::make_shared<spdlog::logger>("VLLM", file_sink);
+            }
+            ConfigureLogger(file_logger_, forked_child_);
+            file_logger_->set_level(logger_->level());
+            if (!thread_pool_) { file_logger_->flush_on(spdlog::level::trace); }
+            if (!forked_child_) {
+                try {
+                    spdlog::register_logger(file_logger_);
+                } catch (...) {
+                }
+            }
+        } catch (...) {
+            file_logger_ = nullptr;
+        }
+        return file_logger_;
+    }
+
+    void Flush()
+    {
+        logger_->flush();
+        std::shared_ptr<spdlog::logger> file_logger;
+        {
+            std::lock_guard<std::mutex> lock(capture_mutex_);
+            file_logger = file_logger_;
+        }
+        if (file_logger) { file_logger->flush(); }
+    }
+
+    bool FilterCallSite(const char* file, int line)
+    {
+        if (!rate_limit_enabled_) { return true; }
+
+        uint64_t now = GetCurrentTimeMs();
+        const std::string_view fv(file);
+        std::hash<std::string_view> h;
+        size_t x = h(fv);
+        x ^= static_cast<size_t>(line) + kHashMixMagic + (x << kHashShiftLeft) +
+             (x >> kHashShiftRight);
+        const uint64_t full_hash = static_cast<uint64_t>(x);
+        const uint64_t key_tag = full_hash + 1u;
+        auto& slot = hash_slots_[static_cast<size_t>(full_hash % HASH_SLOT_NUM)];
+        std::atomic<uint64_t>* rate_state = nullptr;
+
+        for (size_t i = 0; i < HASH_CHAIN_LEN; ++i) {
+            uint64_t stored = slot.chain_entries[i].key_hash.load(std::memory_order_relaxed);
+            if (stored == key_tag) {
+                rate_state = &slot.chain_entries[i].rate_limit_state;
+                break;
+            }
         }
 
-        auto logger = std::make_shared<spdlog::async_logger>(
-            name, sinks.begin(), sinks.end(), tp, spdlog::async_overflow_policy::overrun_oldest);
-        logger->set_pattern("[%Y-%m-%d %H:%M:%S.%f][%n][%^%L%$] %v [%P,%t][%s:%#,%!]");
-
-        auto level_str = spdlog::details::os::getenv("UCM_LOG_LEVEL");
-        if (level_str.empty()) { level_str = spdlog::details::os::getenv("UC_LOGGER_LEVEL"); }
-        if (!level_str.empty()) {
-            auto level = spdlog::level::from_str(level_str);
-            if (level != spdlog::level::off || level_str == "off") { logger->set_level(level); }
+        if (rate_state == nullptr) {
+            for (size_t i = 0; i < HASH_CHAIN_LEN; ++i) {
+                uint64_t expected_empty = 0;
+                if (slot.chain_entries[i].key_hash.compare_exchange_strong(
+                        expected_empty, key_tag, std::memory_order_relaxed,
+                        std::memory_order_relaxed)) {
+                    rate_state = &slot.chain_entries[i].rate_limit_state;
+                    break;
+                }
+            }
         }
-        logger->flush_on(spdlog::level::warn);
-        spdlog::register_logger(logger);
 
-        spdlog::flush_every(std::chrono::seconds(1));
-        this->logger_ = logger;
-        return this->logger_;
-    } catch (...) {
-        return spdlog::default_logger();
+        if (rate_state == nullptr) {
+            const size_t evict_idx = static_cast<size_t>(key_tag % HASH_CHAIN_LEN);
+            rate_state = &slot.chain_entries[evict_idx].rate_limit_state;
+            slot.chain_entries[evict_idx].key_hash.store(key_tag, std::memory_order_relaxed);
+            slot.chain_entries[evict_idx].rate_limit_state.store(0, std::memory_order_relaxed);
+        }
+
+        uint64_t state = rate_state->load(std::memory_order_relaxed);
+        const uint64_t window_start = state >> kRateLimitCountBits;
+        const uint32_t count = static_cast<uint32_t>(state & kRateLimitCountMask);
+
+        if (state == 0 || now - window_start > rate_limit_window_ms_) {
+            const uint64_t desired = (now << kRateLimitCountBits) | 1u;
+            return rate_state->compare_exchange_strong(state, desired, std::memory_order_relaxed,
+                                                       std::memory_order_relaxed);
+        }
+
+        if (count >= rate_limit_max_logs_) { return false; }
+        const uint64_t desired =
+            (window_start << kRateLimitCountBits) | static_cast<uint64_t>(count + 1u);
+        return rate_state->compare_exchange_strong(state, desired, std::memory_order_relaxed,
+                                                   std::memory_order_relaxed);
+    }
+
+    const int32_t pid;
+    std::shared_ptr<spdlog::details::thread_pool> thread_pool_;
+    std::shared_ptr<spdlog::logger> logger_;
+    std::mutex source_mutex_;
+    std::unordered_set<std::string> source_pool_;
+    std::mutex capture_mutex_;
+    std::shared_ptr<spdlog::logger> file_logger_;
+    std::unique_ptr<spdlog::details::periodic_worker> flusher_;
+
+private:
+    void MakeMainLogger()
+    {
+        std::string log_path = path_ + "/ucm-" + std::to_string(pid) + ".log";
+        file_enabled_ = EnvFlag("UCM_LOG_TO_FILE", true);
+        try {
+            std::vector<spdlog::sink_ptr> sinks;
+            sinks.push_back(std::make_shared<ForkSafeStdoutSink>());
+            if (file_enabled_) {
+                sinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
+                    log_path, max_size_, max_files_));
+            }
+            thread_pool_ =
+                std::make_shared<spdlog::details::thread_pool>(kAsyncQueueSize, kAsyncWorkerCount);
+            logger_ = std::make_shared<spdlog::async_logger>(
+                "UC", sinks.begin(), sinks.end(), thread_pool_,
+                spdlog::async_overflow_policy::overrun_oldest);
+        } catch (...) {
+            thread_pool_ = nullptr;
+            logger_ =
+                std::make_shared<spdlog::logger>("UC", std::make_shared<ForkSafeStdoutSink>());
+        }
+        ConfigureLogger(logger_, forked_child_);
+        if (!thread_pool_) { logger_->flush_on(spdlog::level::trace); }
+    }
+
+    std::string path_;
+    int max_files_;
+    int max_size_;
+    bool file_enabled_{true};
+    bool rate_limit_enabled_;
+    uint64_t rate_limit_window_ms_;
+    uint32_t rate_limit_max_logs_;
+    bool forked_child_;
+    std::array<SlotData, HASH_SLOT_NUM> hash_slots_;
+};
+
+Logger::Logger() : creation_pid_(static_cast<int32_t>(getpid()))
+{
+    register_at_exit();
+    LoadRateLimitConfig();
+}
+
+Logger::~Logger()
+{
+    Backend* backend = backend_.load(std::memory_order_acquire);
+    if (backend != nullptr && backend->pid == static_cast<int32_t>(getpid())) { delete backend; }
+}
+
+Logger::Backend* Logger::GetBackend()
+{
+    static_assert(decltype(backend_)::is_always_lock_free);
+    const int32_t pid = static_cast<int32_t>(getpid());
+    for (;;) {
+        Backend* inherited = backend_.load(std::memory_order_acquire);
+        if (inherited != nullptr && inherited->pid == pid) { return inherited; }
+
+        const bool forked_child = creation_pid_ != pid;
+        std::unique_ptr<Backend> fresh =
+            std::make_unique<Backend>(pid, path_, max_files_, max_size_, rate_limit_enabled_,
+                                      rate_limit_window_ms_, rate_limit_max_logs_, forked_child);
+        Backend* expected = inherited;
+        if (backend_.compare_exchange_strong(expected, fresh.get(), std::memory_order_release,
+                                             std::memory_order_acquire)) {
+            Backend* installed = fresh.release();
+            if (inherited == nullptr && !forked_child) { installed->RegisterMainLogger(); }
+            // The inherited Backend is intentionally leaked in the child so its copied mutexes
+            // and missing worker threads are never destroyed or joined.
+            return installed;
+        }
     }
 }
 
-std::shared_ptr<spdlog::logger> Logger::MakeCapture()
+SourceLocation Logger::InternSourceLocation(std::string&& file, std::string&& func, int line)
 {
-    if (this->file_logger_) { return this->file_logger_; }
-    auto main_logger = this->Make();
-    if (!this->file_enabled_) { return nullptr; }
-    std::lock_guard<std::mutex> lg(this->mutex_);
-    if (this->file_logger_) { return this->file_logger_; }
-    std::string pid = std::to_string(getpid());
-    std::string log_path = this->path_ + "/vllm-" + pid + ".log";
-    try {
-        auto file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
-            log_path, this->max_size_, this->max_files_);
-        auto logger =
-            std::make_shared<spdlog::async_logger>("VLLM", file_sink, spdlog::thread_pool(),
-                                                   spdlog::async_overflow_policy::overrun_oldest);
-        logger->set_pattern("[%Y-%m-%d %H:%M:%S.%f][%n][%^%L%$] %v [%P,%t][%s:%#,%!]");
-        if (main_logger) { logger->set_level(main_logger->level()); }
-        logger->flush_on(spdlog::level::warn);
-        spdlog::register_logger(logger);
-        this->file_logger_ = logger;
-        return this->file_logger_;
-    } catch (...) {
-        return nullptr;
-    }
+    return GetBackend()->InternSourceLocation(std::move(file), std::move(func), line);
+}
+
+void Logger::Log(Level&& lv, SourceLocation&& loc, std::string&& msg)
+{
+    Backend* backend = GetBackend();
+    auto level = SpdLevels[fmt::underlying(lv)];
+    backend->logger_->log(spdlog::source_loc{loc.file, loc.line, loc.func}, level, std::move(msg));
+}
+
+void Logger::LogFileOnly(Level&& lv, SourceLocation&& loc, std::string&& msg)
+{
+    Backend* backend = GetBackend();
+    auto logger = backend->MakeCaptureLogger();
+    if (!logger) { return; }
+    auto level = SpdLevels[fmt::underlying(lv)];
+    logger->log(spdlog::source_loc{loc.file, loc.line, loc.func}, level, std::move(msg));
 }
 
 void Logger::Setup(const std::string& path, int max_files, int max_size)
 {
-    this->path_ = path;
-    this->max_files_ = max_files;
-    this->max_size_ = max_size * 1048576;
-    this->logger_ = this->Make();
+    path_ = path;
+    max_files_ = max_files;
+    max_size_ = max_size * 1048576;
+    GetBackend();
 }
 
 void Logger::Flush()
 {
-    std::lock_guard<std::mutex> lg(this->mutex_);
-    if (this->logger_) { this->logger_->flush(); }
-    if (this->file_logger_) { this->file_logger_->flush(); }
+    Backend* backend = backend_.load(std::memory_order_acquire);
+    if (backend != nullptr && backend->pid == static_cast<int32_t>(getpid())) { backend->Flush(); }
 }
 
 bool Logger::IsEnabledFor(Level lv)
 {
     auto level = SpdLevels[fmt::underlying(lv)];
-    if (this->logger_) { return this->logger_->should_log(level); }
-    return false;
+    return GetBackend()->logger_->should_log(level);
+}
+
+bool Logger::FilterCallSite(const char* file, int line)
+{
+    return GetBackend()->FilterCallSite(file, line);
 }
 
 void Logger::LoadRateLimitConfig()

--- a/ucm/shared/infra/logger/cc/spdlog_logger.h
+++ b/ucm/shared/infra/logger/cc/spdlog_logger.h
@@ -67,11 +67,15 @@ public:
     }
     static void _signal_handler(int signum) { Logger::GetInstance().Flush(); }
 
-    void Log(Level&& lv, SourceLocation&& loc, std::string&& msg);
-    void LogFileOnly(Level&& lv, SourceLocation&& loc, std::string&& msg);
+    void Log(Level lv, const SourceLocation& loc, std::string&& msg);
+    void LogDynamic(Level lv, std::string&& file, std::string&& func, int line, std::string&& msg);
+    void LogRateLimit(Level lv, const SourceLocation& loc, std::string&& msg);
+    void LogRateLimitDynamic(Level lv, std::string&& file, std::string&& func, int line,
+                             std::string&& msg);
+    void LogFileOnlyDynamic(Level lv, std::string&& file, std::string&& func, int line,
+                            std::string&& msg);
     void Setup(const std::string& path, int max_files, int max_size);
     void Flush();
-    SourceLocation InternSourceLocation(std::string&& file, std::string&& func, int line);
 
     static Logger& GetInstance()
     {
@@ -80,8 +84,6 @@ public:
     }
 
     bool IsEnabledFor(Level lv);
-
-    bool FilterCallSite(const char* file, int line);
 
 private:
     struct ChainEntryData {

--- a/ucm/shared/infra/logger/cc/spdlog_logger.h
+++ b/ucm/shared/infra/logger/cc/spdlog_logger.h
@@ -28,10 +28,8 @@
 #include <chrono>
 #include <csignal>
 #include <cstdlib>
-#include <mutex>
 #include <spdlog/spdlog.h>
 #include <string>
-#include <unordered_set>
 namespace UC::Logger {
 
 constexpr size_t HASH_SLOT_NUM = 512;
@@ -43,24 +41,19 @@ struct SourceLocation {
     const int32_t line = 0;
 };
 
-const char* InternSourceString(std::string&& s);
-
 class Logger {
     static constexpr uint64_t kDefaultRateLimitWindowMs = 10000;
-    std::shared_ptr<spdlog::logger> logger_;
-    std::shared_ptr<spdlog::logger> file_logger_;
-    std::mutex mutex_;
+    struct Backend;
+
+    std::atomic<Backend*> backend_{nullptr};
+    const int32_t creation_pid_;
     bool rate_limit_enabled_{true};
     uint64_t rate_limit_window_ms_{kDefaultRateLimitWindowMs};
     uint32_t rate_limit_max_logs_{3};
 
 public:
-    Logger()
-    {
-        logger_ = nullptr;
-        register_at_exit();
-        LoadRateLimitConfig();
-    }
+    Logger();
+    ~Logger();
 
     void LoadRateLimitConfig();
 
@@ -78,6 +71,7 @@ public:
     void LogFileOnly(Level&& lv, SourceLocation&& loc, std::string&& msg);
     void Setup(const std::string& path, int max_files, int max_size);
     void Flush();
+    SourceLocation InternSourceLocation(std::string&& file, std::string&& func, int line);
 
     static Logger& GetInstance()
     {
@@ -99,11 +93,7 @@ private:
         std::array<ChainEntryData, HASH_CHAIN_LEN> chain_entries;
     };
 
-    std::array<SlotData, HASH_SLOT_NUM> hash_slots_;
-
-    std::shared_ptr<spdlog::logger> Make();
-    std::shared_ptr<spdlog::logger> MakeCapture();
-    bool file_enabled_{true};
+    Backend* GetBackend();
     std::string path_{"log"};
     int max_files_{3};
     int max_size_{5 * 1048576};  // 5MB

--- a/ucm/shared/infra/logger/logger.cc
+++ b/ucm/shared/infra/logger/logger.cc
@@ -29,25 +29,19 @@ namespace UC::Logger {
 
 void Log(Level lv, std::string file, std::string func, int line, std::string msg)
 {
-    auto& logger = Logger::GetInstance();
-    SourceLocation loc = logger.InternSourceLocation(std::move(file), std::move(func), line);
-    logger.Log(std::move(lv), std::move(loc), std::move(msg));
+    Logger::GetInstance().LogDynamic(lv, std::move(file), std::move(func), line, std::move(msg));
 }
 
 void LogFileOnly(Level lv, std::string file, std::string func, int line, std::string msg)
 {
-    auto& logger = Logger::GetInstance();
-    SourceLocation loc = logger.InternSourceLocation(std::move(file), std::move(func), line);
-    logger.LogFileOnly(std::move(lv), std::move(loc), std::move(msg));
+    Logger::GetInstance().LogFileOnlyDynamic(lv, std::move(file), std::move(func), line,
+                                             std::move(msg));
 }
 
 void LogRateLimit(Level lv, std::string file, std::string func, int line, std::string msg)
 {
-    auto& logger = Logger::GetInstance();
-    SourceLocation loc = logger.InternSourceLocation(std::move(file), std::move(func), line);
-    if (logger.FilterCallSite(loc.file, line)) {
-        logger.Log(std::move(lv), std::move(loc), std::move(msg));
-    }
+    Logger::GetInstance().LogRateLimitDynamic(lv, std::move(file), std::move(func), line,
+                                              std::move(msg));
 }
 
 void Setup(const std::string& path, int max_files, int max_size)

--- a/ucm/shared/infra/logger/logger.cc
+++ b/ucm/shared/infra/logger/logger.cc
@@ -29,24 +29,24 @@ namespace UC::Logger {
 
 void Log(Level lv, std::string file, std::string func, int line, std::string msg)
 {
-    SourceLocation loc{InternSourceString(std::move(file)), InternSourceString(std::move(func)),
-                       line};
-    Logger::GetInstance().Log(std::move(lv), std::move(loc), std::move(msg));
+    auto& logger = Logger::GetInstance();
+    SourceLocation loc = logger.InternSourceLocation(std::move(file), std::move(func), line);
+    logger.Log(std::move(lv), std::move(loc), std::move(msg));
 }
 
 void LogFileOnly(Level lv, std::string file, std::string func, int line, std::string msg)
 {
-    SourceLocation loc{InternSourceString(std::move(file)), InternSourceString(std::move(func)),
-                       line};
-    Logger::GetInstance().LogFileOnly(std::move(lv), std::move(loc), std::move(msg));
+    auto& logger = Logger::GetInstance();
+    SourceLocation loc = logger.InternSourceLocation(std::move(file), std::move(func), line);
+    logger.LogFileOnly(std::move(lv), std::move(loc), std::move(msg));
 }
 
 void LogRateLimit(Level lv, std::string file, std::string func, int line, std::string msg)
 {
-    SourceLocation loc{InternSourceString(std::move(file)), InternSourceString(std::move(func)),
-                       line};
-    if (Logger::GetInstance().FilterCallSite(loc.file, line)) {
-        Logger::GetInstance().Log(std::move(lv), std::move(loc), std::move(msg));
+    auto& logger = Logger::GetInstance();
+    SourceLocation loc = logger.InternSourceLocation(std::move(file), std::move(func), line);
+    if (logger.FilterCallSite(loc.file, line)) {
+        logger.Log(std::move(lv), std::move(loc), std::move(msg));
     }
 }
 

--- a/ucm/shared/infra/logger/logger.h
+++ b/ucm/shared/infra/logger/logger.h
@@ -39,7 +39,7 @@ template <typename... Args>
 void Log(Level lv, const SourceLocation& loc, fmt::format_string<Args...> fmt, Args&&... args)
 {
     std::string msg = fmt::format(fmt, std::forward<Args>(args)...);
-    Log(lv, std::string(loc.file), std::string(loc.func), loc.line, std::move(msg));
+    Logger::GetInstance().Log(lv, loc, std::move(msg));
 }
 
 template <typename... Args>
@@ -47,7 +47,7 @@ void LogRateLimit(Level lv, const SourceLocation& loc, fmt::format_string<Args..
                   Args&&... args)
 {
     std::string msg = fmt::format(fmt, std::forward<Args>(args)...);
-    LogRateLimit(lv, std::string(loc.file), std::string(loc.func), loc.line, std::move(msg));
+    Logger::GetInstance().LogRateLimit(lv, loc, std::move(msg));
 }
 
 void Setup(const std::string& path, int max_files, int max_size);

--- a/ucm/shared/test/case/infra/logger/logger_test.cc
+++ b/ucm/shared/test/case/infra/logger/logger_test.cc
@@ -29,7 +29,9 @@
 #include <fstream>
 #include <gtest/gtest.h>
 #include <spdlog/spdlog.h>
+#include <sys/wait.h>
 #include <thread>
+#include <unistd.h>
 
 using namespace UC::Logger;
 
@@ -135,4 +137,46 @@ TEST_F(UCLoggerTest, FileOnlyLogEventuallyReachesVllmFile)
     Flush();
 
     ASSERT_TRUE(WaitFor([&] { return AnyLogFileContains(test_log_dir_, "vllm-", msg); }));
+}
+
+TEST_F(UCLoggerTest, ForkedChildCreatesIndependentLoggers)
+{
+    const std::string parent_capture = "parent capture initialized before fork";
+    LogFileOnly(Level::WARN, "logger_test.cc", "ForkedChildCreatesIndependentLoggers", 100,
+                std::string(parent_capture));
+    Flush();
+    ASSERT_TRUE(
+        WaitFor([&] { return AnyLogFileContains(test_log_dir_, "vllm-", parent_capture); }));
+
+    const pid_t child_pid = fork();
+    ASSERT_NE(child_pid, -1);
+    if (child_pid == 0) {
+        const std::string ucm_message = "fork child ucm logger message";
+        const std::string vllm_message = "fork child vllm logger message";
+        Log(Level::WARN, "logger_test.cc", "ForkedChildCreatesIndependentLoggers", 110,
+            std::string(ucm_message));
+        LogFileOnly(Level::WARN, "logger_test.cc", "ForkedChildCreatesIndependentLoggers", 112,
+                    std::string(vllm_message));
+        Flush();
+
+        const auto ucm_path =
+            std::filesystem::path(test_log_dir_) / ("ucm-" + std::to_string(getpid()) + ".log");
+        const auto vllm_path =
+            std::filesystem::path(test_log_dir_) / ("vllm-" + std::to_string(getpid()) + ".log");
+        const bool logged = WaitFor([&] {
+            return FileContains(ucm_path, ucm_message) && FileContains(vllm_path, vllm_message);
+        });
+        _exit(logged ? 0 : 1);
+    }
+
+    int status = 0;
+    ASSERT_EQ(waitpid(child_pid, &status, 0), child_pid);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+    EXPECT_TRUE(FileContains(
+        std::filesystem::path(test_log_dir_) / ("ucm-" + std::to_string(child_pid) + ".log"),
+        "fork child ucm logger message"));
+    EXPECT_TRUE(FileContains(
+        std::filesystem::path(test_log_dir_) / ("vllm-" + std::to_string(child_pid) + ".log"),
+        "fork child vllm logger message"));
 }


### PR DESCRIPTION
## Why

vLLM initializes UCM logging before starting the V1 EngineCore. With the `fork` multiprocessing method, EngineCore inherits spdlog objects, mutexes, and async queue state, but it does not inherit the logger worker threads. EngineCore and tensor-parallel workers can therefore execute normally while their UCM-managed file logs are never drained.

The child now detects the PID mismatch on its first logger operation and initializes its own backend. The parent does not need to stop or reinitialize its logger.

## What changed

- Replace process-global spdlog state with a lazily created per-process backend identified by PID.
- When a forked child observes an inherited backend, create independent UCM and vLLM sinks, an async queue, a worker thread, dynamic source-location storage, and rate-limit state for that child.
- Avoid touching or destroying the inherited backend in the child because its copied mutexes and background-thread state may be invalid after `fork()`.
- Use a fork-safe stdout sink that does not depend on spdlog's process-global console mutex.
- Keep the same readable timestamp pattern in parent, fork, and spawn processes.
- Use spdlog's native `%t` so async logs retain the caller thread ID instead of reporting the logger worker thread ID. TLS thread-ID caching remains enabled to avoid a per-log `gettid()` syscall.
- Add a static `SourceLocation` fast path for C++ logging macros. Dynamic Python source strings remain interned so their pointers stay valid in the async queue.
- Resolve the per-process backend once per log call, including rate-limited and file-only paths. Rate-limited dynamic logs no longer intern source strings when the log is dropped.
- Clear Python `*_once` logger caches through `os.register_at_fork()` so child logging is not suppressed by parent cache entries.
- Add Python coverage for fork cache cleanup and C++ coverage that verifies a child creates and writes its own `ucm-<pid>.log` and `vllm-<pid>.log` files.

## Spawn multiprocessing performance

The performance comparison ran on the same A2 ARM64 host and in the same isolated container. The baseline was `f45b2b9` (fork fix before the logger hot-path changes); the current tree was `ea3ad8b8eeed009c3c094fb04225b1798821a000`.

- Python `multiprocessing` start method: `spawn`
- 8 processes, 6,000 INFO logs per process
- 8 measured samples per revision, executed in an interleaved baseline/current order
- File logging enabled; every measured log was counted after the async queue was flushed

| Path | Metric | Baseline | Current | Change |
| --- | ---: | ---: | ---: | ---: |
| Python/pybind logging | Median worker loop | 12.32 ms | 11.04 ms | 10.4% faster |
| C++ logging | Median worker loop | 7.27 ms | 4.60 ms | 36.7% faster |

Each revision wrote `384,000/384,000` expected lines for the dynamic path and `384,000/384,000` for the static path. No measured run lost logs.
