### PR TITLE
[Opt] Asu unit tests speedup

### DIFF
--- a/ucm/transport/kv/asu/CMakeLists.txt
+++ b/ucm/transport/kv/asu/CMakeLists.txt
@@ -105,7 +105,7 @@ if(BUILD_UNIT_TESTS)
     )
     target_link_libraries(asu.test PRIVATE
         asu_client
-        gtest_main gtest
+        gtest
     )
     gtest_discover_tests(asu.test)
 endif()

--- a/ucm/transport/kv/asu/test/transport/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/asu_submit_flow_test.cpp
@@ -25,6 +25,7 @@
 #include <functional>
 #include <gtest/gtest.h>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 #define private public
 #include "asu_transport_impl.h"
@@ -130,6 +131,24 @@ void CreateTaskExecutor(AsuTransportImpl& transport)
         transport.config_, transport.transProvider_, transport.connManager_);
 }
 
+Status InitTaskExecutorWithoutRecoverLoop(AsuTransportImpl& transport,
+                                          std::shared_ptr<TransProvider> provider)
+{
+    transport.SetTransProvider(std::move(provider));
+    CreateTaskExecutor(transport);
+    const auto status = transport.taskExecutor_->Init();
+    if (!status.ok()) { transport.taskExecutor_.reset(); }
+    return status;
+}
+
+Status ShutdownTaskExecutorWithoutRecoverLoop(AsuTransportImpl& transport)
+{
+    if (!transport.taskExecutor_) { return Status::OK(); }
+    const auto status = transport.taskExecutor_->Shutdown();
+    if (status.ok()) { transport.taskExecutor_.reset(); }
+    return status;
+}
+
 class AsuSubmitFlowBufferTest : public ::testing::Test {
 protected:
     static void SetUpTestSuite()
@@ -187,7 +206,7 @@ TEST_F(AsuTransportBufferRegistrationTest, InitRegistersAndShutdownUnregistersBo
     auto provider = std::make_shared<StubTransProvider>();
     AsuTransportImpl transport;
 
-    auto status = transport.Init(TransportConfig{}, provider);
+    auto status = InitTaskExecutorWithoutRecoverLoop(transport, provider);
     ASSERT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(provider->registerCount, 2);
     EXPECT_EQ(provider->registerCallCount, 2);
@@ -198,7 +217,7 @@ TEST_F(AsuTransportBufferRegistrationTest, InitRegistersAndShutdownUnregistersBo
     EXPECT_EQ(transport.taskExecutor_->sendBufferManager_.GetTokenId(), 1);
     EXPECT_EQ(transport.taskExecutor_->flagBufferManager_.GetTokenId(), 1);
 
-    status = transport.Shutdown();
+    status = ShutdownTaskExecutorWithoutRecoverLoop(transport);
     EXPECT_TRUE(status.ok()) << status.message;
     EXPECT_EQ(provider->unregisterCount, 2);
     EXPECT_EQ(transport.taskExecutor_, nullptr);
@@ -210,7 +229,7 @@ TEST_F(AsuTransportBufferRegistrationTest, DestructorUnregistersBothBuffers)
 
     {
         AsuTransportImpl transport;
-        const auto status = transport.Init(TransportConfig{}, provider);
+        const auto status = InitTaskExecutorWithoutRecoverLoop(transport, provider);
         ASSERT_TRUE(status.ok()) << status.message;
         EXPECT_EQ(provider->registerCount, 2);
         EXPECT_EQ(provider->unregisterCount, 0);
@@ -225,7 +244,7 @@ TEST_F(AsuTransportBufferRegistrationTest, FirstRegistrationFailureDoesNotUnregi
     provider->failRegisterAt = 1;
     AsuTransportImpl transport;
 
-    const auto status = transport.Init(TransportConfig{}, provider);
+    const auto status = InitTaskExecutorWithoutRecoverLoop(transport, provider);
     EXPECT_FALSE(status.ok());
     EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_NE(status.message.find("send buffer"), std::string::npos);
@@ -242,7 +261,7 @@ TEST_F(AsuTransportBufferRegistrationTest, FirstTokenLookupFailureCleansUpRegist
     provider->failTokenLookupAt = 1;
     AsuTransportImpl transport;
 
-    const auto status = transport.Init(TransportConfig{}, provider);
+    const auto status = InitTaskExecutorWithoutRecoverLoop(transport, provider);
     EXPECT_FALSE(status.ok());
     EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_NE(status.message.find("send buffer"), std::string::npos);
@@ -260,7 +279,7 @@ TEST_F(AsuTransportBufferRegistrationTest, TokenLookupRollbackFailureIsRetriedDu
     provider->failUnregisterAt = 1;
     AsuTransportImpl transport;
 
-    const auto status = transport.Init(TransportConfig{}, provider);
+    const auto status = InitTaskExecutorWithoutRecoverLoop(transport, provider);
     EXPECT_FALSE(status.ok());
     EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_NE(status.message.find("send buffer"), std::string::npos);
@@ -276,7 +295,7 @@ TEST_F(AsuTransportBufferRegistrationTest, SecondRegistrationFailureCleansUpFirs
     provider->failRegisterAt = 2;
     AsuTransportImpl transport;
 
-    const auto status = transport.Init(TransportConfig{}, provider);
+    const auto status = InitTaskExecutorWithoutRecoverLoop(transport, provider);
     EXPECT_FALSE(status.ok());
     EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_NE(status.message.find("flag buffer"), std::string::npos);
@@ -291,7 +310,7 @@ TEST_F(AsuTransportBufferRegistrationTest, SecondTokenLookupFailureCleansUpBothB
     provider->failTokenLookupAt = 2;
     AsuTransportImpl transport;
 
-    const auto status = transport.Init(TransportConfig{}, provider);
+    const auto status = InitTaskExecutorWithoutRecoverLoop(transport, provider);
     EXPECT_FALSE(status.ok());
     EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_NE(status.message.find("flag buffer"), std::string::npos);
@@ -306,10 +325,10 @@ TEST_F(AsuTransportBufferRegistrationTest, FlagUnregistrationFailureIncludesCall
     auto provider = std::make_shared<StubTransProvider>();
     AsuTransportImpl transport;
 
-    ASSERT_TRUE(transport.Init(TransportConfig{}, provider).ok());
+    ASSERT_TRUE(InitTaskExecutorWithoutRecoverLoop(transport, provider).ok());
     provider->failUnregisterAt = 1;
 
-    const auto status = transport.Shutdown();
+    const auto status = ShutdownTaskExecutorWithoutRecoverLoop(transport);
     EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_NE(status.message.find("flag buffer"), std::string::npos);
     EXPECT_EQ(provider->unregisterCount, 2);
@@ -317,7 +336,7 @@ TEST_F(AsuTransportBufferRegistrationTest, FlagUnregistrationFailureIncludesCall
     EXPECT_NE(transport.taskExecutor_->flagBufferMrHandle_, kInvalidMRHandle);
     EXPECT_EQ(transport.taskExecutor_->sendBufferMrHandle_, kInvalidMRHandle);
 
-    EXPECT_TRUE(transport.Shutdown().ok());
+    EXPECT_TRUE(ShutdownTaskExecutorWithoutRecoverLoop(transport).ok());
     EXPECT_EQ(provider->unregisterCount, 3);
     EXPECT_EQ(transport.taskExecutor_, nullptr);
 }
@@ -327,10 +346,10 @@ TEST_F(AsuTransportBufferRegistrationTest, SendUnregistrationFailureIncludesCall
     auto provider = std::make_shared<StubTransProvider>();
     AsuTransportImpl transport;
 
-    ASSERT_TRUE(transport.Init(TransportConfig{}, provider).ok());
+    ASSERT_TRUE(InitTaskExecutorWithoutRecoverLoop(transport, provider).ok());
     provider->failUnregisterAt = 2;
 
-    const auto status = transport.Shutdown();
+    const auto status = ShutdownTaskExecutorWithoutRecoverLoop(transport);
     EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
     EXPECT_NE(status.message.find("send buffer"), std::string::npos);
     EXPECT_EQ(provider->unregisterCount, 2);
@@ -338,7 +357,7 @@ TEST_F(AsuTransportBufferRegistrationTest, SendUnregistrationFailureIncludesCall
     EXPECT_EQ(transport.taskExecutor_->flagBufferMrHandle_, kInvalidMRHandle);
     EXPECT_NE(transport.taskExecutor_->sendBufferMrHandle_, kInvalidMRHandle);
 
-    EXPECT_TRUE(transport.Shutdown().ok());
+    EXPECT_TRUE(ShutdownTaskExecutorWithoutRecoverLoop(transport).ok());
     EXPECT_EQ(provider->unregisterCount, 3);
     EXPECT_EQ(transport.taskExecutor_, nullptr);
 }

--- a/ucm/transport/kv/asu/test/transport/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/asu_submit_flow_test.cpp
@@ -33,7 +33,6 @@
 #include "asu_transport/trans_provider.h"
 #include "buffer_manager.h"
 #include "connection_internal.h"
-#include "trans/device.h"
 
 namespace UC::ASU {
 namespace {
@@ -151,21 +150,6 @@ Status ShutdownTaskExecutorWithoutRecoverLoop(AsuTransportImpl& transport)
 
 class AsuSubmitFlowBufferTest : public ::testing::Test {
 protected:
-    static void SetUpTestSuite()
-    {
-        const auto initStatus = device_.Init();
-        if (initStatus.Failure() && initStatus != UC::Status::DuplicateKey()) {
-            FAIL() << "Device::Init failed: " << initStatus.ToString();
-        }
-        ASSERT_TRUE(device_.Setup(0).Success());
-    }
-
-    static void TearDownTestSuite()
-    {
-        (void)device_.Reset(0);
-        (void)device_.Finalize();
-    }
-
     void SetUp() override
     {
         transport_ = std::make_unique<AsuTransportImpl>();
@@ -174,32 +158,13 @@ protected:
     }
 
     std::unique_ptr<AsuTransportImpl> transport_;
-    static inline Trans::Device device_;
 };
 
 }  // namespace
 
 namespace {
 
-class AsuTransportBufferRegistrationTest : public ::testing::Test {
-protected:
-    static void SetUpTestSuite()
-    {
-        const auto initStatus = device_.Init();
-        if (initStatus.Failure() && initStatus != UC::Status::DuplicateKey()) {
-            FAIL() << "Device::Init failed: " << initStatus.ToString();
-        }
-        ASSERT_TRUE(device_.Setup(0).Success());
-    }
-
-    static void TearDownTestSuite()
-    {
-        (void)device_.Reset(0);
-        (void)device_.Finalize();
-    }
-
-    static inline Trans::Device device_;
-};
+class AsuTransportBufferRegistrationTest : public ::testing::Test {};
 
 TEST_F(AsuTransportBufferRegistrationTest, InitRegistersAndShutdownUnregistersBothBuffers)
 {

--- a/ucm/transport/kv/asu/test/transport/asu_test_main.cpp
+++ b/ucm/transport/kv/asu/test/transport/asu_test_main.cpp
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+#include "trans/device.h"
+
+namespace UC::ASU {
+namespace {
+
+class AsuDeviceTestEnvironment final : public ::testing::Environment {
+public:
+    void SetUp() override
+    {
+        const auto initStatus = device_.Init();
+        ASSERT_TRUE(initStatus.Success() || initStatus == UC::Status::DuplicateKey())
+            << "Device::Init failed: " << initStatus.ToString();
+        ASSERT_TRUE(device_.Setup(0).Success());
+    }
+
+    void TearDown() override
+    {
+        EXPECT_TRUE(device_.Reset(0).Success());
+        EXPECT_TRUE(device_.Finalize().Success());
+    }
+
+private:
+    Trans::Device device_;
+};
+
+}  // namespace
+}  // namespace UC::ASU
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(new UC::ASU::AsuDeviceTestEnvironment);
+    return RUN_ALL_TESTS();
+}

--- a/ucm/transport/kv/asu/test/transport/buffer_manager_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/buffer_manager_test.cpp
@@ -27,30 +27,14 @@
 #include <thread>
 #include <vector>
 #include "asu_transport/trans_provider.h"
-#include "trans/device.h"
 
 namespace UC::ASU {
 namespace {
 
 class BufferManagerTest : public ::testing::Test {
 protected:
-    static void SetUpTestSuite()
-    {
-        const auto initStatus = device_.Init();
-        if (initStatus.Failure() && initStatus != UC::Status::DuplicateKey()) {
-            FAIL() << "Device::Init failed: " << initStatus.ToString();
-        }
-        ASSERT_TRUE(device_.Setup(0).Success());
-    }
-    static void TearDownTestSuite()
-    {
-        (void)device_.Reset(0);
-        (void)device_.Finalize();
-    }
     void SetUp() override {}
     void TearDown() override {}
-
-    static inline Trans::Device device_;
 };
 
 TEST_F(BufferManagerTest, InitAndDestroy)

--- a/ucm/transport/kv/asu/test/transport/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/sqe_request_test.cpp
@@ -38,7 +38,6 @@
 #include "asu_transport/trans_provider.h"
 #include "buffer_manager.h"
 #include "kv_protocol.h"
-#include "trans/device.h"
 #include "transport_config_parser.h"
 
 namespace UC::ASU {
@@ -183,21 +182,6 @@ std::uint32_t PackedBatchEntryMrKey(const std::uint32_t* sqe, std::size_t entryI
 
 class SqeRequestTest : public ::testing::Test {
 protected:
-    static void SetUpTestSuite()
-    {
-        const auto initStatus = device_.Init();
-        if (initStatus.Failure() && initStatus != UC::Status::DuplicateKey()) {
-            FAIL() << "Device::Init failed: " << initStatus.ToString();
-        }
-        ASSERT_TRUE(device_.Setup(0).Success());
-    }
-
-    static void TearDownTestSuite()
-    {
-        (void)device_.Reset(0);
-        (void)device_.Finalize();
-    }
-
     void SetUp() override
     {
         transport_ = std::make_unique<AsuTransportImpl>();
@@ -222,7 +206,6 @@ protected:
     }
 
     std::unique_ptr<AsuTransportImpl> transport_;
-    static inline Trans::Device device_;
 };
 
 TEST_F(SqeRequestTest, ValidateSqeRequestAttrsRejectsMalformedValues)

--- a/ucm/transport/kv/asu/test/transport/transport_task_completion_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/transport_task_completion_test.cpp
@@ -140,16 +140,18 @@ TEST_F(TransportTaskCompletionTest, InitRejectsZeroMaxErrorCount)
     EXPECT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
 }
 
-TEST_F(TransportTaskCompletionTest, TaskExecutorFollowsInitializedTransportLifetime)
+TEST_F(TransportTaskCompletionTest, TaskExecutorSupportsExplicitLifecycle)
 {
     AsuTransportImpl transport;
     EXPECT_EQ(transport.taskExecutor_, nullptr);
     transport.SetTransProvider(std::make_unique<StubTransProvider>());
 
-    ASSERT_TRUE(transport.Init(TransportConfig{}, transport.transProvider_).ok());
+    CreateTaskExecutor(transport);
+    ASSERT_TRUE(transport.taskExecutor_->Init().ok());
     EXPECT_NE(transport.taskExecutor_, nullptr);
 
-    EXPECT_TRUE(transport.Shutdown().ok());
+    EXPECT_TRUE(transport.taskExecutor_->Shutdown().ok());
+    transport.taskExecutor_.reset();
     EXPECT_EQ(transport.taskExecutor_, nullptr);
 }
 

--- a/ucm/transport/kv/asu/test/transport/transport_task_completion_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/transport_task_completion_test.cpp
@@ -34,7 +34,6 @@
 #include "asu_transport/trans_provider.h"
 #include "buffer_manager.h"
 #include "connection_internal.h"
-#include "trans/device.h"
 
 namespace UC::ASU {
 namespace {
@@ -90,21 +89,6 @@ void CreateTaskExecutor(AsuTransportImpl& transport)
 
 class TransportTaskCompletionTest : public ::testing::Test {
 protected:
-    static void SetUpTestSuite()
-    {
-        const auto initStatus = device_.Init();
-        if (initStatus.Failure() && initStatus != UC::Status::DuplicateKey()) {
-            FAIL() << "Device::Init failed: " << initStatus.ToString();
-        }
-        ASSERT_TRUE(device_.Setup(0).Success());
-    }
-
-    static void TearDownTestSuite()
-    {
-        (void)device_.Reset(0);
-        (void)device_.Finalize();
-    }
-
     void SetUp() override
     {
         transport_ = std::make_unique<AsuTransportImpl>();
@@ -127,7 +111,6 @@ protected:
     }
 
     std::unique_ptr<AsuTransportImpl> transport_;
-    static inline Trans::Device device_;
 };
 
 TEST_F(TransportTaskCompletionTest, InitRejectsZeroMaxErrorCount)


### PR DESCRIPTION
## Purpose
This PR speeds up unit tests of Asu module.

## Modifications 
Do Acl setup/reset once at the entrance/exit.

## Test
Execute `asu.test` for 17.27s in the first run and 2.80s in the secend run.