### PR TITLE
[opt] cache: drop redundant node locks in TransBuffer::FindAt/ExistAt traversal

### DIFF
--- a/ucm/store/cache/cc/trans_buffer.cc
+++ b/ucm/store/cache/cc/trans_buffer.cc
@@ -612,14 +612,8 @@ bool TransBuffer::ExistAt(size_t iBucket, const Detail::BlockId& blockId, size_t
     auto iNode = strategy_->FirstAt(iBucket);
     while (iNode != invalidIndex) {
         auto meta = strategy_->MetaAt(iNode);
-        strategy_->NodeLock(iNode);
-        if (meta->block == blockId && meta->shard == shardIdx) {
-            strategy_->NodeUnlock(iNode);
-            return true;
-        }
-        auto next = meta->next;
-        strategy_->NodeUnlock(iNode);
-        iNode = next;
+        if (meta->block == blockId && meta->shard == shardIdx) { return true; }
+        iNode = meta->next;
     }
     return false;
 }
@@ -630,8 +624,8 @@ size_t TransBuffer::FindAt(size_t iBucket, const Detail::BlockId& blockId, size_
     auto iNode = strategy_->FirstAt(iBucket);
     while (iNode != invalidIndex) {
         auto meta = strategy_->MetaAt(iNode);
-        strategy_->NodeLock(iNode);
         if (meta->block == blockId && meta->shard == shardIdx) {
+            strategy_->NodeLock(iNode);
             owner = meta->reference == 0;
             if (owner && meta->state.load(std::memory_order_relaxed) == State::FAILED) {
                 meta->state.store(State::LOADING, std::memory_order_relaxed);
@@ -642,9 +636,7 @@ size_t TransBuffer::FindAt(size_t iBucket, const Detail::BlockId& blockId, size_
             strategy_->NodeUnlock(iNode);
             break;
         }
-        auto next = meta->next;
-        strategy_->NodeUnlock(iNode);
-        iNode = next;
+        iNode = meta->next;
     }
     return iNode;
 }


### PR DESCRIPTION
## Summary
Remove redundant per-node spinlock acquisitions in `TransBuffer::FindAt` and `ExistAt`. `FindAt` is always called under `BucketLock`, which already serializes `block`/`shard`/`next` reads — the node lock only needs to guard `reference` on a match.

## Changes
`ucm/store/cache/cc/trans_buffer.cc`:
- `FindAt`: move `NodeLock/NodeUnlock` from the traversal loop into the match branch only. Non-matching nodes are read lock-free. Per-lookup lock ops drop from O(L) to O(1).
- `ExistAt`: drop all node locks (read-only of bucket-lock-protected fields).

Unchanged: `Alloc`/`MoveTo`/`Remove`/`Acquire`/`Release`. The matched-node lock in `FindAt` is kept to preserve atomicity of `owner=(ref==0)` → reset state → `++ref` against concurrent `Acquire`/`Release`.