### PR TITLE
[Opt] Asu fakebackend adds concurrent task processing in provider

### DIFF
--- a/docs/source/developer-guide/kv-test.md
+++ b/docs/source/developer-guide/kv-test.md
@@ -182,6 +182,7 @@ wait_timeout_ms=5000
 
 fake_backend.path=./kv-test-fake-backend-store
 fake_backend.latency_ms=1
+fake_backend.worker_threads=4
 
 view.config_path=./ucm/transport/kv/kv-test/asu_view.conf
 hash_table.type=RING_HASH
@@ -250,6 +251,7 @@ These fields are parsed by `kv-test` itself:
 | `asu.transport_library_path` | Optional `libasu_transport.so` path used by kv-test's runtime proxy. The environment variable `KV_TEST_ASU_TRANSPORT_LIB` is also accepted. |
 | `fake_backend.path` | FAKE provider storage root. Defaults to `./kv-test-fake-backend-store`. |
 | `fake_backend.latency_ms` | Mock backend completion delay in milliseconds. Default is `1`. |
+| `fake_backend.worker_threads` | Number of FAKE provider IO workers. Default is `4`. |
 | `kv.key_prefix` | Prefix for count-based key generation. |
 | `kv.seed` | Seed for deterministic value generation. |
 | `kv.value_size` | Value size for normal commands. |
@@ -295,9 +297,9 @@ Mocked or not covered in this mode:
 - real connection failure, drain, and recovery behavior
 
 For every transport configured with the FAKE provider, kv-test fills required
-SQE/send attrs and passes `fake_backend.path`, `fake_backend.latency_ms`, and
-`fake_backend.device_id` through `TransportConfig.attrs`. Other provider entries
-are left unchanged.
+SQE/send attrs and passes `fake_backend.path`, `fake_backend.latency_ms`,
+`fake_backend.worker_threads`, and `fake_backend.device_id` through
+`TransportConfig.attrs`. Other provider entries are left unchanged.
 `FakeTransProvider::CreateConnection` returns placeholder connection handles so
 `ConnectionManager` can create channels during this software-only integration
 phase.
@@ -321,7 +323,9 @@ recover a per-ASU namespace from the send buffer without changing the Transport
 `Send` interface. This is a kv-test-only temporary semantic mapping, not a
 long-term protocol statement that KVNS_ID is ASU ID.
 
-The fake backend writes the CQE/flag buffer synchronously before `Send` returns.
+The fake backend copies and queues each SQE before `Send` returns. Dedicated IO
+workers process queued requests in parallel and publish the CQE/flag buffer when
+the mock file operation completes.
 Query returns CQE status `0` when every key exists and `0x732` with a
 result-buffer payload when only some keys exist. Delete treats missing keys as
 successful entries; a result-buffer byte value of `0` means success and `1`

--- a/examples/ucm_config_asu.yaml
+++ b/examples/ucm_config_asu.yaml
@@ -36,6 +36,7 @@ ucm_connectors:
       # and replaces the missing device Send/backend execution with local files.
       # asu_fake_backend_path: "./asu-fake-backend-store"
       # asu_fake_backend_latency_ms: 1
+      # asu_fake_backend_worker_threads: 4
 
       # ASU wait/task timeout and connection recovery.
       asu_wait_timeout_ms: 5000

--- a/examples/ucm_config_delegator.yaml
+++ b/examples/ucm_config_delegator.yaml
@@ -39,6 +39,7 @@ ucm_connectors:
       # and replaces the missing device Send/backend execution with local files.
       asu_fake_backend_path: "/mnt/test"
       asu_fake_backend_latency_ms: 1
+      asu_fake_backend_worker_threads: 4
 
       # ASU wait/task timeout and connection recovery.
       asu_wait_timeout_ms: 5000

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -199,6 +199,8 @@ UC::ASU::TransportConfig BuildTransportConfig(const Config& config, std::size_t 
         transportConfig.attrs["fake_backend.path"] = config.fakeBackendPath;
         transportConfig.attrs["fake_backend.latency_ms"] =
             std::to_string(config.fakeBackendLatencyMs);
+        transportConfig.attrs["fake_backend.worker_threads"] =
+            std::to_string(config.fakeBackendWorkerThreads);
         transportConfig.attrs["fake_backend.device_id"] = std::to_string(fakeDeviceId);
         if (transportConfig.endpoints.empty()) {
             UC::ASU::AsuEndpoint endpoint;
@@ -411,6 +413,7 @@ private:
         }
         inConfig.Get("asu_fake_backend_path", config.fakeBackendPath);
         inConfig.GetNumber("asu_fake_backend_latency_ms", config.fakeBackendLatencyMs);
+        inConfig.GetNumber("asu_fake_backend_worker_threads", config.fakeBackendWorkerThreads);
         inConfig.GetNumber("asu_shared_provider", config.sharedProviderMode);
         inConfig.Get("asu_sc", config.sc);
         ReadClientAttr(inConfig, "asu_router_type", "hash_table.type", config);
@@ -536,6 +539,11 @@ private:
         }
         if (config.queryTimeoutMs == 0) {
             return Status::InvalidParam("asu_query_timeout_ms must be greater than zero");
+        }
+        if (config.transProviderType == UC::ASU::TransProviderType::FAKE &&
+            config.fakeBackendWorkerThreads == 0) {
+            return Status::InvalidParam(
+                "asu_fake_backend_worker_threads must be greater than zero");
         }
         if (config.clientMaxInflightTasks > std::numeric_limits<std::uint32_t>::max()) {
             return Status::InvalidParam("asu_client_max_inflight_tasks exceeds uint32 range");
@@ -761,6 +769,7 @@ private:
         UC_INFO("Set AsuStore::TransProviderBackend to {}.",
                 TransProviderBackendName(config.transProviderType));
         UC_INFO("Set AsuStore::FakeBackendPath to {}.", config.fakeBackendPath);
+        UC_INFO("Set AsuStore::FakeBackendWorkerThreads to {}.", config.fakeBackendWorkerThreads);
     }
 
     UC::ASU::MRHandle FindPersistentHandle(const UC::ASU::MemoryRegion& region) const

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -37,6 +37,7 @@ struct Config {
     UC::ASU::TransProviderType transProviderType{UC::ASU::TransProviderType::AICPU};
     std::string fakeBackendPath;
     std::uint64_t fakeBackendLatencyMs{1};
+    std::uint64_t fakeBackendWorkerThreads{4};
     ssize_t sharedProviderMode{0};
     bool sc{true};
     std::unordered_map<std::string, std::string> clientAttrs;

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -446,6 +446,22 @@ TEST(UCAsuStoreTest, FakeProviderPreservesConfiguredSc)
     EXPECT_EQ(transportConfig.attrs.at("sc"), "false");
 }
 
+TEST(UCAsuStoreTest, PropagatesFakeBackendWorkerThreads)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeClient(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("asu_trans_provider_backend", std::string{"fake"});
+    config.SetNumber("asu_fake_backend_worker_threads", std::uint64_t{8});
+
+    ASSERT_TRUE(store.Setup(config).Success());
+    ASSERT_FALSE(state->initConfigs.empty());
+
+    const auto transportConfig = UC::AsuStore::BuildTransportConfig(state->initConfigs.back(), 0);
+    EXPECT_EQ(transportConfig.attrs.at("fake_backend.worker_threads"), "8");
+}
+
 TEST(UCAsuStoreTest, RejectsMissingKvNamespaces)
 {
     UC::AsuStore::AsuStore store;

--- a/ucm/transport/kv/asu/test/transport/fake_trans_provider_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/fake_trans_provider_test.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 #include <iomanip>
 #include <sstream>
+#include <thread>
 #include <unordered_set>
 #include "kv_protocol.h"
 
@@ -121,7 +122,11 @@ TEST(FakeTransProviderTest, SendQueuesCompletionForWorker)
     ASSERT_TRUE(statuses[0].ok()) << statuses[0].message;
     EXPECT_EQ(__atomic_load_n(completion.data() + 3, __ATOMIC_ACQUIRE), 0U);
 
-    WaitForFakeBackendIdleForTest(provider);
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while ((__atomic_load_n(completion.data() + 3, __ATOMIC_ACQUIRE) & 0xFFFF) == 0 &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
     EXPECT_EQ(__atomic_load_n(completion.data() + 3, __ATOMIC_ACQUIRE) & 0xFFFF, cid);
 }
 

--- a/ucm/transport/kv/asu/test/transport/fake_trans_provider_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/fake_trans_provider_test.cpp
@@ -1,6 +1,7 @@
 #define private public
 #include "fake_trans_provider.h"
 #undef private
+#include <array>
 #include <chrono>
 #include <cstring>
 #include <filesystem>
@@ -41,6 +42,14 @@ std::vector<std::uint32_t> BuildExistRequest(const std::vector<CacheKey>& keys, 
     return request;
 }
 
+std::array<std::uint32_t, kSqeDwordCount> BuildKeepAliveRequest(std::uint16_t cid)
+{
+    std::array<std::uint32_t, kSqeDwordCount> request{};
+    request[0] =
+        static_cast<std::uint32_t>(KvOpcode::KeepAlive) | (static_cast<std::uint32_t>(cid) << 16);
+    return request;
+}
+
 TEST(FakeTransProviderTest, RegisterMemoryReturnsUniqueHandlesAcrossCalls)
 {
     FakeTransProvider provider(FakeTransProviderConfig{});
@@ -76,6 +85,51 @@ TEST(FakeTransProviderTest, BindMemoryCreatesProviderLocalHandles)
     EXPECT_NE(handles[0], kInvalidMRHandle);
     EXPECT_NE(handles[1], kInvalidMRHandle);
     EXPECT_NE(handles[0], handles[1]);
+}
+
+TEST(FakeTransProviderTest, SendQueuesCompletionForWorker)
+{
+    FakeTransProviderConfig config;
+    config.latencyMs = 20;
+    config.workerThreads = 2;
+    FakeTransProvider provider(config);
+
+    constexpr std::uint16_t cid = 7;
+    auto request = BuildKeepAliveRequest(cid);
+    std::array<std::uint32_t, kCqeDwordCount> completion{};
+    std::vector<MRHandle> handles;
+    ASSERT_TRUE(
+        provider
+            .RegisterMemory(
+                {
+                    {TransProvider::MemType::MEM_HOST,
+                     reinterpret_cast<std::uintptr_t>(request.data()),    sizeof(request),
+                     reinterpret_cast<std::uintptr_t>(request.data())   },
+                    {TransProvider::MemType::MEM_HOST,
+                     reinterpret_cast<std::uintptr_t>(completion.data()), sizeof(completion),
+                     reinterpret_cast<std::uintptr_t>(completion.data())}
+    },
+                handles)
+            .ok());
+
+    const auto statuses = provider.Send(
+        {
+            {nullptr, request.data(), completion.data(), sizeof(request)}
+    },
+        0, 0);
+    ASSERT_EQ(statuses.size(), 1U);
+    ASSERT_TRUE(statuses[0].ok()) << statuses[0].message;
+    EXPECT_EQ(__atomic_load_n(completion.data() + 3, __ATOMIC_ACQUIRE), 0U);
+
+    WaitForFakeBackendIdleForTest(provider);
+    EXPECT_EQ(__atomic_load_n(completion.data() + 3, __ATOMIC_ACQUIRE) & 0xFFFF, cid);
+}
+
+TEST(FakeTransProviderTest, ParsesWorkerThreadCount)
+{
+    TransportConfig config;
+    config.attrs["fake_backend.worker_threads"] = "6";
+    EXPECT_EQ(MakeFakeTransProviderConfig(config).workerThreads, 6U);
 }
 
 TEST(FakeTransProviderTest, ExistHonorsSeekControl)

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
@@ -23,15 +23,20 @@
  * */
 #include "fake_trans_provider.h"
 #include <algorithm>
+#include <array>
 #include <chrono>
+#include <condition_variable>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <deque>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <limits>
+#include <shared_mutex>
 #include <sstream>
+#include <stdexcept>
 #include <thread>
 #include <utility>
 #include <vector>
@@ -42,6 +47,7 @@ namespace UC::ASU {
 namespace {
 
 constexpr std::uint16_t kCqeSuccess = 0x000;
+constexpr std::uint16_t kCqeInternalError = 0x006;
 constexpr std::uint16_t kCqeCheckResultBuffer = 0x732;
 constexpr std::uint8_t kBatchEntryOk = 0x0;
 constexpr std::uint8_t kBatchEntryKeyNotFound = 0x3;
@@ -50,6 +56,9 @@ constexpr std::uint8_t kDeleteEntryFailed = 0x1;
 constexpr std::uint8_t kExistEntryNotExist = 0x0;
 constexpr std::uint8_t kExistEntryExist = 0x1;
 constexpr std::uint32_t kExistSeekControlMask = 1U << 16;
+constexpr std::size_t kKeyLockCount = 256;
+
+std::array<std::shared_mutex, kKeyLockCount> g_keyMutexes;
 
 std::uint64_t ReadU64(std::uint32_t low, std::uint32_t high)
 {
@@ -72,7 +81,7 @@ CacheKey ReadKey(const std::uint32_t* data)
     return key;
 }
 
-std::string KeyFileName(const CacheKey& key)
+std::uint64_t KeyHash(const CacheKey& key)
 {
     std::uint64_t hash = 1469598103934665603ULL;
     for (auto byte : key) {
@@ -80,10 +89,19 @@ std::string KeyFileName(const CacheKey& key)
         hash ^= ch;
         hash *= 1099511628211ULL;
     }
+    return hash;
+}
 
+std::string KeyFileName(const CacheKey& key)
+{
     std::ostringstream stream;
-    stream << std::hex << std::setw(16) << std::setfill('0') << hash << ".bin";
+    stream << std::hex << std::setw(16) << std::setfill('0') << KeyHash(key) << ".bin";
     return stream.str();
+}
+
+std::shared_mutex& KeyMutex(const CacheKey& key)
+{
+    return g_keyMutexes[KeyHash(key) % kKeyLockCount];
 }
 
 std::filesystem::path AsuRoot(const std::string& storePath, AsuId asuId)
@@ -171,7 +189,117 @@ std::size_t CompletionDwordCount(const std::uint32_t* request)
     return kCqeDwordCount + resultDwordCount;
 }
 
+std::size_t RequestDwordCount(const std::uint32_t* request)
+{
+    const auto opcode = RequestOpcode(request);
+    if (opcode == KvOpcode::Store || opcode == KvOpcode::Retrieve ||
+        opcode == KvOpcode::KeepAlive) {
+        return kSqeDwordCount;
+    }
+
+    const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
+    const auto entryDwordCount = opcode == KvOpcode::BatchStore || opcode == KvOpcode::BatchRetrieve
+                                     ? kBatchEntryDwordCount
+                                     : kKeyEntryDwordCount;
+    return kSqeDwordCount + static_cast<std::size_t>(batchNumber) * entryDwordCount;
+}
+
+void PublishCompletion(std::uint32_t* flagBuffer, const std::vector<std::uint32_t>& completion)
+{
+    std::memcpy(flagBuffer, completion.data(), 3 * sizeof(std::uint32_t));
+    if (completion.size() > kCqeDwordCount) {
+        std::memcpy(flagBuffer + kCqeDwordCount, completion.data() + kCqeDwordCount,
+                    (completion.size() - kCqeDwordCount) * sizeof(std::uint32_t));
+    }
+    __atomic_store_n(flagBuffer + 3, completion[3], __ATOMIC_RELEASE);
+}
+
 }  // namespace
+
+class FakeTransProvider::WorkerPool {
+public:
+    WorkerPool(FakeTransProvider& provider, std::size_t workerCount) : provider_(provider)
+    {
+        if (workerCount == 0) { throw std::invalid_argument("fake backend worker count is zero"); }
+        workers_.reserve(workerCount);
+        try {
+            for (std::size_t index = 0; index < workerCount; ++index) {
+                workers_.emplace_back(&WorkerPool::WorkerLoop, this);
+            }
+        } catch (...) {
+            StopAndJoin();
+            throw;
+        }
+    }
+
+    ~WorkerPool() { StopAndJoin(); }
+
+    WorkerPool(const WorkerPool&) = delete;
+    WorkerPool& operator=(const WorkerPool&) = delete;
+
+    bool Push(IoTask task)
+    {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (stopping_) { return false; }
+            tasks_.emplace_back(std::move(task));
+            ++pendingTaskCount_;
+        }
+        workReady_.notify_one();
+        return true;
+    }
+
+    void WaitUntilIdle()
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        idle_.wait(lock, [this] { return pendingTaskCount_ == 0; });
+    }
+
+private:
+    void WorkerLoop()
+    {
+        while (true) {
+            IoTask task;
+            {
+                std::unique_lock<std::mutex> lock(mutex_);
+                workReady_.wait(lock, [this] { return stopping_ || !tasks_.empty(); });
+                if (stopping_ && tasks_.empty()) { return; }
+                task = std::move(tasks_.front());
+                tasks_.pop_front();
+            }
+
+            provider_.ProcessIoTask(task);
+
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                --pendingTaskCount_;
+                if (pendingTaskCount_ == 0) { idle_.notify_all(); }
+            }
+        }
+    }
+
+    void StopAndJoin()
+    {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            stopping_ = true;
+        }
+        workReady_.notify_all();
+        for (auto& worker : workers_) {
+            if (worker.joinable()) { worker.join(); }
+        }
+        workers_.clear();
+    }
+
+    FakeTransProvider& provider_;
+    std::mutex mutex_;
+    std::condition_variable workReady_;
+    std::condition_variable idle_;
+    std::deque<IoTask> tasks_;
+    std::vector<std::thread> workers_;
+    std::size_t pendingTaskCount_{0};
+    bool stopping_{false};
+};
 
 FakeTransProviderConfig MakeFakeTransProviderConfig(const TransportConfig& config)
 {
@@ -189,13 +317,21 @@ FakeTransProviderConfig MakeFakeTransProviderConfig(const TransportConfig& confi
     if (deviceIter != config.attrs.end()) {
         fakeConfig.deviceId = static_cast<std::int32_t>(std::stol(deviceIter->second));
     }
+    auto workerIter = config.attrs.find("fake_backend.worker_threads");
+    if (workerIter != config.attrs.end()) {
+        fakeConfig.workerThreads = static_cast<std::size_t>(std::stoull(workerIter->second));
+    }
     return fakeConfig;
 }
 
-FakeTransProvider::FakeTransProvider(FakeTransProviderConfig config) : config_(std::move(config))
+FakeTransProvider::FakeTransProvider(FakeTransProviderConfig config)
+    : config_(std::move(config)),
+      workerPool_(std::make_unique<WorkerPool>(*this, config_.workerThreads))
 {
     if (SetupDeviceRuntime().ok()) { stream_ = device_.MakeStream(); }
 }
+
+FakeTransProvider::~FakeTransProvider() = default;
 
 Status FakeTransProvider::SetupDeviceRuntime()
 {
@@ -240,6 +376,7 @@ Status FakeTransProvider::ResolveLocalAddress(const void* providerAddr, std::siz
 bool FakeTransProvider::StoreBytes(AsuId asuId, const CacheKey& key, std::uint32_t offset,
                                    std::uint64_t addr, std::uint32_t length)
 {
+    std::unique_lock<std::shared_mutex> keyLock(KeyMutex(key));
     if (stream_ == nullptr) {
         UC_ERROR("ASU fake backend stream not initialized asuId={} key={} addr={} length={}.",
                  asuId, CacheKeyToHex(key), addr, length);
@@ -282,6 +419,7 @@ bool FakeTransProvider::StoreBytes(AsuId asuId, const CacheKey& key, std::uint32
 bool FakeTransProvider::LoadBytes(AsuId asuId, const CacheKey& key, std::uint32_t offset,
                                   std::uint64_t addr, std::uint32_t length)
 {
+    std::shared_lock<std::shared_mutex> keyLock(KeyMutex(key));
     if (stream_ == nullptr) {
         UC_ERROR("ASU fake backend stream not initialized asuId={} key={} addr={} length={}.",
                  asuId, CacheKeyToHex(key), addr, length);
@@ -317,6 +455,7 @@ bool FakeTransProvider::LoadBytes(AsuId asuId, const CacheKey& key, std::uint32_
 
 bool FakeTransProvider::DeleteKey(AsuId asuId, const CacheKey& key)
 {
+    std::unique_lock<std::shared_mutex> keyLock(KeyMutex(key));
     std::error_code errorCode;
     std::filesystem::remove(KeyPath(config_.storePath, asuId, key), errorCode);
     return !errorCode;
@@ -324,6 +463,7 @@ bool FakeTransProvider::DeleteKey(AsuId asuId, const CacheKey& key)
 
 bool FakeTransProvider::ExistsKey(AsuId asuId, const CacheKey& key)
 {
+    std::shared_lock<std::shared_mutex> keyLock(KeyMutex(key));
     std::error_code errorCode;
     return std::filesystem::exists(KeyPath(config_.storePath, asuId, key), errorCode);
 }
@@ -509,13 +649,11 @@ std::vector<Status> FakeTransProvider::Send(const std::vector<SendIoBatch>& ioBa
 {
     (void)kernelCount;
     (void)quietCount;
-    auto runtimeStatus = SetupDeviceRuntime();
-    if (!runtimeStatus.ok()) { return std::vector<Status>(ioBatches.size(), runtimeStatus); }
-
     std::vector<Status> statuses;
     statuses.reserve(ioBatches.size());
     for (const auto& ioBatch : ioBatches) {
         if (ioBatch.sendBuffer == nullptr || ioBatch.flagBuffer == nullptr ||
+            ioBatch.len < kSqeDwordCount * sizeof(std::uint32_t) ||
             ioBatch.len > std::numeric_limits<std::size_t>::max()) {
             statuses.emplace_back(
                 Status::Error(StatusCode::INVALID_ARGUMENT, "fake backend IO buffer is invalid"));
@@ -530,24 +668,64 @@ std::vector<Status> FakeTransProvider::Send(const std::vector<SendIoBatch>& ioBa
             continue;
         }
 
-        std::vector<std::uint32_t> completion;
-        status = CompleteFakeBackendRequest(localSendBuffer, ioBatch.len, completion);
-        if (!status.ok()) {
-            statuses.emplace_back(std::move(status));
+        const auto* request = static_cast<const std::uint32_t*>(localSendBuffer);
+        const auto requestSize = RequestDwordCount(request) * sizeof(std::uint32_t);
+        if (requestSize > ioBatch.len) {
+            statuses.emplace_back(Status::Error(StatusCode::INVALID_ARGUMENT,
+                                                "fake backend send buffer is truncated"));
             continue;
         }
 
-        const auto completionSize = completion.size() * sizeof(std::uint32_t);
+        const auto completionSize = CompletionDwordCount(request) * sizeof(std::uint32_t);
         void* localFlagBuffer = nullptr;
         status = ResolveLocalAddress(ioBatch.flagBuffer, completionSize, localFlagBuffer);
         if (!status.ok()) {
             statuses.emplace_back(std::move(status));
             continue;
         }
-        std::memcpy(localFlagBuffer, completion.data(), completionSize);
+
+        IoTask task;
+        task.request.resize(ioBatch.len / sizeof(std::uint32_t) +
+                            (ioBatch.len % sizeof(std::uint32_t) != 0));
+        std::memcpy(task.request.data(), localSendBuffer, static_cast<std::size_t>(ioBatch.len));
+        task.requestLength = ioBatch.len;
+        task.flagBuffer = static_cast<std::uint32_t*>(localFlagBuffer);
+        if (!workerPool_->Push(std::move(task))) {
+            statuses.emplace_back(
+                Status::Error(StatusCode::NOT_INITIALIZED, "fake backend worker pool is stopping"));
+            continue;
+        }
         statuses.emplace_back(Status::OK());
     }
     return statuses;
+}
+
+void FakeTransProvider::ProcessIoTask(IoTask& task)
+{
+    std::vector<std::uint32_t> completion;
+    Status status;
+    try {
+        status = SetupDeviceRuntime();
+        if (status.ok()) {
+            status =
+                CompleteFakeBackendRequest(task.request.data(), task.requestLength, completion);
+        }
+    } catch (const std::exception& error) {
+        status = Status::Error(StatusCode::INTERNAL_ERROR,
+                               "fake backend worker exception: " + std::string(error.what()));
+    } catch (...) {
+        status = Status::Error(StatusCode::INTERNAL_ERROR,
+                               "fake backend worker raised an unknown exception");
+    }
+    if (!status.ok()) {
+        completion.assign(kCqeDwordCount, 0);
+        PackCqeHeader(completion.data(),
+                      static_cast<std::uint16_t>(RequestCid(task.request.data())),
+                      kCqeInternalError);
+        UC_ERROR("ASU fake backend worker failed code={} message={}", static_cast<int>(status.code),
+                 status.message);
+    }
+    PublishCompletion(task.flagBuffer, completion);
 }
 
 Status FakeTransProvider::RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
@@ -587,10 +765,18 @@ Status FakeTransProvider::BindMemory(const std::vector<BindMemoryDesc>& memoryDe
 std::vector<Status> FakeTransProvider::UnregisterMemory(
     const std::vector<UnregisterMemoryDesc>& handles)
 {
+    workerPool_->WaitUntilIdle();
     std::lock_guard<std::mutex> lock(registeredMemoryMu_);
     for (const auto& desc : handles) { registeredMemories_.erase(desc.mrHandle); }
     return std::vector<Status>(handles.size(), Status::OK());
 }
+
+#ifdef ASU_BUILD_TESTS
+void WaitForFakeBackendIdleForTest(FakeTransProvider& provider)
+{
+    provider.workerPool_->WaitUntilIdle();
+}
+#endif
 
 Status FakeTransProvider::AllocThread(uint32_t, const std::vector<uint32_t>&,
                                       std::vector<ThreadHandle>&)

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
@@ -771,13 +771,6 @@ std::vector<Status> FakeTransProvider::UnregisterMemory(
     return std::vector<Status>(handles.size(), Status::OK());
 }
 
-#ifdef ASU_BUILD_TESTS
-void WaitForFakeBackendIdleForTest(FakeTransProvider& provider)
-{
-    provider.workerPool_->WaitUntilIdle();
-}
-#endif
-
 Status FakeTransProvider::AllocThread(uint32_t, const std::vector<uint32_t>&,
                                       std::vector<ThreadHandle>&)
 {

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
@@ -72,10 +72,6 @@ public:
     Status GetMemTokenId(MRHandle, uint32_t& tokenId) override;
 
 private:
-#ifdef ASU_BUILD_TESTS
-    friend void WaitForFakeBackendIdleForTest(FakeTransProvider& provider);
-#endif
-
     struct IoTask {
         std::vector<std::uint32_t> request;
         std::uint64_t requestLength{0};
@@ -120,9 +116,5 @@ private:
 };
 
 FakeTransProviderConfig MakeFakeTransProviderConfig(const TransportConfig& config);
-
-#ifdef ASU_BUILD_TESTS
-void WaitForFakeBackendIdleForTest(FakeTransProvider& provider);
-#endif
 
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
@@ -24,9 +24,12 @@
 #pragma once
 
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <mutex>
 #include <unordered_map>
+#include <vector>
 #include "asu_transport/asu_transport.h"
 #include "asu_transport/trans_provider.h"
 #include "trans/device.h"
@@ -38,11 +41,13 @@ struct FakeTransProviderConfig {
     std::string storePath{"./asu-fake-backend-store"};
     std::uint64_t latencyMs{1};
     std::int32_t deviceId{0};
+    std::size_t workerThreads{4};
 };
 
 class FakeTransProvider : public TransProvider {
 public:
     explicit FakeTransProvider(FakeTransProviderConfig config);
+    ~FakeTransProvider() override;
 
     Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t qpNum,
                             uint32_t, std::vector<ConnectionHandle>& handles) override;
@@ -67,6 +72,18 @@ public:
     Status GetMemTokenId(MRHandle, uint32_t& tokenId) override;
 
 private:
+#ifdef ASU_BUILD_TESTS
+    friend void WaitForFakeBackendIdleForTest(FakeTransProvider& provider);
+#endif
+
+    struct IoTask {
+        std::vector<std::uint32_t> request;
+        std::uint64_t requestLength{0};
+        std::uint32_t* flagBuffer{nullptr};
+    };
+
+    class WorkerPool;
+
     struct RegisteredMemory {
         std::uintptr_t providerAddr{0};
         std::uintptr_t localAddr{0};
@@ -75,6 +92,7 @@ private:
 
     Status SetupDeviceRuntime();
     Status ResolveLocalAddress(const void* providerAddr, std::size_t size, void*& localAddr);
+    void ProcessIoTask(IoTask& task);
 
     bool StoreBytes(AsuId asuId, const CacheKey& key, std::uint32_t offset, std::uint64_t addr,
                     std::uint32_t length);
@@ -98,8 +116,13 @@ private:
     std::atomic<std::uintptr_t> nextMrHandle_{1};
     std::mutex registeredMemoryMu_;
     std::unordered_map<MRHandle, RegisteredMemory> registeredMemories_;
+    std::unique_ptr<WorkerPool> workerPool_;
 };
 
 FakeTransProviderConfig MakeFakeTransProviderConfig(const TransportConfig& config);
+
+#ifdef ASU_BUILD_TESTS
+void WaitForFakeBackendIdleForTest(FakeTransProvider& provider);
+#endif
 
 }  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/kv_protocol.cpp
+++ b/ucm/transport/kv/asu/trans/src/kv_protocol.cpp
@@ -1239,7 +1239,7 @@ Status ProtocolManager::UnpackResponse(const void* data_ptr, KvOpcode opcode,
 Status ProtocolManager::PollResponseCid(const void* data_ptr, std::uint16_t& cid) const
 {
     auto* data = static_cast<const std::uint32_t*>(data_ptr);
-    cid = data[3] & 0xFFFF;
+    cid = __atomic_load_n(data + 3, __ATOMIC_ACQUIRE) & 0xFFFF;
     return Status::OK();
 }
 

--- a/ucm/transport/kv/asu/trans/src/trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/trans_provider.cpp
@@ -1,4 +1,5 @@
 #include "asu_transport/trans_provider.h"
+#include <exception>
 #include <memory>
 #ifdef UCM_ASU_ENABLE_AICPU_PROVIDER
 #include "aicpu_trans_provider.h"
@@ -29,9 +30,15 @@ Status CreateTransProvider(const TransportConfig& config,
 #endif
         case TransProviderType::FAKE:
 #ifdef UCM_ASU_ENABLE_FAKE_PROVIDER
-            transProvider =
-                std::make_shared<FakeTransProvider>(MakeFakeTransProviderConfig(config));
-            return Status::OK();
+            try {
+                transProvider =
+                    std::make_shared<FakeTransProvider>(MakeFakeTransProviderConfig(config));
+                return Status::OK();
+            } catch (const std::exception& error) {
+                return Status::Error(
+                    StatusCode::INTERNAL_ERROR,
+                    "failed to create fake provider: " + std::string(error.what()));
+            }
 #else
             return Status::Error(
                 StatusCode::UNSUPPORTED,

--- a/ucm/transport/kv/kv-test/asu_kv_test.conf
+++ b/ucm/transport/kv/kv-test/asu_kv_test.conf
@@ -47,6 +47,7 @@ transport.sc=true
 # transport.device_id.
 fake_backend.path=./kv-test-fake-backend-store
 fake_backend.latency_ms=1
+fake_backend.worker_threads=8
 asu_info.1=protocol=TCP,local.comm_id=127.0.0.1,port=19001
 
 # kv-test data generation defaults.

--- a/ucm/transport/kv/kv-test/include/kv_test/kv_test_types.h
+++ b/ucm/transport/kv/kv-test/include/kv_test/kv_test_types.h
@@ -156,6 +156,7 @@ struct OutputConfig {
 struct KvTestFakeBackendConfig {
     std::string storePath;
     std::uint64_t latencyMs{1};
+    std::uint64_t workerThreads{4};
 };
 
 struct AsuRuntimeLibraryConfig {

--- a/ucm/transport/kv/kv-test/src/bench_runner.cpp
+++ b/ucm/transport/kv/kv-test/src/bench_runner.cpp
@@ -2,14 +2,20 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <condition_variable>
+#include <deque>
+#include <functional>
 #include <future>
 #include <iomanip>
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <mutex>
 #include <numeric>
 #include <sstream>
+#include <stdexcept>
 #include <system_error>
+#include <thread>
 #include "kv_test/buffer_allocator.h"
 #include "kv_test/key_value_generator.h"
 #include "kv_test/kv_test_config_helpers.h"
@@ -40,6 +46,75 @@ struct OperationOutcome {
 };
 
 using BenchBufferPool = std::vector<BenchBufferSlot>;
+
+class BenchExecutor {
+public:
+    explicit BenchExecutor(std::size_t workerCount)
+    {
+        workers_.reserve(workerCount);
+        try {
+            for (std::size_t index = 0; index < workerCount; ++index) {
+                workers_.emplace_back(&BenchExecutor::WorkerLoop, this);
+            }
+        } catch (...) {
+            Shutdown();
+            throw;
+        }
+    }
+
+    ~BenchExecutor() { Shutdown(); }
+
+    BenchExecutor(const BenchExecutor&) = delete;
+    BenchExecutor& operator=(const BenchExecutor&) = delete;
+
+    std::future<OperationOutcome> Submit(std::function<OperationOutcome()> handler)
+    {
+        std::packaged_task<OperationOutcome()> task(std::move(handler));
+        auto future = task.get_future();
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (stopping_) { throw std::runtime_error("bench executor is stopping"); }
+            tasks_.emplace_back(std::move(task));
+        }
+        workReady_.notify_one();
+        return future;
+    }
+
+private:
+    void Shutdown()
+    {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            stopping_ = true;
+        }
+        workReady_.notify_all();
+        for (auto& worker : workers_) {
+            if (worker.joinable()) { worker.join(); }
+        }
+        workers_.clear();
+    }
+
+    void WorkerLoop()
+    {
+        while (true) {
+            std::packaged_task<OperationOutcome()> task;
+            {
+                std::unique_lock<std::mutex> lock(mutex_);
+                workReady_.wait(lock, [this] { return stopping_ || !tasks_.empty(); });
+                if (stopping_ && tasks_.empty()) { return; }
+                task = std::move(tasks_.front());
+                tasks_.pop_front();
+            }
+            task();
+        }
+    }
+
+    std::mutex mutex_;
+    std::condition_variable workReady_;
+    std::deque<std::packaged_task<OperationOutcome()>> tasks_;
+    std::vector<std::thread> workers_;
+    bool stopping_{false};
+};
 
 std::uint64_t BenchEntryCount(const BenchConfig& bench, BenchOpType op)
 {
@@ -206,6 +281,16 @@ Status BuildBenchBufferPool(const KvTestConfig& config, bool useDeviceBuffers,
     return Status::Success();
 }
 
+Status SyncStoreBenchDeviceBuffers(const KvTestConfig& config, BenchBufferPool& pool,
+                                   std::size_t entryCount)
+{
+    for (auto& slot : pool) {
+        auto status = SyncBenchDeviceBuffers(config, slot, entryCount);
+        if (!status.Ok()) { return status; }
+    }
+    return Status::Success();
+}
+
 bool IsBenchReadOperation(BenchOpType op, std::uint64_t operationIndex, const BenchConfig& bench)
 {
     if (op == BenchOpType::RETRIEVE || op == BenchOpType::BATCH_RETRIEVE) { return true; }
@@ -328,7 +413,7 @@ Status ExecuteBenchOperation(BenchOpType requestedOp, const KvTestConfig& config
     if (!status.Ok()) { return status; }
     auto& buffers = slot.buffers;
 
-    if (useDeviceBuffers && !isRead) {
+    if (useDeviceBuffers && !isRead && requestedOp == BenchOpType::MIX) {
         auto status = SyncBenchDeviceBuffers(config, slot, entryCount);
         if (!status.Ok()) { return status; }
     }
@@ -420,12 +505,29 @@ Status BenchRunner::Run(const CommandOptions& options, const KvTestConfig& confi
     BenchBufferPool bufferPool;
     status = BuildBenchBufferPool(config, useDeviceBuffers, entryCountPerOperation, bufferPool);
     if (!status.Ok()) { return status; }
+    if (useDeviceBuffers &&
+        (bench.op == BenchOpType::STORE || bench.op == BenchOpType::BATCH_STORE)) {
+        status = SyncStoreBenchDeviceBuffers(config, bufferPool,
+                                             static_cast<std::size_t>(entryCountPerOperation));
+        if (!status.Ok()) { return status; }
+    }
     if (useDeviceBuffers) {
         status = RegisterBenchDeviceBuffers(clientRunner, bufferPool, entryCountPerOperation,
                                             keyPrefix, allocationPolicy, logicalDeviceId);
         if (!status.Ok()) {
             (void)UnregisterBenchDeviceBuffers(clientRunner, bufferPool);
             return status;
+        }
+    }
+
+    std::unique_ptr<BenchExecutor> executor;
+    if (bench.concurrency > 1) {
+        try {
+            executor = std::make_unique<BenchExecutor>(bench.concurrency);
+        } catch (const std::system_error& error) {
+            if (useDeviceBuffers) { (void)UnregisterBenchDeviceBuffers(clientRunner, bufferPool); }
+            return Status::Error(kExitInvalidArgument,
+                                 "bench worker creation failed: " + std::string(error.what()));
         }
     }
 
@@ -497,19 +599,17 @@ Status BenchRunner::Run(const CommandOptions& options, const KvTestConfig& confi
                 }
 
                 try {
-                    futures.emplace_back(std::async(
-                        std::launch::async,
-                        [&, begin, currentEntryCount, currentOperationIndex,
-                         bufferSlot]() -> OperationOutcome {
-                            return RunBenchOperation(bench.op, config, clientRunner, *bufferSlot,
-                                                     begin, currentEntryCount,
-                                                     currentOperationIndex, keyPrefix,
-                                                     useDeviceBuffers);
-                        }));
-                } catch (const std::system_error& e) {
+                    futures.emplace_back(executor->Submit([&, begin, currentEntryCount,
+                                                           currentOperationIndex,
+                                                           bufferSlot]() -> OperationOutcome {
+                        return RunBenchOperation(bench.op, config, clientRunner, *bufferSlot, begin,
+                                                 currentEntryCount, currentOperationIndex,
+                                                 keyPrefix, useDeviceBuffers);
+                    }));
+                } catch (const std::exception& error) {
                     return Status::Error(
                         kExitInvalidArgument,
-                        "bench async worker creation failed: " + std::string(e.what()));
+                        "bench operation submission failed: " + std::string(error.what()));
                 }
             }
 
@@ -597,6 +697,7 @@ Status BenchRunner::Run(const CommandOptions& options, const KvTestConfig& confi
     if (bench.warmupSec != 0) {
         status = runPhase(bench.warmupSec, 0, false);
         if (!status.Ok()) {
+            executor.reset();
             if (useDeviceBuffers) { (void)UnregisterBenchDeviceBuffers(clientRunner, bufferPool); }
             return status;
         }
@@ -605,6 +706,7 @@ Status BenchRunner::Run(const CommandOptions& options, const KvTestConfig& confi
     const auto measureStart = Clock::now();
     status = runPhase(bench.durationSec, bench.ioCount, true);
     const auto measureEnd = Clock::now();
+    executor.reset();
     auto cleanupStatus = useDeviceBuffers ? UnregisterBenchDeviceBuffers(clientRunner, bufferPool)
                                           : Status::Success();
     if (status.Ok() && !cleanupStatus.Ok()) { status = cleanupStatus; }

--- a/ucm/transport/kv/kv-test/src/kv_test_config_helpers.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_config_helpers.cpp
@@ -32,6 +32,7 @@ void PatchFakeBackendTransportConfig(UC::ASU::TransportConfig& config,
     config.attrs.try_emplace("lr", "false");
     config.attrs["fake_backend.path"] = fakeConfig.storePath;
     config.attrs["fake_backend.latency_ms"] = std::to_string(fakeConfig.latencyMs);
+    config.attrs["fake_backend.worker_threads"] = std::to_string(fakeConfig.workerThreads);
     config.attrs["fake_backend.device_id"] = std::to_string(fakeBackendDeviceId);
     if (config.endpoints.empty()) {
         UC::ASU::AsuEndpoint endpoint;

--- a/ucm/transport/kv/kv-test/src/kv_test_config_loader.cpp
+++ b/ucm/transport/kv/kv-test/src/kv_test_config_loader.cpp
@@ -199,6 +199,8 @@ Status KvTestConfigLoader::Load(const std::string& configPath, KvTestConfig& con
                      {"fake_backend.latency_ms", "fakebackend.latency_ms", "fake_backend.latencyms",
                       "fakebackend.latencyms"},
                      config.fakeBackend.latencyMs);
+        GetUint64Any(values, {"fake_backend.worker_threads", "fakebackend.worker_threads"},
+                     config.fakeBackend.workerThreads);
 
         GetStringAny(values, {"kv.key_prefix"}, config.keyPrefix);
 

--- a/ucm/transport/kv/kv-test/test/kv_test_config_helpers_test.cpp
+++ b/ucm/transport/kv/kv-test/test/kv_test_config_helpers_test.cpp
@@ -42,6 +42,7 @@ TEST(KvTestConfigHelpersTest, FakeDefaultsDoNotModifyAivTransport)
     EXPECT_EQ(patchedFake.providerType, UC::ASU::TransProviderType::FAKE);
     EXPECT_EQ(patchedFake.attrs.at("sc"), "false");
     EXPECT_EQ(patchedFake.attrs.at("fake_backend.path"), "./kv-test-fake-backend-store");
+    EXPECT_EQ(patchedFake.attrs.at("fake_backend.worker_threads"), "4");
 
     const auto& unchangedAiv = config.asuClientConfig.transportConfigs[1];
     EXPECT_EQ(unchangedAiv.providerType, UC::ASU::TransProviderType::AIV);


### PR DESCRIPTION
## Purpose
This PR optimizes FakeTransProvider to accelerate task consuming.

## Modifications 
1. FakeTransProvider processes tasks with a worker pool.
2. Add a configuration for workerThreads number in both asu_kv_test.conf and ucm_config_*.yaml.

## Test
Offline inference with fake provider is passed.
kv-test bench proves that multi-concurrency with worker threads > 1 can reduce time cost.