### PR TITLE
[Feat] Add ASU client and transport modules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,8 @@
 /ucm/store/mooncakestore @chinesezyc @mag1c-h @ygwpz
 /ucm/store/nfsstore @mag1c-h @ygwpz
 
+/ucm/transport @mag1c-h @nrj868 @Infinite666 @Wwwzff
+
 /ucm/integration @qyh111 @harrisonyhq @ygwpz @mag1c-h @Infinite666
 
 /ucm/pd @flesher0813 @ygwpz @mag1c-h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(UCM_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
 option(BUILD_UCM_STORE "build ucm store module." ON)
 option(BUILD_UCM_SPARSE "build ucm sparse module." OFF)
+option(BUILD_UCM_ASU "build ucm ASU transport module." OFF)
 option(BUILD_UCM_MINDIE "build ucm MindIE integration module." OFF)
 option(BUILD_UNIT_TESTS "build all unit test suits." OFF)
 option(BUILD_NUMA "build numactl library." OFF)

--- a/ucm/transport/CMakeLists.txt
+++ b/ucm/transport/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(p2p)
+add_subdirectory(kv)

--- a/ucm/transport/kv/CMakeLists.txt
+++ b/ucm/transport/kv/CMakeLists.txt
@@ -1,0 +1,3 @@
+if(BUILD_UCM_ASU)
+    add_subdirectory(asu)
+endif()

--- a/ucm/transport/kv/asu/CMakeLists.txt
+++ b/ucm/transport/kv/asu/CMakeLists.txt
@@ -1,0 +1,111 @@
+if(NOT (RUNTIME_ENVIRONMENT STREQUAL "ascend" OR RUNTIME_ENVIRONMENT STREQUAL "simu"))
+    message(FATAL_ERROR
+        "BUILD_UCM_ASU requires RUNTIME_ENVIRONMENT=ascend or simu. Current value: ${RUNTIME_ENVIRONMENT}")
+endif()
+
+option(BUILD_UCM_ASU_PROVIDER_AICPU "Build ASU AICPU trans provider" OFF)
+option(BUILD_UCM_ASU_PROVIDER_FAKE "Build ASU fake trans provider" ON)
+option(BUILD_UCM_ASU_PROVIDER_AIV "Build ASU AIV trans provider (requires external libumc.a)" OFF)
+
+file(GLOB ASU_COMMON_SOURCES CONFIGURE_DEPENDS common/*.cpp)
+file(GLOB ASU_TRANSPORT_SOURCES CONFIGURE_DEPENDS trans/src/*.cpp)
+file(GLOB LOGGER_SOURCES CONFIGURE_DEPENDS
+    ${UCM_ROOT_DIR}/ucm/shared/infra/logger/*.cc
+    ${UCM_ROOT_DIR}/ucm/shared/infra/logger/cc/*.cc
+)
+list(APPEND ASU_TRANSPORT_SOURCES ${ASU_COMMON_SOURCES})
+list(APPEND ASU_TRANSPORT_SOURCES ${LOGGER_SOURCES})
+add_library(asu_transport SHARED ${ASU_TRANSPORT_SOURCES})
+target_include_directories(asu_transport
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/trans/include
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/common
+        ${CMAKE_CURRENT_SOURCE_DIR}/trans/src
+        ${UCM_ROOT_DIR}/ucm/shared/infra
+        ${UCM_ROOT_DIR}/ucm/shared/infra/logger
+        ${UCM_ROOT_DIR}/ucm/shared/infra/logger/cc
+        ${UCM_ROOT_DIR}/ucm/shared/infra/status
+        ${UCM_ROOT_DIR}/ucm/shared
+)
+target_compile_definitions(asu_transport PRIVATE SPDLOG_FMT_EXTERNAL)
+target_link_libraries(asu_transport
+    PUBLIC
+        pthread fmt spdlog zlibstatic trans
+)
+
+if(BUILD_UCM_ASU_PROVIDER_AICPU)
+    target_compile_definitions(asu_transport PRIVATE UCM_ASU_ENABLE_AICPU_PROVIDER=1)
+endif()
+
+if(BUILD_UCM_ASU_PROVIDER_FAKE)
+    target_compile_definitions(asu_transport PRIVATE UCM_ASU_ENABLE_FAKE_PROVIDER=1)
+endif()
+
+if(BUILD_UCM_ASU_PROVIDER_AIV)
+    if(NOT DEFINED ASU_AIV_PROVIDER_ROOT)
+        if(DEFINED ENV{ASU_AIV_PROVIDER_ROOT})
+            set(ASU_AIV_PROVIDER_ROOT "$ENV{ASU_AIV_PROVIDER_ROOT}" CACHE PATH "Install prefix of libumc.a")
+        else()
+            set(ASU_AIV_PROVIDER_ROOT "" CACHE PATH "Install prefix of libumc.a")
+        endif()
+    endif()
+
+    find_library(ASU_AIV_PROVIDER_LIB
+        NAMES libumc.a umc
+        HINTS
+            ${ASU_AIV_PROVIDER_ROOT}/lib
+            ${ASU_AIV_PROVIDER_ROOT}/lib64
+        NO_DEFAULT_PATH
+    )
+    if(NOT ASU_AIV_PROVIDER_LIB)
+        message(FATAL_ERROR "Cannot find libumc.a under ASU_AIV_PROVIDER_ROOT=${ASU_AIV_PROVIDER_ROOT}")
+    endif()
+
+    message(STATUS "ASU AIV provider lib: ${ASU_AIV_PROVIDER_LIB}")
+    target_link_libraries(asu_transport PRIVATE ${ASU_AIV_PROVIDER_LIB} ${CMAKE_DL_LIBS})
+    target_compile_definitions(asu_transport PRIVATE UCM_ASU_ENABLE_AIV_PROVIDER=1)
+endif()
+
+file(GLOB ASU_CLIENT_SOURCES CONFIGURE_DEPENDS client/src/*.cpp)
+add_library(asu_client SHARED ${ASU_CLIENT_SOURCES})
+target_include_directories(asu_client
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}/client/include
+)
+target_include_directories(asu_client
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/common
+        ${CMAKE_CURRENT_SOURCE_DIR}/client/src
+        ${UCM_ROOT_DIR}/ucm/shared/infra
+)
+target_link_libraries(asu_client PUBLIC asu_transport router pthread)
+target_compile_definitions(asu_client PRIVATE SPDLOG_FMT_EXTERNAL)
+
+file(RELATIVE_PATH INSTALL_REL_PATH ${UCM_ROOT_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+set_target_properties(asu_client PROPERTIES INSTALL_RPATH "$ORIGIN")
+set_target_properties(asu_transport PROPERTIES INSTALL_RPATH "$ORIGIN")
+install(TARGETS asu_client asu_transport LIBRARY DESTINATION ${INSTALL_REL_PATH} COMPONENT ucm)
+install(TARGETS asu_client asu_transport LIBRARY DESTINATION ucm/store/asu COMPONENT ucm)
+
+if(BUILD_UNIT_TESTS)
+    target_compile_definitions(asu_transport PRIVATE ASU_BUILD_TESTS)
+    include(GoogleTest)
+    file(GLOB ASU_TEST_SOURCE_FILES CONFIGURE_DEPENDS
+        test/client/*.cpp
+        test/transport/*.cpp
+    )
+    add_executable(asu.test ${ASU_TEST_SOURCE_FILES})
+    target_compile_definitions(asu.test PRIVATE ASU_BUILD_TESTS)
+    target_include_directories(asu.test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/common
+        ${CMAKE_CURRENT_SOURCE_DIR}/client/src
+        ${CMAKE_CURRENT_SOURCE_DIR}/trans/src
+        ${UCM_ROOT_DIR}/ucm/shared/infra
+    )
+    target_link_libraries(asu.test PRIVATE
+        asu_client
+        gtest
+    )
+    gtest_discover_tests(asu.test)
+endif()

--- a/ucm/transport/kv/asu/client/include/asu_client/asu_client.h
+++ b/ucm/transport/kv/asu/client/include/asu_client/asu_client.h
@@ -1,0 +1,84 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "asu_transport/asu_transport.h"
+
+namespace UC::ASU {
+
+enum class SharedProviderMode : std::uint8_t { INDEPENDENT = 0, SHARED = 1 };
+
+struct AsuClientConfig {
+    std::string clientId;
+    std::vector<std::string> viewServiceAddrs;
+
+    std::vector<TransportConfig> transportConfigs;
+
+    std::uint32_t maxInflightTasks{1024};
+    std::uint64_t defaultWaitTimeoutMs{100};
+    std::uint64_t timeoutMs{100};
+    SharedProviderMode sharedProviderMode{SharedProviderMode::INDEPENDENT};
+    std::unordered_map<std::string, std::string> attrs;
+};
+
+class AsuClient {
+public:
+    virtual ~AsuClient() = default;
+
+    virtual Status Init(const AsuClientConfig& config) = 0;
+    virtual Status Init(const std::string& configPath) = 0;
+    virtual Status Shutdown() = 0;
+
+    virtual Status QueryAsync(const std::vector<CacheKey>& keys, TaskId& taskId) = 0;
+    virtual Status LoadAsync(const std::vector<KVBuffer>& entries, TaskId& taskId) = 0;
+    virtual Status StoreAsync(const std::vector<KVBuffer>& entries, TaskId& taskId) = 0;
+    virtual Status BatchLoadAsync(const std::vector<KVBuffer>& entries, TaskId& taskId) = 0;
+    virtual Status BatchStoreAsync(const std::vector<KVBuffer>& entries, TaskId& taskId) = 0;
+    virtual Status DeleteAsync(const std::vector<CacheKey>& keys, TaskId& taskId) = 0;
+
+    // Returns false only while the task is still in progress. Wait retrieves the final result.
+    virtual bool Check(TaskId taskId) = 0;
+    virtual Status Wait(TaskId taskId, std::uint64_t timeoutMs, TaskResult& result) = 0;
+
+    virtual Status RegisterRegions(const std::vector<MemoryRegion>& regions,
+                                   std::vector<RegisteredMemory>& registeredRegions) = 0;
+    // Handles referenced by queued or in-flight tasks must remain registered until those tasks
+    // complete.
+    virtual Status UnregisterRegions(const std::vector<MRHandle>& handles) = 0;
+};
+
+using TransportFactory = std::function<std::unique_ptr<AsuTransport>()>;
+using TransProviderFactory =
+    std::function<Status(const TransportConfig&, std::shared_ptr<TransProvider>&)>;
+
+std::unique_ptr<AsuClient> CreateAsuClient(
+    TransportFactory transportFactory = CreateAsuTransport,
+    TransProviderFactory transProviderFactory = CreateTransProvider);
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.cpp
@@ -1,0 +1,849 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "asu_client_impl.h"
+#include <algorithm>
+#include <limits>
+#include <thread>
+#include <utility>
+#include "asu_transport/types.h"
+#include "client_config_parser.h"
+#include "client_router_config.h"
+#include "logger/logger.h"
+#include "router/router.h"
+
+namespace UC::ASU {
+
+constexpr std::uint32_t kMaxShutdownDrainAttempts = 64;
+
+AsuClientImpl::AsuClientImpl(TransportFactory transportFactory, ViewServerFactory viewServerFactory,
+                             TransProviderFactory transProviderFactory)
+    : transportFactory_(std::move(transportFactory)),
+      transProviderFactory_(std::move(transProviderFactory)),
+      viewServerFactory_(std::move(viewServerFactory))
+{
+    if (!transportFactory_) { transportFactory_ = CreateAsuTransport; }
+    if (!transProviderFactory_) { transProviderFactory_ = CreateTransProvider; }
+    if (!viewServerFactory_) { viewServerFactory_ = CreateDefaultViewServer; }
+}
+
+AsuClientImpl::~AsuClientImpl() { Shutdown(); }
+
+Status AsuClientImpl::Init(const std::string& configPath)
+{
+    AsuClientConfig config;
+    auto status = LoadConfig(configPath, config);
+    if (!status.ok()) { return status; }
+    return Init(config);
+}
+
+Status AsuClientImpl::Init(const AsuClientConfig& config)
+{
+    if (initialized_) {
+        return Status::Error(StatusCode::RESOURCE_BUSY, "asu client has already been initialized");
+    }
+    if (config.sharedProviderMode != SharedProviderMode::INDEPENDENT &&
+        config.sharedProviderMode != SharedProviderMode::SHARED) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "sharedProviderMode must be 0 or 1");
+    }
+
+    config_ = config;
+    viewServer_ = viewServerFactory_(config);
+    if (viewServer_ == nullptr) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "view server factory returned null");
+    }
+    transportConfigs_.clear();
+    for (const auto& transportConfig : config.transportConfigs) {
+        transportConfigs_[transportConfig.asuId] = transportConfig;
+    }
+    if (config.transportConfigs.empty()) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "at least one transport config is required");
+    }
+    const auto queueDepth =
+        std::max<std::size_t>(2, static_cast<std::size_t>(config.maxInflightTasks));
+
+    GlobalView view;
+    auto status = viewServer_->GetGlobalView(view);
+    if (!status.ok()) { return status; }
+
+    std::shared_ptr<TransProvider> memoryProvider;
+    status = transProviderFactory_(config.transportConfigs.front(), memoryProvider);
+    if (!status.ok()) { return WithContext(status, "create business-memory provider failed"); }
+    if (!memoryProvider) {
+        return Status::Error(StatusCode::INTERNAL_ERROR,
+                             "business-memory provider factory returned null");
+    }
+    {
+        std::lock_guard<std::mutex> memoryLock{memoryMu_};
+        memoryProvider_ = std::move(memoryProvider);
+        providerMemoryStates_.push_back({memoryProvider_, {}});
+    }
+
+    std::shared_ptr<ViewSnapshot> nextSnapshot;
+    status = BuildSnapshot(view, nullptr, nextSnapshot);
+    if (!status.ok()) {
+        std::lock_guard<std::mutex> memoryLock{memoryMu_};
+        providerMemoryStates_.clear();
+        memoryProvider_.reset();
+        return status;
+    }
+
+    taskQueue_.Setup(queueDepth + 1);
+    stopWorker_.store(false, std::memory_order_release);
+    worker_ = std::thread(&AsuClientImpl::WorkerLoop, this);
+    snapshot_ = std::move(nextSnapshot);
+    initialized_ = true;
+    return Status::OK();
+}
+
+Status AsuClientImpl::Shutdown()
+{
+    std::uint64_t waitTimeoutMs = 0;
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+        initialized_ = false;
+        waitTimeoutMs = config_.defaultWaitTimeoutMs;
+    }
+    {
+        std::lock_guard<std::mutex> lock{producerMu_};
+        stopWorker_.store(true, std::memory_order_release);
+    }
+    JoinBackgroundRefresh();
+    if (worker_.joinable()) { worker_.join(); }
+
+    std::shared_ptr<ViewSnapshot> snapshot;
+    std::vector<std::shared_ptr<AsuTransport>> retiredTransports;
+    std::vector<ProviderMemoryState> providerMemoryStates;
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+        snapshot = std::move(snapshot_);
+        retiredTransports = std::move(retiredTransports_);
+        config_ = AsuClientConfig{};
+        viewServer_.reset();
+        transportConfigs_.clear();
+    }
+    {
+        std::lock_guard<std::mutex> lock{memoryMu_};
+        providerMemoryStates = std::move(providerMemoryStates_);
+        memoryProvider_.reset();
+        registeredRegions_.clear();
+    }
+
+    Status finalStatus = Status::OK();
+    auto drainStatus = taskManager_.Drain(waitTimeoutMs);
+    if (!drainStatus.ok()) { finalStatus = drainStatus; }
+    if (snapshot) {
+        auto shutdownStatus = ShutdownSnapshotTransports(snapshot);
+        if (!shutdownStatus.ok() && finalStatus.ok()) { finalStatus = shutdownStatus; }
+    }
+    for (auto& transport : retiredTransports) {
+        if (transport == nullptr) { continue; }
+        auto status = transport->Shutdown();
+        if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+    }
+    const auto unregisterState = [this, &finalStatus](const ProviderMemoryState& state) {
+        std::vector<MRHandle> localHandles;
+        localHandles.reserve(state.regionHandles.size());
+        for (const auto& item : state.regionHandles) { localHandles.emplace_back(item.second); }
+        auto status = UnregisterProviderRegions(state.provider, localHandles);
+        if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+    };
+    for (auto iter = providerMemoryStates.rbegin(); iter != providerMemoryStates.rend(); ++iter) {
+        unregisterState(*iter);
+    }
+    return finalStatus;
+}
+
+Status AsuClientImpl::QueryAsync(const std::vector<CacheKey>& keys, TaskId& taskId)
+{
+    auto status = SubmitAsync(AsuOpType::QUERY, keys, taskId);
+    if (IsRefreshNeeded(status)) { RequestBackgroundRefresh(); }
+    return status;
+}
+
+Status AsuClientImpl::LoadAsync(const std::vector<KVBuffer>& entries, TaskId& taskId)
+{
+    return SubmitAsync(AsuOpType::LOAD, entries, taskId);
+}
+
+Status AsuClientImpl::StoreAsync(const std::vector<KVBuffer>& entries, TaskId& taskId)
+{
+    return SubmitAsync(AsuOpType::STORE, entries, taskId);
+}
+
+Status AsuClientImpl::BatchLoadAsync(const std::vector<KVBuffer>& entries, TaskId& taskId)
+{
+    return SubmitAsync(AsuOpType::BATCH_LOAD, entries, taskId);
+}
+
+Status AsuClientImpl::BatchStoreAsync(const std::vector<KVBuffer>& entries, TaskId& taskId)
+{
+    return SubmitAsync(AsuOpType::BATCH_STORE, entries, taskId);
+}
+
+Status AsuClientImpl::DeleteAsync(const std::vector<CacheKey>& keys, TaskId& taskId)
+{
+    return SubmitAsync(AsuOpType::DELETE, keys, taskId);
+}
+
+bool AsuClientImpl::Check(TaskId taskId) { return taskManager_.Check(taskId); }
+
+Status AsuClientImpl::Wait(TaskId taskId, std::uint64_t timeoutMs, TaskResult& result)
+{
+    const auto waitMs = timeoutMs == 0 ? config_.defaultWaitTimeoutMs : timeoutMs;
+    auto status = taskManager_.Wait(taskId, waitMs, result);
+    if (status.code == StatusCode::TASK_NOT_FOUND) { return status; }
+    if (viewServer_ != nullptr &&
+        (viewServer_->ShouldRefreshView(status) || viewServer_->ShouldRefreshView(result))) {
+        RequestBackgroundRefresh();
+    }
+    return status;
+}
+
+Status AsuClientImpl::RegisterRegions(const std::vector<MemoryRegion>& regions,
+                                      std::vector<RegisteredMemory>& registeredRegions)
+{
+    bool needRefresh = false;
+    auto status = RegisterRegionsOnce(regions, registeredRegions, needRefresh);
+    if (needRefresh) { RequestBackgroundRefresh(); }
+    return status;
+}
+
+Status AsuClientImpl::RegisterRegionsOnce(const std::vector<MemoryRegion>& regions,
+                                          std::vector<RegisteredMemory>& registeredRegions,
+                                          bool& needRefresh)
+{
+    auto snapshot = GetSnapshot();
+    if (!snapshot) { return NotInitialized(); }
+
+    registeredRegions.clear();
+    if (snapshot->transports.empty()) { return Status::OK(); }
+    if (regions.empty()) { return Status::OK(); }
+
+    std::lock_guard<std::mutex> memoryLock{memoryMu_};
+    if (!memoryProvider_) {
+        return Status::Error(StatusCode::NOT_INITIALIZED,
+                             "client business-memory provider is not initialized");
+    }
+
+    std::vector<TransProvider::RegisterMemoryDesc> registerDescs;
+    registerDescs.reserve(regions.size());
+    for (const auto& region : regions) {
+        const auto memType = region.memoryType == MemoryType::DEVICE
+                                 ? TransProvider::MemType::MEM_DEVICE
+                                 : TransProvider::MemType::MEM_HOST;
+        registerDescs.push_back({memType, static_cast<std::uintptr_t>(region.addr),
+                                 static_cast<std::size_t>(region.size)});
+    }
+
+    std::vector<MRHandle> mrHandles;
+    auto status = memoryProvider_->RegisterMemory(registerDescs, mrHandles);
+    if (!status.ok()) {
+        needRefresh |= IsRefreshNeeded(status);
+        const auto cleanupStatus = UnregisterProviderRegions(memoryProvider_, mrHandles);
+        return Status::Error(StatusCode::PARTIAL_FAILED,
+                             cleanupStatus.ok()
+                                 ? "one or more memory regions failed to register"
+                                 : "memory region registration failed and cleanup was incomplete");
+    }
+    if (mrHandles.size() != regions.size()) {
+        const auto cleanupStatus = UnregisterProviderRegions(memoryProvider_, mrHandles);
+        return Status::Error(StatusCode::PARTIAL_FAILED,
+                             cleanupStatus.ok()
+                                 ? "register result count does not match region count"
+                                 : "register result count mismatch and cleanup was incomplete");
+    }
+
+    std::vector<std::uint32_t> tokenIds(regions.size());
+    for (std::size_t index = 0; index < mrHandles.size(); ++index) {
+        status = memoryProvider_->GetMemTokenId(mrHandles[index], tokenIds[index]);
+        if (status.ok()) { continue; }
+
+        const auto cleanupStatus = UnregisterProviderRegions(memoryProvider_, mrHandles);
+        return Status::Error(StatusCode::PARTIAL_FAILED,
+                             cleanupStatus.ok()
+                                 ? "one or more memory region token lookups failed"
+                                 : "memory region token lookup failed and cleanup was incomplete");
+    }
+
+    for (std::size_t index = 0; index < regions.size(); ++index) {
+        registeredRegions.emplace_back(
+            RegisteredMemory{regions[index], mrHandles[index], tokenIds[index]});
+    }
+
+    std::vector<std::vector<MRHandle>> providerHandles(providerMemoryStates_.size());
+    for (std::size_t index = 0; index < providerMemoryStates_.size(); ++index) {
+        auto& state = providerMemoryStates_[index];
+        if (state.provider == memoryProvider_) {
+            providerHandles[index] = mrHandles;
+            continue;
+        }
+        status = BindProviderRegions(state.provider, registeredRegions, providerHandles[index]);
+        if (status.ok()) { continue; }
+
+        for (std::size_t rollback = index; rollback > 0; --rollback) {
+            const auto stateIndex = rollback - 1;
+            if (providerHandles[stateIndex].empty()) { continue; }
+            (void)UnregisterProviderRegions(providerMemoryStates_[stateIndex].provider,
+                                            providerHandles[stateIndex]);
+        }
+        registeredRegions.clear();
+        return WithContext(Status::Error(StatusCode::PARTIAL_FAILED,
+                                         "one or more providers failed to bind memory"),
+                           "providerIndex=" + std::to_string(index) + " message=" + status.message);
+    }
+
+    for (std::size_t providerIndex = 0; providerIndex < providerMemoryStates_.size();
+         ++providerIndex) {
+        auto& handleMap = providerMemoryStates_[providerIndex].regionHandles;
+        for (std::size_t regionIndex = 0; regionIndex < registeredRegions.size(); ++regionIndex) {
+            handleMap.emplace(registeredRegions[regionIndex].handle,
+                              providerHandles[providerIndex][regionIndex]);
+        }
+    }
+    for (const auto& registeredRegion : registeredRegions) {
+        registeredRegions_.emplace(registeredRegion.handle, registeredRegion);
+    }
+    return Status::OK();
+}
+
+Status AsuClientImpl::SubmitAsync(AsuOpType opType, const std::vector<KVBuffer>& entries,
+                                  TaskId& taskId)
+{
+    auto snapshot = GetSnapshot();
+    if (!snapshot || !snapshot->router || snapshot->transports.empty()) {
+        taskId = kInvalidTaskId;
+        return Status::Error(StatusCode::NOT_INITIALIZED, "client has no ASU transports");
+    }
+
+    if (opType != AsuOpType::LOAD && opType != AsuOpType::STORE &&
+        opType != AsuOpType::BATCH_LOAD && opType != AsuOpType::BATCH_STORE) {
+        taskId = kInvalidTaskId;
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "entries submit only supports load/store");
+    }
+
+    auto ctx = std::make_unique<ClientTask>();
+    ctx->opType = opType;
+    ctx->viewSnapshot = snapshot;
+    ctx->entries = entries;
+    {
+        std::lock_guard<std::mutex> memoryLock{memoryMu_};
+        for (auto& entry : ctx->entries) {
+            // mrKey is client-owned metadata. Ignore any value supplied by the caller.
+            entry.mrKey.reset();
+            auto iter = registeredRegions_.find(entry.buffer.handle);
+            if (iter != registeredRegions_.end()) { entry.mrKey = iter->second.tokenId; }
+        }
+    }
+    ctx->entryStatus.assign(entries.size(), Status::OK());
+
+    auto status = taskManager_.Submit(std::move(ctx), taskId);
+    if (!status.ok()) { return status; }
+
+    auto rawCtx = taskManager_.Get(taskId);
+    if (!rawCtx) {
+        taskId = kInvalidTaskId;
+        return Status::Error(StatusCode::INTERNAL_ERROR, "client task disappeared after submit");
+    }
+
+    {
+        std::lock_guard<std::mutex> lock{producerMu_};
+        if (stopWorker_.load(std::memory_order_acquire)) {
+            (void)taskManager_.Remove(taskId);
+            taskId = kInvalidTaskId;
+            return NotInitialized();
+        }
+        if (!taskQueue_.TryPush(std::move(rawCtx))) {
+            (void)taskManager_.Remove(taskId);
+            taskId = kInvalidTaskId;
+            return Status::Error(StatusCode::RESOURCE_BUSY, "client task queue is full");
+        }
+    }
+    return Status::OK();
+}
+
+Status AsuClientImpl::SubmitAsync(AsuOpType opType, const std::vector<CacheKey>& keys,
+                                  TaskId& taskId)
+{
+    auto snapshot = GetSnapshot();
+    if (!snapshot || !snapshot->router || snapshot->transports.empty()) {
+        taskId = kInvalidTaskId;
+        return Status::Error(StatusCode::NOT_INITIALIZED, "client has no ASU transports");
+    }
+
+    if (opType != AsuOpType::QUERY && opType != AsuOpType::DELETE) {
+        taskId = kInvalidTaskId;
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "keys submit only supports query/delete");
+    }
+
+    auto ctx = std::make_unique<ClientTask>();
+    ctx->opType = opType;
+    ctx->viewSnapshot = snapshot;
+    ctx->keys = keys;
+    ctx->entryStatus.assign(keys.size(), Status::OK());
+    ctx->queryResult.exists.assign(opType == AsuOpType::QUERY ? keys.size() : 0, 0);
+
+    auto status = taskManager_.Submit(std::move(ctx), taskId);
+    if (!status.ok()) { return status; }
+
+    auto rawCtx = taskManager_.Get(taskId);
+    if (!rawCtx) {
+        taskId = kInvalidTaskId;
+        return Status::Error(StatusCode::INTERNAL_ERROR, "client task disappeared after submit");
+    }
+
+    {
+        std::lock_guard<std::mutex> lock{producerMu_};
+        if (stopWorker_.load(std::memory_order_acquire)) {
+            (void)taskManager_.Remove(taskId);
+            taskId = kInvalidTaskId;
+            return NotInitialized();
+        }
+        if (!taskQueue_.TryPush(std::move(rawCtx))) {
+            (void)taskManager_.Remove(taskId);
+            taskId = kInvalidTaskId;
+            return Status::Error(StatusCode::RESOURCE_BUSY, "client task queue is full");
+        }
+    }
+    return Status::OK();
+}
+
+void AsuClientImpl::WorkerLoop()
+{
+    auto processTask = [this](ClientTaskPtr ctx) {
+        auto status = taskManager_.Process(ctx);
+        if (IsRefreshNeeded(status)) { RequestBackgroundRefresh(); }
+    };
+    taskQueue_.ConsumerLoop(stopWorker_, processTask);
+
+    ClientTaskPtr ctx;
+    while (taskQueue_.TryPop(ctx)) { processTask(std::move(ctx)); }
+}
+
+Status AsuClientImpl::UnregisterRegions(const std::vector<MRHandle>& handles)
+{
+    std::lock_guard<std::mutex> memoryLock{memoryMu_};
+    std::vector<MRHandle> canonicalHandles;
+    canonicalHandles.reserve(handles.size());
+    for (auto handle : handles) {
+        if (handle == kInvalidMRHandle) { continue; }
+        if (registeredRegions_.count(handle) != 0) { canonicalHandles.emplace_back(handle); }
+    }
+
+    Status finalStatus = Status::OK();
+    const auto unregisterState = [this, &canonicalHandles,
+                                  &finalStatus](ProviderMemoryState& state) {
+        std::vector<MRHandle> localHandles;
+        std::vector<MRHandle> mappedCanonicalHandles;
+        for (auto canonicalHandle : canonicalHandles) {
+            auto iter = state.regionHandles.find(canonicalHandle);
+            if (iter == state.regionHandles.end()) { continue; }
+            mappedCanonicalHandles.emplace_back(canonicalHandle);
+            localHandles.emplace_back(iter->second);
+        }
+        auto status = UnregisterProviderRegions(state.provider, localHandles);
+        if (!status.ok()) {
+            if (finalStatus.ok()) { finalStatus = status; }
+            return;
+        }
+        for (auto canonicalHandle : mappedCanonicalHandles) {
+            state.regionHandles.erase(canonicalHandle);
+        }
+    };
+
+    for (auto iter = providerMemoryStates_.rbegin(); iter != providerMemoryStates_.rend(); ++iter) {
+        unregisterState(*iter);
+    }
+
+    std::vector<MRHandle> removedHandles;
+    for (auto canonicalHandle : canonicalHandles) {
+        const auto isStillRegistered =
+            std::any_of(providerMemoryStates_.begin(), providerMemoryStates_.end(),
+                        [canonicalHandle](const ProviderMemoryState& state) {
+                            return state.regionHandles.count(canonicalHandle) != 0;
+                        });
+        if (!isStillRegistered) { removedHandles.emplace_back(canonicalHandle); }
+    }
+    for (auto handle : removedHandles) { registeredRegions_.erase(handle); }
+
+    if (!finalStatus.ok()) {
+        return WithContext(finalStatus, "handle_count=" + std::to_string(canonicalHandles.size()));
+    }
+    return finalStatus;
+}
+
+Status AsuClientImpl::BuildSnapshot(const GlobalView& view,
+                                    const std::shared_ptr<ViewSnapshot>& oldSnapshot,
+                                    std::shared_ptr<ViewSnapshot>& snapshot)
+{
+    auto nextSnapshot = std::make_shared<ViewSnapshot>();
+    auto asuIds = GetSortedAsuIds(view);
+    nextSnapshot->view = view;
+
+    for (std::size_t asuIndex = 0; asuIndex < asuIds.size(); ++asuIndex) {
+        auto asuId = asuIds[asuIndex];
+        std::shared_ptr<AsuTransport> transport;
+        if (oldSnapshot != nullptr) {
+            auto oldIter = oldSnapshot->transports.find(asuId);
+            if (oldIter != oldSnapshot->transports.end()) { transport = oldIter->second; }
+        }
+
+        if (transport == nullptr) {
+            auto viewIter = view.asuMap.find(asuId);
+            auto asuInfo = viewIter == view.asuMap.end() ? AsuInfo{} : viewIter->second;
+            auto status = BuildTransport(asuId, asuInfo, transport);
+            if (!status.ok()) {
+                return WithContext(status, "asuIndex=" + std::to_string(asuIndex) +
+                                               " asuId=" + std::to_string(asuId));
+            }
+        }
+
+        nextSnapshot->transports.emplace(asuId, std::move(transport));
+    }
+
+    UC::Router::RouterConfig routerConfig;
+    auto status = BuildRouterConfigFromAttrs(config_.attrs, routerConfig);
+    if (!status.ok()) {
+        UC_ERROR("BuildSnapshot build router config failed: {}", status.message);
+        return status;
+    }
+
+    std::vector<UC::Router::NodeId> nodeIds(asuIds.begin(), asuIds.end());
+    nextSnapshot->router =
+        UC::Router::CreateRouter(nodeIds, UC::Router::HashFunction{}, routerConfig);
+    nextSnapshot->asuIds = std::move(asuIds);
+    snapshot = std::move(nextSnapshot);
+    return Status::OK();
+}
+
+Status AsuClientImpl::BuildTransport(AsuId asuId, const AsuInfo& asuInfo,
+                                     std::shared_ptr<AsuTransport>& transport)
+{
+    TransportConfig config;
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+        auto configIter = transportConfigs_.find(asuId);
+        if (configIter == transportConfigs_.end()) {
+            return Status::Error(StatusCode::NOT_FOUND,
+                                 "transport config not found, asuId=" + std::to_string(asuId));
+        }
+        config = configIter->second;
+    }
+    ApplyAsuInfoToTransportConfig(asuInfo, config);
+
+    std::lock_guard<std::mutex> memoryLock{memoryMu_};
+    std::shared_ptr<TransProvider> transProvider;
+    if (config_.sharedProviderMode == SharedProviderMode::SHARED) {
+        transProvider = memoryProvider_;
+    }
+    const bool createdProvider = !transProvider;
+    if (createdProvider) {
+        auto status = transProviderFactory_(config, transProvider);
+        if (!status.ok()) {
+            return WithContext(status,
+                               "create transport provider failed, asuId=" + std::to_string(asuId));
+        }
+        if (!transProvider) {
+            return Status::Error(
+                StatusCode::INTERNAL_ERROR,
+                "transport provider factory returned null, asuId=" + std::to_string(asuId));
+        }
+    }
+
+    auto nextTransport = transportFactory_();
+    if (!nextTransport) {
+        return Status::Error(StatusCode::INTERNAL_ERROR,
+                             "transport factory returned null, asuId=" + std::to_string(asuId));
+    }
+
+    auto status = nextTransport->Init(config, transProvider);
+    if (!status.ok()) {
+        return WithContext(status, "init transport failed, asuId=" + std::to_string(asuId));
+    }
+    if (!createdProvider) {
+        transport = std::shared_ptr<AsuTransport>(std::move(nextTransport));
+        return Status::OK();
+    }
+
+    std::vector<RegisteredMemory> regionsToBind;
+    regionsToBind.reserve(registeredRegions_.size());
+    for (const auto& item : registeredRegions_) { regionsToBind.emplace_back(item.second); }
+
+    std::vector<MRHandle> localHandles;
+    if (!regionsToBind.empty()) {
+        status = BindProviderRegions(transProvider, regionsToBind, localHandles);
+        if (!status.ok()) {
+            (void)nextTransport->Shutdown();
+            return WithContext(status,
+                               "bind provider memory failed, asuId=" + std::to_string(asuId));
+        }
+    }
+    ProviderMemoryState providerState;
+    providerState.provider = transProvider;
+    for (std::size_t index = 0; index < regionsToBind.size(); ++index) {
+        providerState.regionHandles.emplace(regionsToBind[index].handle, localHandles[index]);
+    }
+    providerMemoryStates_.emplace_back(std::move(providerState));
+    transport = std::shared_ptr<AsuTransport>(std::move(nextTransport));
+    return Status::OK();
+}
+
+Status AsuClientImpl::BindProviderRegions(const std::shared_ptr<TransProvider>& transProvider,
+                                          const std::vector<RegisteredMemory>& registeredRegions,
+                                          std::vector<MRHandle>& localHandles)
+{
+    localHandles.clear();
+    if (registeredRegions.empty()) { return Status::OK(); }
+    if (!transProvider) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "transport provider is not initialized");
+    }
+
+    std::vector<TransProvider::BindMemoryDesc> bindDescs;
+    bindDescs.reserve(registeredRegions.size());
+    for (const auto& registeredRegion : registeredRegions) {
+        const auto memType = registeredRegion.region.memoryType == MemoryType::DEVICE
+                                 ? TransProvider::MemType::MEM_DEVICE
+                                 : TransProvider::MemType::MEM_HOST;
+        bindDescs.push_back({memType, static_cast<std::uintptr_t>(registeredRegion.region.addr),
+                             static_cast<std::size_t>(registeredRegion.region.size),
+                             registeredRegion.tokenId});
+    }
+
+    auto status = transProvider->BindMemory(bindDescs, localHandles);
+    if (!status.ok() || localHandles.size() != registeredRegions.size()) {
+        (void)UnregisterProviderRegions(transProvider, localHandles);
+        localHandles.clear();
+        return status.ok() ? Status::Error(StatusCode::INTERNAL_ERROR,
+                                           "bind result count does not match region count")
+                           : status;
+    }
+
+    for (std::size_t index = 0; index < localHandles.size(); ++index) {
+        std::uint32_t tokenId = 0;
+        status = transProvider->GetMemTokenId(localHandles[index], tokenId);
+        if (status.ok() && tokenId == registeredRegions[index].tokenId) { continue; }
+
+        (void)UnregisterProviderRegions(transProvider, localHandles);
+        localHandles.clear();
+        return status.ok() ? Status::Error(StatusCode::INTERNAL_ERROR,
+                                           "bound memory token does not match registered token")
+                           : status;
+    }
+    return Status::OK();
+}
+
+Status AsuClientImpl::UnregisterProviderRegions(const std::shared_ptr<TransProvider>& transProvider,
+                                                const std::vector<MRHandle>& handles)
+{
+    if (handles.empty()) { return Status::OK(); }
+    if (!transProvider) {
+        return Status::Error(StatusCode::NOT_INITIALIZED,
+                             "client business-memory provider is not initialized");
+    }
+
+    std::vector<TransProvider::UnregisterMemoryDesc> unregisterDescs;
+    unregisterDescs.reserve(handles.size());
+    for (auto handle : handles) {
+        unregisterDescs.emplace_back(TransProvider::UnregisterMemoryDesc{handle});
+    }
+
+    const auto statuses = transProvider->UnregisterMemory(unregisterDescs);
+    Status failure = statuses.size() == handles.size()
+                         ? Status::OK()
+                         : Status::Error(StatusCode::INTERNAL_ERROR,
+                                         "unregister result count does not match handle count");
+    for (std::size_t index = 0; index < handles.size(); ++index) {
+        if ((index >= statuses.size() || !statuses[index].ok()) && failure.ok()) {
+            failure = index < statuses.size()
+                          ? statuses[index]
+                          : Status::Error(StatusCode::INTERNAL_ERROR,
+                                          "unregister result count does not match handle count");
+        }
+    }
+    return failure;
+}
+
+Status AsuClientImpl::RefreshView()
+{
+    std::shared_ptr<ViewServer> viewServer;
+    std::shared_ptr<ViewSnapshot> oldSnapshot;
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+        if (!initialized_ && !refreshInProgress_) { return NotInitialized(); }
+        viewServer = viewServer_;
+        oldSnapshot = snapshot_;
+    }
+    if (viewServer == nullptr) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "view server is not initialized");
+    }
+
+    GlobalView view;
+    auto status = viewServer->GetGlobalView(view);
+    if (!status.ok()) { return status; }
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+        if (!initialized_ && !refreshInProgress_) { return NotInitialized(); }
+        if (snapshot_ != nullptr && !viewServer->ShouldPublishView(snapshot_->view, view)) {
+            return Status::OK();
+        }
+    }
+
+    std::shared_ptr<ViewSnapshot> nextSnapshot;
+    status = BuildSnapshot(view, oldSnapshot, nextSnapshot);
+    if (!status.ok()) { return status; }
+
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+        if (!initialized_ && !refreshInProgress_) { return NotInitialized(); }
+        if (snapshot_ != nullptr && !viewServer->ShouldPublishView(snapshot_->view, view)) {
+            return Status::OK();
+        }
+        if (oldSnapshot != nullptr) {
+            for (const auto& item : oldSnapshot->transports) {
+                if (nextSnapshot->transports.find(item.first) == nextSnapshot->transports.end()) {
+                    retiredTransports_.emplace_back(item.second);
+                }
+            }
+        }
+        snapshot_ = std::move(nextSnapshot);
+    }
+
+    return Status::OK();
+}
+
+void AsuClientImpl::RequestBackgroundRefresh()
+{
+    std::thread completedThread;
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+        if (!initialized_ || refreshInProgress_) { return; }
+        completedThread = std::move(refreshThread_);
+        refreshInProgress_ = true;
+        refreshThread_ = std::thread([this] {
+            const auto status = RefreshView();
+            if (!status.ok()) {
+                UC_WARN("Background view refresh failed: code={} message={}",
+                        static_cast<int>(status.code), status.message);
+            }
+            std::lock_guard<std::mutex> lock{mutex_};
+            refreshInProgress_ = false;
+        });
+    }
+
+    if (completedThread.joinable()) { completedThread.join(); }
+}
+
+void AsuClientImpl::JoinBackgroundRefresh()
+{
+    std::thread refreshThread;
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+        refreshThread = std::move(refreshThread_);
+    }
+    if (refreshThread.joinable()) { refreshThread.join(); }
+}
+
+Status AsuClientImpl::ShutdownSnapshotTransports(const std::shared_ptr<ViewSnapshot>& snapshot)
+{
+    if (!snapshot) { return Status::OK(); }
+    Status finalStatus = Status::OK();
+    for (auto& item : snapshot->transports) {
+        auto status = item.second->Shutdown();
+        if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+    }
+    return finalStatus;
+}
+
+std::shared_ptr<ViewSnapshot> AsuClientImpl::GetSnapshot() const
+{
+    std::lock_guard<std::mutex> lock{mutex_};
+    if (!initialized_) { return nullptr; }
+    return snapshot_;
+}
+
+bool AsuClientImpl::IsRefreshNeeded(const Status& status) const
+{
+    return viewServer_ != nullptr && viewServer_->ShouldRefreshView(status);
+}
+
+std::vector<AsuId> AsuClientImpl::GetSortedAsuIds(const GlobalView& view)
+{
+    std::vector<AsuId> asuIds;
+    asuIds.reserve(view.asuMap.size());
+    for (const auto& item : view.asuMap) {
+        if (item.first != static_cast<AsuId>(UC::Router::kInvalidNodeId)) {
+            asuIds.emplace_back(item.first);
+        }
+    }
+    std::sort(asuIds.begin(), asuIds.end());
+    return asuIds;
+}
+
+Status AsuClientImpl::LoadConfig(const std::string& configPath, AsuClientConfig& config)
+{
+    return LoadAsuClientConfig(configPath, config);
+}
+
+Status AsuClientImpl::WithContext(Status status, const std::string& context)
+{
+    if (context.empty()) { return status; }
+    if (status.message.empty()) {
+        status.message = context;
+    } else {
+        status.message += ", " + context;
+    }
+    return status;
+}
+
+Status AsuClientImpl::NotInitialized()
+{
+    return Status::Error(StatusCode::NOT_INITIALIZED, "asu client is not initialized");
+}
+
+std::unique_ptr<AsuClient> CreateAsuClient(TransportFactory transportFactory,
+                                           TransProviderFactory transProviderFactory)
+{
+    return std::make_unique<AsuClientImpl>(std::move(transportFactory), nullptr,
+                                           std::move(transProviderFactory));
+}
+
+extern "C" std::unique_ptr<AsuClient> UcmAsuCreateAsuClient(
+    const TransportFactory* transportFactory)
+{
+    if (transportFactory == nullptr) { return CreateAsuClient(); }
+    return CreateAsuClient(*transportFactory);
+}
+
+extern "C" Status UcmAsuLoadAsuClientConfig(const char* configPath, AsuClientConfig* config)
+{
+    if (configPath == nullptr || config == nullptr) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "UcmAsuLoadAsuClientConfig received null argument");
+    }
+    return LoadAsuClientConfig(configPath, *config);
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/client/src/asu_client_impl.h
+++ b/ucm/transport/kv/asu/client/src/asu_client_impl.h
@@ -1,0 +1,189 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+#include "asu_client/asu_client.h"
+#include "asu_transport/types.h"
+#include "client_task_manager.h"
+#include "template/spsc_ring_queue.h"
+#include "view_server.h"
+
+namespace UC::Router {
+class Router;
+}  // namespace UC::Router
+
+namespace UC::ASU {
+
+// ViewSnapshot is the immutable routing state used by foreground IO and submitted tasks.
+struct ViewSnapshot {
+    std::shared_ptr<UC::Router::Router> router;
+    std::vector<AsuId> asuIds;
+    GlobalView view;
+    std::unordered_map<AsuId, std::shared_ptr<AsuTransport>> transports;
+};
+
+class AsuClientImpl;
+
+// AsuClientImpl coordinates routing, transports, and aggregate task tracking.
+class AsuClientImpl final : public AsuClient {
+public:
+    // Builds a client with the provided transport factory.
+    explicit AsuClientImpl(TransportFactory transportFactory,
+                           ViewServerFactory viewServerFactory = nullptr,
+                           TransProviderFactory transProviderFactory = nullptr);
+    // Shuts down the client during destruction.
+    ~AsuClientImpl() override;
+
+    // Initializes routing and transport resources.
+    Status Init(const std::string& configPath) override;
+    // Initializes from an already parsed config; intended for internal tests and adapters.
+    Status Init(const AsuClientConfig& config) override;
+    // Gracefully drains tracked client tasks and releases resources.
+    Status Shutdown() override;
+
+    // Submits query operations to routed transports.
+    Status QueryAsync(const std::vector<CacheKey>& keys, TaskId& taskId) override;
+    // Submits load operations to routed transports.
+    Status LoadAsync(const std::vector<KVBuffer>& entries, TaskId& taskId) override;
+    // Submits store operations to routed transports.
+    Status StoreAsync(const std::vector<KVBuffer>& entries, TaskId& taskId) override;
+    // Submits batch load operations to routed transports.
+    Status BatchLoadAsync(const std::vector<KVBuffer>& entries, TaskId& taskId) override;
+    // Submits batch store operations to routed transports.
+    Status BatchStoreAsync(const std::vector<KVBuffer>& entries, TaskId& taskId) override;
+    // Submits delete operations to routed transports.
+    Status DeleteAsync(const std::vector<CacheKey>& keys, TaskId& taskId) override;
+
+    // Checks an aggregate task.
+    bool Check(TaskId taskId) override;
+    // Waits for an aggregate task.
+    Status Wait(TaskId taskId, std::uint64_t timeoutMs, TaskResult& result) override;
+
+    // Registers regions and remembers successful resources for future views.
+    Status RegisterRegions(const std::vector<MemoryRegion>& regions,
+                           std::vector<RegisteredMemory>& registeredRegions) override;
+    // Unregisters regions and forgets successful resources.
+    Status UnregisterRegions(const std::vector<MRHandle>& handles) override;
+
+private:
+    struct ProviderMemoryState {
+        std::shared_ptr<TransProvider> provider;
+        std::unordered_map<MRHandle, MRHandle> regionHandles;
+    };
+
+    // Creates and queues one entry-based client task.
+    Status SubmitAsync(AsuOpType opType, const std::vector<KVBuffer>& entries, TaskId& taskId);
+    // Creates and queues one key-based client task.
+    Status SubmitAsync(AsuOpType opType, const std::vector<CacheKey>& keys, TaskId& taskId);
+
+    // Runs queued tasks until shutdown and the queue are both complete.
+    void WorkerLoop();
+
+    // Performs one register operation on the current snapshot.
+    Status RegisterRegionsOnce(const std::vector<MemoryRegion>& regions,
+                               std::vector<RegisteredMemory>& registeredRegions, bool& needRefresh);
+    // Builds a complete immutable snapshot for a view.
+    Status BuildSnapshot(const GlobalView& view, const std::shared_ptr<ViewSnapshot>& oldSnapshot,
+                         std::shared_ptr<ViewSnapshot>& snapshot);
+    // Creates and initializes a transport for one ASU.
+    Status BuildTransport(AsuId asuId, const AsuInfo& asuInfo,
+                          std::shared_ptr<AsuTransport>& transport);
+    Status BindProviderRegions(const std::shared_ptr<TransProvider>& transProvider,
+                               const std::vector<RegisteredMemory>& registeredRegions,
+                               std::vector<MRHandle>& localHandles);
+    Status UnregisterProviderRegions(const std::shared_ptr<TransProvider>& transProvider,
+                                     const std::vector<MRHandle>& handles);
+    // Returns the current immutable snapshot if initialized.
+    std::shared_ptr<ViewSnapshot> GetSnapshot() const;
+
+    // Refreshes the view and publishes it if it is newer.
+    Status RefreshView();
+    // Starts a non-blocking refresh after a status indicates stale routing or transport state.
+    void RequestBackgroundRefresh();
+    // Waits for the background refresh worker to finish.
+    void JoinBackgroundRefresh();
+
+    // Shuts down transports owned by a snapshot.
+    Status ShutdownSnapshotTransports(const std::shared_ptr<ViewSnapshot>& snapshot);
+
+    // Returns whether a status suggests the published snapshot should be refreshed.
+    bool IsRefreshNeeded(const Status& status) const;
+    // Extracts sorted ASU ids from a view.
+    static std::vector<AsuId> GetSortedAsuIds(const GlobalView& view);
+    // Parses client config from a file path supplied through the public interface.
+    static Status LoadConfig(const std::string& configPath, AsuClientConfig& config);
+    // Adds context to a status message.
+    static Status WithContext(Status status, const std::string& context);
+    // Builds the standard not-initialized status.
+    static Status NotInitialized();
+
+    // Tracks aggregate client tasks returned through public TaskId values.
+    ClientTaskManager taskManager_;
+    // Serializes producers and protects the shutdown acceptance boundary.
+    std::mutex producerMu_;
+    UC::SpscRingQueue<ClientTaskPtr> taskQueue_;
+    std::atomic_bool stopWorker_{true};
+    std::thread worker_;
+    // Creates ASU transports; tests inject fake transports through this hook.
+    TransportFactory transportFactory_;
+    // Creates providers; tests inject fake providers through this hook.
+    TransProviderFactory transProviderFactory_;
+    // Creates the external view server during Init.
+    ViewServerFactory viewServerFactory_;
+    // mutex_ protects background refresh state and resource/view caches.
+    mutable std::mutex mutex_;
+    // memoryMu_ serializes provider creation with business-memory register/bind/unregister.
+    std::mutex memoryMu_;
+    // Tracks whether Init has published a usable snapshot.
+    bool initialized_{false};
+    // Prevents duplicate background refresh workers.
+    bool refreshInProgress_{false};
+    // Last accepted initialization config.
+    AsuClientConfig config_;
+    // Source for dynamic global views; may be backed by viewServiceAddrs.
+    std::shared_ptr<ViewServer> viewServer_;
+    // Transport configs indexed by ASU id for snapshot construction.
+    std::unordered_map<AsuId, TransportConfig> transportConfigs_;
+    // Provider-local handles indexed by the canonical handles returned by this client.
+    std::vector<ProviderMemoryState> providerMemoryStates_;
+    // Provider selected for all client business-memory registration operations.
+    std::shared_ptr<TransProvider> memoryProvider_;
+    // Regions registered by the client and rebound to newly added providers.
+    std::unordered_map<MRHandle, RegisteredMemory> registeredRegions_;
+    // Current immutable routing and transport snapshot.
+    std::shared_ptr<ViewSnapshot> snapshot_;
+    // Transports removed from the active snapshot but still needed by old tasks.
+    std::vector<std::shared_ptr<AsuTransport>> retiredTransports_;
+    // Worker used for non-blocking refresh requests.
+    std::thread refreshThread_;
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/client/src/client_config_parser.cpp
+++ b/ucm/transport/kv/asu/client/src/client_config_parser.cpp
@@ -1,0 +1,176 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "client_config_parser.h"
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "asu_client/asu_client.h"
+#include "config_parser_common.h"
+#include "status_utils.h"
+#include "view_server.h"
+
+namespace UC::ASU {
+namespace {
+
+AsuInfo ParseAsuInfo(const std::string& value)
+{
+    AsuInfo info;
+    for (const auto& endpointValue : SplitConfigValue(value, ';')) {
+        info.endpoints.emplace_back(ParseClientViewEndpoint(endpointValue));
+    }
+    return info;
+}
+
+}  // namespace
+
+Status LoadAsuClientConfig(const std::string& configPath, AsuClientConfig& config)
+{
+    std::ifstream configFile{configPath};
+    if (!configFile.is_open()) {
+        const auto message = "failed to open asu client config, path=" + configPath;
+        return ASU_LOG_ERROR_STATUS(StatusCode::NOT_FOUND, message);
+    }
+
+    config = AsuClientConfig{};
+    std::unordered_map<AsuId, AsuInfo> asuInfos;
+    std::vector<std::pair<std::string, std::string>> transportFields;
+    std::string line;
+    while (std::getline(configFile, line)) {
+        line = TrimConfigValue(line);
+        if (line.empty() || line[0] == '#') { continue; }
+
+        const auto pos = line.find('=');
+        if (pos == std::string::npos) { continue; }
+
+        const auto key = TrimConfigValue(line.substr(0, pos));
+        const auto value = TrimConfigValue(line.substr(pos + 1));
+        if (key == "clientId" || key == "client_id") {
+            config.clientId = value;
+        } else if (key == "client.maxInflightTasks" || key == "client.max_inflight_tasks") {
+            config.maxInflightTasks = static_cast<std::uint32_t>(ParseConfigUint64(value));
+        } else if (key == "viewServiceAddrs" || key == "view_service_addrs") {
+            config.viewServiceAddrs = SplitConfigValue(value, ',');
+        } else if (key == "view.config_path" || key == "viewConfigPath" ||
+                   key == "view_config_path") {
+            config.attrs["view.config_path"] = value;
+        } else if (key == "waitTimeoutMs" || key == "wait_timeout_ms") {
+            const auto waitTimeoutMs = ParseConfigUint64(value);
+            config.defaultWaitTimeoutMs = waitTimeoutMs;
+            config.timeoutMs = waitTimeoutMs;
+        } else if (key == "asuSharedProvider" || key == "asu_shared_provider") {
+            config.sharedProviderMode = static_cast<SharedProviderMode>(ParseConfigUint64(value));
+        } else if (key == "router.type" || key == "routerType" || key == "hashTable.type" ||
+                   key == "hash_table.type") {
+            auto type = value;
+            std::transform(type.begin(), type.end(), type.begin(),
+                           [](unsigned char ch) { return static_cast<char>(std::toupper(ch)); });
+            if (type == "MAGLEV" || type == "MAGLEV_FULL_SPREAD") {
+                config.attrs["hash_table.type"] = "MAGLEV";
+            } else if (type == "CONTIGUOUS_BLOCK_AFFINITY") {
+                config.attrs["hash_table.type"] = "CONTIGUOUS_BLOCK_AFFINITY";
+            } else if (type == "BATCH_TOPK_AFFINITY") {
+                config.attrs["hash_table.type"] = "BATCH_TOPK_AFFINITY";
+            } else {
+                config.attrs["hash_table.type"] = "RING_HASH";
+            }
+        } else if (key == "hashTable.ringHash.virtualNodeCount" ||
+                   key == "ring_hash.virtual_node_count") {
+            config.attrs["ring_hash.virtual_node_count"] = value;
+        } else if (key == "hashTable.maglev.tableSize" || key == "maglev.table_size") {
+            config.attrs["maglev.table_size"] = value;
+        } else if (key == "hashTable.contiguousBlockAffinity.blockCount" ||
+                   key == "contiguous_block_affinity.block_count") {
+            config.attrs["contiguous_block_affinity.block_count"] = value;
+        } else if (key == "hashTable.contiguousBlockAffinity.fullSpreadType" ||
+                   key == "contiguous_block_affinity.full_spread_type") {
+            config.attrs["contiguous_block_affinity.full_spread_type"] = value;
+        } else if (key == "hashTable.contiguousBlockAffinity.dynamicAdjustEnabled" ||
+                   key == "contiguous_block_affinity.dynamic_adjust_enabled") {
+            config.attrs["contiguous_block_affinity.dynamic_adjust_enabled"] = value;
+        } else if (key == "hashTable.batchTopKAffinity.topK" ||
+                   key == "batch_topk_affinity.top_k") {
+            config.attrs["batch_topk_affinity.top_k"] = value;
+        } else if (key == "hashTable.batchTopKAffinity.dynamicAdjustEnabled" ||
+                   key == "batch_topk_affinity.dynamic_adjust_enabled") {
+            config.attrs["batch_topk_affinity.dynamic_adjust_enabled"] = value;
+        } else if (key == "transport.asuIds" || key == "transport.asu_ids" || key == "asuIds" ||
+                   key == "asu_ids") {
+            for (const auto& asuIdText : SplitConfigValue(value, ',')) {
+                TransportConfig transportConfig;
+                transportConfig.asuId = ParseConfigUint64(asuIdText);
+                config.transportConfigs.emplace_back(std::move(transportConfig));
+            }
+        } else {
+            AsuId asuId{0};
+            std::string attrKey;
+            if (TryParseAsuInfoKey(key, asuId)) {
+                asuInfos[asuId] = ParseAsuInfo(value);
+            } else if (TryGetTransportAttrKey(key, attrKey)) {
+                transportFields.emplace_back(attrKey, value);
+            }
+        }
+    }
+
+    for (auto& transportConfig : config.transportConfigs) {
+        transportConfig.timeoutMs = config.timeoutMs;
+        for (const auto& field : transportFields) {
+            if (ApplyTransportCompletionConfigField(transportConfig, field.first, field.second)) {
+                continue;
+            }
+            if (ApplyTransportBufferConfigField(transportConfig, field.first, field.second)) {
+                continue;
+            }
+            if (ApplyTransportIoNumConfigField(transportConfig, field.first, field.second)) {
+                continue;
+            }
+            if (ApplyTransportProviderConfigField(transportConfig, field.first, field.second)) {
+                continue;
+            }
+            if (ApplyTransportDeviceConfigField(transportConfig, field.first, field.second)) {
+                continue;
+            }
+            if (field.first == "maxErrorCount" || field.first == "max_error_count") {
+                transportConfig.maxErrorCount =
+                    static_cast<std::uint32_t>(ParseConfigUint64(field.second));
+                continue;
+            }
+            if (field.first == "maxInflightTasks" || field.first == "max_inflight_tasks") {
+                transportConfig.maxInflightTasks =
+                    static_cast<std::uint32_t>(ParseConfigUint64(field.second));
+                continue;
+            }
+            transportConfig.attrs.emplace(field);
+        }
+
+        auto iter = asuInfos.find(transportConfig.asuId);
+        if (iter == asuInfos.end()) { continue; }
+        ApplyAsuInfoToTransportConfig(iter->second, transportConfig);
+    }
+    return Status::OK();
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/client/src/client_config_parser.h
+++ b/ucm/transport/kv/asu/client/src/client_config_parser.h
@@ -1,0 +1,35 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <string>
+#include "asu_transport/types.h"
+
+namespace UC::ASU {
+
+struct AsuClientConfig;
+
+Status LoadAsuClientConfig(const std::string& configPath, AsuClientConfig& config);
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/client/src/client_router_config.cpp
+++ b/ucm/transport/kv/asu/client/src/client_router_config.cpp
@@ -1,0 +1,144 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "client_router_config.h"
+#include <algorithm>
+#include <cctype>
+#include <string>
+#include "status_utils.h"
+
+namespace UC::ASU {
+namespace {
+
+std::string NormalizeAttrValue(std::string value)
+{
+    std::replace(value.begin(), value.end(), '-', '_');
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::toupper(ch)); });
+    return value;
+}
+
+bool GetAttr(const std::unordered_map<std::string, std::string>& attrs, const std::string& key,
+             std::string& value)
+{
+    auto iter = attrs.find(key);
+    if (iter == attrs.end()) { return false; }
+    value = iter->second;
+    return true;
+}
+
+Status GetUint64Attr(const std::unordered_map<std::string, std::string>& attrs,
+                     const std::string& key, std::uint64_t& value)
+{
+    std::string text;
+    if (!GetAttr(attrs, key, text)) { return Status::OK(); }
+
+    try {
+        std::size_t parsed{0};
+        const auto parsedValue = std::stoull(text, &parsed, 0);
+        if (parsed != text.size()) {
+            return ASU_LOG_ERROR_STATUS(StatusCode::INVALID_ARGUMENT,
+                                        "invalid router config " + key + "=" + text);
+        }
+        value = parsedValue;
+        return Status::OK();
+    } catch (const std::exception&) {
+        return ASU_LOG_ERROR_STATUS(StatusCode::INVALID_ARGUMENT,
+                                    "invalid router config " + key + "=" + text);
+    }
+}
+
+Status GetBoolAttr(const std::unordered_map<std::string, std::string>& attrs,
+                   const std::string& key, bool& value)
+{
+    std::string text;
+    if (!GetAttr(attrs, key, text)) { return Status::OK(); }
+
+    const auto normalized = NormalizeAttrValue(text);
+    if (normalized == "1" || normalized == "TRUE" || normalized == "ON" || normalized == "YES") {
+        value = true;
+        return Status::OK();
+    }
+    if (normalized == "0" || normalized == "FALSE" || normalized == "OFF" || normalized == "NO") {
+        value = false;
+        return Status::OK();
+    }
+    return ASU_LOG_ERROR_STATUS(StatusCode::INVALID_ARGUMENT,
+                                "invalid router config " + key + "=" + text);
+}
+
+UC::Router::RouterType ParseRouterType(const std::string& value, UC::Router::RouterType fallback)
+{
+    const auto type = NormalizeAttrValue(value);
+    if (type == "RING_HASH" || type == "RING_HASH_FULL_SPREAD") {
+        return UC::Router::RouterType::RING_HASH_FULL_SPREAD;
+    }
+    if (type == "MAGLEV" || type == "MAGLEV_FULL_SPREAD") {
+        return UC::Router::RouterType::MAGLEV_FULL_SPREAD;
+    }
+    if (type == "CONTIGUOUS_BLOCK_AFFINITY") {
+        return UC::Router::RouterType::CONTIGUOUS_BLOCK_AFFINITY;
+    }
+    if (type == "BATCH_TOPK_AFFINITY") { return UC::Router::RouterType::BATCH_TOPK_AFFINITY; }
+    return fallback;
+}
+
+}  // namespace
+
+Status BuildRouterConfigFromAttrs(const std::unordered_map<std::string, std::string>& attrs,
+                                  UC::Router::RouterConfig& config)
+{
+    config = UC::Router::RouterConfig{};
+
+    std::string type;
+    if (GetAttr(attrs, "hash_table.type", type)) {
+        config.type = ParseRouterType(type, config.type);
+    }
+
+    auto status =
+        GetUint64Attr(attrs, "ring_hash.virtual_node_count", config.ringHash.virtualNodeCount);
+    if (!status.ok()) { return status; }
+    status = GetUint64Attr(attrs, "maglev.table_size", config.maglev.tableSize);
+    if (!status.ok()) { return status; }
+    status = GetUint64Attr(attrs, "contiguous_block_affinity.block_count",
+                           config.contiguousBlockAffinity.blockCount);
+    if (!status.ok()) { return status; }
+    status = GetUint64Attr(attrs, "batch_topk_affinity.top_k", config.batchTopKAffinity.topK);
+    if (!status.ok()) { return status; }
+
+    std::string fullSpreadType;
+    if (GetAttr(attrs, "contiguous_block_affinity.full_spread_type", fullSpreadType)) {
+        config.contiguousBlockAffinity.fullSpreadType =
+            ParseRouterType(fullSpreadType, config.contiguousBlockAffinity.fullSpreadType);
+    }
+
+    status = GetBoolAttr(attrs, "contiguous_block_affinity.dynamic_adjust_enabled",
+                         config.contiguousBlockAffinity.dynamicAdjustEnabled);
+    if (!status.ok()) { return status; }
+    status = GetBoolAttr(attrs, "batch_topk_affinity.dynamic_adjust_enabled",
+                         config.batchTopKAffinity.dynamicAdjustEnabled);
+    if (!status.ok()) { return status; }
+    return Status::OK();
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/client/src/client_router_config.h
+++ b/ucm/transport/kv/asu/client/src/client_router_config.h
@@ -1,0 +1,36 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include "asu_transport/types.h"
+#include "router/router.h"
+
+namespace UC::ASU {
+
+Status BuildRouterConfigFromAttrs(const std::unordered_map<std::string, std::string>& attrs,
+                                  UC::Router::RouterConfig& config);
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/client/src/client_task_manager.cpp
+++ b/ucm/transport/kv/asu/client/src/client_task_manager.cpp
@@ -1,0 +1,354 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "client_task_manager.h"
+#include <algorithm>
+#include <chrono>
+#include <string>
+#include <utility>
+#include "asu_client_impl.h"
+#include "logger/logger.h"
+#include "router/router.h"
+
+namespace UC::ASU {
+
+namespace {
+
+const char* AsuOpTypeName(AsuOpType opType)
+{
+    switch (opType) {
+        case AsuOpType::QUERY: return "query";
+        case AsuOpType::LOAD: return "load";
+        case AsuOpType::STORE: return "store";
+        case AsuOpType::BATCH_LOAD: return "batch_load";
+        case AsuOpType::BATCH_STORE: return "batch_store";
+        case AsuOpType::DELETE: return "delete";
+        case AsuOpType::KEEP_ALIVE: return "keep_alive";
+        default: return "unknown";
+    }
+}
+
+std::vector<UC::Router::CacheKey> ToRouterKeys(const std::vector<CacheKey>& keys)
+{
+    std::vector<UC::Router::CacheKey> routerKeys;
+    routerKeys.reserve(keys.size());
+    for (const auto& key : keys) { routerKeys.emplace_back(std::string(CacheKeyView(key))); }
+    return routerKeys;
+}
+
+std::vector<UC::Router::CacheKey> ExtractEntryKeys(const std::vector<KVBuffer>& entries)
+{
+    std::vector<UC::Router::CacheKey> keys;
+    keys.reserve(entries.size());
+    for (const auto& entry : entries) { keys.emplace_back(std::string(CacheKeyView(entry.key))); }
+    return keys;
+}
+
+Status AddContext(Status status, const std::string& context)
+{
+    if (context.empty()) { return status; }
+    if (status.message.empty()) {
+        status.message = context;
+    } else {
+        status.message += ", " + context;
+    }
+    return status;
+}
+
+}  // namespace
+
+bool ClientTask::Done() const
+{
+    return state.load(std::memory_order_acquire) == ClientTaskState::COMPLETED;
+}
+
+bool ClientTask::AllTransportTasksCompleted() const
+{
+    return remainingTransportTasks.load(std::memory_order_acquire) == 0;
+}
+
+bool ClientTaskManager::Check(TaskId taskId)
+{
+    auto task = Get(taskId);
+    return !task || task->Done();
+}
+
+Status ClientTaskManager::Wait(TaskId taskId, std::uint64_t waitTimeoutMs, TaskResult& result)
+{
+    auto task = Get(taskId);
+    if (!task) { return Status::Error(StatusCode::TASK_NOT_FOUND, "task not found"); }
+
+    auto status = WaitContext(task, waitTimeoutMs, result);
+    (void)Remove(taskId);
+    return status;
+}
+
+Status ClientTaskManager::Drain(std::uint64_t waitTimeoutMs)
+{
+    Status finalStatus = Status::OK();
+    for (const auto& task : GetAll()) {
+        if (!task) { continue; }
+
+        if (!task->Done()) {
+            TaskResult result;
+            auto status = WaitContext(task, waitTimeoutMs, result);
+            if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+        }
+        (void)Remove(task->taskId);
+    }
+    return finalStatus;
+}
+
+Status ClientTaskManager::Process(const ClientTaskPtr& task)
+{
+    if (!task) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "client task context is null");
+    }
+    task->state.store(ClientTaskState::INFLIGHT, std::memory_order_release);
+
+    auto status = BuildTransportTasks(task);
+    if (!status.ok()) {
+        CompleteWithError(task, status);
+        return status;
+    }
+    return DispatchTask(task);
+}
+
+void ClientTaskManager::CompleteWithError(const ClientTaskPtr& task, const Status& status)
+{
+    std::lock_guard<std::mutex> lock{task->waitMu};
+    std::fill(task->entryStatus.begin(), task->entryStatus.end(), status);
+    task->finalStatus = status;
+    UC_ERROR("ASU client task failed: client_task_id={} op={} code={} message={}.", task->taskId,
+             AsuOpTypeName(task->opType), static_cast<int>(status.code), status.message);
+    task->state.store(ClientTaskState::COMPLETED, std::memory_order_release);
+    task->cv.notify_all();
+}
+
+void ClientTaskManager::CompleteTransportTask(const ClientTaskPtr& task,
+                                              std::size_t transportTaskIndex, TaskResult result)
+{
+    std::lock_guard<std::mutex> lock(task->waitMu);
+    auto& transportTask = task->transportTasks[transportTaskIndex];
+    if (transportTask->clientCompleted) { return; }
+
+    auto completionStatus = result.status;
+    bool invalidQueryResult = false;
+    if (task->opType == AsuOpType::QUERY && completionStatus.ok()) {
+        if (!result.queryResult.has_value()) {
+            completionStatus =
+                Status::Error(StatusCode::INTERNAL_ERROR, "transport query result is missing");
+            invalidQueryResult = true;
+        } else if (result.queryResult->exists.size() != transportTask->originalIndices.size()) {
+            completionStatus =
+                Status::Error(StatusCode::INTERNAL_ERROR, "transport query result size mismatch");
+            invalidQueryResult = true;
+        } else {
+            for (std::size_t index = 0; index < transportTask->originalIndices.size(); ++index) {
+                task->queryResult.exists[transportTask->originalIndices[index]] =
+                    result.queryResult->exists[index];
+            }
+        }
+    }
+
+    transportTask->clientCompleted = true;
+    transportTask->finalStatus = completionStatus;
+    for (std::size_t index = 0; index < transportTask->originalIndices.size(); ++index) {
+        task->entryStatus[transportTask->originalIndices[index]] =
+            !invalidQueryResult && index < result.entryStatus.size() ? result.entryStatus[index]
+                                                                     : completionStatus;
+    }
+
+    if (task->remainingTransportTasks.fetch_sub(1, std::memory_order_acq_rel) == 1) {
+        Finalize(task);
+    }
+}
+
+void ClientTaskManager::CompleteUndispatchedTransportTasks(const ClientTaskPtr& task,
+                                                           std::size_t firstTransportTaskIndex,
+                                                           const Status& dispatchStatus)
+{
+    std::lock_guard<std::mutex> lock(task->waitMu);
+    for (std::size_t index = firstTransportTaskIndex; index < task->transportTasks.size();
+         ++index) {
+        auto& failedTask = task->transportTasks[index];
+        failedTask->clientCompleted = true;
+        failedTask->finalStatus =
+            index == firstTransportTaskIndex
+                ? dispatchStatus
+                : Status::Error(StatusCode::CANCELED,
+                                "transport task not dispatched after a dispatch failure");
+        for (auto originalIndex : failedTask->originalIndices) {
+            task->entryStatus[originalIndex] = failedTask->finalStatus;
+        }
+        task->remainingTransportTasks.fetch_sub(1, std::memory_order_acq_rel);
+    }
+
+    if (task->AllTransportTasksCompleted()) { Finalize(task); }
+}
+
+void ClientTaskManager::Finalize(const ClientTaskPtr& task)
+{
+    if (task->opType == AsuOpType::QUERY) {
+        task->queryResult.prefixHitKeys = 0;
+        for (auto exists : task->queryResult.exists) {
+            if (exists == 0) { break; }
+            ++task->queryResult.prefixHitKeys;
+        }
+    }
+
+    std::size_t failedTransportTasks = 0;
+    for (const auto& transportTask : task->transportTasks) {
+        if (transportTask->finalStatus.ok()) { continue; }
+
+        ++failedTransportTasks;
+        const auto itemCount = transportTask->entries.empty() ? transportTask->keys.size()
+                                                              : transportTask->entries.size();
+        UC_ERROR(
+            "ASU client transport task failed: client_task_id={} op={} asuId={} "
+            "transport_task_id={} item_count={} code={} message={}.",
+            task->taskId, AsuOpTypeName(task->opType), transportTask->asuId, transportTask->taskId,
+            itemCount, static_cast<int>(transportTask->finalStatus.code),
+            transportTask->finalStatus.message);
+    }
+    task->finalStatus = failedTransportTasks == 0 ? Status::OK()
+                                                  : Status::Error(StatusCode::PARTIAL_FAILED,
+                                                                  "client task partially failed");
+    if (task->finalStatus.ok()) {
+        UC_DEBUG("ASU client task completed: client_task_id={} op={} transport_tasks={}.",
+                 task->taskId, AsuOpTypeName(task->opType), task->transportTasks.size());
+    }
+    task->state.store(ClientTaskState::COMPLETED, std::memory_order_release);
+    task->cv.notify_all();
+}
+
+Status ClientTaskManager::BuildTransportTasks(const ClientTaskPtr& task)
+{
+    auto snapshot = task->viewSnapshot;
+    if (!snapshot || !snapshot->router || snapshot->transports.empty()) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "client has no ASU transports");
+    }
+
+    const auto routes = task->opType == AsuOpType::QUERY || task->opType == AsuOpType::DELETE
+                            ? snapshot->router->RouteKeys(ToRouterKeys(task->keys))
+                            : snapshot->router->RouteKeys(ExtractEntryKeys(task->entries));
+    for (const auto& [asuId, indices] : routes) {
+        if (snapshot->transports.find(asuId) == snapshot->transports.end()) {
+            return AddContext(
+                Status::Error(StatusCode::NOT_FOUND, "routed asu transport not found"),
+                "asuId=" + std::to_string(asuId));
+        }
+    }
+
+    task->transportTasks.reserve(routes.size());
+    for (const auto& [asuId, indices] : routes) {
+        auto transportTask = std::make_shared<TransportTask>();
+        transportTask->asuId = asuId;
+        transportTask->transport = snapshot->transports.at(asuId);
+        transportTask->originalIndices.reserve(indices.size());
+        if (task->opType == AsuOpType::QUERY || task->opType == AsuOpType::DELETE) {
+            transportTask->keys.reserve(indices.size());
+            for (auto index : indices) {
+                transportTask->keys.push_back(std::move(task->keys[index]));
+                transportTask->originalIndices.push_back(index);
+            }
+        } else {
+            transportTask->entries.reserve(indices.size());
+            for (auto index : indices) {
+                transportTask->entries.push_back(std::move(task->entries[index]));
+                transportTask->originalIndices.push_back(index);
+            }
+        }
+        task->transportTasks.push_back(std::move(transportTask));
+    }
+    std::vector<KVBuffer>{}.swap(task->entries);
+    std::vector<CacheKey>{}.swap(task->keys);
+    task->remainingTransportTasks.store(task->transportTasks.size(), std::memory_order_release);
+    return Status::OK();
+}
+
+Status ClientTaskManager::DispatchTask(const ClientTaskPtr& task)
+{
+    if (task->transportTasks.empty()) {
+        std::lock_guard<std::mutex> lock(task->waitMu);
+        Finalize(task);
+        return Status::OK();
+    }
+
+    for (std::size_t taskIndex = 0; taskIndex < task->transportTasks.size(); ++taskIndex) {
+        auto& transportTask = task->transportTasks[taskIndex];
+        auto transport = transportTask->transport.lock();
+
+        std::weak_ptr<ClientTask> clientTask = task;
+        transportTask->onComplete = [clientTask, taskIndex](TaskResult result) {
+            auto task = clientTask.lock();
+            if (!task) { return; }
+            CompleteTransportTask(task, taskIndex, std::move(result));
+        };
+        transportTask->opType = task->opType;
+        auto status = transport->Submit(transportTask);
+        if (!status.ok()) {
+            const auto dispatchStatus =
+                AddContext(status, "asuId=" + std::to_string(transportTask->asuId));
+            CompleteUndispatchedTransportTasks(task, taskIndex, dispatchStatus);
+            return dispatchStatus;
+        }
+    }
+    return Status::OK();
+}
+
+Status ClientTaskManager::BuildResult(const ClientTaskPtr& task, TaskResult& result)
+{
+    result.status = task->Done()
+                        ? task->finalStatus
+                        : Status::Error(StatusCode::IN_PROGRESS, "client task in progress");
+    result.entryStatus = task->entryStatus;
+    if (task->opType == AsuOpType::QUERY) {
+        result.queryResult = task->queryResult;
+    } else {
+        result.queryResult.reset();
+    }
+    return result.status;
+}
+
+Status ClientTaskManager::WaitContext(const ClientTaskPtr& task, std::uint64_t waitTimeoutMs,
+                                      TaskResult& result)
+{
+    if (!task) { return Status::Error(StatusCode::TASK_NOT_FOUND, "client task not found"); }
+
+    std::unique_lock<std::mutex> lock(task->waitMu);
+    const bool done = task->cv.wait_for(lock, std::chrono::milliseconds(waitTimeoutMs),
+                                        [task] { return task->Done(); });
+    BuildResult(task, result);
+    if (!done) {
+        result.status = Status::Error(
+            StatusCode::TIMEOUT,
+            "client task wait timeout: client_task_id=" + std::to_string(task->taskId) +
+                " op=" + AsuOpTypeName(task->opType) + " wait_ms=" + std::to_string(waitTimeoutMs));
+        UC_ERROR("ASU client task wait timeout: client_task_id={} op={} wait_ms={}.", task->taskId,
+                 AsuOpTypeName(task->opType), waitTimeoutMs);
+    }
+    return result.status;
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/client/src/client_task_manager.h
+++ b/ucm/transport/kv/asu/client/src/client_task_manager.h
@@ -1,0 +1,59 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include "task_context.h"
+#include "task_manager_base.h"
+
+namespace UC::ASU {
+
+class ClientTaskManager : public TaskManagerBase<ClientTask, ClientTaskState> {
+public:
+    ClientTaskManager() : TaskManagerBase(ClientTaskState::PENDING, "client") {}
+
+    bool Check(TaskId taskId);
+    Status Wait(TaskId taskId, std::uint64_t waitTimeoutMs, TaskResult& result);
+    Status Drain(std::uint64_t waitTimeoutMs);
+    Status Process(const ClientTaskPtr& task);
+
+    static void CompleteWithError(const ClientTaskPtr& task, const Status& status);
+    static void CompleteTransportTask(const ClientTaskPtr& task, std::size_t transportTaskIndex,
+                                      TaskResult result);
+    static void CompleteUndispatchedTransportTasks(const ClientTaskPtr& task,
+                                                   std::size_t firstTransportTaskIndex,
+                                                   const Status& dispatchStatus);
+    static void Finalize(const ClientTaskPtr& task);
+
+private:
+    static Status BuildTransportTasks(const ClientTaskPtr& task);
+    static Status DispatchTask(const ClientTaskPtr& task);
+    static Status BuildResult(const ClientTaskPtr& task, TaskResult& result);
+    static Status WaitContext(const ClientTaskPtr& task, std::uint64_t waitTimeoutMs,
+                              TaskResult& result);
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/client/src/view_server.cpp
+++ b/ucm/transport/kv/asu/client/src/view_server.cpp
@@ -1,0 +1,175 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "view_server.h"
+#include <algorithm>
+#include <fstream>
+#include <utility>
+#include "asu_client/asu_client.h"
+#include "config_parser_common.h"
+#include "status_utils.h"
+
+namespace UC::ASU {
+namespace {
+
+AsuInfo ExtractAsuInfo(const TransportConfig& config)
+{
+    AsuInfo info;
+    info.endpoints = config.endpoints;
+    return info;
+}
+
+AsuInfo ParseAsuInfo(const std::string& value)
+{
+    AsuInfo info;
+    for (const auto& endpointValue : SplitConfigValue(value, ';')) {
+        info.endpoints.emplace_back(ParseClientViewEndpoint(endpointValue));
+    }
+    return info;
+}
+
+bool HasKnownViewEpoch(const GlobalView& view) { return view.viewEpoch != 0; }
+
+class ConfigFileViewServer final : public ViewServer {
+public:
+    explicit ConfigFileViewServer(std::string configPath) : configPath_(std::move(configPath)) {}
+
+    Status GetGlobalView(GlobalView& view) override
+    {
+        std::ifstream configFile{configPath_};
+        if (!configFile.is_open()) {
+            const auto message = "failed to open global view config, path=" + configPath_;
+            return ASU_LOG_ERROR_STATUS(StatusCode::NOT_FOUND, message);
+        }
+
+        GlobalView nextView;
+        std::string line;
+        while (std::getline(configFile, line)) {
+            line = TrimConfigValue(line);
+            if (line.empty() || line[0] == '#') { continue; }
+
+            const auto pos = line.find('=');
+            if (pos == std::string::npos) { continue; }
+
+            const auto key = TrimConfigValue(line.substr(0, pos));
+            const auto value = TrimConfigValue(line.substr(pos + 1));
+            if (key == "viewEpoch" || key == "view_epoch") {
+                nextView.viewEpoch = ParseConfigUint64(value);
+            } else if (key == "viewId" || key == "view_id") {
+                nextView.viewId = ParseConfigUint64(value);
+            } else if (key == "createTimeMs" || key == "create_time_ms") {
+                nextView.createTimeMs = ParseConfigUint64(value);
+            } else if (key == "expireTimeMs" || key == "expire_time_ms") {
+                nextView.expireTimeMs = ParseConfigUint64(value);
+            } else if (key == "asuIds" || key == "asu_ids") {
+                nextView.asuMap.clear();
+                for (const auto& asuId : SplitConfigValue(value, ',')) {
+                    nextView.asuMap.emplace(ParseConfigUint64(asuId), AsuInfo{});
+                }
+            } else {
+                AsuId asuId{0};
+                if (TryParseAsuInfoKey(key, asuId)) {
+                    nextView.asuMap[asuId] = ParseAsuInfo(value);
+                }
+            }
+        }
+
+        view = std::move(nextView);
+        return Status::OK();
+    }
+
+private:
+    std::string configPath_;
+};
+
+class ConfigBackedViewServer final : public ViewServer {
+public:
+    explicit ConfigBackedViewServer(GlobalView view) : view_(std::move(view)) {}
+
+    Status GetGlobalView(GlobalView& view) override
+    {
+        view = view_;
+        return Status::OK();
+    }
+
+private:
+    GlobalView view_;
+};
+
+}  // namespace
+
+void ApplyAsuInfoToTransportConfig(const AsuInfo& info, TransportConfig& config)
+{
+    if (info.endpoints.empty()) { return; }
+
+    config.endpoints = info.endpoints;
+}
+
+GlobalView BuildConfigGlobalView(const AsuClientConfig& config)
+{
+    GlobalView view;
+    for (const auto& transportConfig : config.transportConfigs) {
+        view.asuMap.emplace(transportConfig.asuId, ExtractAsuInfo(transportConfig));
+    }
+    return view;
+}
+
+bool ViewServer::ShouldPublishView(const GlobalView& publishedView,
+                                   const GlobalView& fetchedView) const
+{
+    if (!HasKnownViewEpoch(fetchedView) || !HasKnownViewEpoch(publishedView)) { return true; }
+    return fetchedView.viewEpoch > publishedView.viewEpoch;
+}
+
+bool ViewServer::ShouldRefreshView(const Status& status) const
+{
+    switch (status.code) {
+        case StatusCode::CONNECTION_ERROR:
+        case StatusCode::IO_ERROR:
+        case StatusCode::TIMEOUT:
+        case StatusCode::NOT_FOUND:
+        case StatusCode::BUFFER_NOT_REGISTERED: return true;
+        default: return false;
+    }
+}
+
+bool ViewServer::ShouldRefreshView(const TaskResult& result) const
+{
+    if (ShouldRefreshView(result.status)) { return true; }
+    return std::any_of(result.entryStatus.begin(), result.entryStatus.end(),
+                       [this](const Status& status) { return ShouldRefreshView(status); });
+}
+
+std::shared_ptr<ViewServer> CreateDefaultViewServer(const AsuClientConfig& config)
+{
+    auto viewConfigPath = config.attrs.find("view.config_path");
+    if (viewConfigPath != config.attrs.end() && !viewConfigPath->second.empty()) {
+        return std::make_shared<ConfigFileViewServer>(viewConfigPath->second);
+    }
+    if (config.viewServiceAddrs.empty()) {
+        return std::make_shared<ConfigBackedViewServer>(BuildConfigGlobalView(config));
+    }
+    return std::make_shared<ConfigFileViewServer>(config.viewServiceAddrs.front());
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/client/src/view_server.h
+++ b/ucm/transport/kv/asu/client/src/view_server.h
@@ -1,0 +1,72 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+#include "asu_transport/asu_transport.h"
+
+namespace UC::ASU {
+
+struct AsuClientConfig;
+
+struct AsuInfo {
+    std::vector<AsuEndpoint> endpoints;
+};
+
+// GlobalView carries the routing membership and view metadata.
+struct GlobalView {
+    std::uint64_t viewEpoch{0};
+    std::uint64_t viewId{0};
+    std::unordered_map<AsuId, AsuInfo> asuMap;
+    std::uint64_t createTimeMs{0};
+    std::uint64_t expireTimeMs{0};
+};
+
+// ViewServer owns global view fetching and refresh decisions.
+class ViewServer {
+public:
+    // Destroys the view server interface.
+    virtual ~ViewServer() = default;
+    // Fetches the current global view.
+    virtual Status GetGlobalView(GlobalView& view) = 0;
+    // Returns whether a fetched view should replace the published view.
+    virtual bool ShouldPublishView(const GlobalView& publishedView,
+                                   const GlobalView& fetchedView) const;
+    // Returns whether an operation status should schedule view refresh.
+    virtual bool ShouldRefreshView(const Status& status) const;
+    // Returns whether any task status should schedule view refresh.
+    virtual bool ShouldRefreshView(const TaskResult& result) const;
+};
+
+using ViewServerFactory = std::function<std::shared_ptr<ViewServer>(const AsuClientConfig&)>;
+
+std::shared_ptr<ViewServer> CreateDefaultViewServer(const AsuClientConfig& config);
+GlobalView BuildConfigGlobalView(const AsuClientConfig& config);
+void ApplyAsuInfoToTransportConfig(const AsuInfo& info, TransportConfig& config);
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/common/config_parser_common.cpp
+++ b/ucm/transport/kv/asu/common/config_parser_common.cpp
@@ -1,0 +1,270 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "config_parser_common.h"
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+#include <utility>
+
+namespace UC::ASU {
+namespace {
+
+void SetEndpointAttr(AsuEndpoint& endpoint, const std::string& key, const std::string& value)
+{
+    endpoint.attrs[key] = value;
+}
+
+void ApplyTransportEndpointField(AsuEndpoint& endpoint, const std::string& key,
+                                 const std::string& value)
+{
+    if (key == "ip" || key == "local.comm_id" || key == "localCommId") {
+        endpoint.ip = value;
+    } else if (key == "port") {
+        endpoint.port = static_cast<std::uint16_t>(ParseConfigUint64(value));
+    } else if (key == "protocol") {
+        endpoint.protocol = ParseConfigProtocol(value);
+    } else if (key == "numa_node" || key == "numaNode") {
+        endpoint.numaNode = static_cast<std::int32_t>(ParseConfigUint64(value));
+    } else if (key == "hca_name" || key == "hcaName") {
+        endpoint.hcaName = value;
+    } else if (key == "hca_port" || key == "hcaPort") {
+        endpoint.hcaPort = static_cast<std::uint8_t>(ParseConfigUint64(value));
+    } else {
+        endpoint.attrs[key] = value;
+    }
+}
+
+void ApplyClientViewEndpointField(AsuEndpoint& endpoint, const std::string& key,
+                                  const std::string& value)
+{
+    if (key == "protocol") {
+        endpoint.protocol = ParseConfigProtocol(value);
+        SetEndpointAttr(endpoint, "protocol", value);
+    } else if (key == "placement") {
+        SetEndpointAttr(endpoint, "placement", value);
+    } else if (key == "port") {
+        endpoint.port = static_cast<std::uint16_t>(ParseConfigUint64(value));
+    } else if (key == "local.comm_id" || key == "localCommId") {
+        endpoint.ip = value;
+    } else if (key == "tc") {
+        SetEndpointAttr(endpoint, "tc", value);
+    } else if (key == "sl") {
+        SetEndpointAttr(endpoint, "sl", value);
+    } else if (key == "send_size" || key == "sendSize") {
+        SetEndpointAttr(endpoint, "send_size", value);
+    } else if (key == "flag_size" || key == "flagSize") {
+        SetEndpointAttr(endpoint, "flag_size", value);
+    } else if (key == "remote_send_addr" || key == "remoteSendAddr") {
+        SetEndpointAttr(endpoint, "remote_send_addr", value);
+    } else if (key == "remote_flag_addr" || key == "remoteFlagAddr") {
+        SetEndpointAttr(endpoint, "remote_flag_addr", value);
+    }
+}
+
+}  // namespace
+
+std::string TrimConfigValue(const std::string& value)
+{
+    const auto begin = value.find_first_not_of(" \t\r\n");
+    if (begin == std::string::npos) { return ""; }
+    const auto end = value.find_last_not_of(" \t\r\n");
+    return value.substr(begin, end - begin + 1);
+}
+
+std::vector<std::string> SplitConfigValue(const std::string& value, char delimiter)
+{
+    std::vector<std::string> parts;
+    std::stringstream stream{value};
+    std::string part;
+    while (std::getline(stream, part, delimiter)) {
+        part = TrimConfigValue(part);
+        if (!part.empty()) { parts.emplace_back(std::move(part)); }
+    }
+    return parts;
+}
+
+std::uint64_t ParseConfigUint64(const std::string& value) { return std::stoull(value, nullptr, 0); }
+
+Protocol ParseConfigProtocol(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::toupper(ch)); });
+    if (value == "UB" || value == "UBOE") { return Protocol::UB; }
+    if (value == "ROCE") { return Protocol::ROCE; }
+    if (value == "TCP") { return Protocol::TCP; }
+    return Protocol::TCP;
+}
+
+TransProviderType ParseConfigTransProviderType(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::toupper(ch)); });
+    if (value == "FAKE") { return TransProviderType::FAKE; }
+    if (value == "AIV") { return TransProviderType::AIV; }
+    if (value == "AICPU") { return TransProviderType::AICPU; }
+    return TransProviderType::UNSUPPORTED;
+}
+
+bool ApplyTransportBufferConfigField(TransportConfig& config, const std::string& key,
+                                     const std::string& value)
+{
+    if (key == "sendBufferSlotSize" || key == "send_buffer_slot_size" ||
+        key == "ioBuffer.sendBufferSlotSize" || key == "io_buffer.send_buffer_slot_size") {
+        config.sendBufferSlotSize = static_cast<std::size_t>(ParseConfigUint64(value));
+    } else if (key == "sendBufferSlotNum" || key == "send_buffer_slot_num" ||
+               key == "ioBuffer.sendBufferSlotNum" || key == "io_buffer.send_buffer_slot_num") {
+        config.sendBufferSlotNum = static_cast<std::size_t>(ParseConfigUint64(value));
+    } else if (key == "flagBufferSlotSize" || key == "flag_buffer_slot_size" ||
+               key == "ioBuffer.flagBufferSlotSize" || key == "io_buffer.flag_buffer_slot_size") {
+        config.flagBufferSlotSize = static_cast<std::size_t>(ParseConfigUint64(value));
+    } else if (key == "flagBufferSlotNum" || key == "flag_buffer_slot_num" ||
+               key == "ioBuffer.flagBufferSlotNum" || key == "io_buffer.flag_buffer_slot_num") {
+        config.flagBufferSlotNum = static_cast<std::size_t>(ParseConfigUint64(value));
+    } else {
+        return false;
+    }
+    return true;
+}
+
+bool ApplyTransportIoNumConfigField(TransportConfig& config, const std::string& key,
+                                    const std::string& value)
+{
+    if (key == "batchLoadIoNum" || key == "batch_load_io_num") {
+        config.asuBatchLoadIoNum = static_cast<std::size_t>(ParseConfigUint64(value));
+    } else if (key == "batchStoreIoNum" || key == "batch_store_io_num") {
+        config.asuBatchStoreIoNum = static_cast<std::size_t>(ParseConfigUint64(value));
+    } else if (key == "deleteIoNum" || key == "delete_io_num") {
+        config.asuDeleteIoNum = static_cast<std::size_t>(ParseConfigUint64(value));
+    } else if (key == "queryIoNum" || key == "query_io_num") {
+        config.asuQueryIoNum = static_cast<std::size_t>(ParseConfigUint64(value));
+    } else {
+        return false;
+    }
+    return true;
+}
+
+bool ApplyTransportCompletionConfigField(TransportConfig& config, const std::string& key,
+                                         const std::string& value)
+{
+    if (key != "completionPollSpinLimit" && key != "completion_poll_spin_limit") { return false; }
+    config.completionPollSpinLimit = static_cast<std::size_t>(ParseConfigUint64(value));
+    return true;
+}
+
+bool ApplyTransportProviderConfigField(TransportConfig& config, const std::string& key,
+                                       const std::string& value)
+{
+    if (key == "providerBackend" || key == "provider_backend" || key == "transProviderBackend" ||
+        key == "trans_provider_backend" || key == "providerType" || key == "provider_type" ||
+        key == "transProviderType" || key == "trans_provider_type") {
+        config.providerType = ParseConfigTransProviderType(value);
+    } else {
+        return false;
+    }
+    return true;
+}
+
+bool ApplyTransportDeviceConfigField(TransportConfig& config, const std::string& key,
+                                     const std::string& value)
+{
+    if (key == "deviceId" || key == "device_id") {
+        config.deviceId = static_cast<std::int32_t>(ParseConfigUint64(value));
+        return true;
+    }
+    return false;
+}
+
+bool TryParseAsuInfoKey(const std::string& key, AsuId& asuId)
+{
+    constexpr const char* kCamelPrefix = "asuInfo.";
+    constexpr const char* kSnakePrefix = "asu_info.";
+    if (key.rfind(kCamelPrefix, 0) == 0) {
+        asuId = std::stoull(key.substr(std::string{kCamelPrefix}.size()));
+        return true;
+    }
+    if (key.rfind(kSnakePrefix, 0) == 0) {
+        asuId = std::stoull(key.substr(std::string{kSnakePrefix}.size()));
+        return true;
+    }
+    return false;
+}
+
+bool TryGetTransportAttrKey(const std::string& key, std::string& attrKey)
+{
+    constexpr const char* kCamelPrefix = "transport.";
+    if (key.rfind(kCamelPrefix, 0) == 0) {
+        attrKey = key.substr(std::string{kCamelPrefix}.size());
+        return !attrKey.empty();
+    }
+    return false;
+}
+
+AsuEndpoint ParseTransportEndpoint(const std::string& value)
+{
+    AsuEndpoint endpoint;
+    if (value.find('=') == std::string::npos) {
+        auto parts = SplitConfigValue(value, ':');
+        if (!parts.empty()) { endpoint.ip = parts[0]; }
+        if (parts.size() > 1) {
+            endpoint.port = static_cast<std::uint16_t>(ParseConfigUint64(parts[1]));
+        }
+        if (parts.size() > 2) { endpoint.protocol = ParseConfigProtocol(parts[2]); }
+        return endpoint;
+    }
+
+    for (const auto& item : SplitConfigValue(value, ',')) {
+        const auto pos = item.find('=');
+        if (pos == std::string::npos) { continue; }
+        ApplyTransportEndpointField(endpoint, TrimConfigValue(item.substr(0, pos)),
+                                    TrimConfigValue(item.substr(pos + 1)));
+    }
+    return endpoint;
+}
+
+AsuEndpoint ParseClientViewEndpoint(const std::string& value)
+{
+    AsuEndpoint endpoint;
+    if (value.find('=') == std::string::npos) {
+        auto parts = SplitConfigValue(value, ':');
+        if (!parts.empty()) { endpoint.ip = parts[0]; }
+        if (parts.size() > 1) {
+            endpoint.port = static_cast<std::uint16_t>(ParseConfigUint64(parts[1]));
+        }
+        if (parts.size() > 2) {
+            endpoint.protocol = ParseConfigProtocol(parts[2]);
+            SetEndpointAttr(endpoint, "protocol", parts[2]);
+        }
+        return endpoint;
+    }
+
+    for (const auto& item : SplitConfigValue(value, ',')) {
+        const auto pos = item.find('=');
+        if (pos == std::string::npos) { continue; }
+        ApplyClientViewEndpointField(endpoint, TrimConfigValue(item.substr(0, pos)),
+                                     TrimConfigValue(item.substr(pos + 1)));
+    }
+    return endpoint;
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/common/config_parser_common.h
+++ b/ucm/transport/kv/asu/common/config_parser_common.h
@@ -1,0 +1,55 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+#include "asu_transport/asu_transport.h"
+
+namespace UC::ASU {
+
+std::string TrimConfigValue(const std::string& value);
+std::vector<std::string> SplitConfigValue(const std::string& value, char delimiter);
+std::uint64_t ParseConfigUint64(const std::string& value);
+Protocol ParseConfigProtocol(std::string value);
+TransProviderType ParseConfigTransProviderType(std::string value);
+
+bool ApplyTransportBufferConfigField(TransportConfig& config, const std::string& key,
+                                     const std::string& value);
+bool ApplyTransportIoNumConfigField(TransportConfig& config, const std::string& key,
+                                    const std::string& value);
+bool ApplyTransportCompletionConfigField(TransportConfig& config, const std::string& key,
+                                         const std::string& value);
+bool ApplyTransportProviderConfigField(TransportConfig& config, const std::string& key,
+                                       const std::string& value);
+bool ApplyTransportDeviceConfigField(TransportConfig& config, const std::string& key,
+                                     const std::string& value);
+bool TryParseAsuInfoKey(const std::string& key, AsuId& asuId);
+bool TryGetTransportAttrKey(const std::string& key, std::string& attrKey);
+
+AsuEndpoint ParseTransportEndpoint(const std::string& value);
+AsuEndpoint ParseClientViewEndpoint(const std::string& value);
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/common/status_utils.h
+++ b/ucm/transport/kv/asu/common/status_utils.h
@@ -1,0 +1,36 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <string>
+#include <utility>
+#include "asu_transport/types.h"
+#include "logger/logger.h"
+
+#define ASU_LOG_ERROR_STATUS(code, message)                                   \
+    ([&]() {                                                                  \
+        std::string asuStatusMessage = (message);                             \
+        UC_ERROR("{}", asuStatusMessage);                                     \
+        return ::UC::ASU::Status::Error((code), std::move(asuStatusMessage)); \
+    }())

--- a/ucm/transport/kv/asu/common/task_context.h
+++ b/ucm/transport/kv/asu/common/task_context.h
@@ -1,0 +1,140 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <vector>
+#include "asu_transport/types.h"
+
+namespace UC::ASU {
+
+class AsuTransport;
+struct TransportSubBatchContext;
+struct ViewSnapshot;
+
+enum class ClientTaskState {
+    PENDING = 0,
+    INFLIGHT = 1,
+    COMPLETED = 2,
+};
+
+enum class AsuOpType {
+    QUERY = 0,
+    LOAD = 1,
+    STORE = 2,
+    BATCH_LOAD = 3,
+    BATCH_STORE = 4,
+    DELETE = 5,
+    KEEP_ALIVE = 6,
+};
+
+enum class TransportTaskState {
+    PENDING = 0,
+    INFLIGHT = 1,
+    COMPLETED = 2,
+};
+
+enum class TransportSubBatchState {
+    PENDING = 0,
+    COMPLETED = 1,
+};
+
+inline bool IsEntryBatchOp(AsuOpType opType)
+{
+    return opType == AsuOpType::LOAD || opType == AsuOpType::STORE ||
+           opType == AsuOpType::BATCH_LOAD || opType == AsuOpType::BATCH_STORE;
+}
+
+inline bool IsKeyBatchOp(AsuOpType opType)
+{
+    return opType == AsuOpType::DELETE || opType == AsuOpType::QUERY;
+}
+
+inline bool IsKeepAliveOp(AsuOpType opType) { return opType == AsuOpType::KEEP_ALIVE; }
+
+using TransportSubBatchList = std::vector<TransportSubBatchContext>;
+
+struct TransportTask {
+    TransportTask();
+
+    AsuId asuId{0};
+    TaskId taskId{kInvalidTaskId};
+    AsuOpType opType{AsuOpType::QUERY};
+    std::weak_ptr<AsuTransport> transport;
+    std::vector<CacheKey> keys;
+    std::vector<KVBuffer> entries;
+    std::vector<std::size_t> originalIndices;
+    std::vector<Status> entryStatus;
+    bool clientCompleted{false};
+
+    std::shared_ptr<TransportSubBatchList> subBatchContexts;
+    std::uint32_t remainingSubBatchCount{0};
+    std::chrono::steady_clock::time_point deadline{std::chrono::steady_clock::time_point::max()};
+    TaskCompletionCallback onComplete;
+    std::atomic<bool> completionNotified{false};
+
+    std::atomic<TransportTaskState> state{TransportTaskState::PENDING};
+    Status finalStatus{Status::OK()};
+
+    std::mutex mutex;
+
+    bool Done() const;
+    bool NotifyCompletion(TaskResult result);
+    Status BuildFinalStatus() const;
+    void InitializeRemainingSubBatchCount();
+    void TryFinalizeFromSubBatches();
+};
+
+using TransportTaskPtr = std::shared_ptr<TransportTask>;
+
+struct ClientTask {
+    TaskId taskId{kInvalidTaskId};
+    AsuOpType opType{AsuOpType::LOAD};
+    std::shared_ptr<ViewSnapshot> viewSnapshot;
+    std::vector<KVBuffer> entries;
+    std::vector<CacheKey> keys;
+    std::vector<TransportTaskPtr> transportTasks;
+    std::vector<Status> entryStatus;
+    QueryResult queryResult;
+
+    std::atomic<std::size_t> remainingTransportTasks{0};
+    std::atomic<ClientTaskState> state{ClientTaskState::PENDING};
+    Status finalStatus{Status::OK()};
+
+    std::mutex waitMu;
+    std::condition_variable cv;
+
+    bool Done() const;
+    bool AllTransportTasksCompleted() const;
+};
+
+using ClientTaskPtr = std::shared_ptr<ClientTask>;
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/common/task_manager_base.h
+++ b/ucm/transport/kv/asu/common/task_manager_base.h
@@ -1,0 +1,111 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include "asu_transport/types.h"
+
+namespace UC::ASU {
+
+template <typename Context, typename State>
+class TaskManagerBase {
+public:
+    TaskManagerBase(State initialState, std::string taskName)
+        : initialState_(initialState), taskName_(std::move(taskName))
+    {
+    }
+
+    Status Submit(std::unique_ptr<Context> ctx, TaskId& taskId)
+    {
+        if (!ctx) {
+            taskId = kInvalidTaskId;
+            return Status::Error(StatusCode::INVALID_ARGUMENT, taskName_ + " task context is null");
+        }
+
+        return Submit(std::shared_ptr<Context>(std::move(ctx)), taskId);
+    }
+
+    Status Submit(const std::shared_ptr<Context>& ctx, TaskId& taskId)
+    {
+        if (!ctx) {
+            taskId = kInvalidTaskId;
+            return Status::Error(StatusCode::INVALID_ARGUMENT, taskName_ + " task context is null");
+        }
+
+        auto sharedCtx = ctx;
+        sharedCtx->state.store(initialState_, std::memory_order_release);
+
+        std::lock_guard<std::shared_mutex> lock(mutex_);
+        do {
+            taskId = nextTaskId_.fetch_add(1, std::memory_order_relaxed);
+        } while (taskId == kInvalidTaskId || tasks_.find(taskId) != tasks_.end());
+
+        sharedCtx->taskId = taskId;
+        tasks_.emplace(taskId, std::move(sharedCtx));
+        return Status::OK();
+    }
+
+    std::shared_ptr<Context> Get(TaskId taskId)
+    {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        auto iter = tasks_.find(taskId);
+        if (iter == tasks_.end()) { return nullptr; }
+        return iter->second;
+    }
+
+    std::vector<std::shared_ptr<Context>> GetAll()
+    {
+        std::shared_lock<std::shared_mutex> lock(mutex_);
+        std::vector<std::shared_ptr<Context>> tasks;
+        tasks.reserve(tasks_.size());
+        for (const auto& item : tasks_) { tasks.emplace_back(item.second); }
+        return tasks;
+    }
+
+    Status Remove(TaskId taskId)
+    {
+        std::lock_guard<std::shared_mutex> lock(mutex_);
+        auto erased = tasks_.erase(taskId);
+        if (erased == 0) {
+            return Status::Error(StatusCode::TASK_NOT_FOUND, taskName_ + " task not found");
+        }
+        return Status::OK();
+    }
+
+private:
+    State initialState_;
+    std::string taskName_;
+    std::atomic<TaskId> nextTaskId_{1};
+    // TODO: consider using a lock-free structure !
+    std::shared_mutex mutex_;
+    std::unordered_map<TaskId, std::shared_ptr<Context>> tasks_;
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/client/asu_client_e2e_metrics_test.cpp
+++ b/ucm/transport/kv/asu/test/client/asu_client_e2e_metrics_test.cpp
@@ -1,0 +1,909 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <ctime>
+#include <functional>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <mutex>
+#include <numeric>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+#include "asu_client_impl.h"
+
+namespace UC::ASU {
+namespace {
+
+CacheKey MakeCacheKey(std::string_view text)
+{
+    CacheKey key{};
+    if (text.size() <= key.size()) {
+        if (!text.empty()) { std::memcpy(key.data(), text.data(), text.size()); }
+        return key;
+    }
+    const auto hash = std::hash<std::string_view>{}(text);
+    std::memcpy(key.data(), &hash, key.size());
+    return key;
+}
+
+struct CacheKeyHasher {
+    std::size_t operator()(const CacheKey& key) const
+    {
+        std::uint64_t hash = 1469598103934665603ULL;
+        for (auto byte : key) {
+            hash ^= static_cast<std::uint64_t>(std::to_integer<unsigned char>(byte));
+            hash *= 1099511628211ULL;
+        }
+        return static_cast<std::size_t>(hash);
+    }
+};
+
+enum class OperationKind {
+    QUERY,
+    LOAD,
+    STORE,
+    DELETE,
+};
+
+const char* OperationName(OperationKind kind)
+{
+    switch (kind) {
+        case OperationKind::QUERY: return "Query";
+        case OperationKind::LOAD: return "Load";
+        case OperationKind::STORE: return "Store";
+        case OperationKind::DELETE: return "Delete";
+        default: return "Unknown";
+    }
+}
+
+struct OperationSample {
+    OperationKind kind{OperationKind::QUERY};
+    std::uint64_t latencyNs{0};
+    std::uint64_t bytes{0};
+    bool success{false};
+    bool correct{false};
+};
+
+struct OperationSummary {
+    std::size_t total{0};
+    std::size_t succeeded{0};
+    std::size_t correct{0};
+    std::uint64_t bytes{0};
+    std::uint64_t latencyAvgNs{0};
+    std::uint64_t latencyP50Ns{0};
+    std::uint64_t latencyP95Ns{0};
+    std::uint64_t latencyP99Ns{0};
+    std::uint64_t latencyMaxNs{0};
+    double iops{0.0};
+    double bandwidthBytesPerSec{0.0};
+    double successRate{0.0};
+    double correctnessRate{0.0};
+};
+
+class MetricsRecorder {
+public:
+    void Record(OperationKind kind, std::uint64_t latencyNs, std::uint64_t bytes, bool success,
+                bool correct)
+    {
+        samples_.push_back(
+            OperationSample{kind, std::max<std::uint64_t>(latencyNs, 1), bytes, success, correct});
+    }
+
+    OperationSummary Summarize(OperationKind kind) const
+    {
+        OperationSummary summary;
+        std::vector<std::uint64_t> latencies;
+        std::uint64_t totalLatencyNs = 0;
+        for (const auto& sample : samples_) {
+            if (sample.kind != kind) { continue; }
+            ++summary.total;
+            if (sample.success) { ++summary.succeeded; }
+            if (sample.correct) { ++summary.correct; }
+            summary.bytes += sample.bytes;
+            totalLatencyNs += sample.latencyNs;
+            latencies.emplace_back(sample.latencyNs);
+        }
+
+        if (summary.total == 0) { return summary; }
+
+        std::sort(latencies.begin(), latencies.end());
+        summary.latencyAvgNs = totalLatencyNs / summary.total;
+        summary.latencyP50Ns = Percentile(latencies, 50);
+        summary.latencyP95Ns = Percentile(latencies, 95);
+        summary.latencyP99Ns = Percentile(latencies, 99);
+        summary.latencyMaxNs = latencies.back();
+        summary.iops = static_cast<double>(summary.succeeded) * 1000000000.0 /
+                       static_cast<double>(totalLatencyNs);
+        summary.bandwidthBytesPerSec =
+            static_cast<double>(summary.bytes) * 1000000000.0 / static_cast<double>(totalLatencyNs);
+        summary.successRate =
+            static_cast<double>(summary.succeeded) / static_cast<double>(summary.total);
+        summary.correctnessRate =
+            static_cast<double>(summary.correct) / static_cast<double>(summary.total);
+        return summary;
+    }
+
+    void PrintReport(const std::string& name) const
+    {
+        std::cout << "[AsuClientE2E] " << name << '\n';
+        for (auto kind : {OperationKind::STORE, OperationKind::QUERY, OperationKind::LOAD,
+                          OperationKind::DELETE}) {
+            const auto summary = Summarize(kind);
+            if (summary.total == 0) { continue; }
+            std::cout << "  " << OperationName(kind) << ": total=" << summary.total
+                      << " success_rate=" << summary.successRate
+                      << " correctness_rate=" << summary.correctnessRate << " iops=" << summary.iops
+                      << " bandwidth_Bps=" << summary.bandwidthBytesPerSec
+                      << " latency_avg_ns=" << summary.latencyAvgNs
+                      << " latency_p50_ns=" << summary.latencyP50Ns
+                      << " latency_p95_ns=" << summary.latencyP95Ns
+                      << " latency_p99_ns=" << summary.latencyP99Ns
+                      << " latency_max_ns=" << summary.latencyMaxNs << '\n';
+        }
+    }
+
+private:
+    static std::uint64_t Percentile(const std::vector<std::uint64_t>& latencies,
+                                    std::uint32_t percentile)
+    {
+        if (latencies.empty()) { return 0; }
+        const auto rank = (static_cast<std::uint64_t>(latencies.size()) * percentile + 99U) / 100U;
+        const auto index = static_cast<std::size_t>(std::max<std::uint64_t>(rank, 1) - 1U);
+        return latencies[std::min(index, latencies.size() - 1)];
+    }
+
+    std::vector<OperationSample> samples_;
+};
+
+struct ResourceSnapshot {
+    std::size_t storedKeyCount{0};
+    std::uint64_t storedBytes{0};
+    std::size_t taskCount{0};
+    std::size_t createdTransports{0};
+    std::size_t shutdownTransports{0};
+    std::clock_t cpuTicks{0};
+};
+
+struct ClusterState {
+    mutable std::mutex mutex;
+    std::unordered_set<AsuId> activeAsus;
+    std::unordered_map<AsuId,
+                       std::unordered_map<CacheKey, std::vector<std::uint8_t>, CacheKeyHasher>>
+        stores;
+    std::unordered_map<TaskId, TaskResult> tasks;
+    std::unordered_map<AsuId, std::size_t> queryCalls;
+    std::unordered_map<AsuId, std::size_t> loadCalls;
+    std::unordered_map<AsuId, std::size_t> storeCalls;
+    std::unordered_map<AsuId, std::size_t> deleteCalls;
+    TaskId nextTaskId{1};
+    std::size_t createdTransports{0};
+    std::size_t shutdownTransports{0};
+    std::size_t forcedQueryFailures{0};
+
+    void SetActiveAsus(const std::vector<AsuId>& asuIds)
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        activeAsus.clear();
+        activeAsus.insert(asuIds.begin(), asuIds.end());
+    }
+
+    void ForceNextQueryFailure()
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        ++forcedQueryFailures;
+    }
+
+    void ClearOperationCalls()
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        queryCalls.clear();
+        loadCalls.clear();
+        storeCalls.clear();
+        deleteCalls.clear();
+    }
+
+    ResourceSnapshot Snapshot() const
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        ResourceSnapshot snapshot;
+        snapshot.taskCount = tasks.size();
+        snapshot.createdTransports = createdTransports;
+        snapshot.shutdownTransports = shutdownTransports;
+        snapshot.cpuTicks = std::clock();
+        for (const auto& asuStore : stores) {
+            snapshot.storedKeyCount += asuStore.second.size();
+            for (const auto& item : asuStore.second) { snapshot.storedBytes += item.second.size(); }
+        }
+        return snapshot;
+    }
+
+    std::size_t TouchedAsuCount() const
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        std::unordered_set<AsuId> touched;
+        for (const auto& item : queryCalls) { touched.insert(item.first); }
+        for (const auto& item : loadCalls) { touched.insert(item.first); }
+        for (const auto& item : storeCalls) { touched.insert(item.first); }
+        for (const auto& item : deleteCalls) { touched.insert(item.first); }
+        return touched.size();
+    }
+
+    std::size_t OperationCalls(AsuId asuId) const
+    {
+        std::lock_guard<std::mutex> lock{mutex};
+        return CountCalls(queryCalls, asuId) + CountCalls(loadCalls, asuId) +
+               CountCalls(storeCalls, asuId) + CountCalls(deleteCalls, asuId);
+    }
+
+private:
+    static std::size_t CountCalls(const std::unordered_map<AsuId, std::size_t>& calls, AsuId asuId)
+    {
+        auto iter = calls.find(asuId);
+        return iter == calls.end() ? 0 : iter->second;
+    }
+};
+
+TaskResult BuildTaskResult(const std::vector<Status>& entryStatus)
+{
+    const bool anyFailed = std::any_of(entryStatus.begin(), entryStatus.end(),
+                                       [](const Status& status) { return !status.ok(); });
+    TaskResult result;
+    result.status =
+        anyFailed ? Status::Error(StatusCode::PARTIAL_FAILED, "one or more fake ASU entries failed")
+                  : Status::OK();
+    result.entryStatus = entryStatus;
+    return result;
+}
+
+Status SubmitCompletedTask(ClusterState& state, TaskResult result, TaskId& taskId)
+{
+    taskId = state.nextTaskId++;
+    state.tasks.emplace(taskId, std::move(result));
+    return Status::OK();
+}
+
+bool IsBufferUsable(const MemoryRegion& region) { return region.size == 0 || region.addr != 0; }
+
+class InMemoryAsuTransport final : public AsuTransport {
+public:
+    explicit InMemoryAsuTransport(std::shared_ptr<ClusterState> state) : state_(std::move(state)) {}
+
+    Status Init(const TransportConfig& config,
+                std::shared_ptr<TransProvider> transProvider) override
+    {
+        (void)transProvider;
+        std::lock_guard<std::mutex> lock{state_->mutex};
+        config_ = config;
+        initialized_ = true;
+        ++state_->createdTransports;
+        return Status::OK();
+    }
+
+    Status Init(const std::string& configPath,
+                std::shared_ptr<TransProvider> transProvider) override
+    {
+        (void)configPath;
+        (void)transProvider;
+        return Status::Error(StatusCode::UNSUPPORTED,
+                             "in-memory ASU transport config path is unsupported");
+    }
+
+    Status Shutdown() override
+    {
+        std::lock_guard<std::mutex> lock{state_->mutex};
+        if (initialized_) { ++state_->shutdownTransports; }
+        initialized_ = false;
+        return Status::OK();
+    }
+
+    Status CheckHealth() override
+    {
+        return initialized_ ? Status::OK()
+                            : Status::Error(StatusCode::NOT_INITIALIZED,
+                                            "fake ASU transport is not initialized");
+    }
+
+    Status RunQuery(BatchView<CacheKey> keys, QueryResult& result)
+    {
+        std::lock_guard<std::mutex> lock{state_->mutex};
+        auto status = CheckReadyLocked();
+        if (!status.ok()) { return status; }
+        if (state_->forcedQueryFailures > 0) {
+            --state_->forcedQueryFailures;
+            return Status::Error(StatusCode::CONNECTION_ERROR, "forced stale-view query failure");
+        }
+
+        ++state_->queryCalls[config_.asuId];
+        const auto& store = state_->stores[config_.asuId];
+        result.exists.assign(keys.size, 0);
+        result.prefixHitKeys = 0;
+        for (std::size_t index = 0; index < keys.size; ++index) {
+            result.exists[index] = store.find(keys[index]) == store.end() ? 0 : 1;
+        }
+        return Status::OK();
+    }
+
+    Status Submit(const TransportTaskPtr& task) override
+    {
+        if (!task) {
+            return Status::Error(StatusCode::INVALID_ARGUMENT, "in-memory transport task is null");
+        }
+        switch (task->opType) {
+            case AsuOpType::QUERY:
+                return SubmitQuery({task->keys.data(), task->keys.size()}, task->taskId,
+                                   std::move(task->onComplete));
+            case AsuOpType::LOAD:
+            case AsuOpType::BATCH_LOAD:
+                return SubmitLoad({task->entries.data(), task->entries.size()}, task->taskId,
+                                  std::move(task->onComplete));
+            case AsuOpType::STORE:
+            case AsuOpType::BATCH_STORE:
+                return SubmitStore({task->entries.data(), task->entries.size()}, task->taskId,
+                                   std::move(task->onComplete));
+            case AsuOpType::DELETE:
+                return SubmitDelete({task->keys.data(), task->keys.size()}, task->taskId,
+                                    std::move(task->onComplete));
+            default:
+                task->taskId = kInvalidTaskId;
+                return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                     "unsupported in-memory transport operation");
+        }
+    }
+
+    Status SubmitQuery(BatchView<CacheKey> keys, TaskId& taskId, TaskCompletionCallback onComplete)
+    {
+        QueryResult queryResult;
+        auto status = RunQuery(keys, queryResult);
+        if (!status.ok()) {
+            taskId = kInvalidTaskId;
+            return status;
+        }
+        std::lock_guard<std::mutex> lock{state_->mutex};
+        TaskResult result;
+        result.status = Status::OK();
+        result.entryStatus.assign(keys.size, Status::OK());
+        result.queryResult = queryResult;
+        status = SubmitCompletedTask(*state_, result, taskId);
+        if (status.ok() && onComplete) { onComplete(std::move(result)); }
+        return status;
+    }
+
+    Status SubmitLoad(BatchView<KVBuffer> entries, TaskId& taskId,
+                      TaskCompletionCallback onComplete)
+    {
+        std::lock_guard<std::mutex> lock{state_->mutex};
+        auto status = CheckReadyLocked();
+        if (!status.ok()) {
+            taskId = kInvalidTaskId;
+            return status;
+        }
+
+        ++state_->loadCalls[config_.asuId];
+        std::vector<Status> entryStatus;
+        entryStatus.reserve(entries.size);
+        auto& store = state_->stores[config_.asuId];
+        for (std::size_t index = 0; index < entries.size; ++index) {
+            const auto& entry = entries[index];
+            auto iter = store.find(entry.key);
+            if (iter == store.end()) {
+                entryStatus.emplace_back(
+                    Status::Error(StatusCode::NOT_FOUND, "fake ASU key not found"));
+                continue;
+            }
+            if (!IsBufferUsable(entry.buffer.region) ||
+                entry.buffer.region.size < iter->second.size()) {
+                entryStatus.emplace_back(Status::Error(StatusCode::INVALID_ARGUMENT,
+                                                       "fake ASU load buffer is too small"));
+                continue;
+            }
+
+            auto* data = reinterpret_cast<std::uint8_t*>(entry.buffer.region.addr);
+            std::copy(iter->second.begin(), iter->second.end(), data);
+            entryStatus.emplace_back(Status::OK());
+        }
+        auto result = BuildTaskResult(entryStatus);
+        status = SubmitCompletedTask(*state_, result, taskId);
+        if (status.ok() && onComplete) { onComplete(std::move(result)); }
+        return status;
+    }
+
+    Status SubmitStore(BatchView<KVBuffer> entries, TaskId& taskId,
+                       TaskCompletionCallback onComplete)
+    {
+        std::lock_guard<std::mutex> lock{state_->mutex};
+        auto status = CheckReadyLocked();
+        if (!status.ok()) {
+            taskId = kInvalidTaskId;
+            return status;
+        }
+
+        ++state_->storeCalls[config_.asuId];
+        std::vector<Status> entryStatus;
+        entryStatus.reserve(entries.size);
+        auto& store = state_->stores[config_.asuId];
+        for (std::size_t index = 0; index < entries.size; ++index) {
+            const auto& entry = entries[index];
+            if (!IsBufferUsable(entry.buffer.region)) {
+                entryStatus.emplace_back(Status::Error(StatusCode::INVALID_ARGUMENT,
+                                                       "fake ASU store buffer is invalid"));
+                continue;
+            }
+
+            const auto* data = reinterpret_cast<const std::uint8_t*>(entry.buffer.region.addr);
+            store[entry.key] = std::vector<std::uint8_t>(data, data + entry.buffer.region.size);
+            entryStatus.emplace_back(Status::OK());
+        }
+        auto result = BuildTaskResult(entryStatus);
+        status = SubmitCompletedTask(*state_, result, taskId);
+        if (status.ok() && onComplete) { onComplete(std::move(result)); }
+        return status;
+    }
+
+    Status SubmitDelete(BatchView<CacheKey> keys, TaskId& taskId, TaskCompletionCallback onComplete)
+    {
+        std::lock_guard<std::mutex> lock{state_->mutex};
+        auto status = CheckReadyLocked();
+        if (!status.ok()) {
+            taskId = kInvalidTaskId;
+            return status;
+        }
+
+        ++state_->deleteCalls[config_.asuId];
+        std::vector<Status> entryStatus;
+        entryStatus.reserve(keys.size);
+        auto& store = state_->stores[config_.asuId];
+        for (std::size_t index = 0; index < keys.size; ++index) {
+            const auto& key = keys[index];
+            if (store.erase(key) == 0) {
+                entryStatus.emplace_back(
+                    Status::Error(StatusCode::NOT_FOUND, "fake ASU key not found"));
+            } else {
+                entryStatus.emplace_back(Status::OK());
+            }
+        }
+        auto result = BuildTaskResult(entryStatus);
+        status = SubmitCompletedTask(*state_, result, taskId);
+        if (status.ok() && onComplete) { onComplete(std::move(result)); }
+        return status;
+    }
+
+    Status Cancel(TaskId) override { return Status::Error(StatusCode::UNSUPPORTED, "unsupported"); }
+
+private:
+    Status CheckReadyLocked() const
+    {
+        if (!initialized_) {
+            return Status::Error(StatusCode::NOT_INITIALIZED,
+                                 "fake ASU transport is not initialized");
+        }
+        if (state_->activeAsus.find(config_.asuId) == state_->activeAsus.end()) {
+            return Status::Error(StatusCode::CONNECTION_ERROR,
+                                 "fake ASU has been removed from active view");
+        }
+        return Status::OK();
+    }
+
+    std::shared_ptr<ClusterState> state_;
+    TransportConfig config_;
+    bool initialized_{false};
+};
+
+class DynamicViewServer final : public ViewServer {
+public:
+    DynamicViewServer(std::shared_ptr<ClusterState> state, std::vector<AsuId> asuIds)
+        : state_(std::move(state)), asuIds_(std::move(asuIds))
+    {
+        state_->SetActiveAsus(asuIds_);
+    }
+
+    Status GetGlobalView(GlobalView& view) override
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+        view = GlobalView{};
+        view.viewEpoch = epoch_;
+        for (auto asuId : asuIds_) { view.asuMap.emplace(asuId, AsuInfo{}); }
+        ++fetchCount_;
+        return Status::OK();
+    }
+
+    void Publish(std::vector<AsuId> asuIds)
+    {
+        {
+            std::lock_guard<std::mutex> lock{mutex_};
+            asuIds_ = std::move(asuIds);
+            ++epoch_;
+        }
+        state_->SetActiveAsus(AsuIds());
+    }
+
+    std::size_t FetchCount() const
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+        return fetchCount_;
+    }
+
+private:
+    std::vector<AsuId> AsuIds() const
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+        return asuIds_;
+    }
+
+    std::shared_ptr<ClusterState> state_;
+    mutable std::mutex mutex_;
+    std::vector<AsuId> asuIds_;
+    std::uint64_t epoch_{1};
+    std::size_t fetchCount_{0};
+};
+
+AsuClientConfig MakeClientConfig(const std::vector<AsuId>& allAsuIds)
+{
+    AsuClientConfig config;
+    config.clientId = "asu-client-e2e-metrics-test";
+    config.defaultWaitTimeoutMs = 1000;
+    for (auto asuId : allAsuIds) {
+        TransportConfig transportConfig;
+        transportConfig.asuId = asuId;
+        transportConfig.asuName = "fake-asu-" + std::to_string(asuId);
+        transportConfig.providerType = TransProviderType::FAKE;
+        transportConfig.maxInflightTasks = 1024;
+        config.transportConfigs.emplace_back(std::move(transportConfig));
+    }
+    return config;
+}
+
+ViewServerFactory MakeViewServerFactory(const std::shared_ptr<ViewServer>& viewServer)
+{
+    return [viewServer](const AsuClientConfig&) { return viewServer; };
+}
+
+TransportFactory MakeFactory(const std::shared_ptr<ClusterState>& state)
+{
+    return [state] { return std::make_unique<InMemoryAsuTransport>(state); };
+}
+
+std::vector<std::uint8_t> MakePayload(std::size_t size, std::uint8_t seed)
+{
+    std::vector<std::uint8_t> payload(size);
+    for (std::size_t index = 0; index < payload.size(); ++index) {
+        payload[index] = static_cast<std::uint8_t>(seed + static_cast<std::uint8_t>(index % 251U));
+    }
+    return payload;
+}
+
+KVBuffer MakeBuffer(const CacheKey& key, std::vector<std::uint8_t>& payload)
+{
+    MemoryRegion region;
+    region.memoryType = MemoryType::HOST;
+    region.addr = payload.empty() ? 0 : reinterpret_cast<std::uint64_t>(payload.data());
+    region.size = payload.size();
+    return KVBuffer{
+        key, Buffer{region, kInvalidMRHandle}
+    };
+}
+
+std::vector<KVBuffer> MakeStoreEntries(const std::string& prefix, std::size_t count,
+                                       std::size_t baseSize,
+                                       std::vector<std::vector<std::uint8_t>>& payloads)
+{
+    payloads.clear();
+    payloads.reserve(count);
+    std::vector<KVBuffer> entries;
+    entries.reserve(count);
+    for (std::size_t index = 0; index < count; ++index) {
+        payloads.emplace_back(
+            MakePayload(baseSize + (index % 5U) * 17U, static_cast<std::uint8_t>(index + 1U)));
+        entries.emplace_back(
+            MakeBuffer(MakeCacheKey(prefix + std::to_string(index)), payloads.back()));
+    }
+    return entries;
+}
+
+std::vector<KVBuffer> MakeLoadEntries(const std::vector<KVBuffer>& storeEntries,
+                                      const std::vector<std::vector<std::uint8_t>>& expected,
+                                      std::vector<std::vector<std::uint8_t>>& buffers)
+{
+    buffers.clear();
+    buffers.reserve(expected.size());
+    std::vector<KVBuffer> entries;
+    entries.reserve(storeEntries.size());
+    for (std::size_t index = 0; index < storeEntries.size(); ++index) {
+        buffers.emplace_back(expected[index].size(), 0);
+        entries.emplace_back(MakeBuffer(storeEntries[index].key, buffers.back()));
+    }
+    return entries;
+}
+
+std::vector<CacheKey> ExtractKeys(const std::vector<KVBuffer>& entries)
+{
+    std::vector<CacheKey> keys;
+    keys.reserve(entries.size());
+    for (const auto& entry : entries) { keys.emplace_back(entry.key); }
+    return keys;
+}
+
+std::uint64_t SumPayloadBytes(const std::vector<std::vector<std::uint8_t>>& payloads)
+{
+    return std::accumulate(
+        payloads.begin(), payloads.end(), std::uint64_t{0},
+        [](std::uint64_t sum, const auto& payload) { return sum + payload.size(); });
+}
+
+std::uint64_t ElapsedNs(std::chrono::steady_clock::time_point start)
+{
+    return static_cast<std::uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                          std::chrono::steady_clock::now() - start)
+                                          .count());
+}
+
+bool EntryStatusesOk(const TaskResult& result, std::size_t expectedCount)
+{
+    return result.status.ok() && result.entryStatus.size() == expectedCount &&
+           std::all_of(result.entryStatus.begin(), result.entryStatus.end(),
+                       [](const Status& status) { return status.ok(); });
+}
+
+Status QueryAndWait(AsuClient& client, const std::vector<CacheKey>& keys, QueryResult& result,
+                    std::uint64_t timeoutMs = 0)
+{
+    TaskId taskId{kInvalidTaskId};
+    auto status = client.QueryAsync(keys, taskId);
+    if (!status.ok()) { return status; }
+
+    TaskResult taskResult;
+    status = client.Wait(taskId, timeoutMs, taskResult);
+    if (taskResult.queryResult.has_value()) {
+        result = std::move(*taskResult.queryResult);
+    } else if (status.ok()) {
+        return Status::Error(StatusCode::INTERNAL_ERROR, "client query result is missing");
+    }
+    return status;
+}
+
+bool StoreAndMeasure(AsuClient& client, const std::vector<KVBuffer>& entries, std::uint64_t bytes,
+                     MetricsRecorder& metrics)
+{
+    TaskId taskId{kInvalidTaskId};
+    const auto start = std::chrono::steady_clock::now();
+    auto status = client.StoreAsync(entries, taskId);
+    TaskResult result;
+    if (status.ok()) { status = client.Wait(taskId, 1000, result); }
+    const bool correct = status.ok() && EntryStatusesOk(result, entries.size());
+    metrics.Record(OperationKind::STORE, ElapsedNs(start), correct ? bytes : 0, status.ok(),
+                   correct);
+    return correct;
+}
+
+bool LoadAndMeasure(AsuClient& client, const std::vector<KVBuffer>& entries,
+                    const std::vector<std::vector<std::uint8_t>>& expected,
+                    const std::vector<std::vector<std::uint8_t>>& actual, std::uint64_t bytes,
+                    MetricsRecorder& metrics)
+{
+    TaskId taskId{kInvalidTaskId};
+    const auto start = std::chrono::steady_clock::now();
+    auto status = client.LoadAsync(entries, taskId);
+    TaskResult result;
+    if (status.ok()) { status = client.Wait(taskId, 1000, result); }
+    const bool dataMatches = expected == actual;
+    const bool correct = status.ok() && EntryStatusesOk(result, entries.size()) && dataMatches;
+    metrics.Record(OperationKind::LOAD, ElapsedNs(start), correct ? bytes : 0, status.ok(),
+                   correct);
+    return correct;
+}
+
+bool QueryAndMeasure(AsuClient& client, const std::vector<CacheKey>& keys,
+                     const std::vector<std::uint8_t>& expected, MetricsRecorder& metrics)
+{
+    QueryResult result;
+    const auto start = std::chrono::steady_clock::now();
+    auto status = QueryAndWait(client, keys, result, 1000);
+    const bool correct = status.ok() && result.exists == expected;
+    metrics.Record(OperationKind::QUERY, ElapsedNs(start), 0, status.ok(), correct);
+    return correct;
+}
+
+bool DeleteAndMeasure(AsuClient& client, const std::vector<CacheKey>& keys,
+                      MetricsRecorder& metrics)
+{
+    TaskId taskId{kInvalidTaskId};
+    const auto start = std::chrono::steady_clock::now();
+    auto status = client.DeleteAsync(keys, taskId);
+    TaskResult result;
+    if (status.ok()) { status = client.Wait(taskId, 1000, result); }
+    const bool correct = status.ok() && EntryStatusesOk(result, keys.size());
+    metrics.Record(OperationKind::DELETE, ElapsedNs(start), 0, status.ok(), correct);
+    return correct;
+}
+
+bool WaitUntil(const std::function<bool()>& condition)
+{
+    for (std::uint32_t attempt = 0; attempt < 200; ++attempt) {
+        if (condition()) { return true; }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+std::vector<CacheKey> MakeProbeKeys(std::size_t count)
+{
+    std::vector<CacheKey> keys;
+    keys.reserve(count);
+    for (std::size_t index = 0; index < count; ++index) {
+        keys.emplace_back(MakeCacheKey("refresh-probe-" + std::to_string(index)));
+    }
+    return keys;
+}
+
+void ExpectStoreAndLoadSummaries(const MetricsRecorder& metrics)
+{
+    const auto storeSummary = metrics.Summarize(OperationKind::STORE);
+    ASSERT_GT(storeSummary.total, 0U);
+    EXPECT_DOUBLE_EQ(storeSummary.successRate, 1.0);
+    EXPECT_DOUBLE_EQ(storeSummary.correctnessRate, 1.0);
+    EXPECT_GT(storeSummary.iops, 0.0);
+    EXPECT_GT(storeSummary.bandwidthBytesPerSec, 0.0);
+    EXPECT_GT(storeSummary.latencyP50Ns, 0U);
+
+    const auto loadSummary = metrics.Summarize(OperationKind::LOAD);
+    ASSERT_GT(loadSummary.total, 0U);
+    EXPECT_DOUBLE_EQ(loadSummary.successRate, 1.0);
+    EXPECT_DOUBLE_EQ(loadSummary.correctnessRate, 1.0);
+    EXPECT_GT(loadSummary.iops, 0.0);
+    EXPECT_GT(loadSummary.bandwidthBytesPerSec, 0.0);
+    EXPECT_GT(loadSummary.latencyP50Ns, 0U);
+}
+
+}  // namespace
+
+TEST(AsuClientE2EMetricsTest, NormalWorkloadReportsPrecisionPerformanceAndResources)
+{
+    auto state = std::make_shared<ClusterState>();
+    auto viewServer = std::make_shared<DynamicViewServer>(state, std::vector<AsuId>{1, 2, 3});
+    auto client =
+        std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
+    ASSERT_TRUE(client->Init(MakeClientConfig({1, 2, 3})).ok());
+
+    MetricsRecorder metrics;
+    std::vector<std::vector<std::uint8_t>> payloads;
+    auto storeEntries = MakeStoreEntries("normal-key-", 48, 256, payloads);
+    const auto keys = ExtractKeys(storeEntries);
+    const auto bytes = SumPayloadBytes(payloads);
+
+    ASSERT_TRUE(StoreAndMeasure(*client, storeEntries, bytes, metrics));
+    const auto afterStore = state->Snapshot();
+    EXPECT_EQ(afterStore.storedKeyCount, storeEntries.size());
+    EXPECT_EQ(afterStore.storedBytes, bytes);
+
+    ASSERT_TRUE(QueryAndMeasure(*client, keys, std::vector<std::uint8_t>(keys.size(), 1), metrics));
+
+    std::vector<std::vector<std::uint8_t>> loadBuffers;
+    auto loadEntries = MakeLoadEntries(storeEntries, payloads, loadBuffers);
+    ASSERT_TRUE(LoadAndMeasure(*client, loadEntries, payloads, loadBuffers, bytes, metrics));
+
+    std::vector<std::vector<std::uint8_t>> overwritePayloads;
+    auto overwriteEntries = MakeStoreEntries("normal-key-", 8, 512, overwritePayloads);
+    const auto overwriteBytes = SumPayloadBytes(overwritePayloads);
+    ASSERT_TRUE(StoreAndMeasure(*client, overwriteEntries, overwriteBytes, metrics));
+    std::vector<std::vector<std::uint8_t>> overwriteLoadBuffers;
+    auto overwriteLoadEntries =
+        MakeLoadEntries(overwriteEntries, overwritePayloads, overwriteLoadBuffers);
+    ASSERT_TRUE(LoadAndMeasure(*client, overwriteLoadEntries, overwritePayloads,
+                               overwriteLoadBuffers, overwriteBytes, metrics));
+
+    ASSERT_TRUE(DeleteAndMeasure(*client, keys, metrics));
+    ASSERT_TRUE(QueryAndMeasure(*client, keys, std::vector<std::uint8_t>(keys.size(), 0), metrics));
+
+    const auto afterDelete = state->Snapshot();
+    EXPECT_EQ(afterDelete.storedKeyCount, 0U);
+    EXPECT_EQ(afterDelete.storedBytes, 0U);
+    EXPECT_GE(state->TouchedAsuCount(), 2U);
+
+    ExpectStoreAndLoadSummaries(metrics);
+    const auto querySummary = metrics.Summarize(OperationKind::QUERY);
+    EXPECT_DOUBLE_EQ(querySummary.successRate, 1.0);
+    EXPECT_DOUBLE_EQ(querySummary.correctnessRate, 1.0);
+    const auto deleteSummary = metrics.Summarize(OperationKind::DELETE);
+    EXPECT_DOUBLE_EQ(deleteSummary.successRate, 1.0);
+    EXPECT_DOUBLE_EQ(deleteSummary.correctnessRate, 1.0);
+    metrics.PrintReport("normal workload");
+
+    auto status = client->Shutdown();
+    EXPECT_TRUE(status.ok()) << status.message;
+}
+
+TEST(AsuClientE2EMetricsTest, DiskMembershipChangesRefreshAndContinueWorkload)
+{
+    auto state = std::make_shared<ClusterState>();
+    auto viewServer = std::make_shared<DynamicViewServer>(state, std::vector<AsuId>{1, 2});
+    auto client =
+        std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
+    ASSERT_TRUE(client->Init(MakeClientConfig({1, 2, 3})).ok());
+
+    MetricsRecorder metrics;
+    std::vector<std::vector<std::uint8_t>> payloads;
+    auto storeEntries = MakeStoreEntries("membership-key-", 64, 128, payloads);
+    ASSERT_TRUE(StoreAndMeasure(*client, storeEntries, SumPayloadBytes(payloads), metrics));
+
+    viewServer->Publish({1, 2, 3});
+    state->ForceNextQueryFailure();
+    QueryResult ignoredResult;
+    auto status = QueryAndWait(*client, {MakeCacheKey("membership-refresh-add")}, ignoredResult);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    const auto addProbeKeys = MakeProbeKeys(512);
+    ASSERT_TRUE(WaitUntil([&] {
+        state->ClearOperationCalls();
+        QueryResult result;
+        const auto retryStatus = QueryAndWait(*client, addProbeKeys, result);
+        return retryStatus.ok() && state->OperationCalls(3) > 0;
+    }));
+
+    std::vector<std::vector<std::uint8_t>> addedPayloads;
+    auto addedEntries = MakeStoreEntries("membership-added-key-", 96, 96, addedPayloads);
+    ASSERT_TRUE(StoreAndMeasure(*client, addedEntries, SumPayloadBytes(addedPayloads), metrics));
+    std::vector<std::vector<std::uint8_t>> addedLoadBuffers;
+    auto addedLoadEntries = MakeLoadEntries(addedEntries, addedPayloads, addedLoadBuffers);
+    ASSERT_TRUE(LoadAndMeasure(*client, addedLoadEntries, addedPayloads, addedLoadBuffers,
+                               SumPayloadBytes(addedPayloads), metrics));
+
+    viewServer->Publish({1, 3});
+    state->ForceNextQueryFailure();
+    const auto probeKeys = MakeProbeKeys(512);
+    status = QueryAndWait(*client, probeKeys, ignoredResult);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_TRUE(WaitUntil([&] {
+        state->ClearOperationCalls();
+        QueryResult result;
+        const auto retryStatus = QueryAndWait(*client, probeKeys, result);
+        return retryStatus.ok() && state->OperationCalls(2) == 0 && state->OperationCalls(3) > 0;
+    }));
+
+    state->ClearOperationCalls();
+    std::vector<std::vector<std::uint8_t>> removedPayloads;
+    auto removedEntries = MakeStoreEntries("membership-removed-key-", 96, 96, removedPayloads);
+    ASSERT_TRUE(
+        StoreAndMeasure(*client, removedEntries, SumPayloadBytes(removedPayloads), metrics));
+    std::vector<std::vector<std::uint8_t>> removedLoadBuffers;
+    auto removedLoadEntries = MakeLoadEntries(removedEntries, removedPayloads, removedLoadBuffers);
+    ASSERT_TRUE(LoadAndMeasure(*client, removedLoadEntries, removedPayloads, removedLoadBuffers,
+                               SumPayloadBytes(removedPayloads), metrics));
+    EXPECT_EQ(state->OperationCalls(2), 0U);
+
+    const auto snapshot = state->Snapshot();
+    EXPECT_GE(snapshot.createdTransports, 3U);
+    ExpectStoreAndLoadSummaries(metrics);
+    metrics.PrintReport("disk add and remove");
+
+    status = client->Shutdown();
+    EXPECT_TRUE(status.ok()) << status.message;
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
+++ b/ucm/transport/kv/asu/test/client/asu_client_impl_test.cpp
@@ -1,0 +1,2140 @@
+#include "asu_client_impl.h"
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <future>
+#include <gtest/gtest.h>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#include "client_config_parser.h"
+#include "router/router.h"
+
+namespace UC::ASU {
+
+static CacheKey MakeCacheKey(std::string_view text)
+{
+    CacheKey key{};
+    if (text.size() <= key.size()) {
+        if (!text.empty()) { std::memcpy(key.data(), text.data(), text.size()); }
+        return key;
+    }
+    const auto hash = std::hash<std::string_view>{}(text);
+    std::memcpy(key.data(), &hash, key.size());
+    return key;
+}
+
+MRHandle MakeTestMrHandle(std::uintptr_t value) { return static_cast<MRHandle>(value); }
+
+struct TestState {
+    std::uint32_t createdTransports{0};
+    std::uint32_t createdProviders{0};
+    std::unordered_map<AsuId, TransportConfig> initConfigs;
+    std::unordered_map<AsuId, TransProvider*> initProviders;
+    bool failFirstQuery{false};
+    bool firstQueryFailed{false};
+    StatusCode firstQueryFailureCode{StatusCode::CONNECTION_ERROR};
+    std::string firstQueryFailureMessage{"fake connection error"};
+    bool failFirstLoad{false};
+    bool firstLoadFailed{false};
+    bool failFirstStore{false};
+    bool firstStoreFailed{false};
+    bool failStoreAfterFirstDispatch{false};
+    std::size_t storeDispatchAttempts{0};
+    bool failFirstDelete{false};
+    bool firstDeleteFailed{false};
+    bool deferCompletionCallbacks{false};
+    bool blockStoreDispatch{false};
+    bool storeDispatchStarted{false};
+    bool releaseStoreDispatch{false};
+    std::mutex storeDispatchMu;
+    std::condition_variable storeDispatchCv;
+    std::mutex completionMu;
+    std::condition_variable completionCv;
+    std::unordered_map<AsuId, Status> queryFailures;
+    std::unordered_map<AsuId, Status> loadFailures;
+    std::unordered_map<AsuId, Status> storeFailures;
+    std::unordered_map<AsuId, Status> deleteFailures;
+    std::unordered_map<AsuId, std::vector<Status>> checkEntryStatus;
+    std::unordered_map<AsuId, Status> checkResultStatus;
+    std::vector<AsuId> registerCalls;
+    std::vector<AsuId> providerBindCalls;
+    std::vector<KVBuffer> submittedEntries;
+    std::vector<AsuId> unregisterCalls;
+    bool failRegister{false};
+    bool failProviderBind{false};
+    bool returnPartialRegister{false};
+    bool mismatchRegisterResultCount{false};
+    bool failUnregister{false};
+    std::vector<AsuId> queryCalls;
+    std::unordered_map<AsuId, std::size_t> queryKeyCounts;
+    std::unordered_map<AsuId, std::vector<CacheKey>> queryKeys;
+    std::vector<AsuId> loadCalls;
+    std::vector<AsuId> storeCalls;
+    std::vector<AsuOpType> submittedOpTypes;
+    std::vector<AsuId> deleteCalls;
+    std::vector<AsuId> cancelCalls;
+    std::unordered_map<AsuId, TaskId> childTaskIds;
+    std::unordered_map<AsuId, TaskCompletionCallback> pendingCompletionCallbacks;
+    std::size_t completionCallbackCount{0};
+};
+
+namespace {
+
+class ClientTestTransProvider final : public TransProvider {
+public:
+    ClientTestTransProvider(AsuId asuId, std::shared_ptr<TestState> state)
+        : asuId_(asuId), state_(std::move(state))
+    {
+    }
+
+    Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t, uint32_t,
+                            std::vector<ConnectionHandle>&) override
+    {
+        return Status::OK();
+    }
+
+    std::vector<Status> DeleteConnections(const std::vector<ConnectionHandle>& handles) override
+    {
+        return std::vector<Status>(handles.size(), Status::OK());
+    }
+
+    std::vector<Status> Send(const std::vector<SendIoBatch>& ioBatches, uint32_t, uint32_t) override
+    {
+        return std::vector<Status>(ioBatches.size(), Status::OK());
+    }
+
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
+                          std::vector<MRHandle>& mrHandles) override
+    {
+        state_->registerCalls.emplace_back(asuId_);
+        mrHandles.clear();
+        if (state_->failRegister) {
+            return Status::Error(StatusCode::BUFFER_NOT_REGISTERED, "fake register failure");
+        }
+        if (state_->returnPartialRegister) {
+            if (!memoryDescs.empty()) { mrHandles.emplace_back(MakeTestMrHandle(500)); }
+            return Status::Error(StatusCode::PARTIAL_FAILED,
+                                 "one or more memory regions failed to register");
+        }
+        auto resultCount = memoryDescs.size();
+        if (state_->mismatchRegisterResultCount && resultCount > 0) { --resultCount; }
+        for (std::size_t index = 0; index < resultCount; ++index) {
+            mrHandles.emplace_back(MakeTestMrHandle(500 + index));
+        }
+        return Status::OK();
+    }
+
+    Status BindMemory(const std::vector<BindMemoryDesc>& memoryDescs,
+                      std::vector<MRHandle>& mrHandles) override
+    {
+        state_->providerBindCalls.emplace_back(asuId_);
+        mrHandles.clear();
+        if (state_->failProviderBind) {
+            return Status::Error(StatusCode::BUFFER_NOT_REGISTERED, "fake provider bind failure");
+        }
+        for (std::size_t index = 0; index < memoryDescs.size(); ++index) {
+            mrHandles.emplace_back(MakeTestMrHandle(500 + index));
+        }
+        return Status::OK();
+    }
+
+    std::vector<Status> UnregisterMemory(
+        const std::vector<UnregisterMemoryDesc>& memoryDescs) override
+    {
+        state_->unregisterCalls.emplace_back(asuId_);
+        const auto status = state_->failUnregister
+                                ? Status::Error(StatusCode::IO_ERROR, "fake unregister failure")
+                                : Status::OK();
+        return std::vector<Status>(memoryDescs.size(), status);
+    }
+
+    Status AllocThread(uint32_t, const std::vector<uint32_t>&, std::vector<ThreadHandle>&) override
+    {
+        return Status::OK();
+    }
+
+    std::vector<Status> FreeThread(const std::vector<ThreadHandle>& threads) override
+    {
+        return std::vector<Status>(threads.size(), Status::OK());
+    }
+
+    Status GetMemTokenId(MRHandle mrHandle, uint32_t& tokenId) override
+    {
+        tokenId = 900 + static_cast<std::uint32_t>(mrHandle - MakeTestMrHandle(500));
+        return Status::OK();
+    }
+
+private:
+    AsuId asuId_;
+    std::shared_ptr<TestState> state_;
+};
+
+}  // namespace
+
+class FakeTransport : public AsuTransport {
+public:
+    explicit FakeTransport(std::shared_ptr<TestState> state) : state_(std::move(state)) {}
+
+    Status Init(const TransportConfig& config,
+                std::shared_ptr<TransProvider> transProvider) override
+    {
+        (void)transProvider;
+        config_ = config;
+        state_->initConfigs[config_.asuId] = config_;
+        state_->initProviders[config_.asuId] = transProvider.get();
+        initialized_ = true;
+        return Status::OK();
+    }
+
+    Status Init(const std::string& configPath,
+                std::shared_ptr<TransProvider> transProvider) override
+    {
+        (void)configPath;
+        (void)transProvider;
+        return Status::Error(StatusCode::UNSUPPORTED, "fake transport config path is unsupported");
+    }
+
+    Status Shutdown() override
+    {
+        initialized_ = false;
+        return Status::OK();
+    }
+
+    Status CheckHealth() override { return initialized_ ? Status::OK() : NotInitialized(); }
+
+    virtual Status RunQuery(BatchView<CacheKey> keys, QueryResult& result)
+    {
+        if (!initialized_) { return NotInitialized(); }
+        if (state_->failFirstQuery && !state_->firstQueryFailed) {
+            state_->firstQueryFailed = true;
+            return Status::Error(state_->firstQueryFailureCode, state_->firstQueryFailureMessage);
+        }
+
+        state_->queryCalls.emplace_back(config_.asuId);
+        state_->queryKeyCounts[config_.asuId] += keys.size;
+        auto& routedKeys = state_->queryKeys[config_.asuId];
+        routedKeys.reserve(routedKeys.size() + keys.size);
+        for (std::size_t index = 0; index < keys.size; ++index) {
+            routedKeys.emplace_back(keys[index]);
+        }
+        auto failureIter = state_->queryFailures.find(config_.asuId);
+        if (failureIter != state_->queryFailures.end()) { return failureIter->second; }
+
+        result.exists.clear();
+        result.exists.reserve(keys.size);
+        for (std::size_t index = 0; index < keys.size; ++index) {
+            result.exists.emplace_back(keys[index] == MakeCacheKey("k15") ||
+                                       keys[index] == MakeCacheKey("k25"));
+        }
+        result.prefixHitKeys = 0;
+        return Status::OK();
+    }
+
+    Status Submit(const TransportTaskPtr& task) override
+    {
+        if (!task) {
+            return Status::Error(StatusCode::INVALID_ARGUMENT, "fake transport task is null");
+        }
+        state_->submittedEntries = task->entries;
+        state_->submittedOpTypes.emplace_back(task->opType);
+        switch (task->opType) {
+            case AsuOpType::QUERY: {
+                QueryResult queryResult;
+                auto status = RunQuery({task->keys.data(), task->keys.size()}, queryResult);
+                if (!status.ok()) {
+                    task->taskId = kInvalidTaskId;
+                    return status;
+                }
+
+                task->taskId = 4000 + config_.asuId;
+                TaskResult taskResult;
+                auto statusIter = state_->checkResultStatus.find(config_.asuId);
+                taskResult.status = statusIter == state_->checkResultStatus.end()
+                                        ? Status::OK()
+                                        : statusIter->second;
+                taskResult.entryStatus.assign(task->keys.size(), taskResult.status);
+                taskResult.queryResult = std::move(queryResult);
+                Complete(std::move(taskResult), std::move(task->onComplete));
+                return Status::OK();
+            }
+            case AsuOpType::LOAD:
+            case AsuOpType::BATCH_LOAD: {
+                if (state_->failFirstLoad && !state_->firstLoadFailed) {
+                    state_->firstLoadFailed = true;
+                    return Status::Error(StatusCode::CONNECTION_ERROR,
+                                         "fake load connection error");
+                }
+                auto failureIter = state_->loadFailures.find(config_.asuId);
+                if (failureIter != state_->loadFailures.end()) { return failureIter->second; }
+
+                state_->loadCalls.emplace_back(config_.asuId);
+                task->taskId = 1000 + config_.asuId;
+                state_->childTaskIds[config_.asuId] = task->taskId;
+                Complete(task->entries.size(), std::move(task->onComplete));
+                return Status::OK();
+            }
+            case AsuOpType::STORE:
+            case AsuOpType::BATCH_STORE: {
+                if (state_->blockStoreDispatch) {
+                    std::unique_lock<std::mutex> lock{state_->storeDispatchMu};
+                    state_->storeDispatchStarted = true;
+                    state_->storeDispatchCv.notify_all();
+                    state_->storeDispatchCv.wait(lock,
+                                                 [this] { return state_->releaseStoreDispatch; });
+                }
+                if (state_->failFirstStore && !state_->firstStoreFailed) {
+                    state_->firstStoreFailed = true;
+                    return Status::Error(StatusCode::CONNECTION_ERROR,
+                                         "fake store connection error");
+                }
+                auto failureIter = state_->storeFailures.find(config_.asuId);
+                if (failureIter != state_->storeFailures.end()) { return failureIter->second; }
+                if (state_->failStoreAfterFirstDispatch && ++state_->storeDispatchAttempts > 1) {
+                    return Status::Error(StatusCode::CONNECTION_ERROR,
+                                         "fake partial dispatch failure");
+                }
+
+                state_->storeCalls.emplace_back(config_.asuId);
+                task->taskId = 2000 + config_.asuId;
+                state_->childTaskIds[config_.asuId] = task->taskId;
+                Complete(task->entries.size(), std::move(task->onComplete));
+                return Status::OK();
+            }
+            case AsuOpType::DELETE: {
+                if (state_->failFirstDelete && !state_->firstDeleteFailed) {
+                    state_->firstDeleteFailed = true;
+                    return Status::Error(StatusCode::CONNECTION_ERROR,
+                                         "fake delete connection error");
+                }
+                auto failureIter = state_->deleteFailures.find(config_.asuId);
+                if (failureIter != state_->deleteFailures.end()) { return failureIter->second; }
+
+                state_->deleteCalls.emplace_back(config_.asuId);
+                task->taskId = 3000 + config_.asuId;
+                state_->childTaskIds[config_.asuId] = task->taskId;
+                Complete(task->keys.size(), std::move(task->onComplete));
+                return Status::OK();
+            }
+            default:
+                task->taskId = kInvalidTaskId;
+                return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                     "unsupported fake transport operation");
+        }
+    }
+
+    Status Cancel(TaskId) override
+    {
+        state_->cancelCalls.emplace_back(config_.asuId);
+        return Status::OK();
+    }
+
+private:
+    void Complete(std::size_t entryCount, TaskCompletionCallback onComplete)
+    {
+        TaskResult result;
+        auto statusIter = state_->checkResultStatus.find(config_.asuId);
+        result.status =
+            statusIter == state_->checkResultStatus.end() ? Status::OK() : statusIter->second;
+        auto entryIter = state_->checkEntryStatus.find(config_.asuId);
+        result.entryStatus = entryIter == state_->checkEntryStatus.end()
+                                 ? std::vector<Status>(entryCount, result.status)
+                                 : entryIter->second;
+        Complete(std::move(result), std::move(onComplete));
+    }
+
+    void Complete(TaskResult result, TaskCompletionCallback onComplete)
+    {
+        if (!onComplete) { return; }
+        if (state_->deferCompletionCallbacks) {
+            {
+                std::lock_guard<std::mutex> lock{state_->completionMu};
+                state_->pendingCompletionCallbacks[config_.asuId] = std::move(onComplete);
+            }
+            state_->completionCv.notify_all();
+            return;
+        }
+
+        ++state_->completionCallbackCount;
+        onComplete(std::move(result));
+    }
+
+    static Status NotInitialized()
+    {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "fake transport is not initialized");
+    }
+
+    std::shared_ptr<TestState> state_;
+    TransportConfig config_;
+    bool initialized_{false};
+};
+
+bool InvokePendingCompletion(const std::shared_ptr<TestState>& state, AsuId asuId,
+                             TaskResult result)
+{
+    TaskCompletionCallback callback;
+    {
+        std::lock_guard<std::mutex> lock{state->completionMu};
+        auto callbackIter = state->pendingCompletionCallbacks.find(asuId);
+        if (callbackIter == state->pendingCompletionCallbacks.end()) { return false; }
+        callback = std::move(callbackIter->second);
+        state->pendingCompletionCallbacks.erase(callbackIter);
+    }
+    ++state->completionCallbackCount;
+    callback(std::move(result));
+    return true;
+}
+
+bool WaitForPendingCompletion(const std::shared_ptr<TestState>& state, AsuId asuId)
+{
+    std::unique_lock<std::mutex> lock{state->completionMu};
+    return state->completionCv.wait_for(lock, std::chrono::milliseconds(100), [&] {
+        return state->pendingCompletionCallbacks.find(asuId) !=
+               state->pendingCompletionCallbacks.end();
+    });
+}
+
+class FakeViewServer final : public ViewServer {
+public:
+    explicit FakeViewServer(std::vector<std::vector<AsuId>> views) : views_(std::move(views)) {}
+
+    FakeViewServer(std::vector<std::vector<AsuId>> views, std::vector<std::uint64_t> epochs)
+        : views_(std::move(views)), epochs_(std::move(epochs))
+    {
+    }
+
+    Status GetGlobalView(GlobalView& view) override
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+        if (failFetchFrom_ != 0 && fetchCount_ + 1 >= failFetchFrom_) {
+            ++fetchCount_;
+            return Status::Error(StatusCode::IO_ERROR, "fake view fetch failed");
+        }
+
+        auto index = fetchCount_;
+        if (index >= views_.size()) { index = views_.size() - 1; }
+        ++fetchCount_;
+
+        view = GlobalView{};
+        for (auto asuId : views_[index]) { view.asuMap.emplace(asuId, AsuInfo{}); }
+        view.viewEpoch = index < epochs_.size() ? epochs_[index] : fetchCount_;
+        return Status::OK();
+    }
+
+    void FailFetchFrom(std::size_t fetchCount)
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+        failFetchFrom_ = fetchCount;
+    }
+    std::size_t FetchCount() const
+    {
+        std::lock_guard<std::mutex> lock{mutex_};
+        return fetchCount_;
+    }
+
+private:
+    mutable std::mutex mutex_;
+    std::size_t fetchCount_{0};
+    std::size_t failFetchFrom_{0};
+    std::vector<std::vector<AsuId>> views_;
+    std::vector<std::uint64_t> epochs_;
+};
+
+bool WaitForFetchCount(const std::shared_ptr<FakeViewServer>& viewServer,
+                       std::size_t expectedFetchCount)
+{
+    for (std::uint32_t attempt = 0; attempt < 100; ++attempt) {
+        if (viewServer->FetchCount() >= expectedFetchCount) { return true; }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+bool CheckUntilComplete(AsuClient& client, TaskId taskId)
+{
+    for (std::uint32_t attempt = 0; attempt < 100; ++attempt) {
+        if (client.Check(taskId)) { return true; }
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    return false;
+}
+
+ViewServerFactory MakeViewServerFactory(const std::shared_ptr<ViewServer>& viewServer)
+{
+    return [viewServer](const AsuClientConfig&) { return viewServer; };
+}
+
+AsuClientConfig MakeConfig(const std::vector<AsuId>& asuIds)
+{
+    AsuClientConfig config;
+    for (auto asuId : asuIds) {
+        TransportConfig transportConfig;
+        transportConfig.asuId = asuId;
+        transportConfig.providerType = TransProviderType::FAKE;
+        config.transportConfigs.emplace_back(std::move(transportConfig));
+    }
+    return config;
+}
+
+TransportFactory MakeFactory(const std::shared_ptr<TestState>& state)
+{
+    return [state] {
+        ++state->createdTransports;
+        return std::make_unique<FakeTransport>(state);
+    };
+}
+
+TransProviderFactory MakeProviderFactory(const std::shared_ptr<TestState>& state)
+{
+    return [state](const TransportConfig& config, std::shared_ptr<TransProvider>& transProvider) {
+        ++state->createdProviders;
+        transProvider = std::make_shared<ClientTestTransProvider>(config.asuId, state);
+        return Status::OK();
+    };
+}
+
+void ExpectSameAsuSet(std::vector<AsuId> actual, std::vector<AsuId> expected)
+{
+    std::sort(actual.begin(), actual.end());
+    std::sort(expected.begin(), expected.end());
+    EXPECT_EQ(actual, expected);
+}
+
+Status QueryAndWait(AsuClient& client, const std::vector<CacheKey>& keys, QueryResult& result,
+                    std::uint64_t timeoutMs = 0)
+{
+    TaskId taskId{kInvalidTaskId};
+    auto status = client.QueryAsync(keys, taskId);
+    if (!status.ok()) { return status; }
+
+    TaskResult taskResult;
+    status = client.Wait(taskId, timeoutMs, taskResult);
+    if (taskResult.queryResult.has_value()) {
+        result = std::move(*taskResult.queryResult);
+    } else if (status.ok()) {
+        return Status::Error(StatusCode::INTERNAL_ERROR, "client query result is missing");
+    }
+    return status;
+}
+
+CacheKey FindKeyForAsu(const std::vector<AsuId>& asuIds, AsuId targetAsuId)
+{
+    std::vector<UC::Router::NodeId> nodeIds(asuIds.begin(), asuIds.end());
+    auto router =
+        UC::Router::CreateRouter(nodeIds, UC::Router::HashFunction{}, UC::Router::RouterConfig{});
+    for (std::uint32_t index = 1; index < 1000000; ++index) {
+        std::uint64_t combined = (static_cast<std::uint64_t>(targetAsuId) << 32) | index;
+        CacheKey cacheKey{};
+        std::memcpy(cacheKey.data(), &combined, sizeof(combined));
+        auto routeKey = std::string(CacheKeyView(cacheKey));
+        auto routes = router->RouteKeys({routeKey});
+        if (routes.size() == 1 && routes.begin()->first == targetAsuId) { return cacheKey; }
+    }
+    return {};
+}
+
+std::vector<KVBuffer> BuildRoutedEntries(const std::vector<AsuId>& routeOrder)
+{
+    std::vector<KVBuffer> entries;
+    entries.reserve(routeOrder.size());
+    for (auto asuId : routeOrder) {
+        entries.emplace_back(KVBuffer{FindKeyForAsu(routeOrder, asuId), {}});
+    }
+    return entries;
+}
+
+TEST(AsuClientImplTest, Lifecycle_OperationsBeforeInitReturnExpectedErrors)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state));
+
+    QueryResult queryResult;
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, queryResult);
+    EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
+
+    TaskId taskId = kInvalidTaskId;
+    status = client->StoreAsync(
+        {
+            KVBuffer{MakeCacheKey("k05"), {}}
+    },
+        taskId);
+    EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
+
+    EXPECT_TRUE(client->Check(1));
+}
+
+TEST(AsuClientImplTest, Lifecycle_InitTwiceReturnsResourceBusy)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state));
+    auto config = MakeConfig({10});
+    ASSERT_TRUE(client->Init(config).ok());
+
+    auto status = client->Init(config);
+
+    EXPECT_EQ(status.code, StatusCode::RESOURCE_BUSY);
+}
+
+TEST(AsuClientImplTest, Provider_IndependentModeCreatesMemoryProviderAndOnePerTransport)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
+
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20, 30})).ok());
+
+    EXPECT_EQ(state->createdProviders, std::uint32_t{4});
+    EXPECT_NE(state->initProviders[10], state->initProviders[20]);
+    EXPECT_NE(state->initProviders[20], state->initProviders[30]);
+}
+
+TEST(AsuClientImplTest, Provider_SharedModeUsesOneProviderForAllTransports)
+{
+    auto state = std::make_shared<TestState>();
+    auto config = MakeConfig({10, 20, 30});
+    config.sharedProviderMode = SharedProviderMode::SHARED;
+    auto client = CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
+
+    ASSERT_TRUE(client->Init(config).ok());
+
+    EXPECT_EQ(state->createdProviders, std::uint32_t{1});
+    EXPECT_EQ(state->initProviders[10], state->initProviders[20]);
+    EXPECT_EQ(state->initProviders[20], state->initProviders[30]);
+}
+
+TEST(AsuClientImplTest, Provider_InvalidSharedModeIsRejected)
+{
+    auto state = std::make_shared<TestState>();
+    auto config = MakeConfig({10});
+    config.sharedProviderMode = static_cast<SharedProviderMode>(2);
+    auto client = CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
+
+    const auto status = client->Init(config);
+
+    EXPECT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
+    EXPECT_EQ(state->createdProviders, std::uint32_t{0});
+    EXPECT_EQ(state->createdTransports, std::uint32_t{0});
+}
+
+TEST(AsuClientImplTest, Provider_SharedModeReusesProviderForAddedTransport)
+{
+    auto state = std::make_shared<TestState>();
+    auto config = MakeConfig({10, 20});
+    config.sharedProviderMode = SharedProviderMode::SHARED;
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10},
+            {10, 20}
+    },
+        std::vector<std::uint64_t>{1, 2});
+    auto client = std::make_unique<AsuClientImpl>(
+        MakeFactory(state), MakeViewServerFactory(viewServer), MakeProviderFactory(state));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    state->failFirstQuery = true;
+    QueryResult result;
+    EXPECT_EQ(QueryAndWait(*client, {MakeCacheKey("k05")}, result).code,
+              StatusCode::PARTIAL_FAILED);
+    ASSERT_TRUE(WaitForFetchCount(viewServer, 2));
+    ASSERT_TRUE(client->Shutdown().ok());
+
+    EXPECT_EQ(state->createdProviders, std::uint32_t{1});
+    EXPECT_EQ(state->initProviders[10], state->initProviders[20]);
+}
+
+TEST(AsuClientImplTest, Lifecycle_ShutdownClearsTasksAndRejectsFutureOperations)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
+
+    TaskId taskId = kInvalidTaskId;
+    auto status = client->StoreAsync(
+        {
+            KVBuffer{MakeCacheKey("k05"), {}}
+    },
+        taskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_TRUE(client->Shutdown().ok());
+
+    QueryResult queryResult;
+    status = QueryAndWait(*client, {MakeCacheKey("k05")}, queryResult);
+    EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
+
+    EXPECT_TRUE(client->Check(taskId));
+}
+
+TEST(AsuClientImplTest, Lifecycle_ShutdownDrainsFullTaskQueue)
+{
+    auto state = std::make_shared<TestState>();
+    state->blockStoreDispatch = true;
+    auto client = CreateAsuClient(MakeFactory(state));
+    auto config = MakeConfig({10});
+    config.maxInflightTasks = 2;
+    ASSERT_TRUE(client->Init(config).ok());
+
+    TaskId taskId = kInvalidTaskId;
+    ASSERT_TRUE(client
+                    ->StoreAsync(
+                        {
+                            KVBuffer{MakeCacheKey("active"), {}}
+    },
+                        taskId)
+                    .ok());
+
+    {
+        std::unique_lock<std::mutex> lock{state->storeDispatchMu};
+        EXPECT_TRUE(state->storeDispatchCv.wait_for(lock, std::chrono::milliseconds(100),
+                                                    [&] { return state->storeDispatchStarted; }));
+    }
+
+    for (std::size_t index = 0; index < 2; ++index) {
+        EXPECT_TRUE(client
+                        ->StoreAsync(
+                            {
+                                KVBuffer{MakeCacheKey("queued-" + std::to_string(index)), {}}
+        },
+                            taskId)
+                        .ok());
+    }
+
+    auto shutdown = std::async(std::launch::async, [&] { return client->Shutdown(); });
+    EXPECT_EQ(shutdown.wait_for(std::chrono::milliseconds(20)), std::future_status::timeout);
+
+    {
+        std::lock_guard<std::mutex> lock{state->storeDispatchMu};
+        state->releaseStoreDispatch = true;
+    }
+    state->storeDispatchCv.notify_all();
+
+    ASSERT_EQ(shutdown.wait_for(std::chrono::milliseconds(200)), std::future_status::ready);
+    EXPECT_TRUE(shutdown.get().ok());
+    EXPECT_EQ(state->storeCalls.size(), std::size_t{3});
+}
+
+TEST(AsuClientImplTest, Input_EmptyQueryReturnsEmptyResult)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
+
+    QueryResult result;
+    auto status = QueryAndWait(*client, {}, result);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_TRUE(result.exists.empty());
+    EXPECT_EQ(result.prefixHitKeys, std::uint32_t{0});
+    EXPECT_TRUE(state->queryCalls.empty());
+}
+
+TEST(AsuClientImplTest, Dispatch_UsesSingleProtocolForSingleEntryOperations)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
+
+    TaskId taskId = kInvalidTaskId;
+    ASSERT_TRUE(client
+                    ->StoreAsync(
+                        {
+                            KVBuffer{MakeCacheKey("store-single"), {}}
+    },
+                        taskId)
+                    .ok());
+    TaskResult result;
+    ASSERT_TRUE(client->Wait(taskId, 100, result).ok());
+
+    ASSERT_TRUE(client
+                    ->LoadAsync(
+                        {
+                            KVBuffer{MakeCacheKey("load-single"), {}}
+    },
+                        taskId)
+                    .ok());
+    ASSERT_TRUE(client->Wait(taskId, 100, result).ok());
+
+    ASSERT_TRUE(client
+                    ->BatchStoreAsync(
+                        {
+                            KVBuffer{MakeCacheKey("store-batch-0"), {}},
+                            KVBuffer{MakeCacheKey("store-batch-1"), {}}
+    },
+                        taskId)
+                    .ok());
+    ASSERT_TRUE(client->Wait(taskId, 100, result).ok());
+
+    ASSERT_TRUE(client
+                    ->BatchLoadAsync(
+                        {
+                            KVBuffer{MakeCacheKey("load-batch-0"), {}},
+                            KVBuffer{MakeCacheKey("load-batch-1"), {}}
+    },
+                        taskId)
+                    .ok());
+    ASSERT_TRUE(client->Wait(taskId, 100, result).ok());
+
+    EXPECT_EQ(state->submittedOpTypes,
+              std::vector<AsuOpType>({AsuOpType::STORE, AsuOpType::LOAD, AsuOpType::BATCH_STORE,
+                                      AsuOpType::BATCH_LOAD}));
+}
+
+TEST(AsuClientImplTest, Input_EmptyStoreCreatesCompletableEmptyTask)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
+
+    TaskId taskId = kInvalidTaskId;
+    auto status = client->StoreAsync({}, taskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_NE(taskId, kInvalidTaskId);
+
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_TRUE(result.entryStatus.empty());
+    EXPECT_TRUE(state->storeCalls.empty());
+}
+
+TEST(AsuClientImplTest, Input_EmptyDeleteCreatesCompletableEmptyTask)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
+
+    TaskId taskId = kInvalidTaskId;
+    auto status = client->DeleteAsync({}, taskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_NE(taskId, kInvalidTaskId);
+
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_TRUE(result.entryStatus.empty());
+    EXPECT_TRUE(state->deleteCalls.empty());
+}
+
+TEST(AsuClientImplTest, Input_EmptyRegisterReturnsEmptyResults)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
+
+    std::vector<RegisteredMemory> results;
+    auto status = client->RegisterRegions({}, results);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_TRUE(results.empty());
+    EXPECT_TRUE(state->registerCalls.empty());
+}
+
+TEST(AsuClientImplTest, Lifecycle_PublicInitLoadsClientConfigFile)
+{
+    constexpr const char* kConfigPath = "asu_client_impl_client_config_test.conf";
+    {
+        std::ofstream configFile{kConfigPath};
+        ASSERT_TRUE(configFile.is_open());
+        configFile << "clientId=file-init-test\n";
+        configFile << "asu_shared_provider=1\n";
+        configFile << "transport.asuIds=10,20\n";
+        configFile << "transport.send_buffer_slot_size=8192\n";
+        configFile << "transport.send_buffer_slot_num=2\n";
+        configFile << "transport.flag_buffer_slot_size=256\n";
+        configFile << "transport.flag_buffer_slot_num=32\n";
+        configFile << "transport.batch_load_io_num=11\n";
+        configFile << "transport.batch_store_io_num=12\n";
+        configFile << "transport.delete_io_num=13\n";
+        configFile << "transport.query_io_num=14\n";
+        configFile << "transport.device_id=6\n";
+        configFile << "transport.provider_type=fake\n";
+        configFile << "transport.max_error_count=5\n";
+        configFile << "transport.completion_poll_spin_limit=23\n";
+        configFile << "asuInfo.20=protocol=roce,placement=device,port=6000,"
+                   << "local.comm_id=192.168.1.20\n";
+    }
+
+    auto state = std::make_shared<TestState>();
+    std::unique_ptr<AsuClient> client =
+        CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
+    auto status = client->Init(kConfigPath);
+    std::remove(kConfigPath);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(state->createdTransports, std::uint32_t{2});
+    EXPECT_EQ(state->createdProviders, std::uint32_t{1});
+    EXPECT_EQ(state->initProviders[10], state->initProviders[20]);
+    ASSERT_EQ(state->initConfigs[20].endpoints.size(), std::size_t{1});
+    EXPECT_EQ(state->initConfigs[20].endpoints[0].ip, "192.168.1.20");
+    EXPECT_EQ(state->initConfigs[20].endpoints[0].protocol, Protocol::ROCE);
+    EXPECT_EQ(state->initConfigs[20].deviceId, std::int32_t{6});
+    for (auto asuId : {AsuId{10}, AsuId{20}}) {
+        EXPECT_EQ(state->initConfigs[asuId].sendBufferSlotSize, std::size_t{8192});
+        EXPECT_EQ(state->initConfigs[asuId].sendBufferSlotNum, std::size_t{2});
+        EXPECT_EQ(state->initConfigs[asuId].flagBufferSlotSize, std::size_t{256});
+        EXPECT_EQ(state->initConfigs[asuId].flagBufferSlotNum, std::size_t{32});
+        EXPECT_EQ(state->initConfigs[asuId].asuBatchLoadIoNum, std::size_t{11});
+        EXPECT_EQ(state->initConfigs[asuId].asuBatchStoreIoNum, std::size_t{12});
+        EXPECT_EQ(state->initConfigs[asuId].asuDeleteIoNum, std::size_t{13});
+        EXPECT_EQ(state->initConfigs[asuId].asuQueryIoNum, std::size_t{14});
+        EXPECT_EQ(state->initConfigs[asuId].maxErrorCount, std::uint32_t{5});
+        EXPECT_EQ(state->initConfigs[asuId].completionPollSpinLimit, std::size_t{23});
+    }
+}
+
+TEST(AsuClientImplTest, Config_SeparatesClientAndTransportMaxInflightTasks)
+{
+    constexpr const char* kConfigPath = "asu_client_impl_max_inflight_tasks_test.conf";
+    {
+        std::ofstream configFile{kConfigPath};
+        ASSERT_TRUE(configFile.is_open());
+        configFile << "client.maxInflightTasks=3\n";
+        configFile << "wait_timeout_ms=321\n";
+        configFile << "transport.asuIds=10\n";
+        configFile << "transport.maxInflightTasks=7\n";
+    }
+
+    AsuClientConfig config;
+    const auto status = LoadAsuClientConfig(kConfigPath, config);
+    std::remove(kConfigPath);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(config.maxInflightTasks, std::uint32_t{3});
+    EXPECT_EQ(config.defaultWaitTimeoutMs, std::uint64_t{321});
+    EXPECT_EQ(config.timeoutMs, std::uint64_t{321});
+    ASSERT_EQ(config.transportConfigs.size(), std::size_t{1});
+    EXPECT_EQ(config.transportConfigs.front().timeoutMs, std::uint64_t{321});
+    EXPECT_EQ(config.transportConfigs.front().maxInflightTasks, std::uint32_t{7});
+}
+
+TEST(AsuClientImplTest, Lifecycle_PublicInitRejectsInvalidSharedProviderMode)
+{
+    constexpr const char* kConfigPath = "asu_client_impl_invalid_shared_provider_test.conf";
+    {
+        std::ofstream configFile{kConfigPath};
+        ASSERT_TRUE(configFile.is_open());
+        configFile << "asu_shared_provider=2\n";
+        configFile << "transport.asuIds=10,20\n";
+    }
+
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
+    const auto status = client->Init(kConfigPath);
+    std::remove(kConfigPath);
+
+    EXPECT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
+    EXPECT_EQ(state->createdProviders, std::uint32_t{0});
+    EXPECT_EQ(state->createdTransports, std::uint32_t{0});
+}
+
+TEST(AsuClientImplTest, Lifecycle_PublicInitIndependentModeBindsMemoryAcrossMultipleAsus)
+{
+    constexpr const char* kConfigPath = "asu_client_impl_multi_asu_bind_test.conf";
+    {
+        std::ofstream configFile{kConfigPath};
+        ASSERT_TRUE(configFile.is_open());
+        configFile << "asu_shared_provider=0\n";
+        configFile << "transport.asuIds=10,20\n";
+    }
+
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
+    auto status = client->Init(kConfigPath);
+    std::remove(kConfigPath);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<RegisteredMemory> registeredRegions;
+    status = client->RegisterRegions({MemoryRegion{}}, registeredRegions);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(state->createdProviders, std::uint32_t{3});
+    EXPECT_EQ(state->registerCalls, std::vector<AsuId>({10}));
+    EXPECT_EQ(state->providerBindCalls, std::vector<AsuId>({10, 20}));
+}
+
+TEST(AsuClientImplTest, Routing_UsesRouterConfigFromClientConfigAttrs)
+{
+    auto state = std::make_shared<TestState>();
+    auto config = MakeConfig({10, 20});
+    config.attrs["hash_table.type"] = "CONTIGUOUS_BLOCK_AFFINITY";
+    config.attrs["contiguous_block_affinity.block_count"] = "2";
+    config.attrs["contiguous_block_affinity.full_spread_type"] = "RING_HASH";
+
+    auto keyForAsu10 = FindKeyForAsu({10, 20}, 10);
+    auto keyForAsu20 = FindKeyForAsu({10, 20}, 20);
+    ASSERT_NE(keyForAsu10, CacheKey{});
+    ASSERT_NE(keyForAsu20, CacheKey{});
+
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    TaskId taskId = kInvalidTaskId;
+    auto status = client->StoreAsync(
+        {
+            KVBuffer{keyForAsu10, {}},
+            KVBuffer{keyForAsu20, {}}
+    },
+        taskId);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    TaskResult result;
+    ASSERT_TRUE(client->Wait(taskId, 100, result).ok());
+    EXPECT_EQ(state->storeCalls, std::vector<AsuId>({10}));
+}
+
+TEST(AsuClientImplTest, ViewServer_InitFailsWhenViewReferencesMissingTransportConfig)
+{
+    auto state = std::make_shared<TestState>();
+    auto config = MakeConfig({10});
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10, 20}
+    },
+        std::vector<std::uint64_t>{1});
+    auto client =
+        std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
+
+    auto status = client->Init(config);
+
+    EXPECT_EQ(status.code, StatusCode::NOT_FOUND);
+    EXPECT_NE(status.message.find("asuId=20"), std::string::npos);
+}
+
+TEST(AsuClientImplTest, Query_PerKeyKeepsOriginalOrder)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
+
+    QueryResult result;
+    auto status = QueryAndWait(
+        *client, {MakeCacheKey("k05"), MakeCacheKey("k15"), MakeCacheKey("k25")}, result);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(result.exists, std::vector<std::uint8_t>({0, 1, 1}));
+    EXPECT_EQ(result.prefixHitKeys, std::uint32_t{0});
+    ExpectSameAsuSet(state->queryCalls, {10, 20});
+}
+
+TEST(AsuClientImplTest, QueryAsync_CompletesThroughTransportCallback)
+{
+    auto state = std::make_shared<TestState>();
+    state->deferCompletionCallbacks = true;
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
+
+    TaskId taskId{kInvalidTaskId};
+    auto status = client->QueryAsync({MakeCacheKey("k15")}, taskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_NE(taskId, kInvalidTaskId);
+
+    EXPECT_FALSE(client->Check(taskId));
+
+    ASSERT_TRUE(WaitForPendingCompletion(state, 10));
+    TaskResult completionResult;
+    completionResult.status = Status::OK();
+    completionResult.entryStatus = {Status::OK()};
+    completionResult.queryResult = QueryResult{{1}, 0};
+    ASSERT_TRUE(InvokePendingCompletion(state, 10, std::move(completionResult)));
+
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_TRUE(result.queryResult.has_value());
+    EXPECT_EQ(result.queryResult->exists, std::vector<std::uint8_t>({1}));
+}
+
+TEST(AsuClientImplTest, Query_PerKeyDispatchFailureCancelsOtherTransports)
+{
+    auto state = std::make_shared<TestState>();
+    state->queryFailures[20] = Status::Error(StatusCode::IO_ERROR, "fake per-key query failure");
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
+
+    QueryResult result;
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05"), MakeCacheKey("k15")}, result);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_EQ(result.exists, std::vector<std::uint8_t>({0, 0}));
+    ExpectSameAsuSet(state->queryCalls, {20});
+}
+
+TEST(AsuClientImplTest, Query_PerKeyResultSizeMismatchReturnsPartialFailed)
+{
+    class ShortQueryTransport final : public FakeTransport {
+    public:
+        explicit ShortQueryTransport(std::shared_ptr<TestState> state)
+            : FakeTransport(std::move(state))
+        {
+        }
+
+        Status RunQuery(BatchView<CacheKey>, QueryResult& result) override
+        {
+            result.exists.clear();
+            result.prefixHitKeys = 0;
+            return Status::OK();
+        }
+    };
+
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient([state] {
+        ++state->createdTransports;
+        return std::unique_ptr<AsuTransport>(new ShortQueryTransport(state));
+    });
+    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
+
+    QueryResult result;
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+}
+
+TEST(AsuClientImplTest, Query_ComputesPrefixInOriginalKeyOrder)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
+
+    QueryResult result;
+    auto status = QueryAndWait(
+        *client, {MakeCacheKey("k15"), MakeCacheKey("k25"), MakeCacheKey("k05")}, result);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(result.exists, std::vector<std::uint8_t>({1, 1, 0}));
+    EXPECT_EQ(result.prefixHitKeys, std::uint32_t{2});
+    ExpectSameAsuSet(state->queryCalls, {10, 20});
+}
+
+TEST(AsuClientImplTest, Query_CompletionFailuresDoNotSkipOtherTransports)
+{
+    auto state = std::make_shared<TestState>();
+    state->checkResultStatus[10] =
+        Status::Error(StatusCode::IO_ERROR, "fake query completion failure");
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
+
+    QueryResult result;
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05"), MakeCacheKey("k15")}, result);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ExpectSameAsuSet(state->queryCalls, {10, 20});
+    EXPECT_EQ(result.exists, std::vector<std::uint8_t>({0, 1}));
+}
+
+TEST(AsuClientImplTest, BackgroundRefresh_QueryReturnsErrorWithoutRetry)
+{
+    auto state = std::make_shared<TestState>();
+    state->failFirstQuery = true;
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
+    EXPECT_EQ(state->createdTransports, std::uint32_t{2});
+
+    QueryResult result;
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+
+    status = QueryAndWait(*client, {MakeCacheKey("k15")}, result);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(result.exists, std::vector<std::uint8_t>({1}));
+}
+
+TEST(AsuClientImplTest, BackgroundRefresh_QueryDoesNotRefreshNonRefreshableError)
+{
+    auto state = std::make_shared<TestState>();
+    state->failFirstQuery = true;
+    state->firstQueryFailureCode = StatusCode::INVALID_ARGUMENT;
+    state->firstQueryFailureMessage = "fake invalid argument";
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10},
+            {10, 20}
+    },
+        std::vector<std::uint64_t>{1, 2});
+    auto config = MakeConfig({10, 20});
+    auto client =
+        std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    QueryResult result;
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_EQ(viewServer->FetchCount(), std::size_t{1});
+    EXPECT_EQ(state->createdTransports, std::uint32_t{1});
+}
+
+TEST(AsuClientImplTest, BackgroundRefresh_QueryRefreshesOnIoError)
+{
+    auto state = std::make_shared<TestState>();
+    state->failFirstQuery = true;
+    state->firstQueryFailureCode = StatusCode::IO_ERROR;
+    state->firstQueryFailureMessage = "fake io error";
+    auto config = MakeConfig({10, 20});
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10},
+            {10, 20}
+    },
+        std::vector<std::uint64_t>{1, 2});
+    auto client =
+        std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    QueryResult result;
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_TRUE(client->Shutdown().ok());
+    EXPECT_EQ(state->createdTransports, std::uint32_t{2});
+}
+
+TEST(AsuClientImplTest, BackgroundRefresh_QueryRefreshesOnTimeout)
+{
+    auto state = std::make_shared<TestState>();
+    state->failFirstQuery = true;
+    state->firstQueryFailureCode = StatusCode::TIMEOUT;
+    state->firstQueryFailureMessage = "fake timeout";
+    auto config = MakeConfig({10, 20});
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10},
+            {10, 20}
+    },
+        std::vector<std::uint64_t>{1, 2});
+    auto client =
+        std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    QueryResult result;
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_TRUE(client->Shutdown().ok());
+    EXPECT_EQ(state->createdTransports, std::uint32_t{2});
+}
+
+TEST(AsuClientImplTest, BackgroundRefresh_QueryReturnsPartialFailedWhenViewFetchFails)
+{
+    auto state = std::make_shared<TestState>();
+    state->failFirstQuery = true;
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10},
+            {10, 20}
+    },
+        std::vector<std::uint64_t>{1, 2});
+    viewServer->FailFetchFrom(2);
+    auto config = MakeConfig({10, 20});
+    auto client =
+        std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    QueryResult result;
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_TRUE(client->Shutdown().ok());
+    EXPECT_EQ(state->createdTransports, std::uint32_t{1});
+}
+
+TEST(AsuClientImplTest, BackgroundRefresh_LoadRecordsDispatchErrorWithoutRetry)
+{
+    auto state = std::make_shared<TestState>();
+    state->failFirstLoad = true;
+    auto config = MakeConfig({10, 20});
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10},
+            {10, 20}
+    },
+        std::vector<std::uint64_t>{1, 2});
+    auto client =
+        std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    TaskId taskId = kInvalidTaskId;
+    auto status = client->LoadAsync(
+        {
+            KVBuffer{MakeCacheKey("k05"), {}}
+    },
+        taskId);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_NE(taskId, kInvalidTaskId);
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_EQ(result.entryStatus.size(), std::size_t{1});
+    EXPECT_EQ(result.entryStatus[0].code, StatusCode::CONNECTION_ERROR);
+    ASSERT_TRUE(client->Shutdown().ok());
+    EXPECT_EQ(state->createdTransports, std::uint32_t{2});
+    EXPECT_TRUE(state->loadCalls.empty());
+}
+
+TEST(AsuClientImplTest, BackgroundRefresh_StoreRecordsDispatchErrorWithoutRetry)
+{
+    auto state = std::make_shared<TestState>();
+    state->failFirstStore = true;
+    auto config = MakeConfig({10, 20});
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10},
+            {10, 20}
+    },
+        std::vector<std::uint64_t>{1, 2});
+    auto client =
+        std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    TaskId taskId = kInvalidTaskId;
+    auto status = client->StoreAsync(
+        {
+            KVBuffer{MakeCacheKey("k05"), {}}
+    },
+        taskId);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_NE(taskId, kInvalidTaskId);
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_EQ(result.entryStatus.size(), std::size_t{1});
+    EXPECT_EQ(result.entryStatus[0].code, StatusCode::CONNECTION_ERROR);
+    ASSERT_TRUE(client->Shutdown().ok());
+    EXPECT_EQ(state->createdTransports, std::uint32_t{2});
+    EXPECT_TRUE(state->storeCalls.empty());
+}
+
+TEST(AsuClientImplTest, BackgroundRefresh_DeleteRecordsDispatchErrorWithoutRetry)
+{
+    auto state = std::make_shared<TestState>();
+    state->failFirstDelete = true;
+    auto config = MakeConfig({10, 20});
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10},
+            {10, 20}
+    },
+        std::vector<std::uint64_t>{1, 2});
+    auto client =
+        std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    TaskId taskId = kInvalidTaskId;
+    auto status = client->DeleteAsync({MakeCacheKey("k05")}, taskId);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_NE(taskId, kInvalidTaskId);
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_EQ(result.entryStatus.size(), std::size_t{1});
+    EXPECT_EQ(result.entryStatus[0].code, StatusCode::CONNECTION_ERROR);
+    ASSERT_TRUE(client->Shutdown().ok());
+    EXPECT_EQ(state->createdTransports, std::uint32_t{2});
+    EXPECT_TRUE(state->deleteCalls.empty());
+}
+
+TEST(AsuClientImplTest, ViewEpoch_DoesNotPublishSameOrOlderViewEpoch)
+{
+    auto state = std::make_shared<TestState>();
+    state->failFirstQuery = true;
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10},
+            {10, 20},
+            {10, 20}
+    },
+        std::vector<std::uint64_t>{5, 5, 4});
+    auto config = MakeConfig({10, 20});
+    auto client =
+        std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    QueryResult result;
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_TRUE(client->Shutdown().ok());
+    EXPECT_EQ(state->createdTransports, std::uint32_t{1});
+}
+
+TEST(AsuClientImplTest, SnapshotRefresh_BuildFailureKeepsOldSnapshot)
+{
+    auto state = std::make_shared<TestState>();
+    state->failFirstQuery = true;
+    auto config = MakeConfig({10});
+    auto viewServer = std::make_shared<FakeViewServer>(std::vector<std::vector<AsuId>>{{10}, {20}},
+                                                       std::vector<std::uint64_t>{1, 2});
+    auto client =
+        std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    QueryResult result;
+    auto status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_TRUE(WaitForFetchCount(viewServer, 2));
+
+    status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(state->createdTransports, std::uint32_t{1});
+    EXPECT_EQ(state->queryCalls, std::vector<AsuId>({10}));
+}
+
+TEST(AsuClientImplTest, MemoryRegister_RegistersOwnerAndBindsAllIndependentProviders)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20, 30})).ok());
+
+    std::vector<RegisteredMemory> results;
+    auto status = client->RegisterRegions({MemoryRegion{}, MemoryRegion{}}, results);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(state->registerCalls, std::vector<AsuId>({10}));
+    EXPECT_EQ(state->providerBindCalls, std::vector<AsuId>({10, 20, 30}));
+    ASSERT_EQ(results.size(), std::size_t{2});
+    EXPECT_EQ(results[0].handle, MakeTestMrHandle(500));
+    EXPECT_EQ(results[1].handle, MakeTestMrHandle(501));
+    EXPECT_EQ(results[0].tokenId, std::uint32_t{900});
+    EXPECT_EQ(results[1].tokenId, std::uint32_t{901});
+}
+
+TEST(AsuClientImplTest, MemoryRegister_NewIndependentProviderBindsRememberedRegions)
+{
+    auto state = std::make_shared<TestState>();
+    auto config = MakeConfig({10, 20});
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10},
+            {10, 20}
+    },
+        std::vector<std::uint64_t>{1, 2});
+    auto client = std::make_unique<AsuClientImpl>(
+        MakeFactory(state), MakeViewServerFactory(viewServer), MakeProviderFactory(state));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    std::vector<RegisteredMemory> results;
+    ASSERT_TRUE(client->RegisterRegions({MemoryRegion{}}, results).ok());
+    ASSERT_EQ(results.size(), std::size_t{1});
+
+    state->failFirstQuery = true;
+    QueryResult queryResult;
+    EXPECT_EQ(QueryAndWait(*client, {MakeCacheKey("k05")}, queryResult).code,
+              StatusCode::PARTIAL_FAILED);
+    ASSERT_TRUE(WaitForFetchCount(viewServer, 2));
+    ASSERT_TRUE(client->Shutdown().ok());
+
+    EXPECT_EQ(state->createdProviders, std::uint32_t{3});
+    EXPECT_EQ(state->providerBindCalls, std::vector<AsuId>({10, 20}));
+}
+
+TEST(AsuClientImplTest, MemoryRegister_PartialRegisterFailureDoesNotBindProviders)
+{
+    auto state = std::make_shared<TestState>();
+    state->returnPartialRegister = true;
+    auto client = CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
+
+    std::vector<RegisteredMemory> results;
+    auto status = client->RegisterRegions({MemoryRegion{}, MemoryRegion{}}, results);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_EQ(state->registerCalls, std::vector<AsuId>({10}));
+    EXPECT_EQ(state->unregisterCalls, std::vector<AsuId>({10}));
+    EXPECT_TRUE(results.empty());
+}
+
+TEST(AsuClientImplTest, MemoryRegister_ProviderBindFailureRollsBackOwner)
+{
+    auto state = std::make_shared<TestState>();
+    state->failProviderBind = true;
+    auto client = CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
+
+    std::vector<RegisteredMemory> results;
+    const auto status = client->RegisterRegions({MemoryRegion{}}, results);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_EQ(state->registerCalls, std::vector<AsuId>({10}));
+    EXPECT_EQ(state->providerBindCalls, std::vector<AsuId>({10}));
+    EXPECT_EQ(state->unregisterCalls, std::vector<AsuId>({10}));
+    EXPECT_TRUE(results.empty());
+}
+
+TEST(AsuClientImplTest, MemoryRegister_RegisterFailureDoesNotBindProviders)
+{
+    auto state = std::make_shared<TestState>();
+    state->failRegister = true;
+    auto config = MakeConfig({10, 20});
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10},
+            {10, 20}
+    },
+        std::vector<std::uint64_t>{1, 2});
+    auto client = std::make_unique<AsuClientImpl>(
+        MakeFactory(state), MakeViewServerFactory(viewServer), MakeProviderFactory(state));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    std::vector<RegisteredMemory> results;
+    auto status = client->RegisterRegions({MemoryRegion{}}, results);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_TRUE(client->Shutdown().ok());
+    EXPECT_EQ(state->createdTransports, std::uint32_t{2});
+}
+
+TEST(AsuClientImplTest, MemoryRegister_SuccessWithMismatchedResultCountReturnsInternalError)
+{
+    auto state = std::make_shared<TestState>();
+    state->mismatchRegisterResultCount = true;
+    auto client = CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
+
+    std::vector<RegisteredMemory> results;
+    auto status = client->RegisterRegions({MemoryRegion{}}, results);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+}
+
+TEST(AsuClientImplTest, MemoryRegister_ProviderBindFailureIncludesProviderContext)
+{
+    auto state = std::make_shared<TestState>();
+    state->failProviderBind = true;
+    auto client = CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
+
+    std::vector<RegisteredMemory> results;
+    auto status = client->RegisterRegions({MemoryRegion{}}, results);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_NE(status.message.find("providerIndex=1"), std::string::npos);
+}
+
+TEST(AsuClientImplTest, MemoryRegister_ProviderBindFailureDoesNotCacheResource)
+{
+    auto state = std::make_shared<TestState>();
+    state->failProviderBind = true;
+    auto config = MakeConfig({10, 20, 30});
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10, 20},
+            {10, 20, 30}
+    },
+        std::vector<std::uint64_t>{1, 2});
+    auto client = std::make_unique<AsuClientImpl>(
+        MakeFactory(state), MakeViewServerFactory(viewServer), MakeProviderFactory(state));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    std::vector<RegisteredMemory> results;
+    auto status = client->RegisterRegions({MemoryRegion{}}, results);
+    ASSERT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    state->failProviderBind = false;
+
+    state->failFirstQuery = true;
+    QueryResult queryResult;
+    status = QueryAndWait(*client, {MakeCacheKey("k05")}, queryResult);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_TRUE(client->Shutdown().ok());
+    EXPECT_EQ(state->createdTransports, std::uint32_t{3});
+    EXPECT_EQ(state->providerBindCalls, std::vector<AsuId>({10}));
+}
+
+TEST(AsuClientImplTest, MemoryRegister_UnregisterFailureIncludesAsuContext)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
+
+    std::vector<RegisteredMemory> registeredRegions;
+    ASSERT_TRUE(client->RegisterRegions({MemoryRegion{}}, registeredRegions).ok());
+    ASSERT_EQ(registeredRegions.size(), std::size_t{1});
+    state->failUnregister = true;
+
+    auto status = client->UnregisterRegions({registeredRegions[0].handle});
+
+    EXPECT_EQ(status.code, StatusCode::IO_ERROR);
+    EXPECT_NE(status.message.find("handle_count=1"), std::string::npos);
+}
+
+TEST(AsuClientImplTest, MemoryRegister_UnregisterReleasesBoundProvidersBeforeOwner)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20, 30})).ok());
+
+    std::vector<RegisteredMemory> registeredRegions;
+    ASSERT_TRUE(client->RegisterRegions({MemoryRegion{}}, registeredRegions).ok());
+    state->unregisterCalls.clear();
+
+    const auto status = client->UnregisterRegions({registeredRegions[0].handle});
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(state->unregisterCalls, std::vector<AsuId>({30, 20, 10, 10}));
+}
+
+TEST(AsuClientImplTest, MemoryRegister_UnregisterRemovesCachedResourceBeforeFutureAsuIsAdded)
+{
+    auto state = std::make_shared<TestState>();
+    auto config = MakeConfig({10, 20});
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10},
+            {10, 20}
+    },
+        std::vector<std::uint64_t>{1, 2});
+    auto client = std::make_unique<AsuClientImpl>(
+        MakeFactory(state), MakeViewServerFactory(viewServer), MakeProviderFactory(state));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    std::vector<RegisteredMemory> results;
+    auto status = client->RegisterRegions({MemoryRegion{}}, results);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(results.size(), std::size_t{1});
+
+    status = client->UnregisterRegions({results[0].handle});
+    ASSERT_TRUE(status.ok()) << status.message;
+    state->providerBindCalls.clear();
+
+    state->failFirstQuery = true;
+    QueryResult queryResult;
+    status = QueryAndWait(*client, {MakeCacheKey("k05")}, queryResult);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_TRUE(client->Shutdown().ok());
+    EXPECT_EQ(state->createdTransports, std::uint32_t{2});
+    EXPECT_TRUE(state->providerBindCalls.empty());
+}
+
+TEST(AsuClientImplTest, Task_CheckKeepsTaskForWait)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
+
+    TaskId taskId = 0;
+    auto status = client->StoreAsync(
+        {
+            KVBuffer{MakeCacheKey("k05"), {}}
+    },
+        taskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    ASSERT_TRUE(CheckUntilComplete(*client, taskId));
+    EXPECT_TRUE(client->Check(taskId));
+
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    status = client->Wait(taskId, 100, result);
+    EXPECT_EQ(status.code, StatusCode::TASK_NOT_FOUND);
+}
+
+TEST(ClientTaskTest, TransportTaskCompletionDoesNotReplaceLifecycleState)
+{
+    ClientTask ctx;
+    ctx.remainingTransportTasks.store(1, std::memory_order_release);
+    ctx.state.store(ClientTaskState::INFLIGHT, std::memory_order_release);
+
+    EXPECT_FALSE(ctx.AllTransportTasksCompleted());
+    EXPECT_FALSE(ctx.Done());
+
+    ctx.remainingTransportTasks.fetch_sub(1, std::memory_order_acq_rel);
+
+    EXPECT_TRUE(ctx.AllTransportTasksCompleted());
+    EXPECT_FALSE(ctx.Done());
+
+    ctx.state.store(ClientTaskState::COMPLETED, std::memory_order_release);
+    EXPECT_TRUE(ctx.Done());
+}
+
+TEST(AsuClientImplTest, Task_PassesOneCompletionCallbackPerTransportTask)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20})).ok());
+    auto entries = BuildRoutedEntries({10, 20});
+    ASSERT_EQ(entries.size(), std::size_t{2});
+
+    TaskId taskId = kInvalidTaskId;
+    auto status = client->StoreAsync(entries, taskId);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    TaskResult result;
+    EXPECT_TRUE(client->Wait(taskId, 100, result).ok());
+    EXPECT_EQ(state->completionCallbackCount, std::size_t{2});
+}
+
+TEST(AsuClientImplTest, Task_SubmitReturnsWhileWorkerDispatchIsBlocked)
+{
+    auto state = std::make_shared<TestState>();
+    state->blockStoreDispatch = true;
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
+
+    TaskId taskId = kInvalidTaskId;
+    auto submit = std::async(std::launch::async, [&] {
+        return client->StoreAsync(
+            {
+                KVBuffer{MakeCacheKey("k05"), {}}
+        },
+            taskId);
+    });
+
+    bool dispatchStarted = false;
+    {
+        std::unique_lock<std::mutex> lock{state->storeDispatchMu};
+        dispatchStarted = state->storeDispatchCv.wait_for(
+            lock, std::chrono::milliseconds(100), [&] { return state->storeDispatchStarted; });
+    }
+    const bool submitReturned =
+        submit.wait_for(std::chrono::milliseconds(100)) == std::future_status::ready;
+    {
+        std::lock_guard<std::mutex> lock{state->storeDispatchMu};
+        state->releaseStoreDispatch = true;
+    }
+    state->storeDispatchCv.notify_all();
+
+    auto status = submit.get();
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_TRUE(dispatchStarted);
+    EXPECT_TRUE(submitReturned);
+    EXPECT_NE(taskId, kInvalidTaskId);
+
+    TaskResult result;
+    EXPECT_TRUE(client->Wait(taskId, 100, result).ok());
+}
+
+TEST(AsuClientImplTest, Task_SubmitReturnsResourceBusyWhenQueueIsFull)
+{
+    auto state = std::make_shared<TestState>();
+    state->blockStoreDispatch = true;
+    auto client = CreateAsuClient(MakeFactory(state));
+    auto config = MakeConfig({10});
+    config.maxInflightTasks = 2;
+    ASSERT_TRUE(client->Init(config).ok());
+
+    std::vector<TaskId> taskIds;
+    TaskId taskId = kInvalidTaskId;
+    ASSERT_TRUE(client
+                    ->StoreAsync(
+                        {
+                            KVBuffer{MakeCacheKey("k05"), {}}
+    },
+                        taskId)
+                    .ok());
+    taskIds.emplace_back(taskId);
+
+    bool dispatchStarted = false;
+    {
+        std::unique_lock<std::mutex> lock{state->storeDispatchMu};
+        dispatchStarted = state->storeDispatchCv.wait_for(
+            lock, std::chrono::milliseconds(100), [&] { return state->storeDispatchStarted; });
+    }
+
+    std::vector<Status> queuedStatuses;
+    for (std::size_t index = 0; index < 2; ++index) {
+        taskId = kInvalidTaskId;
+        queuedStatuses.emplace_back(client->StoreAsync(
+            {
+                KVBuffer{MakeCacheKey("queued-" + std::to_string(index)), {}}
+        },
+            taskId));
+        if (queuedStatuses.back().ok()) { taskIds.emplace_back(taskId); }
+    }
+
+    taskId = 0;
+    const auto status = client->StoreAsync(
+        {
+            KVBuffer{MakeCacheKey("queue-full"), {}}
+    },
+        taskId);
+    EXPECT_EQ(status.code, StatusCode::RESOURCE_BUSY);
+    EXPECT_EQ(taskId, kInvalidTaskId);
+
+    {
+        std::lock_guard<std::mutex> lock{state->storeDispatchMu};
+        state->releaseStoreDispatch = true;
+    }
+    state->storeDispatchCv.notify_all();
+
+    ASSERT_TRUE(dispatchStarted);
+    ASSERT_EQ(queuedStatuses.size(), std::size_t{2});
+    EXPECT_TRUE(queuedStatuses[0].ok()) << queuedStatuses[0].message;
+    EXPECT_TRUE(queuedStatuses[1].ok()) << queuedStatuses[1].message;
+    for (const auto submittedTaskId : taskIds) {
+        TaskResult result;
+        EXPECT_TRUE(client->Wait(submittedTaskId, 100, result).ok());
+    }
+}
+
+TEST(AsuClientImplTest, Task_CheckUsesClientStateUntilCompletionCallback)
+{
+    auto state = std::make_shared<TestState>();
+    state->deferCompletionCallbacks = true;
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
+
+    TaskId taskId = 0;
+    auto status = client->StoreAsync(
+        {
+            KVBuffer{MakeCacheKey("k05"), {}}
+    },
+        taskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    EXPECT_FALSE(client->Check(taskId));
+
+    ASSERT_TRUE(WaitForPendingCompletion(state, 10));
+    TaskResult completionResult;
+    completionResult.status = Status::OK();
+    completionResult.entryStatus = {Status::OK()};
+    ASSERT_TRUE(InvokePendingCompletion(state, 10, std::move(completionResult)));
+    EXPECT_TRUE(client->Check(taskId));
+
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    status = client->Wait(taskId, 100, result);
+    EXPECT_EQ(status.code, StatusCode::TASK_NOT_FOUND);
+}
+
+TEST(AsuClientImplTest, Task_CheckThenWaitHandlesRefreshableChildFailure)
+{
+    auto state = std::make_shared<TestState>();
+    state->checkResultStatus[10] = Status::Error(StatusCode::IO_ERROR, "fake child io error");
+    auto config = MakeConfig({10, 20});
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10},
+            {10, 20}
+    },
+        std::vector<std::uint64_t>{1, 2});
+    auto client =
+        std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    TaskId taskId = 0;
+    auto status = client->StoreAsync(
+        {
+            KVBuffer{MakeCacheKey("k05"), {}}
+    },
+        taskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    ASSERT_TRUE(CheckUntilComplete(*client, taskId));
+    EXPECT_TRUE(client->Check(taskId));
+    EXPECT_EQ(viewServer->FetchCount(), std::size_t{1});
+
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_TRUE(WaitForFetchCount(viewServer, 2));
+    ASSERT_TRUE(client->Shutdown().ok());
+    EXPECT_EQ(state->createdTransports, std::uint32_t{2});
+}
+
+TEST(AsuClientImplTest, Task_PartialDispatchFailureWaitsForDispatchedSubtasks)
+{
+    auto state = std::make_shared<TestState>();
+    state->failStoreAfterFirstDispatch = true;
+    state->deferCompletionCallbacks = true;
+    auto client = CreateAsuClient(MakeFactory(state));
+    const std::vector<AsuId> asuIds{10, 20, 30};
+    ASSERT_TRUE(client->Init(MakeConfig(asuIds)).ok());
+    auto entries = BuildRoutedEntries(asuIds);
+    ASSERT_EQ(entries.size(), asuIds.size());
+
+    TaskId taskId = kInvalidTaskId;
+    auto status = client->StoreAsync(entries, taskId);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_NE(taskId, kInvalidTaskId);
+    AsuId dispatchedAsuId = 0;
+    {
+        std::unique_lock<std::mutex> lock{state->completionMu};
+        ASSERT_TRUE(state->completionCv.wait_for(lock, std::chrono::milliseconds(100), [&] {
+            return !state->pendingCompletionCallbacks.empty();
+        }));
+        dispatchedAsuId = state->pendingCompletionCallbacks.begin()->first;
+    }
+    ASSERT_EQ(state->storeCalls.size(), std::size_t{1});
+    EXPECT_EQ(state->storeCalls[0], dispatchedAsuId);
+    EXPECT_FALSE(client->Check(taskId));
+    EXPECT_TRUE(state->cancelCalls.empty());
+
+    TaskResult completionResult;
+    completionResult.status = Status::OK();
+    completionResult.entryStatus = {Status::OK()};
+    ASSERT_TRUE(InvokePendingCompletion(state, dispatchedAsuId, std::move(completionResult)));
+
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    EXPECT_EQ(state->completionCallbackCount, std::size_t{1});
+    ASSERT_EQ(result.entryStatus.size(), std::size_t{3});
+    EXPECT_EQ(std::count_if(result.entryStatus.begin(), result.entryStatus.end(),
+                            [](const Status& entryStatus) { return entryStatus.ok(); }),
+              1);
+    EXPECT_EQ(std::count_if(result.entryStatus.begin(), result.entryStatus.end(),
+                            [](const Status& entryStatus) {
+                                return entryStatus.code == StatusCode::CONNECTION_ERROR;
+                            }),
+              1);
+    EXPECT_EQ(std::count_if(result.entryStatus.begin(), result.entryStatus.end(),
+                            [](const Status& entryStatus) {
+                                return entryStatus.code == StatusCode::CANCELED;
+                            }),
+              1);
+}
+
+TEST(AsuClientImplTest, Task_WaitRemovesTaskAfterCompletion)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
+
+    TaskId taskId = 0;
+    auto status = client->StoreAsync(
+        {
+            KVBuffer{MakeCacheKey("k05"), {}}
+    },
+        taskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    TaskResult result;
+    status = client->Wait(taskId, 10, result);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    status = client->Wait(taskId, 10, result);
+    EXPECT_EQ(status.code, StatusCode::TASK_NOT_FOUND);
+}
+
+TEST(AsuClientImplTest, Task_WaitTimeoutRemovesTask)
+{
+    auto state = std::make_shared<TestState>();
+    state->deferCompletionCallbacks = true;
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
+
+    TaskId taskId = 0;
+    auto status = client->StoreAsync(
+        {
+            KVBuffer{MakeCacheKey("k05"), {}}
+    },
+        taskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
+    EXPECT_EQ(status.code, StatusCode::TIMEOUT);
+
+    EXPECT_TRUE(client->Check(taskId));
+
+    ASSERT_TRUE(WaitForPendingCompletion(state, 10));
+    TaskResult completionResult;
+    completionResult.status = Status::OK();
+    completionResult.entryStatus = {Status::OK()};
+    EXPECT_TRUE(InvokePendingCompletion(state, 10, std::move(completionResult)));
+}
+
+TEST(AsuClientImplTest, Task_CheckKeepsEntryStatusInOriginalOrderAcrossAsus)
+{
+    auto state = std::make_shared<TestState>();
+    state->checkEntryStatus[10] = {Status::OK()};
+    state->checkEntryStatus[20] = {Status::Error(StatusCode::IO_ERROR, "entry on asu 20")};
+    state->checkEntryStatus[30] = {Status::Error(StatusCode::NOT_FOUND, "entry on asu 30")};
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20, 30})).ok());
+    auto entries = BuildRoutedEntries({30, 10, 20});
+    ASSERT_EQ(entries.size(), std::size_t{3});
+    ASSERT_NE(entries[0].key, CacheKey{});
+    ASSERT_NE(entries[1].key, CacheKey{});
+    ASSERT_NE(entries[2].key, CacheKey{});
+
+    TaskId taskId = 0;
+    auto status = client->StoreAsync(entries, taskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(result.entryStatus.size(), std::size_t{3});
+    EXPECT_EQ(result.entryStatus[0].code, StatusCode::NOT_FOUND);
+    EXPECT_EQ(result.entryStatus[1].code, StatusCode::OK);
+    EXPECT_EQ(result.entryStatus[2].code, StatusCode::IO_ERROR);
+}
+
+TEST(AsuClientImplTest, Task_LoadKeepsEntryStatusInOriginalOrderAcrossAsus)
+{
+    auto state = std::make_shared<TestState>();
+    state->checkEntryStatus[10] = {Status::OK()};
+    state->checkEntryStatus[20] = {Status::Error(StatusCode::IO_ERROR, "load entry on asu 20")};
+    state->checkEntryStatus[30] = {Status::Error(StatusCode::NOT_FOUND, "load entry on asu 30")};
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20, 30})).ok());
+    auto entries = BuildRoutedEntries({30, 10, 20});
+    ASSERT_EQ(entries.size(), std::size_t{3});
+    ASSERT_NE(entries[0].key, CacheKey{});
+    ASSERT_NE(entries[1].key, CacheKey{});
+    ASSERT_NE(entries[2].key, CacheKey{});
+
+    TaskId taskId = kInvalidTaskId;
+    auto status = client->LoadAsync(entries, taskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(result.entryStatus.size(), std::size_t{3});
+    EXPECT_EQ(result.entryStatus[0].code, StatusCode::NOT_FOUND);
+    EXPECT_EQ(result.entryStatus[1].code, StatusCode::OK);
+    EXPECT_EQ(result.entryStatus[2].code, StatusCode::IO_ERROR);
+}
+
+TEST(AsuClientImplTest, Task_DeleteKeepsEntryStatusInOriginalOrderAcrossAsus)
+{
+    auto state = std::make_shared<TestState>();
+    state->checkEntryStatus[10] = {Status::OK()};
+    state->checkEntryStatus[20] = {Status::Error(StatusCode::IO_ERROR, "delete entry on asu 20")};
+    state->checkEntryStatus[30] = {Status::Error(StatusCode::NOT_FOUND, "delete entry on asu 30")};
+    auto client = CreateAsuClient(MakeFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10, 20, 30})).ok());
+    auto entries = BuildRoutedEntries({30, 10, 20});
+    ASSERT_EQ(entries.size(), std::size_t{3});
+    ASSERT_NE(entries[0].key, CacheKey{});
+    ASSERT_NE(entries[1].key, CacheKey{});
+    ASSERT_NE(entries[2].key, CacheKey{});
+    std::vector<CacheKey> keys;
+    keys.reserve(entries.size());
+    for (const auto& entry : entries) { keys.emplace_back(entry.key); }
+
+    TaskId taskId = kInvalidTaskId;
+    auto status = client->DeleteAsync(keys, taskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    TaskResult result;
+    status = client->Wait(taskId, 100, result);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(result.entryStatus.size(), std::size_t{3});
+    EXPECT_EQ(result.entryStatus[0].code, StatusCode::NOT_FOUND);
+    EXPECT_EQ(result.entryStatus[1].code, StatusCode::OK);
+    EXPECT_EQ(result.entryStatus[2].code, StatusCode::IO_ERROR);
+}
+
+TEST(AsuClientImplTest, SnapshotRefresh_ReusesTransportAndBindsProviderForAddedAsu)
+{
+    auto state = std::make_shared<TestState>();
+    auto config = MakeConfig({10, 20});
+    auto viewServer = std::make_shared<FakeViewServer>(std::vector<std::vector<AsuId>>{
+        {10},
+        {10, 20}
+    });
+    auto client = std::make_unique<AsuClientImpl>(
+        MakeFactory(state), MakeViewServerFactory(viewServer), MakeProviderFactory(state));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    std::vector<RegisteredMemory> results;
+    auto status = client->RegisterRegions({MemoryRegion{}}, results);
+    ASSERT_TRUE(status.ok()) << status.message;
+    state->failFirstQuery = true;
+
+    QueryResult result;
+    status = QueryAndWait(*client, {MakeCacheKey("k05")}, result);
+
+    EXPECT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_TRUE(client->Shutdown().ok());
+    EXPECT_EQ(state->createdTransports, std::uint32_t{2});
+    EXPECT_EQ(state->providerBindCalls, std::vector<AsuId>({10, 20}));
+}
+
+TEST(AsuClientImplTest, MemoryRegister_StoreTaskCarriesMrKeyInEntry)
+{
+    auto state = std::make_shared<TestState>();
+    auto client = CreateAsuClient(MakeFactory(state), MakeProviderFactory(state));
+    ASSERT_TRUE(client->Init(MakeConfig({10})).ok());
+
+    std::vector<RegisteredMemory> registeredRegions;
+    ASSERT_TRUE(client->RegisterRegions({MemoryRegion{}}, registeredRegions).ok());
+    ASSERT_EQ(registeredRegions.size(), std::size_t{1});
+    KVBuffer entry{MakeCacheKey("k05"), {}};
+    entry.buffer.handle = registeredRegions[0].handle;
+
+    TaskId taskId = kInvalidTaskId;
+    ASSERT_TRUE(client->StoreAsync({entry}, taskId).ok());
+    TaskResult result;
+    ASSERT_TRUE(client->Wait(taskId, 100, result).ok());
+
+    ASSERT_EQ(state->submittedEntries.size(), std::size_t{1});
+    ASSERT_TRUE(state->submittedEntries[0].mrKey.has_value());
+    EXPECT_EQ(*state->submittedEntries[0].mrKey, registeredRegions[0].tokenId);
+}
+
+TEST(AsuClientImplTest,
+     SnapshotRefresh_RemovedAsuStopsReceivingNewRequestsButExistingTaskCanComplete)
+{
+    auto state = std::make_shared<TestState>();
+    auto config = MakeConfig({10, 20});
+    auto viewServer = std::make_shared<FakeViewServer>(
+        std::vector<std::vector<AsuId>>{
+            {10, 20},
+            {10}
+    },
+        std::vector<std::uint64_t>{1, 2});
+    auto client =
+        std::make_unique<AsuClientImpl>(MakeFactory(state), MakeViewServerFactory(viewServer));
+    ASSERT_TRUE(client->Init(config).ok());
+
+    TaskId taskId = 0;
+    auto status = client->StoreAsync(
+        {
+            KVBuffer{MakeCacheKey("k15"), {}}
+    },
+        taskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    state->failFirstQuery = true;
+    QueryResult queryResult;
+    status = QueryAndWait(*client, {MakeCacheKey("k05")}, queryResult);
+    ASSERT_EQ(status.code, StatusCode::PARTIAL_FAILED);
+    ASSERT_TRUE(WaitForFetchCount(viewServer, 2));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    TaskResult taskResult;
+    ASSERT_TRUE(CheckUntilComplete(*client, taskId));
+    status = client->Wait(taskId, 100, taskResult);
+    EXPECT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(state->storeCalls, std::vector<AsuId>({20}));
+
+    status = client->StoreAsync(
+        {
+            KVBuffer{MakeCacheKey("k15"), {}}
+    },
+        taskId);
+    EXPECT_TRUE(status.ok()) << status.message;
+    TaskResult secondTaskResult;
+    EXPECT_TRUE(client->Wait(taskId, 100, secondTaskResult).ok());
+    EXPECT_EQ(state->storeCalls, std::vector<AsuId>({20, 10}));
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/client/asu_smoke_test.cpp
+++ b/ucm/transport/kv/asu/test/client/asu_smoke_test.cpp
@@ -1,0 +1,242 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <string_view>
+#include <unordered_map>
+#include "asu_client_impl.h"
+
+namespace UC::ASU {
+namespace {
+
+CacheKey MakeCacheKey(std::string_view text)
+{
+    CacheKey key{};
+    const auto size = std::min(text.size(), key.size());
+    if (size > 0) { std::memcpy(key.data(), text.data(), size); }
+    return key;
+}
+
+class StubTransport : public AsuTransport {
+public:
+    Status Init(const TransportConfig& config,
+                std::shared_ptr<TransProvider> transProvider) override
+    {
+        (void)transProvider;
+        config_ = config;
+        initialized_ = true;
+        return Status::OK();
+    }
+
+    Status Init(const std::string&, std::shared_ptr<TransProvider>) override
+    {
+        return Status::Error(StatusCode::UNSUPPORTED, "stub transport config path unsupported");
+    }
+
+    Status Shutdown() override
+    {
+        initialized_ = false;
+        return Status::OK();
+    }
+
+    Status CheckHealth() override { return Status::OK(); }
+
+    Status RunQuery(BatchView<CacheKey> keys, QueryResult& result)
+    {
+        result.exists.assign(keys.size, true);
+        result.prefixHitKeys = 0;
+        return Status::OK();
+    }
+
+    Status Submit(const TransportTaskPtr& task) override
+    {
+        if (!task) {
+            return Status::Error(StatusCode::INVALID_ARGUMENT, "stub transport task is null");
+        }
+        if (task->opType == AsuOpType::QUERY) {
+            QueryResult queryResult;
+            auto status = RunQuery({task->keys.data(), task->keys.size()}, queryResult);
+            if (!status.ok()) {
+                task->taskId = kInvalidTaskId;
+                return status;
+            }
+
+            task->taskId = nextTaskId_++;
+            if (task->onComplete) {
+                TaskResult result;
+                result.status = Status::OK();
+                result.entryStatus.assign(task->keys.size(), Status::OK());
+                result.queryResult = std::move(queryResult);
+                task->onComplete(std::move(result));
+            }
+            return Status::OK();
+        }
+
+        switch (task->opType) {
+            case AsuOpType::LOAD:
+            case AsuOpType::STORE:
+            case AsuOpType::BATCH_LOAD:
+            case AsuOpType::BATCH_STORE:
+            case AsuOpType::DELETE: break;
+            default:
+                task->taskId = kInvalidTaskId;
+                return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                     "unsupported stub transport operation");
+        }
+        task->taskId = nextTaskId_++;
+        if (task->onComplete) {
+            TaskResult result;
+            result.status = Status::OK();
+            task->onComplete(std::move(result));
+        }
+        return Status::OK();
+    }
+
+    Status Cancel(TaskId) override { return Status::OK(); }
+
+private:
+    TransportConfig config_;
+    bool initialized_{false};
+    TaskId nextTaskId_{1000};
+};
+
+AsuClientConfig MakeClientConfig()
+{
+    AsuClientConfig config;
+    config.clientId = "asu-smoke-client";
+    config.defaultWaitTimeoutMs = 100;
+
+    TransportConfig first;
+    first.asuName = "asu-smoke-0";
+    first.asuId = 1001;
+    first.providerType = TransProviderType::FAKE;
+    first.maxInflightTasks = 64;
+    first.timeoutMs = 100;
+
+    TransportConfig second;
+    second.asuName = "asu-smoke-1";
+    second.asuId = 1002;
+    second.providerType = TransProviderType::FAKE;
+    second.maxInflightTasks = 64;
+    second.timeoutMs = 100;
+
+    config.transportConfigs = {first, second};
+    return config;
+}
+
+std::vector<KVBuffer> MakeEntries(std::vector<std::uint8_t>& payload)
+{
+    payload.assign(4096, 7);
+    MemoryRegion region;
+    region.memoryType = MemoryType::HOST;
+    region.addr = reinterpret_cast<std::uint64_t>(payload.data());
+    region.size = payload.size();
+
+    Buffer buffer;
+    buffer.region = region;
+
+    return {
+        KVBuffer{MakeCacheKey("alpha"), buffer},
+        KVBuffer{MakeCacheKey("beta"),  buffer},
+        KVBuffer{MakeCacheKey("gamma"), buffer},
+        KVBuffer{MakeCacheKey("delta"), buffer},
+    };
+}
+
+void ExpectCompleted(AsuClient& client, TaskId taskId, std::size_t entryCount)
+{
+    TaskResult waitResult;
+    auto status = client.Wait(taskId, 500, waitResult);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_TRUE(waitResult.status.ok()) << waitResult.status.message;
+    ASSERT_EQ(waitResult.entryStatus.size(), entryCount);
+    for (const auto& entryStatus : waitResult.entryStatus) {
+        EXPECT_TRUE(entryStatus.ok()) << entryStatus.message;
+    }
+
+    ASSERT_TRUE(client.Check(taskId));
+}
+
+Status QueryAndWait(AsuClient& client, const std::vector<CacheKey>& keys, QueryResult& result,
+                    std::uint64_t timeoutMs)
+{
+    TaskId taskId{kInvalidTaskId};
+    auto status = client.QueryAsync(keys, taskId);
+    if (!status.ok()) { return status; }
+
+    TaskResult taskResult;
+    status = client.Wait(taskId, timeoutMs, taskResult);
+    if (taskResult.queryResult.has_value()) {
+        result = std::move(*taskResult.queryResult);
+    } else if (status.ok()) {
+        return Status::Error(StatusCode::INTERNAL_ERROR, "client query result is missing");
+    }
+    return status;
+}
+
+}  // namespace
+
+TEST(AsuSmokeTest, ClientAsyncTasksCompleteEndToEnd)
+{
+    auto client = CreateAsuClient([] { return std::make_unique<StubTransport>(); });
+    ASSERT_NE(client, nullptr);
+
+    auto status = client->Init(MakeClientConfig());
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint8_t> payload;
+    auto entries = MakeEntries(payload);
+
+    TaskId loadTaskId{kInvalidTaskId};
+    status = client->LoadAsync(entries, loadTaskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_NE(loadTaskId, kInvalidTaskId);
+    ExpectCompleted(*client, loadTaskId, entries.size());
+
+    TaskId storeTaskId{kInvalidTaskId};
+    status = client->StoreAsync(entries, storeTaskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_NE(storeTaskId, kInvalidTaskId);
+    ExpectCompleted(*client, storeTaskId, entries.size());
+
+    std::vector<CacheKey> keys{MakeCacheKey("alpha"), MakeCacheKey("beta"), MakeCacheKey("gamma"),
+                               MakeCacheKey("delta")};
+    QueryResult queryResult;
+    status = QueryAndWait(*client, keys, queryResult, 500);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(queryResult.exists.size(), keys.size());
+
+    TaskId deleteTaskId{kInvalidTaskId};
+    status = client->DeleteAsync(keys, deleteTaskId);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_NE(deleteTaskId, kInvalidTaskId);
+    ExpectCompleted(*client, deleteTaskId, keys.size());
+
+    status = client->Shutdown();
+    ASSERT_TRUE(status.ok()) << status.message;
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/client/view_server_test.cpp
+++ b/ucm/transport/kv/asu/test/client/view_server_test.cpp
@@ -1,0 +1,98 @@
+#include "view_server.h"
+#include <cstdio>
+#include <fstream>
+#include <gtest/gtest.h>
+#include "asu_client/asu_client.h"
+
+namespace UC::ASU {
+namespace {
+
+TEST(ViewServerTest, ConfigFileViewServerLoadsView)
+{
+    constexpr const char* kConfigPath = "asu_view_server_test.conf";
+    {
+        std::ofstream configFile{kConfigPath};
+        ASSERT_TRUE(configFile.is_open());
+        configFile << "viewEpoch=7\n";
+        configFile << "viewId=3\n";
+        configFile << "asuIds=10,20\n";
+        configFile << "asuInfo.20=protocol=uboe,placement=device,port=6000,"
+                   << "local.comm_id=192.168.1.20,send_size=4096,"
+                   << "remote_send_addr=0x100000000\n";
+    }
+
+    AsuClientConfig config;
+    config.viewServiceAddrs = {kConfigPath};
+    auto viewServer = CreateDefaultViewServer(config);
+
+    GlobalView view;
+    auto status = viewServer->GetGlobalView(view);
+    std::remove(kConfigPath);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(view.viewEpoch, std::uint64_t{7});
+    EXPECT_EQ(view.viewId, std::uint64_t{3});
+    ASSERT_EQ(view.asuMap.size(), std::size_t{2});
+    ASSERT_EQ(view.asuMap[20].endpoints.size(), std::size_t{1});
+    EXPECT_EQ(view.asuMap[20].endpoints[0].ip, "192.168.1.20");
+    EXPECT_EQ(view.asuMap[20].endpoints[0].port, std::uint16_t{6000});
+    EXPECT_EQ(view.asuMap[20].endpoints[0].protocol, Protocol::UB);
+    EXPECT_EQ(view.asuMap[20].endpoints[0].attrs["protocol"], "uboe");
+    EXPECT_EQ(view.asuMap[20].endpoints[0].attrs["placement"], "device");
+    EXPECT_EQ(view.asuMap[20].endpoints[0].attrs["send_size"], "4096");
+    EXPECT_EQ(view.asuMap[20].endpoints[0].attrs["remote_send_addr"], "0x100000000");
+}
+
+TEST(ViewServerTest, ConfigBackedViewServerBuildsViewFromTransportConfigs)
+{
+    AsuClientConfig config;
+    TransportConfig transportConfig;
+    transportConfig.asuId = 10;
+    AsuEndpoint endpoint;
+    endpoint.ip = "127.0.0.1";
+    endpoint.port = 6000;
+    endpoint.protocol = Protocol::ROCE;
+    transportConfig.endpoints.emplace_back(endpoint);
+    config.transportConfigs.emplace_back(transportConfig);
+
+    auto viewServer = CreateDefaultViewServer(config);
+
+    GlobalView view;
+    auto status = viewServer->GetGlobalView(view);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(view.asuMap.size(), std::size_t{1});
+    ASSERT_EQ(view.asuMap[10].endpoints.size(), std::size_t{1});
+    EXPECT_EQ(view.asuMap[10].endpoints[0].ip, "127.0.0.1");
+    EXPECT_EQ(view.asuMap[10].endpoints[0].protocol, Protocol::ROCE);
+}
+
+TEST(ViewServerTest, PublishAndRefreshPolicies)
+{
+    AsuClientConfig config;
+    auto viewServer = CreateDefaultViewServer(config);
+
+    GlobalView published;
+    published.viewEpoch = 4;
+    GlobalView older;
+    older.viewEpoch = 3;
+    GlobalView newer;
+    newer.viewEpoch = 5;
+    GlobalView unknownEpoch;
+
+    EXPECT_FALSE(viewServer->ShouldPublishView(published, older));
+    EXPECT_TRUE(viewServer->ShouldPublishView(published, newer));
+    EXPECT_TRUE(viewServer->ShouldPublishView(published, unknownEpoch));
+
+    EXPECT_TRUE(viewServer->ShouldRefreshView(Status::Error(StatusCode::IO_ERROR, "io")));
+    EXPECT_TRUE(viewServer->ShouldRefreshView(Status::Error(StatusCode::TIMEOUT, "timeout")));
+    EXPECT_FALSE(viewServer->ShouldRefreshView(Status::Error(StatusCode::INVALID_ARGUMENT, "bad")));
+
+    TaskResult result;
+    result.status = Status::OK();
+    result.entryStatus = {Status::OK(), Status::Error(StatusCode::NOT_FOUND, "missing")};
+    EXPECT_TRUE(viewServer->ShouldRefreshView(result));
+}
+
+}  // namespace
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/transport/asu_response_status_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/asu_response_status_test.cpp
@@ -1,0 +1,172 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "asu_response_status.h"
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+
+namespace UC::ASU {
+namespace {
+
+TEST(AsuResponseStatusTest, MapsCqeRawStatusToSubBatchStatus)
+{
+    EXPECT_TRUE(KvResponseStatusToSubBatchStatus(0x00).ok());
+    EXPECT_EQ(KvResponseStatusToSubBatchStatus(0x731).code, StatusCode::ASU_CQE_RESOURCE_BUSY);
+    EXPECT_EQ(KvResponseStatusToSubBatchStatus(0xFFFF).code, StatusCode::IO_ERROR);
+}
+
+TEST(AsuResponseStatusTest, SuccessfulSubBatchFillsAllEntriesOk)
+{
+    KvResponse response;
+    TransportSubBatchContext subBatchContext;
+    subBatchContext.opType = AsuOpType::BATCH_STORE;
+    subBatchContext.status = Status::OK();
+    subBatchContext.entryStatus.assign(3, Status::Error(StatusCode::IO_ERROR, "old"));
+
+    FillEntryStatusFromCqeResult(response, subBatchContext);
+
+    for (const auto& status : subBatchContext.entryStatus) { EXPECT_TRUE(status.ok()); }
+}
+
+TEST(AsuResponseStatusTest, CheckResultBufferFillsPerEntryBatchStatus)
+{
+    KvResponse response;
+    response.result_buffer = {0x00, 0x03, 0x04};
+
+    TransportSubBatchContext subBatchContext;
+    subBatchContext.opType = AsuOpType::BATCH_LOAD;
+    subBatchContext.status =
+        Status::Error(StatusCode::ASU_CQE_CHECK_RESULT_BUFFER, "check result buffer");
+    subBatchContext.entryStatus.assign(3, Status::OK());
+
+    FillEntryStatusFromCqeResult(response, subBatchContext);
+
+    EXPECT_TRUE(subBatchContext.entryStatus[0].ok());
+    EXPECT_EQ(subBatchContext.entryStatus[1].code, StatusCode::ASU_ENTRY_KEY_NOT_FOUND);
+    EXPECT_EQ(subBatchContext.entryStatus[2].code, StatusCode::ASU_ENTRY_DATA_NOT_EXIST);
+}
+
+TEST(AsuResponseStatusTest, QueryOkWithoutResultBufferMarksAllKeysExist)
+{
+    KvResponse response;
+    response.existing_key_number = 1;
+
+    TransportSubBatchContext subBatchContext;
+    subBatchContext.opType = AsuOpType::QUERY;
+    subBatchContext.status = Status::OK();
+    subBatchContext.entryStatus.assign(3, Status::OK());
+
+    FillEntryStatusFromCqeResult(response, subBatchContext);
+    const auto queryResult = BuildQueryResultFromEntryStatus(subBatchContext.entryStatus);
+
+    ASSERT_EQ(queryResult.exists.size(), std::size_t{3});
+    EXPECT_EQ(queryResult.exists[0], std::uint8_t{1});
+    EXPECT_EQ(queryResult.exists[1], std::uint8_t{1});
+    EXPECT_EQ(queryResult.exists[2], std::uint8_t{1});
+    EXPECT_EQ(queryResult.prefixHitKeys, std::uint32_t{3});
+}
+
+TEST(AsuResponseStatusTest, QueryOkIgnoresExistingKeyNumber)
+{
+    KvResponse response;
+    response.existing_key_number = 2;
+
+    TransportSubBatchContext subBatchContext;
+    subBatchContext.opType = AsuOpType::QUERY;
+    subBatchContext.useSeekControl = false;
+    subBatchContext.status = Status::OK();
+    subBatchContext.entryStatus.assign(4, Status::OK());
+
+    FillEntryStatusFromCqeResult(response, subBatchContext);
+    const auto queryResult = BuildQueryResultFromEntryStatus(subBatchContext.entryStatus);
+
+    ASSERT_EQ(queryResult.exists.size(), std::size_t{4});
+    EXPECT_EQ(queryResult.exists[0], std::uint8_t{1});
+    EXPECT_EQ(queryResult.exists[1], std::uint8_t{1});
+    EXPECT_EQ(queryResult.exists[2], std::uint8_t{1});
+    EXPECT_EQ(queryResult.exists[3], std::uint8_t{1});
+    EXPECT_EQ(queryResult.prefixHitKeys, std::uint32_t{4});
+}
+
+TEST(AsuResponseStatusTest, QueryCheckResultBufferWithoutSeekControlUsesExistingKeyNumber)
+{
+    KvResponse response;
+    response.existing_key_number = 2;
+
+    TransportSubBatchContext subBatchContext;
+    subBatchContext.opType = AsuOpType::QUERY;
+    subBatchContext.useSeekControl = false;
+    subBatchContext.status =
+        Status::Error(StatusCode::ASU_CQE_CHECK_RESULT_BUFFER, "check result buffer");
+    subBatchContext.entryStatus.assign(4, Status::OK());
+
+    FillEntryStatusFromCqeResult(response, subBatchContext);
+    const auto queryResult = BuildQueryResultFromEntryStatus(subBatchContext.entryStatus);
+
+    ASSERT_EQ(queryResult.exists.size(), std::size_t{4});
+    EXPECT_EQ(queryResult.exists[0], std::uint8_t{1});
+    EXPECT_EQ(queryResult.exists[1], std::uint8_t{1});
+    EXPECT_EQ(queryResult.exists[2], std::uint8_t{0});
+    EXPECT_EQ(queryResult.exists[3], std::uint8_t{0});
+    EXPECT_EQ(queryResult.prefixHitKeys, std::uint32_t{2});
+}
+
+TEST(AsuResponseStatusTest, QueryCheckResultBufferUsesExistEntryStatuses)
+{
+    KvResponse response;
+    response.result_buffer = {0x01, 0x00, 0x01};
+
+    TransportSubBatchContext subBatchContext;
+    subBatchContext.opType = AsuOpType::QUERY;
+    subBatchContext.useSeekControl = true;
+    subBatchContext.status =
+        Status::Error(StatusCode::ASU_CQE_CHECK_RESULT_BUFFER, "check result buffer");
+    subBatchContext.entryStatus.assign(3, Status::OK());
+
+    FillEntryStatusFromCqeResult(response, subBatchContext);
+    const auto queryResult = BuildQueryResultFromEntryStatus(subBatchContext.entryStatus);
+
+    ASSERT_EQ(queryResult.exists.size(), std::size_t{3});
+    EXPECT_EQ(queryResult.exists[0], std::uint8_t{1});
+    EXPECT_EQ(queryResult.exists[1], std::uint8_t{0});
+    EXPECT_EQ(queryResult.exists[2], std::uint8_t{1});
+    EXPECT_EQ(queryResult.prefixHitKeys, std::uint32_t{1});
+}
+
+TEST(AsuResponseStatusTest, MissingResultBufferPropagatesSubBatchError)
+{
+    KvResponse response;
+    TransportSubBatchContext subBatchContext;
+    subBatchContext.opType = AsuOpType::DELETE;
+    subBatchContext.status = Status::Error(StatusCode::ASU_CQE_RESOURCE_BUSY, "busy");
+    subBatchContext.entryStatus.assign(2, Status::OK());
+
+    FillEntryStatusFromCqeResult(response, subBatchContext);
+
+    EXPECT_EQ(subBatchContext.entryStatus[0].code, StatusCode::ASU_CQE_RESOURCE_BUSY);
+    EXPECT_EQ(subBatchContext.entryStatus[1].code, StatusCode::ASU_CQE_RESOURCE_BUSY);
+}
+
+}  // namespace
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/transport/asu_submit_flow_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/asu_submit_flow_test.cpp
@@ -1,0 +1,509 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <cstdint>
+#include <functional>
+#include <gtest/gtest.h>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+#define private public
+#include "asu_transport_impl.h"
+#undef private
+#include "asu_transport/trans_provider.h"
+#include "buffer_manager.h"
+#include "connection_internal.h"
+
+namespace UC::ASU {
+namespace {
+
+std::uint32_t g_kernelCount = 0;
+std::uint32_t g_quietCount = 0;
+std::vector<Status> g_sendStatuses;
+
+class StubTransProvider : public TransProvider {
+public:
+    std::uint32_t registerCount{0};
+    std::uint32_t registerCallCount{0};
+    std::uint32_t unregisterCount{0};
+    std::uint32_t failRegisterAt{0};
+    std::uint32_t tokenLookupCount{0};
+    std::uint32_t failTokenLookupAt{0};
+    std::uint32_t failUnregisterAt{0};
+    bool failUnregister{false};
+
+    Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t qpNum,
+                            uint32_t, std::vector<ConnectionHandle>& handles) override
+    {
+        handles.clear();
+        handles.resize(qpNum, nullptr);
+        return Status::OK();
+    }
+
+    std::vector<Status> DeleteConnections(const std::vector<ConnectionHandle>& handles) override
+    {
+        return std::vector<Status>(handles.size(), Status::OK());
+    }
+
+    std::vector<Status> Send(const std::vector<TransProvider::SendIoBatch>& ioBatches,
+                             uint32_t kernelCount, uint32_t quietCount) override
+    {
+        g_kernelCount = kernelCount;
+        g_quietCount = quietCount;
+        if (!g_sendStatuses.empty()) { return g_sendStatuses; }
+        return std::vector<Status>(ioBatches.size(), Status::OK());
+    }
+
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
+                          std::vector<MRHandle>& handles) override
+    {
+        ++registerCallCount;
+        handles.clear();
+        handles.reserve(memoryDescs.size());
+        for (std::size_t index = 0; index < memoryDescs.size(); ++index) {
+            ++registerCount;
+            if (failRegisterAt != 0 && registerCount == failRegisterAt) {
+                return Status::Error(StatusCode::INTERNAL_ERROR, "stub register failed");
+            }
+            handles.push_back(reinterpret_cast<MRHandle>(static_cast<uintptr_t>(registerCount)));
+        }
+        return Status::OK();
+    }
+
+    std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& descs) override
+    {
+        std::vector<Status> statuses;
+        statuses.reserve(descs.size());
+        for (std::size_t index = 0; index < descs.size(); ++index) {
+            ++unregisterCount;
+            if (failUnregister || (failUnregisterAt != 0 && unregisterCount == failUnregisterAt)) {
+                statuses.emplace_back(
+                    Status::Error(StatusCode::INTERNAL_ERROR, "stub unregister failed"));
+            } else {
+                statuses.emplace_back(Status::OK());
+            }
+        }
+        return statuses;
+    }
+
+    Status AllocThread(uint32_t, const std::vector<uint32_t>&, std::vector<ThreadHandle>&) override
+    {
+        return Status::OK();
+    }
+
+    std::vector<Status> FreeThread(const std::vector<ThreadHandle>&) override { return {}; }
+
+    Status GetMemTokenId(MRHandle, uint32_t& tokenId) override
+    {
+        ++tokenLookupCount;
+        if (failTokenLookupAt != 0 && tokenLookupCount == failTokenLookupAt) {
+            return Status::Error(StatusCode::INTERNAL_ERROR, "stub token lookup failed");
+        }
+        tokenId = 1;
+        return Status::OK();
+    }
+};
+
+void CreateTaskExecutor(AsuTransportImpl& transport)
+{
+    transport.taskExecutor_ = std::make_unique<TransportTaskExecutor>(
+        transport.config_, transport.transProvider_, transport.connManager_);
+}
+
+Status InitTaskExecutorWithoutRecoverLoop(AsuTransportImpl& transport,
+                                          std::shared_ptr<TransProvider> provider)
+{
+    transport.SetTransProvider(std::move(provider));
+    CreateTaskExecutor(transport);
+    const auto status = transport.taskExecutor_->Init();
+    if (!status.ok()) { transport.taskExecutor_.reset(); }
+    return status;
+}
+
+Status ShutdownTaskExecutorWithoutRecoverLoop(AsuTransportImpl& transport)
+{
+    if (!transport.taskExecutor_) { return Status::OK(); }
+    const auto status = transport.taskExecutor_->Shutdown();
+    if (status.ok()) { transport.taskExecutor_.reset(); }
+    return status;
+}
+
+class AsuSubmitFlowBufferTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        transport_ = std::make_unique<AsuTransportImpl>();
+        transport_->SetTransProvider(std::make_unique<StubTransProvider>());
+        CreateTaskExecutor(*transport_);
+    }
+
+    std::unique_ptr<AsuTransportImpl> transport_;
+};
+
+}  // namespace
+
+namespace {
+
+class AsuTransportBufferRegistrationTest : public ::testing::Test {};
+
+TEST_F(AsuTransportBufferRegistrationTest, InitRegistersAndShutdownUnregistersBothBuffers)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    AsuTransportImpl transport;
+
+    auto status = InitTaskExecutorWithoutRecoverLoop(transport, provider);
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(provider->registerCount, 2);
+    EXPECT_EQ(provider->registerCallCount, 2);
+    EXPECT_EQ(provider->tokenLookupCount, 2);
+    ASSERT_NE(transport.taskExecutor_, nullptr);
+    EXPECT_NE(transport.taskExecutor_->sendBufferMrHandle_, kInvalidMRHandle);
+    EXPECT_NE(transport.taskExecutor_->flagBufferMrHandle_, kInvalidMRHandle);
+    EXPECT_EQ(transport.taskExecutor_->sendBufferManager_.GetTokenId(), 1);
+    EXPECT_EQ(transport.taskExecutor_->flagBufferManager_.GetTokenId(), 1);
+
+    status = ShutdownTaskExecutorWithoutRecoverLoop(transport);
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(provider->unregisterCount, 2);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, DestructorUnregistersBothBuffers)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+
+    {
+        AsuTransportImpl transport;
+        const auto status = InitTaskExecutorWithoutRecoverLoop(transport, provider);
+        ASSERT_TRUE(status.ok()) << status.message;
+        EXPECT_EQ(provider->registerCount, 2);
+        EXPECT_EQ(provider->unregisterCount, 0);
+    }
+
+    EXPECT_EQ(provider->unregisterCount, 2);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, FirstRegistrationFailureDoesNotUnregister)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    provider->failRegisterAt = 1;
+    AsuTransportImpl transport;
+
+    const auto status = InitTaskExecutorWithoutRecoverLoop(transport, provider);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("send buffer"), std::string::npos);
+    EXPECT_EQ(provider->registerCount, 1);
+    EXPECT_EQ(provider->registerCallCount, 1);
+    EXPECT_EQ(provider->tokenLookupCount, 0);
+    EXPECT_EQ(provider->unregisterCount, 0);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, FirstTokenLookupFailureCleansUpRegisteredBuffer)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    provider->failTokenLookupAt = 1;
+    AsuTransportImpl transport;
+
+    const auto status = InitTaskExecutorWithoutRecoverLoop(transport, provider);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("send buffer"), std::string::npos);
+    EXPECT_EQ(provider->registerCount, 1);
+    EXPECT_EQ(provider->registerCallCount, 1);
+    EXPECT_EQ(provider->tokenLookupCount, 1);
+    EXPECT_EQ(provider->unregisterCount, 1);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, TokenLookupRollbackFailureIsRetriedDuringShutdown)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    provider->failTokenLookupAt = 1;
+    provider->failUnregisterAt = 1;
+    AsuTransportImpl transport;
+
+    const auto status = InitTaskExecutorWithoutRecoverLoop(transport, provider);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("send buffer"), std::string::npos);
+    EXPECT_EQ(provider->registerCount, 1);
+    EXPECT_EQ(provider->tokenLookupCount, 1);
+    EXPECT_EQ(provider->unregisterCount, 2);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, SecondRegistrationFailureCleansUpFirstBuffer)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    provider->failRegisterAt = 2;
+    AsuTransportImpl transport;
+
+    const auto status = InitTaskExecutorWithoutRecoverLoop(transport, provider);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("flag buffer"), std::string::npos);
+    EXPECT_EQ(provider->registerCount, 2);
+    EXPECT_EQ(provider->unregisterCount, 1);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, SecondTokenLookupFailureCleansUpBothBuffers)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    provider->failTokenLookupAt = 2;
+    AsuTransportImpl transport;
+
+    const auto status = InitTaskExecutorWithoutRecoverLoop(transport, provider);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("flag buffer"), std::string::npos);
+    EXPECT_EQ(provider->registerCount, 2);
+    EXPECT_EQ(provider->tokenLookupCount, 2);
+    EXPECT_EQ(provider->unregisterCount, 2);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, FlagUnregistrationFailureIncludesCallerContext)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    AsuTransportImpl transport;
+
+    ASSERT_TRUE(InitTaskExecutorWithoutRecoverLoop(transport, provider).ok());
+    provider->failUnregisterAt = 1;
+
+    const auto status = ShutdownTaskExecutorWithoutRecoverLoop(transport);
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("flag buffer"), std::string::npos);
+    EXPECT_EQ(provider->unregisterCount, 2);
+    ASSERT_NE(transport.taskExecutor_, nullptr);
+    EXPECT_NE(transport.taskExecutor_->flagBufferMrHandle_, kInvalidMRHandle);
+    EXPECT_EQ(transport.taskExecutor_->sendBufferMrHandle_, kInvalidMRHandle);
+
+    EXPECT_TRUE(ShutdownTaskExecutorWithoutRecoverLoop(transport).ok());
+    EXPECT_EQ(provider->unregisterCount, 3);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(AsuTransportBufferRegistrationTest, SendUnregistrationFailureIncludesCallerContext)
+{
+    auto provider = std::make_shared<StubTransProvider>();
+    AsuTransportImpl transport;
+
+    ASSERT_TRUE(InitTaskExecutorWithoutRecoverLoop(transport, provider).ok());
+    provider->failUnregisterAt = 2;
+
+    const auto status = ShutdownTaskExecutorWithoutRecoverLoop(transport);
+    EXPECT_EQ(status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_NE(status.message.find("send buffer"), std::string::npos);
+    EXPECT_EQ(provider->unregisterCount, 2);
+    ASSERT_NE(transport.taskExecutor_, nullptr);
+    EXPECT_EQ(transport.taskExecutor_->flagBufferMrHandle_, kInvalidMRHandle);
+    EXPECT_NE(transport.taskExecutor_->sendBufferMrHandle_, kInvalidMRHandle);
+
+    EXPECT_TRUE(ShutdownTaskExecutorWithoutRecoverLoop(transport).ok());
+    EXPECT_EQ(provider->unregisterCount, 3);
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST(AsuSubmitFlowTest, SendSubBatchBuffersReadsSendCountsFromAttrs)
+{
+    g_kernelCount = 0;
+    g_quietCount = 0;
+    g_sendStatuses.clear();
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::make_unique<StubTransProvider>());
+    transport.config_.attrs = {
+        {"kernel_count", "3"},
+        {"quiet_count",  "7"},
+    };
+    CreateTaskExecutor(transport);
+
+    TransProvider::SendIoBatch ioBatch{nullptr, nullptr, nullptr, 0};
+    std::vector<TransProvider::SendIoBatch> ioBatches = {ioBatch};
+
+    std::vector<TransportSubBatchContext> subBatchContexts(1);
+    subBatchContexts[0].state = TransportSubBatchState::PENDING;
+    subBatchContexts[0].entryStatus.assign(1, Status::OK());
+
+    transport.taskExecutor_->SendSubBatchBuffers(subBatchContexts, ioBatches);
+
+    EXPECT_EQ(g_kernelCount, std::uint32_t{3});
+    EXPECT_EQ(g_quietCount, std::uint32_t{7});
+    EXPECT_EQ(subBatchContexts[0].state, TransportSubBatchState::PENDING);
+    EXPECT_TRUE(subBatchContexts[0].status.ok());
+}
+
+TEST(AsuSubmitFlowTest, AbortBeforeSendPreservesStatusesBeforeFailureAndCancelsFollowing)
+{
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::make_unique<StubTransProvider>());
+    CreateTaskExecutor(transport);
+
+    const auto failedStatus =
+        Status::Error(StatusCode::INTERNAL_ERROR, "sub-batch preparation failed");
+    std::vector<TransportSubBatchContext> subBatchContexts(3);
+    for (auto& subBatchContext : subBatchContexts) { subBatchContext.entryStatus = {Status::OK()}; }
+    subBatchContexts[1].status = failedStatus;
+    subBatchContexts[1].entryStatus = {failedStatus};
+
+    TransportTask task;
+    task.entryStatus.assign(3, Status::OK());
+    transport.taskExecutor_->AbortSubBatchesBeforeSend(task, subBatchContexts);
+
+    EXPECT_TRUE(subBatchContexts[0].status.ok());
+    EXPECT_TRUE(subBatchContexts[0].entryStatus[0].ok());
+    EXPECT_EQ(subBatchContexts[1].status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(subBatchContexts[1].entryStatus[0].code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(subBatchContexts[2].status.code, StatusCode::CANCELED);
+    EXPECT_EQ(subBatchContexts[2].entryStatus[0].code, StatusCode::CANCELED);
+    for (const auto& entryStatus : task.entryStatus) {
+        EXPECT_EQ(entryStatus.code, StatusCode::CANCELED);
+    }
+    for (const auto& subBatchContext : subBatchContexts) {
+        EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
+    }
+}
+
+TEST(AsuSubmitFlowTest, SendSubBatchBuffersReportsSendFailures)
+{
+    g_sendStatuses = {
+        Status::Error(StatusCode::CONNECTION_ERROR, "fake send failure"),
+        Status::Error(StatusCode::CONNECTION_ERROR, "fake send failure"),
+    };
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::make_unique<StubTransProvider>());
+    transport.config_.attrs = {
+        {"kernel_count", "3"},
+        {"quiet_count",  "7"},
+    };
+    CreateTaskExecutor(transport);
+
+    transport.connManager_ =
+        std::make_unique<ConnectionManager>(*transport.transProvider_, "", 5000);
+    ASSERT_TRUE(transport.connManager_->AddGroup(AsuEndpoint{}, 1).ok());
+    auto channel0 = transport.connManager_->SelectConnection();
+    auto channel1 = transport.connManager_->SelectConnection();
+    ASSERT_NE(channel0, nullptr);
+    ASSERT_EQ(channel0, channel1);
+
+    std::vector<TransProvider::SendIoBatch> ioBatches = {
+        TransProvider::SendIoBatch{channel0->GetConnection(), nullptr, nullptr, 0},
+        TransProvider::SendIoBatch{channel1->GetConnection(), nullptr, nullptr, 0},
+    };
+    std::vector<TransportSubBatchContext> subBatchContexts(2);
+    subBatchContexts[0].state = TransportSubBatchState::PENDING;
+    subBatchContexts[0].channel = channel0;
+    subBatchContexts[0].entryStatus.assign(1, Status::OK());
+    subBatchContexts[1].state = TransportSubBatchState::PENDING;
+    subBatchContexts[1].channel = channel1;
+    subBatchContexts[1].entryStatus.assign(1, Status::OK());
+
+    transport.taskExecutor_->SendSubBatchBuffers(subBatchContexts, ioBatches);
+
+    EXPECT_EQ(subBatchContexts[0].status.code, StatusCode::CONNECTION_ERROR);
+    EXPECT_EQ(channel0->GetState(), ChannelState::DRAINING);
+    EXPECT_EQ(subBatchContexts[0].state, TransportSubBatchState::COMPLETED);
+    EXPECT_EQ(subBatchContexts[1].state, TransportSubBatchState::COMPLETED);
+    g_sendStatuses.clear();
+}
+
+TEST_F(AsuSubmitFlowBufferTest, BuildSubBatchSendBuffersUsesHostPinnedDeviceAddresses)
+{
+    ASSERT_TRUE(transport_->taskExecutor_->sendBufferManager_
+                    .Init("test send buffer", MemoryType::HOST_PINNED, 4096, 1)
+                    .ok());
+    ASSERT_TRUE(transport_->taskExecutor_->flagBufferManager_
+                    .Init("test flag buffer", MemoryType::HOST_PINNED, 128, 1)
+                    .ok());
+
+    transport_->connManager_ =
+        std::make_unique<ConnectionManager>(*transport_->transProvider_, "", 5000);
+    ASSERT_TRUE(transport_->connManager_->AddGroup(AsuEndpoint{}, 1).ok());
+
+    std::vector<TransportSubBatchContext> subBatchContexts(1);
+    auto& subBatchContext = subBatchContexts[0];
+    subBatchContext.state = TransportSubBatchState::PENDING;
+    subBatchContext.channel = transport_->connManager_->SelectConnection();
+    subBatchContext.entryStatus.assign(1, Status::OK());
+    ASSERT_NE(subBatchContext.channel, nullptr);
+    ASSERT_TRUE(
+        transport_->taskExecutor_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
+    ASSERT_NE(subBatchContext.sendSge.local_addr, std::uint64_t{0});
+    ASSERT_NE(subBatchContext.sendSge.device_addr, std::uint64_t{0});
+    ASSERT_NE(subBatchContext.flagBuffer.local_addr, std::uint64_t{0});
+    ASSERT_NE(subBatchContext.flagBuffer.device_addr, std::uint64_t{0});
+
+    std::vector<TransProvider::SendIoBatch> ioBatches;
+    transport_->taskExecutor_->BuildSubBatchSendBuffers(subBatchContexts, ioBatches);
+
+    ASSERT_EQ(ioBatches.size(), std::size_t{1});
+    EXPECT_EQ(ioBatches[0].connectionHandle, subBatchContext.channel->GetConnection());
+    EXPECT_EQ(ioBatches[0].sendBuffer,
+              reinterpret_cast<void*>(subBatchContext.sendSge.device_addr));
+    EXPECT_EQ(ioBatches[0].flagBuffer,
+              reinterpret_cast<void*>(subBatchContext.flagBuffer.device_addr));
+    EXPECT_EQ(ioBatches[0].len, subBatchContext.sendSge.length);
+}
+
+TEST(AsuSubmitFlowTest, SendSubBatchBuffersFailsAllSentSubBatchesWhenStatusCountMismatches)
+{
+    g_sendStatuses = {Status::OK()};
+
+    AsuTransportImpl transport;
+    transport.SetTransProvider(std::make_unique<StubTransProvider>());
+    transport.config_.attrs = {
+        {"kernel_count", "3"},
+        {"quiet_count",  "7"},
+    };
+    CreateTaskExecutor(transport);
+
+    std::vector<TransProvider::SendIoBatch> ioBatches = {
+        TransProvider::SendIoBatch{nullptr, nullptr, nullptr, 0},
+        TransProvider::SendIoBatch{nullptr, nullptr, nullptr, 0},
+    };
+    std::vector<TransportSubBatchContext> subBatchContexts(2);
+    subBatchContexts[0].state = TransportSubBatchState::PENDING;
+    subBatchContexts[0].entryStatus.assign(1, Status::OK());
+    subBatchContexts[1].state = TransportSubBatchState::PENDING;
+    subBatchContexts[1].entryStatus.assign(1, Status::OK());
+
+    transport.taskExecutor_->SendSubBatchBuffers(subBatchContexts, ioBatches);
+
+    EXPECT_EQ(subBatchContexts[0].state, TransportSubBatchState::COMPLETED);
+    EXPECT_EQ(subBatchContexts[0].status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(subBatchContexts[0].entryStatus[0].code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(subBatchContexts[1].state, TransportSubBatchState::COMPLETED);
+    EXPECT_EQ(subBatchContexts[1].status.code, StatusCode::INTERNAL_ERROR);
+    EXPECT_EQ(subBatchContexts[1].entryStatus[0].code, StatusCode::INTERNAL_ERROR);
+    g_sendStatuses.clear();
+}
+
+}  // namespace
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/transport/asu_test_main.cpp
+++ b/ucm/transport/kv/asu/test/transport/asu_test_main.cpp
@@ -1,0 +1,35 @@
+#include <gtest/gtest.h>
+#include "trans/device.h"
+
+namespace UC::ASU {
+namespace {
+
+class AsuDeviceTestEnvironment final : public ::testing::Environment {
+public:
+    void SetUp() override
+    {
+        const auto initStatus = device_.Init();
+        ASSERT_TRUE(initStatus.Success() || initStatus == UC::Status::DuplicateKey())
+            << "Device::Init failed: " << initStatus.ToString();
+        ASSERT_TRUE(device_.Setup(0).Success());
+    }
+
+    void TearDown() override
+    {
+        EXPECT_TRUE(device_.Reset(0).Success());
+        EXPECT_TRUE(device_.Finalize().Success());
+    }
+
+private:
+    Trans::Device device_;
+};
+
+}  // namespace
+}  // namespace UC::ASU
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::AddGlobalTestEnvironment(new UC::ASU::AsuDeviceTestEnvironment);
+    return RUN_ALL_TESTS();
+}

--- a/ucm/transport/kv/asu/test/transport/buffer_manager_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/buffer_manager_test.cpp
@@ -1,0 +1,444 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "buffer_manager.h"
+#include <cstring>
+#include <gtest/gtest.h>
+#include <thread>
+#include <vector>
+#include "asu_transport/trans_provider.h"
+
+namespace UC::ASU {
+namespace {
+
+class BufferManagerTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(BufferManagerTest, InitAndDestroy)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 1024, 100);
+    ASSERT_TRUE(status.ok()) << status.message;
+}
+
+TEST_F(BufferManagerTest, InitWithZeroSlotSize)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 0, 100);
+    ASSERT_FALSE(status.ok());
+    ASSERT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(BufferManagerTest, InitWithZeroSlotNum)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 1024, 0);
+    ASSERT_FALSE(status.ok());
+    ASSERT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(BufferManagerTest, InitHostWithUnalignedSlotCapacity)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 1000, 10);
+    ASSERT_TRUE(status.ok()) << status.message;
+}
+
+TEST_F(BufferManagerTest, InitDeviceWithUnalignedSlotCapacity)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::DEVICE, 1000, 10);
+    ASSERT_TRUE(status.ok()) << status.message;
+}
+
+TEST_F(BufferManagerTest, DoubleInit)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 1024, 100);
+    ASSERT_TRUE(status.ok());
+    status = mgr.Init("test_buffer", MemoryType::HOST, 1024, 100);
+    ASSERT_FALSE(status.ok());
+    ASSERT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(BufferManagerTest, AllocateWithoutInit)
+{
+    BufferManager mgr;
+    ScatterGatherEntry sge;
+    auto status = mgr.Allocate(64, sge);
+    ASSERT_FALSE(status.ok());
+    ASSERT_EQ(status.code, StatusCode::NOT_INITIALIZED);
+}
+
+TEST_F(BufferManagerTest, AllocateZeroSize)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 1024, 100);
+    ASSERT_TRUE(status.ok());
+
+    ScatterGatherEntry sge;
+    status = mgr.Allocate(0, sge);
+    ASSERT_FALSE(status.ok());
+    ASSERT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(BufferManagerTest, AllocateExceedsSlotSize)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 1024, 100);
+    ASSERT_TRUE(status.ok());
+
+    ScatterGatherEntry sge;
+    status = mgr.Allocate(2048, sge);
+    ASSERT_FALSE(status.ok());
+    ASSERT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(BufferManagerTest, SingleAllocateAndFree)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 1024, 100);
+    ASSERT_TRUE(status.ok());
+
+    ScatterGatherEntry sge;
+    status = mgr.Allocate(64, sge);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_NE(sge.local_addr, 0);
+    ASSERT_EQ(sge.length, 64);
+    ASSERT_EQ(sge.tokenId, 0);
+    ASSERT_NE(sge.slot_index, UINT32_MAX);
+    ASSERT_EQ(sge.memory_type, MemoryType::HOST);
+
+    auto* ptr = reinterpret_cast<void*>(sge.local_addr);
+    std::memset(ptr, 0xAB, 64);
+
+    status = mgr.Free(sge.slot_index);
+    ASSERT_TRUE(status.ok()) << status.message;
+}
+
+TEST_F(BufferManagerTest, MultipleAllocatesAndFrees)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 1024, 100);
+    ASSERT_TRUE(status.ok());
+
+    constexpr int kCount = 50;
+    std::vector<ScatterGatherEntry> sges(kCount);
+
+    for (int i = 0; i < kCount; ++i) {
+        status = mgr.Allocate(128, sges[i]);
+        ASSERT_TRUE(status.ok()) << "Failed at i=" << i << ": " << status.message;
+        ASSERT_NE(sges[i].local_addr, 0);
+        std::memset(reinterpret_cast<void*>(sges[i].local_addr), i, 128);
+    }
+
+    for (int i = 0; i < kCount; ++i) {
+        auto* data = reinterpret_cast<unsigned char*>(sges[i].local_addr);
+        for (int j = 0; j < 128; ++j) { ASSERT_EQ(data[j], static_cast<unsigned char>(i)); }
+    }
+
+    for (int i = 0; i < kCount; ++i) {
+        status = mgr.Free(sges[i].slot_index);
+        ASSERT_TRUE(status.ok()) << status.message;
+    }
+}
+
+TEST_F(BufferManagerTest, FreeWithoutInit)
+{
+    BufferManager mgr;
+    auto status = mgr.Free(0);
+    ASSERT_FALSE(status.ok());
+    ASSERT_EQ(status.code, StatusCode::NOT_INITIALIZED);
+}
+
+TEST_F(BufferManagerTest, FreeOutOfRangeIndex)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 1024, 100);
+    ASSERT_TRUE(status.ok());
+
+    status = mgr.Free(200);
+    ASSERT_FALSE(status.ok());
+    ASSERT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(BufferManagerTest, AllocateFullSlotSize)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 1024, 10);
+    ASSERT_TRUE(status.ok());
+
+    ScatterGatherEntry sge;
+    status = mgr.Allocate(1024, sge);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(sge.length, 1024);
+}
+
+TEST_F(BufferManagerTest, AllocateFull4160ByteSlotCapacity)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 4160, 10);
+    ASSERT_TRUE(status.ok());
+
+    ScatterGatherEntry sge;
+    status = mgr.Allocate(4160, sge);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(sge.length, 4160);
+}
+
+TEST_F(BufferManagerTest, AllocateExceeds4160ByteSlotCapacity)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 4160, 10);
+    ASSERT_TRUE(status.ok());
+
+    ScatterGatherEntry sge;
+    status = mgr.Allocate(4161, sge);
+    ASSERT_FALSE(status.ok());
+    ASSERT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(BufferManagerTest, AllMemoryTypesUseAlignedSlotStride)
+{
+    for (const auto type : {MemoryType::HOST, MemoryType::HOST_PINNED, MemoryType::DEVICE}) {
+        BufferManager mgr;
+        auto status = mgr.Init("test_buffer", type, 4160, 2);
+        ASSERT_TRUE(status.ok()) << status.message;
+
+        ScatterGatherEntry first;
+        ScatterGatherEntry second;
+        ASSERT_TRUE(mgr.Allocate(4160, first).ok());
+        ASSERT_TRUE(mgr.Allocate(4160, second).ok());
+        ASSERT_EQ(second.local_addr - first.local_addr, 4160);
+        ASSERT_EQ(second.device_addr - first.device_addr, 4160);
+    }
+}
+
+TEST_F(BufferManagerTest, FlagBufferCapacity71Uses128ByteStride)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("flag_buffer", MemoryType::HOST_PINNED, 71, 2);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    ScatterGatherEntry first;
+    ScatterGatherEntry second;
+    ASSERT_TRUE(mgr.Allocate(71, first).ok());
+    ASSERT_TRUE(mgr.Allocate(71, second).ok());
+    ASSERT_EQ(first.length, 71);
+    ASSERT_EQ(second.local_addr - first.local_addr, 128);
+    ASSERT_EQ(second.device_addr - first.device_addr, 128);
+}
+
+TEST_F(BufferManagerTest, ReuseAfterFree)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 1024, 1);
+    ASSERT_TRUE(status.ok());
+
+    ScatterGatherEntry sge1;
+    status = mgr.Allocate(64, sge1);
+    ASSERT_TRUE(status.ok());
+
+    mgr.Free(sge1.slot_index);
+
+    ScatterGatherEntry sge2;
+    status = mgr.Allocate(64, sge2);
+    ASSERT_TRUE(status.ok());
+    ASSERT_EQ(sge2.local_addr, sge1.local_addr);
+    ASSERT_EQ(sge2.slot_index, sge1.slot_index);
+
+    mgr.Free(sge2.slot_index);
+}
+
+TEST_F(BufferManagerTest, ConcurrentAllocateAndFree)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 1024, 100);
+    ASSERT_TRUE(status.ok());
+
+    constexpr int kThreadCount = 4;
+    constexpr int kOpsPerThread = 500;
+
+    auto worker = [&mgr](int thread_id) {
+        for (int i = 0; i < kOpsPerThread; ++i) {
+            ScatterGatherEntry sge;
+            auto s = mgr.Allocate(64, sge);
+            ASSERT_TRUE(s.ok()) << "Thread " << thread_id << " op " << i << ": " << s.message;
+
+            std::memset(reinterpret_cast<void*>(sge.local_addr), thread_id, 64);
+
+            s = mgr.Free(sge.slot_index);
+            ASSERT_TRUE(s.ok()) << s.message;
+        }
+    };
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < kThreadCount; ++i) { threads.emplace_back(worker, i); }
+    for (auto& t : threads) { t.join(); }
+}
+
+TEST_F(BufferManagerTest, ConcurrentStressTest)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_buffer", MemoryType::HOST, 256, 16);
+    ASSERT_TRUE(status.ok());
+
+    constexpr int kThreadCount = 4;
+    constexpr int kOpsPerThread = 1000;
+
+    auto worker = [&mgr](int thread_id) {
+        for (int i = 0; i < kOpsPerThread; ++i) {
+            ScatterGatherEntry sge;
+            auto s = mgr.Allocate(128, sge);
+            ASSERT_TRUE(s.ok());
+
+            std::memset(reinterpret_cast<void*>(sge.local_addr), thread_id, 128);
+
+            for (int j = 0; j < 128; ++j) {
+                ASSERT_EQ(reinterpret_cast<unsigned char*>(sge.local_addr)[j], thread_id);
+            }
+
+            s = mgr.Free(sge.slot_index);
+            ASSERT_TRUE(s.ok());
+        }
+    };
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < kThreadCount; ++i) { threads.emplace_back(worker, i); }
+    for (auto& t : threads) { t.join(); }
+}
+
+TEST_F(BufferManagerTest, FreeZeroesMemory)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test", MemoryType::HOST, 1024, 1);
+    ASSERT_TRUE(status.ok());
+
+    ScatterGatherEntry sge1;
+    status = mgr.Allocate(64, sge1);
+    ASSERT_TRUE(status.ok());
+
+    auto* ptr = reinterpret_cast<uint8_t*>(sge1.local_addr);
+    std::memset(ptr, 0xAB, 1024);
+
+    status = mgr.Free(sge1.slot_index);
+    ASSERT_TRUE(status.ok());
+
+    ScatterGatherEntry sge2;
+    status = mgr.Allocate(64, sge2);
+    ASSERT_TRUE(status.ok());
+    ASSERT_EQ(sge2.local_addr, sge1.local_addr);
+    ASSERT_EQ(sge2.slot_index, sge1.slot_index);
+
+    auto* ptr2 = reinterpret_cast<uint8_t*>(sge2.local_addr);
+    for (size_t i = 0; i < 1024; ++i) {
+        ASSERT_EQ(ptr2[i], 0) << "byte " << i << " not zeroed after free";
+    }
+
+    mgr.Free(sge2.slot_index);
+}
+
+TEST_F(BufferManagerTest, AllocateReturnsBusyWhenFull)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test", MemoryType::HOST, 1024, 2);
+    ASSERT_TRUE(status.ok());
+
+    ScatterGatherEntry sge1, sge2, sge3;
+    ASSERT_TRUE(mgr.Allocate(64, sge1).ok());
+    ASSERT_TRUE(mgr.Allocate(64, sge2).ok());
+
+    status = mgr.Allocate(64, sge3);
+    ASSERT_FALSE(status.ok());
+    ASSERT_EQ(status.code, StatusCode::RESOURCE_BUSY);
+
+    mgr.Free(sge1.slot_index);
+    mgr.Free(sge2.slot_index);
+}
+
+TEST_F(BufferManagerTest, HostMemoryExposesRegistrationDescription)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_host", MemoryType::HOST, 1024, 10);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    TransProvider::RegisterMemoryDesc desc;
+    status = mgr.GetRegisterMemoryDesc(desc);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(desc.memoryType, TransProvider::MemType::MEM_HOST);
+    ASSERT_NE(desc.addr, 0);
+    ASSERT_EQ(desc.localAddr, desc.addr);
+    ASSERT_EQ(desc.size, 1024 * 10);
+}
+
+TEST_F(BufferManagerTest, HostPinnedMemoryExposesDeviceRegistrationDescription)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_pinned", MemoryType::HOST_PINNED, 4096, 1);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    ScatterGatherEntry sge;
+    ASSERT_TRUE(mgr.Allocate(64, sge).ok());
+    TransProvider::RegisterMemoryDesc desc;
+    status = mgr.GetRegisterMemoryDesc(desc);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(desc.memoryType, TransProvider::MemType::MEM_DEVICE);
+    ASSERT_EQ(desc.addr, sge.device_addr);
+    ASSERT_EQ(desc.localAddr, sge.local_addr);
+
+    // The CPU writes through local_addr while HCOMM and remote RDMA use device_addr.
+    // ACL simulators may map both roles to the same numeric address.
+    std::memset(reinterpret_cast<void*>(sge.local_addr), 0x5A, sge.length);
+    ASSERT_EQ(*reinterpret_cast<unsigned char*>(sge.local_addr), 0x5A);
+}
+
+TEST_F(BufferManagerTest, SetTokenIdIsReflectedInAllocatedSge)
+{
+    BufferManager mgr;
+    auto status = mgr.Init("test_token", MemoryType::HOST, 1024, 10);
+    ASSERT_TRUE(status.ok()) << status.message;
+    mgr.SetTokenId(99);
+    ASSERT_EQ(mgr.GetTokenId(), 99);
+
+    ScatterGatherEntry sge;
+    status = mgr.Allocate(64, sge);
+    ASSERT_TRUE(status.ok()) << status.message;
+    ASSERT_EQ(sge.tokenId, 99);
+
+    mgr.Free(sge.slot_index);
+}
+
+TEST_F(BufferManagerTest, RegistrationDescriptionRequiresInitialization)
+{
+    BufferManager mgr;
+    TransProvider::RegisterMemoryDesc desc;
+    const auto status = mgr.GetRegisterMemoryDesc(desc);
+    ASSERT_FALSE(status.ok());
+    ASSERT_EQ(status.code, StatusCode::NOT_INITIALIZED);
+}
+
+}  // namespace
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/transport/connection_manager_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/connection_manager_test.cpp
@@ -1,0 +1,652 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "connection_manager.h"
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <set>
+#include <thread>
+#include <vector>
+#include "asu_transport/trans_provider.h"
+#include "connection_internal.h"
+
+namespace UC::ASU {
+namespace {
+
+static std::atomic<int> g_deleteCount{0};
+static std::atomic<int> g_createCount{0};
+static std::atomic<int> g_capabilityQueryCount{0};
+
+class StubTransProvider : public TransProvider {
+public:
+    Status createStatus{Status::OK()};
+    Status capabilityStatus{Status::OK()};
+    ServerKvCapabilities serverCapabilities;
+    ConnectionHandle capabilityQueryHandle{nullptr};
+
+    Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t qpNum,
+                            uint32_t, std::vector<ConnectionHandle>& handles) override
+    {
+        g_createCount.fetch_add(1);
+        handles.clear();
+        if (!createStatus.ok()) { return createStatus; }
+        for (std::uint32_t i = 0; i < qpNum; ++i) {
+            handles.push_back(reinterpret_cast<ConnectionHandle>(
+                static_cast<uintptr_t>(g_createCount.load() * 100 + i + 1)));
+        }
+        return Status::OK();
+    }
+
+    Status GetServerCapabilities(ConnectionHandle handle,
+                                 ServerKvCapabilities& capabilities) override
+    {
+        g_capabilityQueryCount.fetch_add(1);
+        capabilityQueryHandle = handle;
+        capabilities = serverCapabilities;
+        return capabilityStatus;
+    }
+
+    std::vector<Status> DeleteConnections(const std::vector<ConnectionHandle>& handles) override
+    {
+        for (std::size_t i = 0; i < handles.size(); ++i) { g_deleteCount.fetch_add(1); }
+        return std::vector<Status>(handles.size(), Status::OK());
+    }
+
+    std::vector<Status> Send(const std::vector<TransProvider::SendIoBatch>&, uint32_t,
+                             uint32_t) override
+    {
+        return {};
+    }
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>& descs,
+                          std::vector<MRHandle>& handles) override
+    {
+        handles.clear();
+        handles.reserve(descs.size());
+        for (std::size_t index = 0; index < descs.size(); ++index) {
+            handles.push_back(reinterpret_cast<MRHandle>(static_cast<std::uintptr_t>(index) +
+                                                         static_cast<std::uintptr_t>(1)));
+        }
+        return Status::OK();
+    }
+    std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>&) override
+    {
+        return {};
+    }
+    Status AllocThread(uint32_t, const std::vector<uint32_t>&, std::vector<ThreadHandle>&) override
+    {
+        return Status::OK();
+    }
+    std::vector<Status> FreeThread(const std::vector<ThreadHandle>&) override { return {}; }
+    Status GetMemTokenId(MRHandle, uint32_t& tokenId) override
+    {
+        tokenId = 1;
+        return Status::OK();
+    }
+};
+
+AsuEndpoint MakeEndpoint(const std::string& ip = "10.0.0.1")
+{
+    AsuEndpoint ep;
+    ep.ip = ip;
+    ep.port = 16666;
+    return ep;
+}
+
+}  // namespace
+
+// ─── ConnectionChannel Tests ───
+
+TEST(ConnectionChannelTest, InitialStateIsActiveWithZeroCounters)
+{
+    g_deleteCount = 0;
+    StubTransProvider provider;
+    ConnectionGroup group(0, MakeEndpoint());
+    auto handle = reinterpret_cast<ConnectionHandle>(static_cast<uintptr_t>(0x1234));
+    ConnectionChannel ch(0, &group, handle, &provider);
+
+    EXPECT_EQ(ch.GetState(), ChannelState::ACTIVE);
+    EXPECT_EQ(ch.GetInflightCount(), 0u);
+    EXPECT_EQ(ch.GetErrorCount(), 0u);
+    EXPECT_EQ(ch.GetChannelId(), 0u);
+    EXPECT_EQ(ch.GetGroup(), &group);
+    EXPECT_EQ(ch.GetConnection(), handle);
+}
+
+TEST(ConnectionChannelTest, IncrementAndReleaseInflight)
+{
+    ConnectionGroup group(0, MakeEndpoint());
+    ConnectionChannel ch(0, &group, nullptr, nullptr);
+
+    ch.IncrementInflight();
+    ch.IncrementInflight();
+    ch.IncrementInflight();
+    EXPECT_EQ(ch.GetInflightCount(), 3u);
+
+    ch.ReleaseInflight();
+    EXPECT_EQ(ch.GetInflightCount(), 2u);
+}
+
+TEST(ConnectionChannelTest, FetchAddErrorCountAccumulates)
+{
+    ConnectionGroup group(0, MakeEndpoint());
+    ConnectionChannel ch(0, &group, nullptr, nullptr);
+
+    auto old = ch.FetchAddErrorCount(1);
+    EXPECT_EQ(old, 0u);
+
+    old = ch.FetchAddErrorCount(1);
+    EXPECT_EQ(old, 1u);
+
+    old = ch.FetchAddErrorCount(3);
+    EXPECT_EQ(old, 2u);
+}
+
+TEST(ConnectionChannelTest, ErrorCountAccumulatesAndResets)
+{
+    ConnectionGroup group(0, MakeEndpoint());
+    ConnectionChannel ch(0, &group, nullptr, nullptr);
+
+    EXPECT_EQ(ch.FetchAddErrorCount(1), 0u);
+    EXPECT_EQ(ch.FetchAddErrorCount(1), 1u);
+    EXPECT_EQ(ch.GetErrorCount(), 2u);
+
+    ch.ResetErrorCount();
+    EXPECT_EQ(ch.GetErrorCount(), 0u);
+}
+
+TEST(ConnectionChannelTest, MarkForDrainTransitionsActiveToDraining)
+{
+    ConnectionGroup group(0, MakeEndpoint());
+    ConnectionChannel ch(0, &group, nullptr, nullptr);
+
+    EXPECT_EQ(ch.GetState(), ChannelState::ACTIVE);
+    bool ok = ch.MarkForDrain();
+    EXPECT_TRUE(ok);
+    EXPECT_EQ(ch.GetState(), ChannelState::DRAINING);
+}
+
+TEST(ConnectionChannelTest, MarkForDrainFailsIfAlreadyDraining)
+{
+    ConnectionGroup group(0, MakeEndpoint());
+    ConnectionChannel ch(0, &group, nullptr, nullptr);
+
+    EXPECT_TRUE(ch.MarkForDrain());
+    EXPECT_FALSE(ch.MarkForDrain());
+    EXPECT_EQ(ch.GetState(), ChannelState::DRAINING);
+}
+
+TEST(ConnectionChannelTest, DestructorCallsDeleteFn)
+{
+    g_deleteCount = 0;
+    auto handle = reinterpret_cast<ConnectionHandle>(static_cast<uintptr_t>(0xABCD));
+    {
+        StubTransProvider provider;
+        ConnectionGroup group(0, MakeEndpoint());
+        ConnectionChannel ch(0, &group, handle, &provider);
+    }
+    EXPECT_EQ(g_deleteCount.load(), 1);
+}
+
+TEST(ConnectionChannelTest, DestructorDoesNotCallDeleteFnWhenHandleIsNull)
+{
+    g_deleteCount = 0;
+    {
+        StubTransProvider provider;
+        ConnectionGroup group(0, MakeEndpoint());
+        ConnectionChannel ch(0, &group, nullptr, &provider);
+    }
+    EXPECT_EQ(g_deleteCount.load(), 0);
+}
+
+// ─── ConnectionGroup Tests ───
+
+TEST(ConnectionGroupTest, ConstructionSetsGroupIdAndEndpoint)
+{
+    auto ep = MakeEndpoint("192.168.1.1");
+    ConnectionGroup group(42, ep);
+
+    EXPECT_EQ(group.GetGroupId(), 42u);
+    EXPECT_EQ(group.GetEndpoint().ip, "192.168.1.1");
+    EXPECT_TRUE(group.GetChannels().empty());
+}
+
+TEST(ConnectionGroupTest, AddChannelCreatesChannelsWithIncrementingIds)
+{
+    StubTransProvider provider;
+    ConnectionGroup group(0, MakeEndpoint());
+
+    auto ch0 = group.AddChannel(reinterpret_cast<ConnectionHandle>(1), &provider);
+    auto ch1 = group.AddChannel(reinterpret_cast<ConnectionHandle>(2), &provider);
+    auto ch2 = group.AddChannel(reinterpret_cast<ConnectionHandle>(3), &provider);
+
+    EXPECT_EQ(group.GetChannels().size(), 3u);
+    EXPECT_EQ(ch0->GetChannelId(), 0u);
+    EXPECT_EQ(ch1->GetChannelId(), 1u);
+    EXPECT_EQ(ch2->GetChannelId(), 2u);
+}
+
+TEST(ConnectionGroupTest, RemoveChannelRemovesCorrectChannel)
+{
+    StubTransProvider provider;
+    ConnectionGroup group(0, MakeEndpoint());
+
+    auto ch0 = group.AddChannel(reinterpret_cast<ConnectionHandle>(1), &provider);
+    auto ch1 = group.AddChannel(reinterpret_cast<ConnectionHandle>(2), &provider);
+    auto ch2 = group.AddChannel(reinterpret_cast<ConnectionHandle>(3), &provider);
+
+    group.RemoveChannel(ch1.get());
+    EXPECT_EQ(group.GetChannels().size(), 2u);
+    EXPECT_EQ(group.GetChannels()[0]->GetChannelId(), 0u);
+    EXPECT_EQ(group.GetChannels()[1]->GetChannelId(), 2u);
+}
+
+TEST(ConnectionGroupTest, HasActiveChannelReturnsCorrectValue)
+{
+    StubTransProvider provider;
+    ConnectionGroup group(0, MakeEndpoint());
+
+    EXPECT_FALSE(group.HasActiveChannel());
+
+    auto ch = group.AddChannel(reinterpret_cast<ConnectionHandle>(1), &provider);
+    EXPECT_TRUE(group.HasActiveChannel());
+
+    ch->MarkForDrain();
+    EXPECT_FALSE(group.HasActiveChannel());
+}
+
+// ─── ConnectionManager Tests ───
+
+TEST(ConnectionManagerTest, AddGroupCreatesGroupWithChannels)
+{
+    g_createCount = 0;
+    g_deleteCount = 0;
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000);
+
+    auto status = mgr.AddGroup(MakeEndpoint(), 3);
+    EXPECT_TRUE(status.ok()) << status.message;
+
+    EXPECT_EQ(mgr.TotalInflightCount(), 0);
+}
+
+TEST(ConnectionManagerTest, AddGroupQueriesCapabilitiesOnceUsingFirstHandle)
+{
+    g_createCount = 0;
+    g_capabilityQueryCount = 0;
+    StubTransProvider provider;
+    provider.serverCapabilities.batchStoreKeys = 77;
+    ConnectionManager mgr(provider, "", 5000);
+
+    const auto status = mgr.AddGroup(MakeEndpoint(), 3);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(g_capabilityQueryCount.load(), 1);
+    EXPECT_EQ(provider.capabilityQueryHandle,
+              reinterpret_cast<ConnectionHandle>(static_cast<uintptr_t>(101)));
+    const auto capabilities = mgr.GetServerCapabilities();
+    ASSERT_EQ(capabilities.size(), std::size_t{1});
+    EXPECT_EQ(capabilities.front().batchStoreKeys, 77u);
+    auto channel = mgr.SelectConnection();
+    ASSERT_NE(channel, nullptr);
+    EXPECT_EQ(channel->GetGroup()->GetServerCapabilities().batchStoreKeys, 77u);
+}
+
+TEST(ConnectionManagerTest, AddGroupRollsBackConnectionsWhenCapabilityQueryFails)
+{
+    g_createCount = 0;
+    g_deleteCount = 0;
+    g_capabilityQueryCount = 0;
+    StubTransProvider provider;
+    provider.capabilityStatus = Status::Error(StatusCode::IO_ERROR, "capability query failure");
+    ConnectionManager mgr(provider, "", 5000);
+
+    const auto status = mgr.AddGroup(MakeEndpoint(), 3);
+
+    EXPECT_EQ(status.code, StatusCode::IO_ERROR);
+    EXPECT_EQ(status.message, "capability query failure");
+    EXPECT_EQ(g_capabilityQueryCount.load(), 1);
+    EXPECT_EQ(g_deleteCount.load(), 3);
+    EXPECT_EQ(mgr.SelectConnection(), nullptr);
+}
+
+TEST(ConnectionManagerTest, AddGroupReturnsProviderCreateError)
+{
+    StubTransProvider provider;
+    provider.createStatus = Status::Error(StatusCode::IO_ERROR, "provider create failure");
+    ConnectionManager mgr(provider, "", 5000);
+
+    const auto status = mgr.AddGroup(MakeEndpoint(), 3);
+
+    EXPECT_EQ(status.code, StatusCode::IO_ERROR);
+    EXPECT_EQ(status.message, "provider create failure");
+}
+
+TEST(ConnectionManagerTest, AddGroupFailsAfterShutdown)
+{
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000);
+    mgr.Shutdown();
+
+    auto status = mgr.AddGroup(MakeEndpoint(), 1);
+    EXPECT_FALSE(status.ok());
+    EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
+}
+
+TEST(ConnectionManagerTest, SelectConnectionRoundRobinCyclesThroughChannels)
+{
+    g_createCount = 0;
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000);
+    mgr.AddGroup(MakeEndpoint(), 3);
+    mgr.SetRoutingPolicy(RoutingPolicy::ROUND_ROBIN);
+
+    auto ch0 = mgr.SelectConnection();
+    auto ch1 = mgr.SelectConnection();
+    auto ch2 = mgr.SelectConnection();
+    auto ch3 = mgr.SelectConnection();
+
+    ASSERT_NE(ch0, nullptr);
+    ASSERT_NE(ch1, nullptr);
+    ASSERT_NE(ch2, nullptr);
+    ASSERT_NE(ch3, nullptr);
+
+    EXPECT_NE(ch0->GetChannelId(), ch1->GetChannelId());
+    EXPECT_NE(ch1->GetChannelId(), ch2->GetChannelId());
+    EXPECT_EQ(ch0->GetChannelId(), ch3->GetChannelId());
+}
+
+TEST(ConnectionManagerTest, SelectConnectionLeastLoadedPicksLowestInflight)
+{
+    g_createCount = 0;
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000);
+    mgr.AddGroup(MakeEndpoint(), 3);
+    mgr.SetRoutingPolicy(RoutingPolicy::LEAST_LOADED);
+
+    auto ch0 = mgr.SelectConnection();
+    auto ch1 = mgr.SelectConnection();
+    auto ch2 = mgr.SelectConnection();
+
+    ASSERT_NE(ch0, nullptr);
+    ASSERT_NE(ch1, nullptr);
+    ASSERT_NE(ch2, nullptr);
+
+    auto ch3 = mgr.SelectConnection();
+    ASSERT_NE(ch3, nullptr);
+    EXPECT_EQ(ch3->GetInflightCount(), 2u);
+}
+
+TEST(ConnectionManagerTest, SelectConnectionReturnsNullptrWhenNoChannels)
+{
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000);
+
+    auto ch = mgr.SelectConnection();
+    EXPECT_EQ(ch, nullptr);
+}
+
+TEST(ConnectionManagerTest, SelectConnectionReturnsNullptrAfterShutdown)
+{
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000);
+    mgr.AddGroup(MakeEndpoint(), 3);
+    mgr.Shutdown();
+
+    auto ch = mgr.SelectConnection();
+    EXPECT_EQ(ch, nullptr);
+}
+
+TEST(ConnectionManagerTest, ReportFailureBelowThresholdDoesNotDrain)
+{
+    g_createCount = 0;
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000);
+    mgr.AddGroup(MakeEndpoint(), 1);
+
+    auto ch = mgr.SelectConnection();
+    ASSERT_NE(ch, nullptr);
+
+    mgr.ReportFailure(ch);
+    EXPECT_EQ(ch->GetState(), ChannelState::ACTIVE);
+}
+
+TEST(ConnectionManagerTest, ReportFailureAtThresholdMarksForDrain)
+{
+    g_createCount = 0;
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000);
+    mgr.AddGroup(MakeEndpoint(), 1);
+
+    auto ch = mgr.SelectConnection();
+    ASSERT_NE(ch, nullptr);
+
+    mgr.ReportFailure(ch);
+    mgr.ReportFailure(ch);
+    EXPECT_EQ(ch->GetState(), ChannelState::DRAINING);
+}
+
+TEST(ConnectionManagerTest, ReportFailureUsesConfiguredThreshold)
+{
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000, 3);
+    ASSERT_TRUE(mgr.AddGroup(MakeEndpoint(), 1).ok());
+
+    auto ch = mgr.SelectConnection();
+    ASSERT_NE(ch, nullptr);
+
+    mgr.ReportFailure(ch);
+    mgr.ReportFailure(ch);
+    EXPECT_EQ(ch->GetErrorCount(), 2u);
+    EXPECT_EQ(ch->GetState(), ChannelState::ACTIVE);
+
+    mgr.ReportFailure(ch);
+    EXPECT_EQ(ch->GetErrorCount(), 3u);
+    EXPECT_EQ(ch->GetState(), ChannelState::DRAINING);
+}
+
+TEST(ConnectionManagerTest, SuccessfulCompletionResetsErrorCount)
+{
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000, 3);
+    ASSERT_TRUE(mgr.AddGroup(MakeEndpoint(), 1).ok());
+
+    auto ch = mgr.SelectConnection();
+    ASSERT_NE(ch, nullptr);
+
+    mgr.ReportFailure(ch);
+    mgr.ReportFailure(ch);
+    mgr.ReportSuccess(ch);
+    EXPECT_EQ(ch->GetErrorCount(), 0u);
+
+    mgr.ReportFailure(ch);
+    mgr.ReportFailure(ch);
+    EXPECT_EQ(ch->GetState(), ChannelState::ACTIVE);
+}
+
+TEST(ConnectionManagerTest, FailureThresholdRecreatesConnection)
+{
+    g_createCount = 0;
+    g_deleteCount = 0;
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000, 1);
+    ASSERT_TRUE(mgr.AddGroup(MakeEndpoint(), 1).ok());
+    mgr.StartRecoverLoop();
+
+    auto oldChannel = mgr.SelectConnection();
+    ASSERT_NE(oldChannel, nullptr);
+    oldChannel->ReleaseInflight();
+    mgr.ReportFailure(oldChannel);
+    oldChannel.reset();
+
+    std::shared_ptr<ConnectionChannel> newChannel;
+    for (std::uint32_t attempt = 0; attempt < 100 && newChannel == nullptr; ++attempt) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        newChannel = mgr.GetActiveConnection();
+    }
+    mgr.StopRecoverLoop();
+
+    ASSERT_NE(newChannel, nullptr);
+    EXPECT_EQ(newChannel->GetChannelId(), std::uint32_t{1});
+    EXPECT_EQ(g_createCount.load(), 2);
+    EXPECT_EQ(g_deleteCount.load(), 1);
+}
+
+TEST(ConnectionManagerTest, ShutdownClearsAllResources)
+{
+    g_deleteCount = 0;
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000);
+    mgr.AddGroup(MakeEndpoint(), 3);
+
+    auto status = mgr.Shutdown();
+    EXPECT_TRUE(status.ok());
+    EXPECT_EQ(g_deleteCount.load(), 3);
+    EXPECT_EQ(mgr.TotalInflightCount(), 0);
+}
+
+TEST(ConnectionManagerTest, TotalInflightCountSumsCorrectly)
+{
+    g_createCount = 0;
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000);
+    mgr.AddGroup(MakeEndpoint(), 3);
+
+    auto ch0 = mgr.SelectConnection();
+    auto ch1 = mgr.SelectConnection();
+    ch0->IncrementInflight();
+    ch0->IncrementInflight();
+    ch1->IncrementInflight();
+
+    EXPECT_EQ(mgr.TotalInflightCount(), 5);
+}
+
+TEST(ConnectionManagerTest, LeastLoadedAlwaysPicksLowestWhileRoundRobinCycles)
+{
+    g_createCount = 0;
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000);
+    mgr.AddGroup(MakeEndpoint(), 2);
+
+    mgr.SetRoutingPolicy(RoutingPolicy::ROUND_ROBIN);
+    auto rr1 = mgr.SelectConnection();
+    auto rr2 = mgr.SelectConnection();
+    ASSERT_NE(rr1, nullptr);
+    ASSERT_NE(rr2, nullptr);
+    EXPECT_NE(rr1->GetChannelId(), rr2->GetChannelId());
+
+    mgr.SetRoutingPolicy(RoutingPolicy::LEAST_LOADED);
+    auto ll1 = mgr.SelectConnection();
+    ASSERT_NE(ll1, nullptr);
+    EXPECT_EQ(ll1->GetInflightCount(), 2u);
+
+    auto ll2 = mgr.SelectConnection();
+    ASSERT_NE(ll2, nullptr);
+    EXPECT_NE(ll1->GetChannelId(), ll2->GetChannelId());
+    EXPECT_EQ(ll2->GetInflightCount(), 2u);
+}
+
+// ─── ConnectionManager Multi-Group Tests ───
+
+TEST(ConnectionManagerTest, SelectConnectionRoundRobinAcrossMultipleGroups)
+{
+    g_createCount = 0;
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000);
+    mgr.AddGroup(MakeEndpoint("10.0.0.1"), 2);
+    mgr.AddGroup(MakeEndpoint("10.0.0.2"), 2);
+
+    mgr.SetRoutingPolicy(RoutingPolicy::ROUND_ROBIN);
+
+    std::set<std::uint32_t> selectedIds;
+    for (int i = 0; i < 4; ++i) {
+        auto ch = mgr.SelectConnection();
+        ASSERT_NE(ch, nullptr);
+        selectedIds.insert(ch->GetChannelId());
+    }
+    EXPECT_EQ(selectedIds.size(), 2u);
+
+    auto ch5 = mgr.SelectConnection();
+    ASSERT_NE(ch5, nullptr);
+}
+
+TEST(ConnectionManagerTest, SelectConnectionReturnsNullptrWhenAllChannelsAtMaxInflight)
+{
+    g_createCount = 0;
+    StubTransProvider provider;
+    provider.serverCapabilities.ioQueueDepth = 3;
+    ConnectionManager mgr(provider, "", 5000);
+    mgr.AddGroup(MakeEndpoint(), 2);
+    mgr.SetRoutingPolicy(RoutingPolicy::ROUND_ROBIN);
+
+    auto ch0 = mgr.SelectConnection();
+    auto ch1 = mgr.SelectConnection();
+    ASSERT_NE(ch0, nullptr);
+    ASSERT_NE(ch1, nullptr);
+
+    ch0->SetInflightCount(3);
+    ch1->SetInflightCount(3);
+
+    auto ch = mgr.SelectConnection();
+    EXPECT_EQ(ch, nullptr);
+}
+
+TEST(ConnectionManagerTest, ShutdownIsIdempotent)
+{
+    g_deleteCount = 0;
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000);
+    mgr.AddGroup(MakeEndpoint(), 3);
+
+    auto status1 = mgr.Shutdown();
+    EXPECT_TRUE(status1.ok());
+    EXPECT_EQ(g_deleteCount.load(), 3);
+
+    auto status2 = mgr.Shutdown();
+    EXPECT_TRUE(status2.ok());
+    EXPECT_EQ(g_deleteCount.load(), 3);
+}
+
+TEST(ConnectionManagerTest, ReportFailureMultipleTimesDoesNotDuplicateInDrainList)
+{
+    g_createCount = 0;
+    g_deleteCount = 0;
+    StubTransProvider provider;
+    ConnectionManager mgr(provider, "", 5000);
+    mgr.AddGroup(MakeEndpoint(), 1);
+
+    {
+        auto ch = mgr.SelectConnection();
+        ASSERT_NE(ch, nullptr);
+
+        for (int i = 0; i < 5; ++i) { mgr.ReportFailure(ch); }
+
+        EXPECT_EQ(ch->GetState(), ChannelState::DRAINING);
+    }
+
+    mgr.Shutdown();
+    EXPECT_EQ(g_deleteCount.load(), 1);
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/transport/fake_trans_provider_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/fake_trans_provider_test.cpp
@@ -1,0 +1,185 @@
+#define private public
+#include "fake_trans_provider.h"
+#undef private
+#include <array>
+#include <chrono>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <iomanip>
+#include <sstream>
+#include <thread>
+#include <unordered_set>
+#include "kv_protocol.h"
+
+namespace UC::ASU {
+namespace {
+
+std::string FakeBackendKeyFileName(const CacheKey& key)
+{
+    std::uint64_t hash = 1469598103934665603ULL;
+    for (auto byte : key) {
+        hash ^= std::to_integer<unsigned char>(byte);
+        hash *= 1099511628211ULL;
+    }
+
+    std::ostringstream stream;
+    stream << std::hex << std::setw(16) << std::setfill('0') << hash << ".bin";
+    return stream.str();
+}
+
+std::vector<std::uint32_t> BuildExistRequest(const std::vector<CacheKey>& keys, bool sc)
+{
+    std::vector<std::uint32_t> request(kSqeDwordCount + keys.size() * kKeyEntryDwordCount, 0);
+    request[0] = static_cast<std::uint32_t>(KvOpcode::Exist);
+    request[1] = 1;
+    request[10] = static_cast<std::uint32_t>(keys.size());
+    if (sc) { request[10] |= 1U << 16; }
+    for (std::size_t index = 0; index < keys.size(); ++index) {
+        std::memcpy(request.data() + kSqeDwordCount + index * kKeyEntryDwordCount,
+                    keys[index].data(), kCacheKeySizeBytes);
+    }
+    return request;
+}
+
+std::array<std::uint32_t, kSqeDwordCount> BuildKeepAliveRequest(std::uint16_t cid)
+{
+    std::array<std::uint32_t, kSqeDwordCount> request{};
+    request[0] =
+        static_cast<std::uint32_t>(KvOpcode::KeepAlive) | (static_cast<std::uint32_t>(cid) << 16);
+    return request;
+}
+
+TEST(FakeTransProviderTest, RegisterMemoryReturnsUniqueHandlesAcrossCalls)
+{
+    FakeTransProvider provider(FakeTransProviderConfig{});
+    const std::vector<TransProvider::RegisterMemoryDesc> descs{
+        {TransProvider::MemType::MEM_DEVICE, 0x1000, 4096},
+        {TransProvider::MemType::MEM_DEVICE, 0x2000, 4096}
+    };
+
+    std::vector<MRHandle> firstHandles;
+    ASSERT_TRUE(provider.RegisterMemory(descs, firstHandles).ok());
+    std::vector<MRHandle> secondHandles;
+    ASSERT_TRUE(provider.RegisterMemory(descs, secondHandles).ok());
+
+    std::unordered_set<MRHandle> uniqueHandles;
+    uniqueHandles.insert(firstHandles.begin(), firstHandles.end());
+    uniqueHandles.insert(secondHandles.begin(), secondHandles.end());
+    EXPECT_EQ(uniqueHandles.size(), firstHandles.size() + secondHandles.size());
+    EXPECT_EQ(uniqueHandles.count(kInvalidMRHandle), 0);
+}
+
+TEST(FakeTransProviderTest, BindMemoryCreatesProviderLocalHandles)
+{
+    FakeTransProvider provider(FakeTransProviderConfig{});
+    const std::vector<TransProvider::BindMemoryDesc> descs{
+        {TransProvider::MemType::MEM_DEVICE, 0x1000, 4096, 1},
+        {TransProvider::MemType::MEM_DEVICE, 0x2000, 4096, 1}
+    };
+
+    std::vector<MRHandle> handles;
+    ASSERT_TRUE(provider.BindMemory(descs, handles).ok());
+
+    ASSERT_EQ(handles.size(), descs.size());
+    EXPECT_NE(handles[0], kInvalidMRHandle);
+    EXPECT_NE(handles[1], kInvalidMRHandle);
+    EXPECT_NE(handles[0], handles[1]);
+}
+
+TEST(FakeTransProviderTest, SendQueuesCompletionForWorker)
+{
+    FakeTransProviderConfig config;
+    config.latencyMs = 20;
+    config.workerThreads = 2;
+    FakeTransProvider provider(config);
+
+    constexpr std::uint16_t cid = 7;
+    auto request = BuildKeepAliveRequest(cid);
+    std::array<std::uint32_t, kCqeDwordCount> completion{};
+    std::vector<MRHandle> handles;
+    ASSERT_TRUE(
+        provider
+            .RegisterMemory(
+                {
+                    {TransProvider::MemType::MEM_HOST,
+                     reinterpret_cast<std::uintptr_t>(request.data()),    sizeof(request),
+                     reinterpret_cast<std::uintptr_t>(request.data())   },
+                    {TransProvider::MemType::MEM_HOST,
+                     reinterpret_cast<std::uintptr_t>(completion.data()), sizeof(completion),
+                     reinterpret_cast<std::uintptr_t>(completion.data())}
+    },
+                handles)
+            .ok());
+
+    const auto statuses = provider.Send(
+        {
+            {nullptr, request.data(), completion.data(), sizeof(request)}
+    },
+        0, 0);
+    ASSERT_EQ(statuses.size(), 1U);
+    ASSERT_TRUE(statuses[0].ok()) << statuses[0].message;
+    EXPECT_EQ(__atomic_load_n(completion.data() + 3, __ATOMIC_ACQUIRE), 0U);
+
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    while ((__atomic_load_n(completion.data() + 3, __ATOMIC_ACQUIRE) & 0xFFFF) == 0 &&
+           std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    EXPECT_EQ(__atomic_load_n(completion.data() + 3, __ATOMIC_ACQUIRE) & 0xFFFF, cid);
+}
+
+TEST(FakeTransProviderTest, ParsesWorkerThreadCount)
+{
+    TransportConfig config;
+    config.attrs["fake_backend.worker_threads"] = "6";
+    EXPECT_EQ(MakeFakeTransProviderConfig(config).workerThreads, 6U);
+}
+
+TEST(FakeTransProviderTest, ExistHonorsSeekControl)
+{
+    const auto storePath =
+        std::filesystem::temp_directory_path() /
+        ("asu-fake-sc-test-" +
+         std::to_string(std::chrono::steady_clock::now().time_since_epoch().count()));
+    const auto asuPath = storePath / "asu-1";
+    std::filesystem::create_directories(asuPath);
+
+    CacheKey first{};
+    first[0] = std::byte{1};
+    CacheKey missing{};
+    missing[0] = std::byte{2};
+    CacheKey third{};
+    third[0] = std::byte{3};
+    std::ofstream{asuPath / FakeBackendKeyFileName(first)}.put('\0');
+    std::ofstream{asuPath / FakeBackendKeyFileName(third)}.put('\0');
+
+    FakeTransProviderConfig config;
+    config.storePath = storePath.string();
+    config.latencyMs = 0;
+    const std::vector<CacheKey> keys{first, missing, third};
+    FakeTransProvider provider{config};
+
+    auto request = BuildExistRequest(keys, false);
+    std::vector<std::uint32_t> completion;
+    auto status = provider.CompleteFakeBackendRequest(
+        request.data(), request.size() * sizeof(std::uint32_t), completion);
+    EXPECT_TRUE(status.ok()) << status.message;
+    ASSERT_GT(completion.size(), kCqeDwordCount);
+    EXPECT_EQ(completion[0] & 0xFFFF, 1U);
+
+    request = BuildExistRequest(keys, true);
+    status = provider.CompleteFakeBackendRequest(
+        request.data(), request.size() * sizeof(std::uint32_t), completion);
+    EXPECT_TRUE(status.ok()) << status.message;
+    ASSERT_GT(completion.size(), kCqeDwordCount);
+    EXPECT_EQ(completion[0] & 0xFFFF, 2U);
+    EXPECT_EQ(completion[kCqeDwordCount] & 0x7, 0x5U);
+
+    std::error_code errorCode;
+    std::filesystem::remove_all(storePath, errorCode);
+}
+
+}  // namespace
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/transport/io_scheduler_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/io_scheduler_test.cpp
@@ -1,0 +1,99 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "io_scheduler.h"
+#include <algorithm>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+namespace UC::ASU {
+namespace {
+
+CacheKey MakeCacheKey(const std::string& text)
+{
+    CacheKey key{};
+    const auto size = std::min(text.size(), key.size());
+    if (size > 0) { std::memcpy(key.data(), text.data(), size); }
+    return key;
+}
+
+TEST(IoSchedulerTest, SplitEntryBatchPreservesOrderAndUsesViews)
+{
+    std::vector<KVBuffer> entries(5);
+    for (std::size_t index = 0; index < entries.size(); ++index) {
+        entries[index].key = MakeCacheKey("key_" + std::to_string(index));
+    }
+
+    TransportConfig config;
+    config.asuBatchLoadIoNum = 2;
+    IoScheduler scheduler(config);
+    const auto batches = scheduler.SplitForAsu(BatchView<KVBuffer>{entries.data(), entries.size()},
+                                               AsuOpType::BATCH_LOAD);
+
+    ASSERT_EQ(batches.size(), std::size_t{3});
+    EXPECT_EQ(batches[0].entries.size, std::size_t{2});
+    EXPECT_EQ(batches[1].entries.size, std::size_t{2});
+    EXPECT_EQ(batches[2].entries.size, std::size_t{1});
+    EXPECT_EQ(&batches[0].entries[0], &entries[0]);
+    EXPECT_EQ(&batches[1].entries[0], &entries[2]);
+    EXPECT_EQ(&batches[2].entries[0], &entries[4]);
+    EXPECT_EQ(batches[1].entries[1].key, MakeCacheKey("key_3"));
+}
+
+TEST(IoSchedulerTest, GetSqeIoNumMatchesOperationKind)
+{
+    TransportConfig config;
+    config.asuBatchLoadIoNum = 3;
+    config.asuBatchStoreIoNum = 4;
+    config.asuDeleteIoNum = 5;
+    config.asuQueryIoNum = 6;
+    IoScheduler scheduler(config);
+
+    EXPECT_EQ(scheduler.GetSqeIoNum(AsuOpType::LOAD), std::size_t{1});
+    EXPECT_EQ(scheduler.GetSqeIoNum(AsuOpType::STORE), std::size_t{1});
+    EXPECT_EQ(scheduler.GetSqeIoNum(AsuOpType::BATCH_LOAD), std::size_t{3});
+    EXPECT_EQ(scheduler.GetSqeIoNum(AsuOpType::BATCH_STORE), std::size_t{4});
+    EXPECT_EQ(scheduler.GetSqeIoNum(AsuOpType::DELETE), std::size_t{5});
+    EXPECT_EQ(scheduler.GetSqeIoNum(AsuOpType::QUERY), std::size_t{6});
+}
+
+TEST(IoSchedulerTest, SplitByOperationUsesHeldConfig)
+{
+    TransportConfig config;
+    config.asuBatchLoadIoNum = 2;
+    IoScheduler scheduler(config);
+    std::vector<KVBuffer> entries(5);
+
+    const auto batches = scheduler.SplitForAsu(BatchView<KVBuffer>{entries.data(), entries.size()},
+                                               AsuOpType::BATCH_LOAD);
+
+    ASSERT_EQ(batches.size(), std::size_t{3});
+    EXPECT_EQ(batches[0].entries.size, std::size_t{2});
+    EXPECT_EQ(batches[1].entries.size, std::size_t{2});
+    EXPECT_EQ(batches[2].entries.size, std::size_t{1});
+}
+
+}  // namespace
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/transport/kv_protocol_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/kv_protocol_test.cpp
@@ -1,0 +1,2564 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "kv_protocol.h"
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <string_view>
+
+namespace UC::ASU {
+namespace {
+
+CacheKey MakeCacheKey(std::string_view text)
+{
+    CacheKey key{};
+    const auto size = std::min(text.size(), key.size());
+    if (size > 0) { std::memcpy(key.data(), text.data(), size); }
+    return key;
+}
+
+CacheKey MakeCacheKey(std::uint64_t value)
+{
+    CacheKey key{};
+    std::memcpy(key.data(), &value, key.size());
+    return key;
+}
+
+class KvProtocolPackTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(KvProtocolPackTest, StoreProtocolPackMatchesProtocol)
+{
+    constexpr std::uint16_t kCid = 0x1234;
+    constexpr std::uint32_t kKvNsId = 0x0001;
+    constexpr std::uint8_t kDtype = 0x1;
+    constexpr std::uint8_t kDspec = 0x05;
+    constexpr std::uint64_t kBufferAddr = 0x0000123456789ABCULL;
+    constexpr std::uint32_t kBufferLength = 0x00010000;
+    constexpr std::uint32_t kMrKey = 0x76543210;
+    constexpr std::uint32_t kOffset = 0x00001000;
+    constexpr bool kLr = true;
+    constexpr std::uint32_t kLength = 0x00000002;
+    const std::string kKey = "test_key_01";
+
+    KvStoreRequest req;
+    req.cid = kCid;
+    req.kv_ns_id = kKvNsId;
+    req.dtype = kDtype;
+    req.dspec = kDspec;
+    req.buffer_addr = kBufferAddr;
+    req.buffer_length = kBufferLength;
+    req.mr_key = kMrKey;
+    req.offset = kOffset;
+    req.lr = kLr;
+    req.length = kLength;
+    req.key = MakeCacheKey(kKey);
+
+    KvStoreProtocol proto;
+    std::vector<std::uint32_t> packed(16, 0);
+    auto status = proto.PackSqe(req, packed.data());
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint32_t> expected(16, 0);
+    expected[0] = (kCid << 16) | (0x3 << 14) | 0x01;
+    expected[1] = kKvNsId;
+    expected[2] = ((kDtype & 0x7) << 13) | ((kDspec & 0x1F) << 8);
+    expected[6] = kBufferAddr & 0xFFFFFFFFULL;
+    expected[7] = (kBufferAddr >> 32) & 0xFFFFFFFFULL;
+    expected[8] = ((kMrKey & 0xFF) << 24) | (kBufferLength & 0xFFFFFF);
+    expected[9] = (0x40 << 24) | ((kMrKey >> 8) & 0xFFFFFF);
+    expected[10] = kOffset;
+    expected[11] = (kLr ? (1U << 31) : 0) | (kLength & 0xFFFFFF);
+    std::size_t key_len = std::min(kKey.size(), kCacheKeySizeBytes);
+    if (key_len > 0) { std::memcpy(&expected[12], kKey.data(), key_len); }
+
+    ASSERT_EQ(packed.size(), expected.size());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i]) << "Mismatch at Dword " << i << ": expected 0x"
+                                          << std::hex << expected[i] << ", got 0x" << packed[i];
+    }
+}
+
+TEST_F(KvProtocolPackTest, RetrieveProtocolPackMatchesProtocol)
+{
+    constexpr std::uint16_t kCid = 0x5678;
+    constexpr std::uint32_t kKvNsId = 0x0002;
+    constexpr std::uint64_t kBufferAddr = 0x0000FEDCBA987654ULL;
+    constexpr std::uint32_t kBufferLength = 0x00020000;
+    constexpr std::uint32_t kMrKey = 0x12345678;
+    constexpr std::uint32_t kOffset = 0x00002000;
+    constexpr bool kLr = false;
+    constexpr std::uint32_t kLength = 0x00000003;
+    const std::string kKey = "retrieve_key";
+
+    KvRetrieveRequest req;
+    req.cid = kCid;
+    req.kv_ns_id = kKvNsId;
+    req.buffer_addr = kBufferAddr;
+    req.buffer_length = kBufferLength;
+    req.mr_key = kMrKey;
+    req.offset = kOffset;
+    req.lr = kLr;
+    req.length = kLength;
+    req.key = MakeCacheKey(kKey);
+
+    KvRetrieveProtocol proto;
+    std::vector<std::uint32_t> packed(proto.PackedSize(req) / sizeof(std::uint32_t), 0);
+    auto status = proto.PackSqe(req, packed.data());
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint32_t> expected(16, 0);
+    expected[0] = (kCid << 16) | (0x3 << 14) | 0x02;
+    expected[1] = kKvNsId;
+    expected[6] = kBufferAddr & 0xFFFFFFFFULL;
+    expected[7] = (kBufferAddr >> 32) & 0xFFFFFFFFULL;
+    expected[8] = ((kMrKey & 0xFF) << 24) | (kBufferLength & 0xFFFFFF);
+    expected[9] = (0x40 << 24) | ((kMrKey >> 8) & 0xFFFFFF);
+    expected[10] = kOffset;
+    expected[11] = (kLr ? (1U << 31) : 0) | (kLength & 0xFFFFFF);
+    std::memcpy(&expected[12], kKey.data(), std::min(kKey.size(), kCacheKeySizeBytes));
+
+    ASSERT_EQ(packed.size(), expected.size());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i]) << "Mismatch at Dword " << i;
+    }
+}
+
+TEST_F(KvProtocolPackTest, BatchStoreProtocolPackMatchesProtocol)
+{
+    constexpr std::uint16_t kCid = 0xABCD;
+    constexpr std::uint32_t kKvNsId = 0x0003;
+    constexpr std::uint8_t kDtype = 0x2;
+    constexpr std::uint8_t kDspec = 0x0A;
+    constexpr std::uint64_t kRespBufferAddr = 0x0000111122223333ULL;
+    constexpr std::uint32_t kRespMrKey = 0x99999999;
+    constexpr bool kLr = true;
+    constexpr bool kRflag = true;
+
+    KvBatchStoreEntry entry1;
+    entry1.offset = 0x1000;
+    entry1.key = MakeCacheKey("batch_key_1");
+    entry1.buffer_addr = 0x0000AAAABBBBCCCCULL;
+    entry1.mr_key = 0x11111111;
+    entry1.length = 0x2000;
+
+    KvBatchStoreEntry entry2;
+    entry2.offset = 0x2000;
+    entry2.key = MakeCacheKey("batch_key_2");
+    entry2.buffer_addr = 0x0000DDDDEEEEFFFFULL;
+    entry2.mr_key = 0x22222222;
+    entry2.length = 0x3000;
+
+    KvBatchStoreRequest req;
+    req.cid = kCid;
+    req.kv_ns_id = kKvNsId;
+    req.dtype = kDtype;
+    req.dspec = kDspec;
+    req.response_buffer_addr = kRespBufferAddr;
+    req.response_mr_key = kRespMrKey;
+    req.lr = kLr;
+    req.rflag = kRflag;
+    req.batch_number = 2;
+    req.entries = {entry1, entry2};
+
+    KvBatchStoreProtocol proto;
+    std::vector<std::uint32_t> packed(proto.PackedSize(req) / sizeof(std::uint32_t), 0);
+    auto status = proto.PackSqe(req, packed.data());
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint32_t> expected(34, 0);
+    expected[0] = (kCid << 16) | (0x3 << 14) | (kRflag ? (1U << 13) : 0) | 0x45;
+    expected[1] = kKvNsId;
+    expected[2] = ((kDtype & 0x7) << 13) | ((kDspec & 0x1F) << 8);
+    expected[3] = kRespBufferAddr & 0xFFFFFFFFULL;
+    expected[4] = (kRespBufferAddr >> 32) & 0xFFFFFFFFULL;
+    expected[5] = kRespMrKey;
+    expected[8] = 2 * 36;
+    expected[9] = 0x01 << 24;
+    expected[10] = 2;
+    expected[11] = kLr ? (1U << 31) : 0;
+
+    expected[16] = entry1.offset;
+    std::memcpy(&expected[17], entry1.key.data(), std::min(entry1.key.size(), kCacheKeySizeBytes));
+    expected[21] = entry1.buffer_addr & 0xFFFFFFFFULL;
+    expected[22] = (entry1.buffer_addr >> 32) & 0xFFFFFFFFULL;
+    expected[23] = ((entry1.mr_key & 0xFF) << 24) | (entry1.length & 0xFFFFFF);
+    expected[24] = (0x40 << 24) | ((entry1.mr_key >> 8) & 0xFFFFFF);
+
+    expected[25] = entry2.offset;
+    std::memcpy(&expected[26], entry2.key.data(), std::min(entry2.key.size(), kCacheKeySizeBytes));
+    expected[30] = entry2.buffer_addr & 0xFFFFFFFFULL;
+    expected[31] = (entry2.buffer_addr >> 32) & 0xFFFFFFFFULL;
+    expected[32] = ((entry2.mr_key & 0xFF) << 24) | (entry2.length & 0xFFFFFF);
+    expected[33] = (0x40 << 24) | ((entry2.mr_key >> 8) & 0xFFFFFF);
+
+    ASSERT_EQ(packed.size(), expected.size());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i]) << "Mismatch at Dword " << i;
+    }
+}
+
+TEST_F(KvProtocolPackTest, BatchRetrieveProtocolPackMatchesProtocol)
+{
+    constexpr std::uint16_t kCid = 0x1111;
+    constexpr std::uint32_t kKvNsId = 0x0004;
+    constexpr std::uint64_t kRespBufferAddr = 0x0000444455556666ULL;
+    constexpr std::uint32_t kRespMrKey = 0x88888888;
+    constexpr bool kLr = false;
+    constexpr bool kRflag = true;
+
+    KvBatchRetrieveEntry entry;
+    entry.offset = 0x3000;
+    entry.key = MakeCacheKey("batch_ret_key");
+    entry.buffer_addr = 0x0000777788889999ULL;
+    entry.mr_key = 0x33333333;
+    entry.length = 0x4000;
+
+    KvBatchRetrieveRequest req;
+    req.cid = kCid;
+    req.kv_ns_id = kKvNsId;
+    req.response_buffer_addr = kRespBufferAddr;
+    req.response_mr_key = kRespMrKey;
+    req.lr = kLr;
+    req.rflag = kRflag;
+    req.batch_number = 1;
+    req.entries = {entry};
+
+    KvBatchRetrieveProtocol proto;
+    std::vector<std::uint32_t> packed(proto.PackedSize(req) / sizeof(std::uint32_t), 0);
+    auto status = proto.PackSqe(req, packed.data());
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint32_t> expected(25, 0);
+    expected[0] = (kCid << 16) | (0x3 << 14) | (1U << 13) | 0x46;
+    expected[1] = kKvNsId;
+    expected[3] = kRespBufferAddr & 0xFFFFFFFFULL;
+    expected[4] = (kRespBufferAddr >> 32) & 0xFFFFFFFFULL;
+    expected[5] = kRespMrKey;
+    expected[8] = 1 * 36;
+    expected[9] = 0x01 << 24;
+    expected[10] = 1;
+    expected[16] = entry.offset;
+    std::memcpy(&expected[17], entry.key.data(), std::min(entry.key.size(), kCacheKeySizeBytes));
+    expected[21] = entry.buffer_addr & 0xFFFFFFFFULL;
+    expected[22] = (entry.buffer_addr >> 32) & 0xFFFFFFFFULL;
+    expected[23] = ((entry.mr_key & 0xFF) << 24) | (entry.length & 0xFFFFFF);
+    expected[24] = (0x40 << 24) | ((entry.mr_key >> 8) & 0xFFFFFF);
+
+    ASSERT_EQ(packed.size(), expected.size());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i]) << "Mismatch at Dword " << i;
+    }
+}
+
+TEST_F(KvProtocolPackTest, DeleteProtocolPackMatchesProtocol)
+{
+    constexpr std::uint16_t kCid = 0x2222;
+    constexpr std::uint32_t kKvNsId = 0x0005;
+    constexpr std::uint64_t kRespBufferAddr = 0x0000AAAA0000BBBBULL;
+    constexpr std::uint32_t kRespMrKey = 0x77777777;
+    constexpr bool kRflag = true;
+
+    KvDeleteRequest req;
+    req.cid = kCid;
+    req.kv_ns_id = kKvNsId;
+    req.response_buffer_addr = kRespBufferAddr;
+    req.response_mr_key = kRespMrKey;
+    req.rflag = kRflag;
+    req.batch_number = 2;
+    req.keys = {MakeCacheKey("delete_key_1"), MakeCacheKey("delete_key_2")};
+
+    KvDeleteProtocol proto;
+    std::vector<std::uint32_t> packed(proto.PackedSize(req) / sizeof(std::uint32_t), 0);
+    auto status = proto.PackSqe(req, packed.data());
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint32_t> expected(24, 0);
+    expected[0] = (kCid << 16) | (0x3 << 14) | (kRflag ? (1U << 13) : 0) | 0x08;
+    expected[1] = kKvNsId;
+    expected[3] = kRespBufferAddr & 0xFFFFFFFFULL;
+    expected[4] = (kRespBufferAddr >> 32) & 0xFFFFFFFFULL;
+    expected[5] = kRespMrKey;
+    expected[8] = 2 * 16;
+    expected[9] = 0x01 << 24;
+    expected[10] = 2;
+    std::memcpy(&expected[16], req.keys[0].data(),
+                std::min(req.keys[0].size(), kCacheKeySizeBytes));
+    std::memcpy(&expected[20], req.keys[1].data(),
+                std::min(req.keys[1].size(), kCacheKeySizeBytes));
+
+    ASSERT_EQ(packed.size(), expected.size());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i]) << "Mismatch at Dword " << i;
+    }
+}
+
+TEST_F(KvProtocolPackTest, ExistProtocolPackMatchesProtocol)
+{
+    constexpr std::uint16_t kCid = 0x3333;
+    constexpr std::uint32_t kKvNsId = 0x0006;
+    constexpr std::uint64_t kRespBufferAddr = 0x0000CCCC0000DDDDULL;
+    constexpr std::uint32_t kRespMrKey = 0x66666666;
+    constexpr bool kRflag = true;
+    constexpr bool kSc = true;
+
+    KvExistRequest req;
+    req.cid = kCid;
+    req.kv_ns_id = kKvNsId;
+    req.response_buffer_addr = kRespBufferAddr;
+    req.response_mr_key = kRespMrKey;
+    req.rflag = kRflag;
+    req.sc = kSc;
+    req.batch_number = 1;
+    req.keys = {MakeCacheKey("exist_key")};
+
+    KvExistProtocol proto;
+    std::vector<std::uint32_t> packed(proto.PackedSize(req) / sizeof(std::uint32_t), 0);
+    auto status = proto.PackSqe(req, packed.data());
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint32_t> expected(20, 0);
+    expected[0] = (kCid << 16) | (0x3 << 14) | (1U << 13) | 0x0C;
+    expected[1] = kKvNsId;
+    expected[3] = kRespBufferAddr & 0xFFFFFFFFULL;
+    expected[4] = (kRespBufferAddr >> 32) & 0xFFFFFFFFULL;
+    expected[5] = kRespMrKey;
+    expected[8] = 1 * 16;
+    expected[9] = 0x01 << 24;
+    expected[10] = 1 | (kSc ? (1U << 16) : 0);
+    std::memcpy(&expected[16], req.keys[0].data(),
+                std::min(req.keys[0].size(), kCacheKeySizeBytes));
+
+    ASSERT_EQ(packed.size(), expected.size());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i]) << "Mismatch at Dword " << i;
+    }
+}
+
+TEST_F(KvProtocolPackTest, KeepAliveProtocolPackMatchesProtocol)
+{
+    constexpr std::uint16_t kCid = 0x4444;
+    constexpr std::uint64_t kRespBufferAddr = 0x0000EEEE0000FFFFULL;
+    constexpr std::uint32_t kRespMrKey = 0x55555555;
+    constexpr bool kRflag = true;
+
+    KvKeepAliveRequest req;
+    req.cid = kCid;
+    req.response_buffer_addr = kRespBufferAddr;
+    req.response_mr_key = kRespMrKey;
+    req.rflag = kRflag;
+
+    KvKeepAliveProtocol proto;
+    std::vector<std::uint32_t> packed(proto.PackedSize(req) / sizeof(std::uint32_t), 0);
+    auto status = proto.PackSqe(req, packed.data());
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint32_t> expected(16, 0);
+    expected[0] = (kCid << 16) | (kRflag ? (1U << 13) : 0) | 0xF4;
+    expected[3] = kRespBufferAddr & 0xFFFFFFFFULL;
+    expected[4] = (kRespBufferAddr >> 32) & 0xFFFFFFFFULL;
+    expected[5] = kRespMrKey;
+
+    ASSERT_EQ(packed.size(), expected.size());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i]) << "Mismatch at Dword " << i;
+    }
+}
+
+TEST_F(KvProtocolPackTest, StoreAndRetrieveUnpackCqe)
+{
+    KvStoreProtocol store_proto;
+    KvResponse resp;
+    std::uint32_t cqe_data[4] = {0, 0, 0, 0};
+    cqe_data[3] = 0x1234 | (0 << 17);
+    auto status = store_proto.UnpackCqe(cqe_data, 0, resp);
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(resp.cid, 0x1234);
+    EXPECT_EQ(resp.status, 0);
+
+    KvRetrieveProtocol retrieve_proto;
+    status = retrieve_proto.UnpackCqe(cqe_data, 0, resp);
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(resp.cid, 0x1234);
+    EXPECT_EQ(resp.status, 0);
+}
+
+TEST_F(KvProtocolPackTest, BatchStoreUnpackCqe)
+{
+    KvResponse resp;
+    std::uint32_t cqe_data[8] = {0, 0, 0, 0, 0, 0, 0, 0};
+    cqe_data[3] = 0x1234 | (0 << 17);
+
+    KvBatchStoreProtocol proto;
+    auto status = proto.UnpackCqe(cqe_data, 2, resp);
+    ASSERT_TRUE(status.ok());
+    EXPECT_EQ(resp.cid, 0x1234);
+}
+
+TEST_F(KvProtocolPackTest, ExistUnpackCqe)
+{
+    KvResponse resp;
+    std::uint32_t cqe_data[8] = {0x0005, 0, 0, 0x1234, 0, 0, 0, 0};
+
+    KvExistProtocol proto;
+    auto status = proto.UnpackCqe(cqe_data, 3, resp);
+    ASSERT_TRUE(status.ok());
+    EXPECT_EQ(resp.cid, 0x1234);
+    EXPECT_EQ(resp.existing_key_number, 5);
+}
+
+TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsZeroBufferAddr)
+{
+    KvStoreRequest req;
+    req.buffer_addr = 0;
+    req.buffer_length = 512;
+    req.offset = 0;
+    req.length = 1;
+    req.key = MakeCacheKey("key");
+
+    KvStoreProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("buffer_addr is zero"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsZeroBufferLength)
+{
+    KvStoreRequest req;
+    req.buffer_addr = 0x1000;
+    req.buffer_length = 0;
+    req.offset = 0;
+    req.length = 1;
+    req.key = MakeCacheKey("key");
+
+    KvStoreProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("buffer_length is zero"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsUnalignedBufferLength)
+{
+    KvStoreRequest req;
+    req.buffer_addr = 0x1000;
+    req.buffer_length = 100;
+    req.offset = 0;
+    req.length = 1;
+    req.key = MakeCacheKey("key");
+
+    KvStoreProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("512B aligned"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsAllZeroKey)
+{
+    KvStoreRequest req;
+    req.buffer_addr = 0x1000;
+    req.buffer_length = 512;
+    req.offset = 0;
+    req.length = 1;
+    req.key = CacheKey{};
+
+    KvStoreProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("all zeros"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsDtypeOverflow)
+{
+    KvStoreRequest req;
+    req.buffer_addr = 0x1000;
+    req.buffer_length = 512;
+    req.offset = 0;
+    req.length = 1;
+    req.key = MakeCacheKey("key");
+    req.dtype = 8;
+
+    KvStoreProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("dtype("), std::string::npos);
+    EXPECT_NE(status.message.find("exceeds 3-bit limit"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsDspecOverflow)
+{
+    KvStoreRequest req;
+    req.buffer_addr = 0x1000;
+    req.buffer_length = 512;
+    req.offset = 0;
+    req.length = 1;
+    req.key = MakeCacheKey("key");
+    req.dspec = 32;
+
+    KvStoreProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("dspec("), std::string::npos);
+    EXPECT_NE(status.message.find("exceeds 5-bit limit"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, StoreValidateRequestAcceptsValidRequest)
+{
+    KvStoreRequest req;
+    req.buffer_addr = 0x1000;
+    req.buffer_length = 512;
+    req.offset = 0;
+    req.length = 1;
+    req.key = MakeCacheKey("valid_key");
+    req.dtype = 1;
+    req.dspec = 5;
+
+    KvStoreProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_TRUE(status.ok()) << status.message;
+}
+
+TEST_F(KvProtocolPackTest, BatchStoreValidateRequestRejectsZeroBatchNumber)
+{
+    KvBatchStoreRequest req;
+    req.batch_number = 0;
+
+    KvBatchStoreProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("batch_number("), std::string::npos);
+    EXPECT_NE(status.message.find("must be in range"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, BatchStoreValidateRequestRejectsRflagWithZeroResponseAddr)
+{
+    KvBatchStoreRequest req;
+    req.batch_number = 1;
+    req.rflag = true;
+    req.response_buffer_addr = 0;
+    req.entries.resize(1);
+    req.entries[0].key = MakeCacheKey("key");
+
+    KvBatchStoreProtocol proto;
+    std::vector<std::uint32_t> target(64, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("response_buffer_addr is zero"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, BatchStoreValidateRequestRejectsUnalignedLength)
+{
+    KvBatchStoreRequest req;
+    req.batch_number = 1;
+    req.entries.resize(1);
+    req.entries[0].key = MakeCacheKey("key");
+    req.entries[0].offset = 0;
+    req.entries[0].buffer_addr = 0x1000;
+    req.entries[0].length = 100;
+
+    KvBatchStoreProtocol proto;
+    std::vector<std::uint32_t> target(64, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("512B aligned"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, BatchStoreValidateRequestRejectsAllZeroKey)
+{
+    KvBatchStoreRequest req;
+    req.batch_number = 1;
+    req.entries.resize(1);
+    req.entries[0].key = CacheKey{};
+    req.entries[0].offset = 0;
+    req.entries[0].buffer_addr = 0x1000;
+    req.entries[0].length = 512;
+
+    KvBatchStoreProtocol proto;
+    std::vector<std::uint32_t> target(64, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("all zeros"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, KeepAliveValidateRequestRejectsRflagWithZeroResponseAddr)
+{
+    KvKeepAliveRequest req;
+    req.rflag = true;
+    req.response_buffer_addr = 0;
+
+    KvKeepAliveProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("response_buffer_addr is zero"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, KeepAliveValidateRequestAcceptsNoRflag)
+{
+    KvKeepAliveRequest req;
+    req.rflag = false;
+    req.response_buffer_addr = 0;
+
+    KvKeepAliveProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_TRUE(status.ok()) << status.message;
+}
+
+TEST_F(KvProtocolPackTest, BatchStoreUnpackCqeResultBuffer)
+{
+    KvResponse resp;
+    std::uint32_t cqe_data[8] = {0};
+    cqe_data[3] = 0x5678 | (0x123 << 17);
+    cqe_data[4] = 0x0 | (0x1 << 4) | (0x3 << 8);
+
+    KvBatchStoreProtocol proto;
+    auto status = proto.UnpackCqe(cqe_data, 3, resp);
+    ASSERT_TRUE(status.ok());
+    EXPECT_EQ(resp.cid, 0x5678);
+    EXPECT_EQ(resp.status, 0x123);
+    ASSERT_EQ(resp.result_buffer.size(), 3);
+    EXPECT_EQ(resp.result_buffer[0], 0x0);
+    EXPECT_EQ(resp.result_buffer[1], 0x1);
+    EXPECT_EQ(resp.result_buffer[2], 0x3);
+}
+
+TEST_F(KvProtocolPackTest, BatchRetrieveUnpackCqe)
+{
+    KvResponse resp;
+    std::uint32_t cqe_data[8] = {0};
+    cqe_data[3] = 0x9ABC | (0x456 << 17);
+    cqe_data[4] = 0x2 | (0x0 << 4);
+
+    KvBatchRetrieveProtocol proto;
+    auto status = proto.UnpackCqe(cqe_data, 2, resp);
+    ASSERT_TRUE(status.ok());
+    EXPECT_EQ(resp.cid, 0x9ABC);
+    EXPECT_EQ(resp.status, 0x456);
+    ASSERT_EQ(resp.result_buffer.size(), 2);
+    EXPECT_EQ(resp.result_buffer[0], 0x2);
+    EXPECT_EQ(resp.result_buffer[1], 0x0);
+}
+
+TEST_F(KvProtocolPackTest, DeleteUnpackCqe)
+{
+    KvResponse resp;
+    std::uint32_t cqe_data[8] = {0};
+    cqe_data[3] = 0xDEF0;
+    cqe_data[4] = 0x5;
+
+    KvDeleteProtocol proto;
+    auto status = proto.UnpackCqe(cqe_data, 3, resp);
+    ASSERT_TRUE(status.ok());
+    EXPECT_EQ(resp.cid, 0xDEF0);
+    ASSERT_EQ(resp.result_buffer.size(), 3);
+    EXPECT_EQ(resp.result_buffer[0], 1);
+    EXPECT_EQ(resp.result_buffer[1], 0);
+    EXPECT_EQ(resp.result_buffer[2], 1);
+}
+
+TEST_F(KvProtocolPackTest, ExistUnpackCqeResultBuffer)
+{
+    KvResponse resp;
+    std::uint32_t cqe_data[8] = {0};
+    cqe_data[0] = 0x000A;
+    cqe_data[3] = 0x1111;
+    cqe_data[4] = 0x3;
+
+    KvExistProtocol proto;
+    auto status = proto.UnpackCqe(cqe_data, 2, resp);
+    ASSERT_TRUE(status.ok());
+    EXPECT_EQ(resp.cid, 0x1111);
+    EXPECT_EQ(resp.existing_key_number, 0x000A);
+    ASSERT_EQ(resp.result_buffer.size(), 2);
+    EXPECT_EQ(resp.result_buffer[0], 1);
+    EXPECT_EQ(resp.result_buffer[1], 1);
+}
+
+TEST_F(KvProtocolPackTest, BatchStoreUnpackCqeCrossDword)
+{
+    KvResponse resp;
+    std::uint32_t cqe_data[8] = {0};
+    cqe_data[3] = 0x2222;
+    cqe_data[4] = 0xFFFFFFFF;
+    cqe_data[5] = 0x4;
+
+    KvBatchStoreProtocol proto;
+    auto status = proto.UnpackCqe(cqe_data, 9, resp);
+    ASSERT_TRUE(status.ok());
+    EXPECT_EQ(resp.cid, 0x2222);
+    ASSERT_EQ(resp.result_buffer.size(), 9);
+    for (int i = 0; i < 8; ++i) { EXPECT_EQ(resp.result_buffer[i], 0xF) << "key " << i; }
+    EXPECT_EQ(resp.result_buffer[8], 0x4);
+}
+
+TEST_F(KvProtocolPackTest, DeleteUnpackCqeSingleKey)
+{
+    KvResponse resp;
+    std::uint32_t cqe_data[8] = {0};
+    cqe_data[3] = 0x3333;
+    cqe_data[4] = 0x1;
+
+    KvDeleteProtocol proto;
+    auto status = proto.UnpackCqe(cqe_data, 1, resp);
+    ASSERT_TRUE(status.ok());
+    EXPECT_EQ(resp.cid, 0x3333);
+    ASSERT_EQ(resp.result_buffer.size(), 1);
+    EXPECT_EQ(resp.result_buffer[0], 1);
+}
+
+TEST_F(KvProtocolPackTest, RetrieveValidateRequestAcceptsValid)
+{
+    KvRetrieveRequest req;
+    req.buffer_addr = 0x2000;
+    req.buffer_length = 1024;
+    req.offset = 512;
+    req.length = 512;
+    req.key = MakeCacheKey("retrieve_key");
+
+    KvRetrieveProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_TRUE(status.ok()) << status.message;
+}
+
+TEST_F(KvProtocolPackTest, RetrieveValidateRequestRejectsZeroBufferAddr)
+{
+    KvRetrieveRequest req;
+    req.buffer_addr = 0;
+    req.buffer_length = 1024;
+    req.offset = 0;
+    req.length = 1;
+    req.key = MakeCacheKey("key");
+
+    KvRetrieveProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("buffer_addr is zero"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, RetrieveValidateRequestRejectsUnalignedBufferLength)
+{
+    KvRetrieveRequest req;
+    req.buffer_addr = 0x2000;
+    req.buffer_length = 100;
+    req.offset = 512;
+    req.length = 512;
+    req.key = MakeCacheKey("retrieve_key");
+
+    KvRetrieveProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("512B aligned"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, RetrieveValidateRequestRejectsAllZeroKey)
+{
+    KvRetrieveRequest req;
+    req.buffer_addr = 0x2000;
+    req.buffer_length = 1024;
+    req.offset = 512;
+    req.length = 512;
+    req.key = CacheKey{};
+
+    KvRetrieveProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("all zeros"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, BatchRetrieveValidateRequestAcceptsValid)
+{
+    KvBatchRetrieveRequest req;
+    req.batch_number = 2;
+    req.entries.resize(2);
+    req.entries[0].key = MakeCacheKey("key1");
+    req.entries[0].offset = 0;
+    req.entries[0].buffer_addr = 0x1000;
+    req.entries[0].length = 512;
+    req.entries[1].key = MakeCacheKey("key2");
+    req.entries[1].offset = 512;
+    req.entries[1].buffer_addr = 0x2000;
+    req.entries[1].length = 512;
+
+    KvBatchRetrieveProtocol proto;
+    std::vector<std::uint32_t> target(64, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_TRUE(status.ok()) << status.message;
+}
+
+TEST_F(KvProtocolPackTest, BatchRetrieveValidateRequestRejectsMismatch)
+{
+    KvBatchRetrieveRequest req;
+    req.batch_number = 3;
+    req.entries.resize(2);
+
+    KvBatchRetrieveProtocol proto;
+    std::vector<std::uint32_t> target(64, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("must equal entries.size()"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, BatchRetrieveValidateRequestRejectsUnalignedLength)
+{
+    KvBatchRetrieveRequest req;
+    req.batch_number = 1;
+    req.entries.resize(1);
+    req.entries[0].key = MakeCacheKey("key");
+    req.entries[0].offset = 0;
+    req.entries[0].buffer_addr = 0x1000;
+    req.entries[0].length = 100;
+
+    KvBatchRetrieveProtocol proto;
+    std::vector<std::uint32_t> target(64, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("512B aligned"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, BatchRetrieveValidateRequestRejectsAllZeroKey)
+{
+    KvBatchRetrieveRequest req;
+    req.batch_number = 1;
+    req.entries.resize(1);
+    req.entries[0].key = CacheKey{};
+    req.entries[0].offset = 0;
+    req.entries[0].buffer_addr = 0x1000;
+    req.entries[0].length = 512;
+
+    KvBatchRetrieveProtocol proto;
+    std::vector<std::uint32_t> target(64, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("all zeros"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, DeleteValidateRequestAcceptsValid)
+{
+    KvDeleteRequest req;
+    req.batch_number = 2;
+    req.keys = {MakeCacheKey("key1"), MakeCacheKey("key2")};
+
+    KvDeleteProtocol proto;
+    std::vector<std::uint32_t> target(32, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_TRUE(status.ok()) << status.message;
+}
+
+TEST_F(KvProtocolPackTest, DeleteValidateRequestRejectsAllZeroKey)
+{
+    KvDeleteRequest req;
+    req.batch_number = 2;
+    req.keys = {MakeCacheKey("key1"), CacheKey{}};
+
+    KvDeleteProtocol proto;
+    std::vector<std::uint32_t> target(32, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("all zeros"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, ExistValidateRequestAcceptsValid)
+{
+    KvExistRequest req;
+    req.batch_number = 1;
+    req.keys = {MakeCacheKey("exist_key")};
+
+    KvExistProtocol proto;
+    std::vector<std::uint32_t> target(32, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_TRUE(status.ok()) << status.message;
+}
+
+TEST_F(KvProtocolPackTest, ExistValidateRequestRejectsBatchNumberOverflow)
+{
+    KvExistRequest req;
+    req.batch_number = 300;
+    req.keys.resize(300, MakeCacheKey("key"));
+
+    KvExistProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("must be in range"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, ExistValidateRequestRejectsAllZeroKey)
+{
+    KvExistRequest req;
+    req.batch_number = 1;
+    req.keys = {CacheKey{}};
+
+    KvExistProtocol proto;
+    std::vector<std::uint32_t> target(32, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("all zeros"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsZeroLength)
+{
+    KvStoreRequest req;
+    req.buffer_addr = 0x1000;
+    req.buffer_length = 512;
+    req.offset = 0;
+    req.length = 0;
+    req.key = MakeCacheKey("key");
+
+    KvStoreProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("must be non-zero"), std::string::npos);
+}
+
+TEST_F(KvProtocolPackTest, StoreValidateRequestRejectsUnalignedOffset)
+{
+    KvStoreRequest req;
+    req.buffer_addr = 0x1000;
+    req.buffer_length = 512;
+    req.offset = 100;
+    req.length = 1;
+    req.key = MakeCacheKey("key");
+
+    KvStoreProtocol proto;
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = proto.PackSqe(req, target.data());
+    EXPECT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("512B aligned"), std::string::npos);
+}
+
+class ProtocolManagerTest : public ::testing::Test {
+protected:
+    void SetUp() override { mgr_ = std::make_unique<ProtocolManager>(); }
+
+    std::unique_ptr<ProtocolManager> mgr_;
+};
+
+TEST_F(ProtocolManagerTest, PackStoreRequest)
+{
+    KvStoreRequest req;
+    req.cid = 0x1234;
+    req.kv_ns_id = 1;
+    req.dtype = 1;
+    req.dspec = 5;
+    req.buffer_addr = 0x1000;
+    req.buffer_length = 512;
+    req.mr_key = 0xABCD;
+    req.offset = 0;
+    req.length = 1;
+    req.key = MakeCacheKey("test_key");
+
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = mgr_->PackRequest(target.data(), KvOpcode::Store, req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    EXPECT_EQ(target[0] & 0xFF, 0x01);
+    EXPECT_EQ((target[0] >> 16) & 0xFFFF, 0x1234);
+    EXPECT_EQ(target[1], 1);
+}
+
+TEST_F(ProtocolManagerTest, PackBatchStoreRequest)
+{
+    KvBatchStoreRequest req;
+    req.cid = 0x5678;
+    req.kv_ns_id = 2;
+    req.dtype = 1;
+    req.dspec = 0;
+    req.response_buffer_addr = 0x2000;
+    req.response_mr_key = 0x1111;
+    req.rflag = true;
+    req.batch_number = 2;
+    req.entries.resize(2);
+    req.entries[0].key = MakeCacheKey("key1");
+    req.entries[0].offset = 0;
+    req.entries[0].buffer_addr = 0x3000;
+    req.entries[0].length = 512;
+    req.entries[1].key = MakeCacheKey("key2");
+    req.entries[1].offset = 512;
+    req.entries[1].buffer_addr = 0x4000;
+    req.entries[1].length = 512;
+
+    std::vector<std::uint32_t> target(64, 0);
+    auto status = mgr_->PackRequest(target.data(), KvOpcode::BatchStore, req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    EXPECT_EQ(target[0] & 0xFF, 0x45);
+    EXPECT_EQ((target[0] >> 16) & 0xFFFF, 0x5678);
+    EXPECT_EQ(target[10], 2);
+}
+
+TEST_F(ProtocolManagerTest, PackKeepAliveRequest)
+{
+    KvKeepAliveRequest req;
+    req.cid = 0xAAAA;
+    req.response_buffer_addr = 0x5000;
+    req.response_mr_key = 0x2222;
+    req.rflag = true;
+
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = mgr_->PackRequest(target.data(), KvOpcode::KeepAlive, req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    EXPECT_EQ(target[0] & 0xFF, 0xF4);
+    EXPECT_EQ((target[0] >> 16) & 0xFFFF, 0xAAAA);
+}
+
+TEST_F(ProtocolManagerTest, PackRequestRejectsInvalidRequest)
+{
+    KvStoreRequest req;
+    req.buffer_addr = 0;
+    req.buffer_length = 512;
+    req.offset = 0;
+    req.length = 1;
+    req.key = MakeCacheKey("key");
+
+    std::vector<std::uint32_t> target(16, 0);
+    auto status = mgr_->PackRequest(target.data(), KvOpcode::Store, req);
+    ASSERT_FALSE(status.ok());
+    EXPECT_NE(status.message.find("buffer_addr is zero"), std::string::npos);
+}
+
+TEST_F(ProtocolManagerTest, PollResponseCid)
+{
+    std::uint32_t cqe_data[8] = {0};
+    cqe_data[3] = 0x9ABC | (0x123 << 17);
+
+    std::uint16_t cid = 0;
+    auto status = mgr_->PollResponseCid(cqe_data, cid);
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(cid, 0x9ABC);
+}
+
+TEST_F(ProtocolManagerTest, UnpackBatchStoreResponse)
+{
+    std::uint32_t cqe_data[8] = {0};
+    cqe_data[3] = 0x1111 | (0x456 << 17);
+    cqe_data[4] = 0x0 | (0x1 << 4) | (0x3 << 8);
+
+    KvResponse resp;
+    auto status = mgr_->UnpackResponse(cqe_data, KvOpcode::BatchStore, 3, resp);
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(resp.cid, 0x1111);
+    EXPECT_EQ(resp.status, 0x456);
+    ASSERT_EQ(resp.result_buffer.size(), 3);
+    EXPECT_EQ(resp.result_buffer[0], 0x0);
+    EXPECT_EQ(resp.result_buffer[1], 0x1);
+    EXPECT_EQ(resp.result_buffer[2], 0x3);
+}
+
+TEST_F(ProtocolManagerTest, UnpackDeleteResponse)
+{
+    std::uint32_t cqe_data[8] = {0};
+    cqe_data[3] = 0x2222;
+    cqe_data[4] = 0x5;
+
+    KvResponse resp;
+    auto status = mgr_->UnpackResponse(cqe_data, KvOpcode::Delete, 3, resp);
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(resp.cid, 0x2222);
+    ASSERT_EQ(resp.result_buffer.size(), 3);
+    EXPECT_EQ(resp.result_buffer[0], 1);
+    EXPECT_EQ(resp.result_buffer[1], 0);
+    EXPECT_EQ(resp.result_buffer[2], 1);
+}
+
+TEST_F(ProtocolManagerTest, UnpackExistResponse)
+{
+    std::uint32_t cqe_data[8] = {0};
+    cqe_data[0] = 0x0003;
+    cqe_data[3] = 0x3333;
+    cqe_data[4] = 0x7;
+
+    KvResponse resp;
+    auto status = mgr_->UnpackResponse(cqe_data, KvOpcode::Exist, 3, resp);
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(resp.cid, 0x3333);
+    EXPECT_EQ(resp.existing_key_number, 3);
+    ASSERT_EQ(resp.result_buffer.size(), 3);
+    EXPECT_EQ(resp.result_buffer[0], 1);
+    EXPECT_EQ(resp.result_buffer[1], 1);
+    EXPECT_EQ(resp.result_buffer[2], 1);
+}
+
+TEST_F(ProtocolManagerTest, GetPackedSizeReturnsCorrectValue)
+{
+    KvStoreRequest store_req;
+    store_req.key = MakeCacheKey("key");
+    EXPECT_EQ(mgr_->GetPackedSize(KvOpcode::Store, store_req), 64);
+
+    KvBatchStoreRequest batch_req;
+    batch_req.batch_number = 3;
+    batch_req.entries.resize(3);
+    EXPECT_EQ(mgr_->GetPackedSize(KvOpcode::BatchStore, batch_req), (16 + 3 * 9) * 4);
+}
+
+TEST_F(ProtocolManagerTest, EndToEndPackAndUnpack)
+{
+    KvBatchStoreRequest req;
+    req.cid = 0xBEEF;
+    req.kv_ns_id = 1;
+    req.batch_number = 2;
+    req.response_buffer_addr = 0x8000;
+    req.response_mr_key = 0x3333;
+    req.rflag = true;
+    req.entries.resize(2);
+    req.entries[0].key = MakeCacheKey("key_a");
+    req.entries[0].offset = 0;
+    req.entries[0].buffer_addr = 0x9000;
+    req.entries[0].length = 512;
+    req.entries[1].key = MakeCacheKey("key_b");
+    req.entries[1].offset = 512;
+    req.entries[1].buffer_addr = 0xA000;
+    req.entries[1].length = 512;
+
+    std::vector<std::uint32_t> send_data(64, 0);
+    auto pack_status = mgr_->PackRequest(send_data.data(), KvOpcode::BatchStore, req);
+    ASSERT_TRUE(pack_status.ok()) << pack_status.message;
+
+    EXPECT_EQ(send_data[0] & 0xFF, 0x45);
+    EXPECT_EQ((send_data[0] >> 16) & 0xFFFF, 0xBEEF);
+
+    std::uint32_t flag_data[8] = {0};
+    flag_data[3] = 0xBEEF | (0 << 17);
+    flag_data[4] = 0x0 | (0x0 << 4);
+
+    std::uint16_t polled_cid = 0;
+    auto poll_status = mgr_->PollResponseCid(flag_data, polled_cid);
+    ASSERT_TRUE(poll_status.ok());
+    EXPECT_EQ(polled_cid, 0xBEEF);
+
+    KvResponse resp;
+    auto unpack_status = mgr_->UnpackResponse(flag_data, KvOpcode::BatchStore, 2, resp);
+    ASSERT_TRUE(unpack_status.ok()) << unpack_status.message;
+    EXPECT_EQ(resp.cid, 0xBEEF);
+    EXPECT_EQ(resp.status, 0);
+    ASSERT_EQ(resp.result_buffer.size(), 2);
+    EXPECT_EQ(resp.result_buffer[0], 0x0);
+    EXPECT_EQ(resp.result_buffer[1], 0x0);
+}
+
+class KvProtocolVerifyTest : public ::testing::Test {
+protected:
+    void SetUp() override { mgr_ = std::make_unique<ProtocolManager>(); }
+    void TearDown() override {}
+
+    std::unique_ptr<ProtocolManager> mgr_;
+
+    static std::vector<std::uint32_t> PackStore(std::uint16_t cid = 0x1234, std::uint32_t ns = 1,
+                                                std::uint8_t dtype = 1, std::uint8_t dspec = 5)
+    {
+        KvStoreRequest req;
+        req.cid = cid;
+        req.kv_ns_id = ns;
+        req.dtype = dtype;
+        req.dspec = dspec;
+        req.buffer_addr = 0x123456789ABCULL;
+        req.buffer_length = 0x10000;
+        req.mr_key = 0x76543210;
+        req.offset = 0x1000;
+        req.lr = true;
+        req.length = 2;
+        req.key = MakeCacheKey("test_key_01");
+        KvStoreProtocol proto;
+        std::vector<std::uint32_t> buf(16, 0);
+        auto s = proto.PackSqe(req, buf.data());
+        EXPECT_TRUE(s.ok()) << s.message;
+        return buf;
+    }
+
+    static std::vector<std::uint32_t> PackRetrieve()
+    {
+        KvRetrieveRequest req;
+        req.cid = 0x5678;
+        req.kv_ns_id = 2;
+        req.buffer_addr = 0xFEDCBA987654ULL;
+        req.buffer_length = 0x20000;
+        req.mr_key = 0x12345678;
+        req.offset = 0x2000;
+        req.lr = false;
+        req.length = 3;
+        req.key = MakeCacheKey("retrieve_key");
+        KvRetrieveProtocol proto;
+        std::vector<std::uint32_t> buf(16, 0);
+        auto s = proto.PackSqe(req, buf.data());
+        EXPECT_TRUE(s.ok()) << s.message;
+        return buf;
+    }
+
+    static std::vector<std::uint32_t> PackBatchStore(std::uint16_t batch_n = 2, bool rflag = false)
+    {
+        KvBatchStoreRequest req;
+        req.cid = 0xABCD;
+        req.kv_ns_id = 3;
+        req.dtype = 2;
+        req.dspec = 10;
+        req.response_buffer_addr = rflag ? 0xAAAA0000ULL : 0;
+        req.response_mr_key = rflag ? 0x1111 : 0;
+        req.lr = false;
+        req.rflag = rflag;
+        req.batch_number = batch_n;
+        for (std::uint16_t i = 0; i < batch_n; ++i) {
+            KvBatchStoreEntry e;
+            e.offset = (i + 1) * 512;
+            e.key = MakeCacheKey(static_cast<std::uint64_t>(0xB500 + i));
+            e.buffer_addr = 0xBBBB0000ULL + i * 0x1000;
+            e.mr_key = 0x2222 + i;
+            e.length = 512;
+            req.entries.push_back(e);
+        }
+        KvBatchStoreProtocol proto;
+        std::size_t sz = proto.PackedSize(req) / sizeof(std::uint32_t);
+        std::vector<std::uint32_t> buf(sz, 0);
+        auto s = proto.PackSqe(req, buf.data());
+        EXPECT_TRUE(s.ok()) << s.message;
+        return buf;
+    }
+
+    static std::vector<std::uint32_t> PackBatchRetrieve(std::uint16_t batch_n = 2,
+                                                        bool rflag = false)
+    {
+        KvBatchRetrieveRequest req;
+        req.cid = 0xDCBA;
+        req.kv_ns_id = 4;
+        req.response_buffer_addr = rflag ? 0xCCCC0000ULL : 0;
+        req.response_mr_key = rflag ? 0x3333 : 0;
+        req.lr = false;
+        req.rflag = rflag;
+        req.batch_number = batch_n;
+        for (std::uint16_t i = 0; i < batch_n; ++i) {
+            KvBatchRetrieveEntry e;
+            e.offset = (i + 1) * 512;
+            e.key = MakeCacheKey(static_cast<std::uint64_t>(0xB600 + i));
+            e.buffer_addr = 0xDDDD0000ULL + i * 0x1000;
+            e.mr_key = 0x4444 + i;
+            e.length = 512;
+            req.entries.push_back(e);
+        }
+        KvBatchRetrieveProtocol proto;
+        std::size_t sz = proto.PackedSize(req) / sizeof(std::uint32_t);
+        std::vector<std::uint32_t> buf(sz, 0);
+        auto s = proto.PackSqe(req, buf.data());
+        EXPECT_TRUE(s.ok()) << s.message;
+        return buf;
+    }
+
+    static std::vector<std::uint32_t> PackDelete(std::uint16_t batch_n = 3, bool rflag = false)
+    {
+        KvDeleteRequest req;
+        req.cid = 0x1111;
+        req.kv_ns_id = 5;
+        req.response_buffer_addr = rflag ? 0xEEEE0000ULL : 0;
+        req.response_mr_key = rflag ? 0x5555 : 0;
+        req.rflag = rflag;
+        req.batch_number = batch_n;
+        for (std::uint16_t i = 0; i < batch_n; ++i) {
+            req.keys.push_back(MakeCacheKey(static_cast<std::uint64_t>(0xD000 + i)));
+        }
+        KvDeleteProtocol proto;
+        std::size_t sz = proto.PackedSize(req) / sizeof(std::uint32_t);
+        std::vector<std::uint32_t> buf(sz, 0);
+        auto s = proto.PackSqe(req, buf.data());
+        EXPECT_TRUE(s.ok()) << s.message;
+        return buf;
+    }
+
+    static std::vector<std::uint32_t> PackExist(std::uint16_t batch_n = 3, bool rflag = false,
+                                                bool sc = false)
+    {
+        KvExistRequest req;
+        req.cid = 0x2222;
+        req.kv_ns_id = 6;
+        req.response_buffer_addr = rflag ? 0xFFFF0000ULL : 0;
+        req.response_mr_key = rflag ? 0x6666 : 0;
+        req.rflag = rflag;
+        req.sc = sc;
+        req.batch_number = batch_n;
+        for (std::uint16_t i = 0; i < batch_n; ++i) {
+            req.keys.push_back(MakeCacheKey(static_cast<std::uint64_t>(0xE000 + i)));
+        }
+        KvExistProtocol proto;
+        std::size_t sz = proto.PackedSize(req) / sizeof(std::uint32_t);
+        std::vector<std::uint32_t> buf(sz, 0);
+        auto s = proto.PackSqe(req, buf.data());
+        EXPECT_TRUE(s.ok()) << s.message;
+        return buf;
+    }
+
+    static std::vector<std::uint32_t> PackKeepAlive(bool rflag = false)
+    {
+        KvKeepAliveRequest req;
+        req.cid = 0x3333;
+        req.response_buffer_addr = rflag ? 0xAAAA0000ULL : 0;
+        req.response_mr_key = rflag ? 0x7777 : 0;
+        req.rflag = rflag;
+        KvKeepAliveProtocol proto;
+        std::vector<std::uint32_t> buf(16, 0);
+        auto s = proto.PackSqe(req, buf.data());
+        EXPECT_TRUE(s.ok()) << s.message;
+        return buf;
+    }
+};
+
+// ── Valid pack-then-verify for all 7 protocols ──
+
+TEST_F(KvProtocolVerifyTest, StoreValidPackedBufferPasses)
+{
+    auto buf = PackStore();
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_TRUE(s.ok()) << s.message;
+}
+
+TEST_F(KvProtocolVerifyTest, RetrieveValidPackedBufferPasses)
+{
+    auto buf = PackRetrieve();
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_TRUE(s.ok()) << s.message;
+}
+
+TEST_F(KvProtocolVerifyTest, BatchStoreValidPackedBufferPasses)
+{
+    auto buf = PackBatchStore(2, false);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_TRUE(s.ok()) << s.message;
+}
+
+TEST_F(KvProtocolVerifyTest, BatchStoreWithRflagValidPackedBufferPasses)
+{
+    auto buf = PackBatchStore(3, true);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_TRUE(s.ok()) << s.message;
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveValidPackedBufferPasses)
+{
+    auto buf = PackBatchRetrieve(2, false);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_TRUE(s.ok()) << s.message;
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveWithRflagValidPackedBufferPasses)
+{
+    auto buf = PackBatchRetrieve(4, true);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_TRUE(s.ok()) << s.message;
+}
+
+TEST_F(KvProtocolVerifyTest, DeleteValidPackedBufferPasses)
+{
+    auto buf = PackDelete(3, false);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_TRUE(s.ok()) << s.message;
+}
+
+TEST_F(KvProtocolVerifyTest, DeleteWithRflagValidPackedBufferPasses)
+{
+    auto buf = PackDelete(5, true);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_TRUE(s.ok()) << s.message;
+}
+
+TEST_F(KvProtocolVerifyTest, ExistValidPackedBufferPasses)
+{
+    auto buf = PackExist(3, false, false);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_TRUE(s.ok()) << s.message;
+}
+
+TEST_F(KvProtocolVerifyTest, ExistWithScAndRflagValidPackedBufferPasses)
+{
+    auto buf = PackExist(4, true, true);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_TRUE(s.ok()) << s.message;
+}
+
+TEST_F(KvProtocolVerifyTest, KeepAliveValidPackedBufferPasses)
+{
+    auto buf = PackKeepAlive(false);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_TRUE(s.ok()) << s.message;
+}
+
+TEST_F(KvProtocolVerifyTest, KeepAliveWithRflagValidPackedBufferPasses)
+{
+    auto buf = PackKeepAlive(true);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_TRUE(s.ok()) << s.message;
+}
+
+// ── ProtocolManager dispatch ──
+
+TEST_F(KvProtocolVerifyTest, ManagerRejectsNullPointer)
+{
+    auto s = mgr_->VerifyPackedBuffer(nullptr, 64);
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("invalid data_ptr"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, ManagerRejectsTooSmallLength)
+{
+    std::uint32_t buf[4] = {0};
+    auto s = mgr_->VerifyPackedBuffer(buf, 16);
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("length too small"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, ManagerRejectsUnknownOpcode)
+{
+    std::vector<std::uint32_t> buf(16, 0);
+    buf[0] = 0xFF;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("unknown opcode"), std::string::npos);
+}
+
+// ── Store: length mismatch ──
+
+TEST_F(KvProtocolVerifyTest, StoreRejectsWrongLength)
+{
+    auto buf = PackStore();
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), (buf.size() - 1) * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("length"), std::string::npos);
+}
+
+// ── Store: fixed bits ──
+
+TEST_F(KvProtocolVerifyTest, StoreRejectsBadFixedBits)
+{
+    auto buf = PackStore();
+    buf[0] &= ~(0x3U << 14);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("fixed bits"), std::string::npos);
+}
+
+// ── Store: reserved bits in data[0] ──
+
+TEST_F(KvProtocolVerifyTest, StoreRejectsReservedBitsInDword0)
+{
+    auto buf = PackStore();
+    buf[0] |= (1U << 10);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── Store: reserved bits in data[2] ──
+
+TEST_F(KvProtocolVerifyTest, StoreRejectsReservedBitsInDword2)
+{
+    auto buf = PackStore();
+    buf[2] |= 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── Store: reserved bits in data[3-5] ──
+
+TEST_F(KvProtocolVerifyTest, StoreRejectsReservedBitsInDword3)
+{
+    auto buf = PackStore();
+    buf[3] = 0xDEAD;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── Store: buffer_addr zero ──
+
+TEST_F(KvProtocolVerifyTest, StoreRejectsZeroBufferAddr)
+{
+    auto buf = PackStore();
+    buf[6] = 0;
+    buf[7] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("buffer_addr"), std::string::npos);
+}
+
+// ── Store: buffer_length zero ──
+
+TEST_F(KvProtocolVerifyTest, StoreRejectsZeroBufferLength)
+{
+    auto buf = PackStore();
+    buf[8] &= 0xFF000000U;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("buffer_length"), std::string::npos);
+}
+
+// ── Store: buffer_length not aligned ──
+
+TEST_F(KvProtocolVerifyTest, StoreRejectsUnalignedBufferLength)
+{
+    auto buf = PackStore();
+    buf[8] = (buf[8] & 0xFF000000U) | 0x100;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("512B aligned"), std::string::npos);
+}
+
+// ── Store: DptrType mismatch ──
+
+TEST_F(KvProtocolVerifyTest, StoreRejectsBadDptrType)
+{
+    auto buf = PackStore();
+    buf[9] = (0x01U << 24) | (buf[9] & 0xFFFFFF);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("DptrType"), std::string::npos);
+}
+
+// ── Store: offset not aligned ──
+
+TEST_F(KvProtocolVerifyTest, StoreRejectsUnalignedOffset)
+{
+    auto buf = PackStore();
+    buf[10] = 0x100;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("offset"), std::string::npos);
+}
+
+// ── Store: length zero ──
+
+TEST_F(KvProtocolVerifyTest, StoreRejectsZeroLength)
+{
+    auto buf = PackStore();
+    buf[11] &= 0xFF000000U;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("length"), std::string::npos);
+}
+
+// ── Store: reserved bits in data[11] ──
+
+TEST_F(KvProtocolVerifyTest, StoreRejectsReservedBitsInDword11)
+{
+    auto buf = PackStore();
+    buf[11] |= (1U << 25);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── Store: key all zeros ──
+
+TEST_F(KvProtocolVerifyTest, StoreRejectsAllZeroKey)
+{
+    auto buf = PackStore();
+    buf[12] = 0;
+    buf[13] = 0;
+    buf[14] = 0;
+    buf[15] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("key"), std::string::npos);
+}
+
+// ── Retrieve: length mismatch ──
+
+TEST_F(KvProtocolVerifyTest, RetrieveRejectsWrongLength)
+{
+    auto buf = PackRetrieve();
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), (buf.size() + 1) * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("length"), std::string::npos);
+}
+
+// ── Retrieve: reserved bits in data[2] ──
+
+TEST_F(KvProtocolVerifyTest, RetrieveRejectsReservedBitsInDword2)
+{
+    auto buf = PackRetrieve();
+    buf[2] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── Retrieve: DptrType mismatch ──
+
+TEST_F(KvProtocolVerifyTest, RetrieveRejectsBadDptrType)
+{
+    auto buf = PackRetrieve();
+    buf[9] = (0x01U << 24) | (buf[9] & 0xFFFFFF);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("DptrType"), std::string::npos);
+}
+
+// ── BatchStore: length mismatch ──
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsWrongLength)
+{
+    auto buf = PackBatchStore(2);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), (buf.size() + 4) * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("length"), std::string::npos);
+}
+
+// ── BatchStore: batch_number out of range ──
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsZeroBatchNumber)
+{
+    auto buf = PackBatchStore(2);
+    buf[10] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("batch_number"), std::string::npos);
+}
+
+// ── BatchStore: data[8] mismatch ──
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsData8Mismatch)
+{
+    auto buf = PackBatchStore(2);
+    buf[8] = 0xDEAD;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("data[8]"), std::string::npos);
+}
+
+// ── BatchStore: DptrType mismatch ──
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsBadDptrType)
+{
+    auto buf = PackBatchStore(2);
+    buf[9] = (0x40U << 24);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("DptrType"), std::string::npos);
+}
+
+// ── BatchStore: reserved bits in data[10] ──
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsReservedBitsInDword10)
+{
+    auto buf = PackBatchStore(2);
+    buf[10] |= (1U << 20);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── BatchStore: reserved bits in data[12-15] ──
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsReservedBitsInDword12)
+{
+    auto buf = PackBatchStore(2);
+    buf[12] = 0xBEEF;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── BatchStore: rflag false but response addr non-zero ──
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsRflagFalseWithResponseAddr)
+{
+    auto buf = PackBatchStore(2, false);
+    buf[3] = 0x1234;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+// ── BatchStore: entry key all zeros ──
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsEntryAllZeroKey)
+{
+    auto buf = PackBatchStore(2);
+    std::uint32_t* entry0 = buf.data() + 16;
+    entry0[1] = 0;
+    entry0[2] = 0;
+    entry0[3] = 0;
+    entry0[4] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("key"), std::string::npos);
+}
+
+// ── BatchStore: entry buffer_addr zero ──
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsEntryZeroBufferAddr)
+{
+    auto buf = PackBatchStore(2);
+    std::uint32_t* entry0 = buf.data() + 16;
+    entry0[5] = 0;
+    entry0[6] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("buffer_addr"), std::string::npos);
+}
+
+// ── BatchStore: entry length zero ──
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsEntryZeroLength)
+{
+    auto buf = PackBatchStore(2);
+    std::uint32_t* entry0 = buf.data() + 16;
+    entry0[7] &= 0xFF000000U;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("length"), std::string::npos);
+}
+
+// ── BatchStore: entry DptrType mismatch ──
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsEntryBadDptrType)
+{
+    auto buf = PackBatchStore(2);
+    std::uint32_t* entry0 = buf.data() + 16;
+    entry0[8] = (0x01U << 24) | (entry0[8] & 0xFFFFFF);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("DptrType"), std::string::npos);
+}
+
+// ── BatchRetrieve: reserved bits in data[2] ──
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsReservedBitsInDword2)
+{
+    auto buf = PackBatchRetrieve(2);
+    buf[2] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── BatchRetrieve: data[8] mismatch ──
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsData8Mismatch)
+{
+    auto buf = PackBatchRetrieve(2);
+    buf[8] = 0xBEEF;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("data[8]"), std::string::npos);
+}
+
+// ── BatchRetrieve: entry offset not aligned ──
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsEntryUnalignedOffset)
+{
+    auto buf = PackBatchRetrieve(2);
+    std::uint32_t* entry0 = buf.data() + 16;
+    entry0[0] = 0x100;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("offset"), std::string::npos);
+}
+
+// ── Delete: data[8] mismatch ──
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsData8Mismatch)
+{
+    auto buf = PackDelete(3);
+    buf[8] = 0xDEAD;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("data[8]"), std::string::npos);
+}
+
+// ── Delete: batch_number out of range ──
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsBatchNumberOutOfRange)
+{
+    auto buf = PackDelete(3);
+    buf[10] = 255;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("batch_number"), std::string::npos);
+}
+
+// ── Delete: reserved bits in data[11-15] ──
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsReservedBitsInDword11)
+{
+    auto buf = PackDelete(3);
+    buf[11] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsReservedBitsInDword15)
+{
+    auto buf = PackDelete(3);
+    buf[15] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── Delete: entry key all zeros ──
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsEntryAllZeroKey)
+{
+    auto buf = PackDelete(3);
+    std::uint32_t* entry0 = buf.data() + 16;
+    entry0[0] = 0;
+    entry0[1] = 0;
+    entry0[2] = 0;
+    entry0[3] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("key"), std::string::npos);
+}
+
+// ── Exist: data[8] mismatch ──
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsData8Mismatch)
+{
+    auto buf = PackExist(3);
+    buf[8] = 0xDEAD;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("data[8]"), std::string::npos);
+}
+
+// ── Exist: batch_number out of range ──
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsBatchNumberOutOfRange)
+{
+    auto buf = PackExist(3);
+    buf[10] = 257;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("batch_number"), std::string::npos);
+}
+
+// ── Exist: reserved bits in data[11] ──
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsReservedBitsInDword11)
+{
+    auto buf = PackExist(3);
+    buf[11] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── Exist: reserved bits in data[12-15] ──
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsReservedBitsInDword12)
+{
+    auto buf = PackExist(3);
+    buf[12] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── Exist: reserved bits in data[10] bit17-31 ──
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsReservedBitsInDword10High)
+{
+    auto buf = PackExist(3, false, true);
+    buf[10] |= (1U << 20);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── KeepAlive: length mismatch ──
+
+TEST_F(KvProtocolVerifyTest, KeepAliveRejectsWrongLength)
+{
+    auto buf = PackKeepAlive();
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), (buf.size() + 1) * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("length"), std::string::npos);
+}
+
+// ── KeepAlive: reserved bits in data[0] ──
+
+TEST_F(KvProtocolVerifyTest, KeepAliveRejectsReservedBitsInDword0)
+{
+    auto buf = PackKeepAlive();
+    buf[0] |= (1U << 10);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── KeepAlive: reserved bits in data[14-15] ──
+
+TEST_F(KvProtocolVerifyTest, KeepAliveRejectsReservedBitsBit14)
+{
+    auto buf = PackKeepAlive();
+    buf[0] |= (1U << 14);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── KeepAlive: reserved bits in data[1-2] ──
+
+TEST_F(KvProtocolVerifyTest, KeepAliveRejectsReservedBitsInDword1)
+{
+    auto buf = PackKeepAlive();
+    buf[1] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── KeepAlive: reserved bits in data[6-15] ──
+
+TEST_F(KvProtocolVerifyTest, KeepAliveRejectsReservedBitsInDword6)
+{
+    auto buf = PackKeepAlive();
+    buf[6] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, KeepAliveRejectsReservedBitsInDword15)
+{
+    auto buf = PackKeepAlive();
+    buf[15] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+// ── KeepAlive: rflag false but response addr non-zero ──
+
+TEST_F(KvProtocolVerifyTest, KeepAliveRejectsRflagFalseWithResponseAddr)
+{
+    auto buf = PackKeepAlive(false);
+    buf[3] = 0x1234;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+// ══════════════════════════════════════════════════════════════
+// Supplementary tests for full branch coverage (store.xlsx spec)
+// ══════════════════════════════════════════════════════════════
+
+// ── Retrieve: missing branches ──
+
+TEST_F(KvProtocolVerifyTest, RetrieveRejectsBadFixedBits)
+{
+    auto buf = PackRetrieve();
+    buf[0] &= ~(0x3U << 14);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("fixed bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, RetrieveRejectsReservedBitsInDword0)
+{
+    auto buf = PackRetrieve();
+    buf[0] |= (1U << 10);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, RetrieveRejectsReservedBitsInDword3)
+{
+    auto buf = PackRetrieve();
+    buf[3] = 0xDEAD;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, RetrieveRejectsZeroBufferAddr)
+{
+    auto buf = PackRetrieve();
+    buf[6] = 0;
+    buf[7] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("buffer_addr"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, RetrieveRejectsZeroBufferLength)
+{
+    auto buf = PackRetrieve();
+    buf[8] &= 0xFF000000U;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("buffer_length"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, RetrieveRejectsUnalignedBufferLength)
+{
+    auto buf = PackRetrieve();
+    buf[8] = (buf[8] & 0xFF000000U) | 0x100;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("512B aligned"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, RetrieveRejectsUnalignedOffset)
+{
+    auto buf = PackRetrieve();
+    buf[10] = 0x100;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("offset"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, RetrieveRejectsZeroLength)
+{
+    auto buf = PackRetrieve();
+    buf[11] &= 0xFF000000U;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("length"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, RetrieveRejectsReservedBitsInDword11)
+{
+    auto buf = PackRetrieve();
+    buf[11] |= (1U << 25);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, RetrieveRejectsAllZeroKey)
+{
+    auto buf = PackRetrieve();
+    buf[12] = 0;
+    buf[13] = 0;
+    buf[14] = 0;
+    buf[15] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("key"), std::string::npos);
+}
+
+// ── BatchStore: missing branches ──
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsBadFixedBits)
+{
+    auto buf = PackBatchStore(2);
+    buf[0] &= ~(0x3U << 14);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("fixed bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsReservedBitsInDword0)
+{
+    auto buf = PackBatchStore(2);
+    buf[0] |= (1U << 10);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsReservedBitsInDword2)
+{
+    auto buf = PackBatchStore(2);
+    buf[2] |= 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsReservedBitsInDword6)
+{
+    auto buf = PackBatchStore(2);
+    buf[6] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsRflagSetWithZeroResponseAddr)
+{
+    auto buf = PackBatchStore(2, true);
+    buf[3] = 0;
+    buf[4] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsRflagSetWithZeroResponseMrKey)
+{
+    auto buf = PackBatchStore(2, true);
+    buf[5] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsRflagFalseWithResponseMrKey)
+{
+    auto buf = PackBatchStore(2, false);
+    buf[5] = 0x1234;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsEntryUnalignedOffset)
+{
+    auto buf = PackBatchStore(2);
+    std::uint32_t* entry0 = buf.data() + 16;
+    entry0[0] = 0x100;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("offset"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchStoreRejectsEntryUnalignedLength)
+{
+    auto buf = PackBatchStore(2);
+    std::uint32_t* entry0 = buf.data() + 16;
+    entry0[7] = (entry0[7] & 0xFF000000U) | 0x100;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("512B aligned"), std::string::npos);
+}
+
+// ── BatchRetrieve: missing branches ──
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsBadFixedBits)
+{
+    auto buf = PackBatchRetrieve(2);
+    buf[0] &= ~(0x3U << 14);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("fixed bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsReservedBitsInDword0)
+{
+    auto buf = PackBatchRetrieve(2);
+    buf[0] |= (1U << 10);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsReservedBitsInDword6)
+{
+    auto buf = PackBatchRetrieve(2);
+    buf[6] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsRflagSetWithZeroResponseAddr)
+{
+    auto buf = PackBatchRetrieve(2, true);
+    buf[3] = 0;
+    buf[4] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsRflagSetWithZeroResponseMrKey)
+{
+    auto buf = PackBatchRetrieve(2, true);
+    buf[5] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsRflagFalseWithResponseAddr)
+{
+    auto buf = PackBatchRetrieve(2, false);
+    buf[3] = 0x1234;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsRflagFalseWithResponseMrKey)
+{
+    auto buf = PackBatchRetrieve(2, false);
+    buf[5] = 0x1234;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsBadDptrType)
+{
+    auto buf = PackBatchRetrieve(2);
+    buf[9] = (0x40U << 24);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("DptrType"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsReservedBitsInDword10)
+{
+    auto buf = PackBatchRetrieve(2);
+    buf[10] |= (1U << 20);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsZeroBatchNumber)
+{
+    auto buf = PackBatchRetrieve(2);
+    buf[10] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("batch_number"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsWrongLength)
+{
+    auto buf = PackBatchRetrieve(2);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), (buf.size() + 4) * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("length"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsReservedBitsInDword11)
+{
+    auto buf = PackBatchRetrieve(2);
+    buf[11] |= (1U << 10);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsEntryAllZeroKey)
+{
+    auto buf = PackBatchRetrieve(2);
+    std::uint32_t* entry0 = buf.data() + 16;
+    entry0[1] = 0;
+    entry0[2] = 0;
+    entry0[3] = 0;
+    entry0[4] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("key"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsEntryZeroBufferAddr)
+{
+    auto buf = PackBatchRetrieve(2);
+    std::uint32_t* entry0 = buf.data() + 16;
+    entry0[5] = 0;
+    entry0[6] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("buffer_addr"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsEntryZeroLength)
+{
+    auto buf = PackBatchRetrieve(2);
+    std::uint32_t* entry0 = buf.data() + 16;
+    entry0[7] &= 0xFF000000U;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("length"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsEntryUnalignedLength)
+{
+    auto buf = PackBatchRetrieve(2);
+    std::uint32_t* entry0 = buf.data() + 16;
+    entry0[7] = (entry0[7] & 0xFF000000U) | 0x100;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("512B aligned"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, BatchRetrieveRejectsEntryBadDptrType)
+{
+    auto buf = PackBatchRetrieve(2);
+    std::uint32_t* entry0 = buf.data() + 16;
+    entry0[8] = (0x01U << 24) | (entry0[8] & 0xFFFFFF);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("DptrType"), std::string::npos);
+}
+
+// ── Delete: missing branches ──
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsBadFixedBits)
+{
+    auto buf = PackDelete(3);
+    buf[0] &= ~(0x3U << 14);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("fixed bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsReservedBitsInDword0)
+{
+    auto buf = PackDelete(3);
+    buf[0] |= (1U << 10);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsReservedBitsInDword2)
+{
+    auto buf = PackDelete(3);
+    buf[2] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsReservedBitsInDword6)
+{
+    auto buf = PackDelete(3);
+    buf[6] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsRflagSetWithZeroResponseAddr)
+{
+    auto buf = PackDelete(3, true);
+    buf[3] = 0;
+    buf[4] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsRflagSetWithZeroResponseMrKey)
+{
+    auto buf = PackDelete(3, true);
+    buf[5] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsRflagFalseWithResponseAddr)
+{
+    auto buf = PackDelete(3, false);
+    buf[3] = 0x1234;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsRflagFalseWithResponseMrKey)
+{
+    auto buf = PackDelete(3, false);
+    buf[5] = 0x1234;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsBadDptrType)
+{
+    auto buf = PackDelete(3);
+    buf[9] = (0x40U << 24);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("DptrType"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsReservedBitsInDword10)
+{
+    auto buf = PackDelete(3);
+    buf[10] |= (1U << 20);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, DeleteRejectsWrongLength)
+{
+    auto buf = PackDelete(3);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), (buf.size() + 4) * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("length"), std::string::npos);
+}
+
+// ── Exist: missing branches ──
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsBadFixedBits)
+{
+    auto buf = PackExist(3);
+    buf[0] &= ~(0x3U << 14);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("fixed bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsReservedBitsInDword0)
+{
+    auto buf = PackExist(3);
+    buf[0] |= (1U << 10);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsReservedBitsInDword2)
+{
+    auto buf = PackExist(3);
+    buf[2] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsReservedBitsInDword6)
+{
+    auto buf = PackExist(3);
+    buf[6] = 0x1;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("reserved bits"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsRflagSetWithZeroResponseAddr)
+{
+    auto buf = PackExist(3, true);
+    buf[3] = 0;
+    buf[4] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsRflagSetWithZeroResponseMrKey)
+{
+    auto buf = PackExist(3, true);
+    buf[5] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsRflagFalseWithResponseAddr)
+{
+    auto buf = PackExist(3, false);
+    buf[3] = 0x1234;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsRflagFalseWithResponseMrKey)
+{
+    auto buf = PackExist(3, false);
+    buf[5] = 0x1234;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsBadDptrType)
+{
+    auto buf = PackExist(3);
+    buf[9] = (0x40U << 24);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("DptrType"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsWrongLength)
+{
+    auto buf = PackExist(3);
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), (buf.size() + 4) * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("length"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, ExistRejectsEntryAllZeroKey)
+{
+    auto buf = PackExist(3);
+    std::uint32_t* entry0 = buf.data() + 16;
+    entry0[0] = 0;
+    entry0[1] = 0;
+    entry0[2] = 0;
+    entry0[3] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("key"), std::string::npos);
+}
+
+// ── KeepAlive: missing branches ──
+
+TEST_F(KvProtocolVerifyTest, KeepAliveRejectsRflagSetWithZeroResponseAddr)
+{
+    auto buf = PackKeepAlive(true);
+    buf[3] = 0;
+    buf[4] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, KeepAliveRejectsRflagSetWithZeroResponseMrKey)
+{
+    auto buf = PackKeepAlive(true);
+    buf[5] = 0;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+TEST_F(KvProtocolVerifyTest, KeepAliveRejectsRflagFalseWithResponseMrKey)
+{
+    auto buf = PackKeepAlive(false);
+    buf[5] = 0x1234;
+    auto s = mgr_->VerifyPackedBuffer(buf.data(), buf.size() * sizeof(std::uint32_t));
+    EXPECT_FALSE(s.ok());
+    EXPECT_NE(s.message.find("rflag"), std::string::npos);
+}
+
+}  // namespace
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/transport/link_protocol_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/link_protocol_test.cpp
@@ -1,0 +1,203 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "link_protocol.h"
+#include <cstdint>
+#include <cstring>
+#include <gtest/gtest.h>
+
+namespace UC::ASU {
+namespace {
+
+class LinkProtoPackTest : public ::testing::Test {
+protected:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(LinkProtoPackTest, NegotiateSqePackMatchesProtocol)
+{
+    NegotiateRequest req;
+    req.cap = 0;
+    req.private_len = 4;
+    req.major_version = 1;
+    req.minor_version = 0;
+    req.kato = 30;
+
+    NegotiateSqe sqe;
+    auto status = sqe.Pack(req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint8_t> expected(kMsgHeaderSize + kNegotiatePayloadSize, 0);
+
+    // Header: crc(4)=0, ver(1)=1, cmd(1)=0, pad(6)=0, len(4)=160
+    expected[4] = 1;  // ver
+    expected[5] = 0;  // cmd = Negotiate
+    std::uint32_t payload_len = kNegotiatePayloadSize;
+    std::memcpy(&expected[12], &payload_len, 4);
+
+    // Offset 16: cap[31:0] = 0
+    // Offset 20: rsv[23:0] = 0 (already zero)
+    // Offset 44: private_len[31:0]
+    std::memcpy(&expected[44], &req.private_len, 4);
+    // Offset 48: major_version
+    expected[48] = req.major_version;
+    // Offset 49: minor_version
+    expected[49] = req.minor_version;
+    // Offset 50: kato[15:0]
+    std::memcpy(&expected[50], &req.kato, 2);
+
+    ASSERT_EQ(sqe.Size(), expected.size());
+    const auto* packed = static_cast<const std::uint8_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i])
+            << "Mismatch at byte " << i << ": expected 0x" << std::hex
+            << static_cast<int>(expected[i]) << ", got 0x" << static_cast<int>(packed[i]);
+    }
+}
+
+TEST_F(LinkProtoPackTest, HandshakeSqePackMatchesProtocol)
+{
+    HandshakeRequest req;
+    for (int i = 0; i < 16; ++i) { req.gid[i] = static_cast<std::uint8_t>(0xA0 + i); }
+    req.lid = 0x1234;
+    req.mtu = 4;  // 2048 bytes
+    req.total_qp_num = 8;
+    req.sl = 1;
+    req.traffic_class = 2;
+    req.rnr_timer = 3;
+    req.rnr_retry_cnt = 7;
+    req.timeout = 14;
+    req.retry_cnt = 5;
+    req.qp_rd_atom = 6;
+    req.rsv = 0;
+    req.start_psn = 0xDEADBEEF;
+    for (int i = 0; i < 32; ++i) { req.qpn[i] = 0x1000 + i; }
+
+    HandshakeSqe sqe;
+    auto status = sqe.Pack(req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint8_t> expected(kMsgHeaderSize + kHandshakePayloadSize, 0);
+
+    // Header: crc(4)=0, ver(1)=1, cmd(1)=1, pad(6)=0, len(4)=160
+    expected[4] = 1;  // ver
+    expected[5] = 1;  // cmd = Handshake
+    std::uint32_t payload_len = kHandshakePayloadSize;
+    std::memcpy(&expected[12], &payload_len, 4);
+
+    // Offset 16: gid[15:0]
+    std::memcpy(&expected[16], req.gid, 16);
+    // Offset 32: lid[15:0]
+    std::memcpy(&expected[32], &req.lid, 2);
+    // Offset 34: mtu
+    expected[34] = req.mtu;
+    // Offset 35: total_qp_num
+    expected[35] = req.total_qp_num;
+    // Offset 36: sl
+    expected[36] = req.sl;
+    // Offset 37: traffic_class
+    expected[37] = req.traffic_class;
+    // Offset 38: rnr_timer
+    expected[38] = req.rnr_timer;
+    // Offset 39: rnr_retry_cnt
+    expected[39] = req.rnr_retry_cnt;
+    // Offset 40: timeout
+    expected[40] = req.timeout;
+    // Offset 41: retry_cnt
+    expected[41] = req.retry_cnt;
+    // Offset 42: qp_rd_atom
+    expected[42] = req.qp_rd_atom;
+    // Offset 43: rsv
+    expected[43] = req.rsv;
+    // Offset 44: start_psn[31:0]
+    std::memcpy(&expected[44], &req.start_psn, 4);
+    // Offset 48: qpn[32] (128 bytes)
+    std::memcpy(&expected[48], req.qpn, 128);
+
+    ASSERT_EQ(sqe.Size(), expected.size());
+    const auto* packed = static_cast<const std::uint8_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i])
+            << "Mismatch at byte " << i << ": expected 0x" << std::hex
+            << static_cast<int>(expected[i]) << ", got 0x" << static_cast<int>(packed[i]);
+    }
+}
+
+TEST_F(LinkProtoPackTest, HandshakeDoneSqePackMatchesProtocol)
+{
+    HandshakeDoneSqe sqe;
+    auto status = sqe.Pack();
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint8_t> expected(kMsgHeaderSize, 0);
+
+    // Header: crc(4)=0, ver(1)=1, cmd(1)=3, pad(6)=0, len(4)=0
+    expected[4] = 1;  // ver
+    expected[5] = 3;  // cmd = HandshakeDone
+    std::uint32_t payload_len = 0;
+    std::memcpy(&expected[12], &payload_len, 4);
+
+    ASSERT_EQ(sqe.Size(), expected.size());
+    const auto* packed = static_cast<const std::uint8_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i])
+            << "Mismatch at byte " << i << ": expected 0x" << std::hex
+            << static_cast<int>(expected[i]) << ", got 0x" << static_cast<int>(packed[i]);
+    }
+}
+
+TEST_F(LinkProtoPackTest, DisconnectSqePackMatchesProtocol)
+{
+    DisconnectRequest req;
+    req.local_qpn = 0x00010001;
+    req.remote_qpn = 0x00020002;
+
+    DisconnectSqe sqe;
+    auto status = sqe.Pack(req);
+    ASSERT_TRUE(status.ok()) << status.message;
+
+    std::vector<std::uint8_t> expected(kMsgHeaderSize + kDisconnectPayloadSize, 0);
+
+    // Header: crc(4)=0, ver(1)=1, cmd(1)=4, pad(6)=0, len(4)=8
+    expected[4] = 1;  // ver
+    expected[5] = 4;  // cmd = Disconnect
+    std::uint32_t payload_len = kDisconnectPayloadSize;
+    std::memcpy(&expected[12], &payload_len, 4);
+
+    // Offset 16: local_qpn[31:0]
+    std::memcpy(&expected[16], &req.local_qpn, 4);
+    // Offset 20: remote_qpn[31:0]
+    std::memcpy(&expected[20], &req.remote_qpn, 4);
+
+    ASSERT_EQ(sqe.Size(), expected.size());
+    const auto* packed = static_cast<const std::uint8_t*>(sqe.Data());
+    for (std::size_t i = 0; i < expected.size(); ++i) {
+        EXPECT_EQ(packed[i], expected[i])
+            << "Mismatch at byte " << i << ": expected 0x" << std::hex
+            << static_cast<int>(expected[i]) << ", got 0x" << static_cast<int>(packed[i]);
+    }
+}
+
+}  // namespace
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/transport/sqe_request_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/sqe_request_test.cpp
@@ -1,0 +1,480 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <gtest/gtest.h>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+#define private public
+#include "asu_transport_impl.h"
+#undef private
+#include "asu_transport/trans_provider.h"
+#include "buffer_manager.h"
+#include "kv_protocol.h"
+#include "transport_config_parser.h"
+
+namespace UC::ASU {
+
+namespace {
+
+TEST(TransportConfigParserTest, LoadsMaxErrorCount)
+{
+    constexpr const char* kConfigPath = "asu_transport_max_error_count_test.conf";
+    {
+        std::ofstream configFile{kConfigPath};
+        ASSERT_TRUE(configFile.is_open());
+        configFile << "max_error_count=7\n"
+                   << "kernel_count=1\n"
+                   << "quiet_count=1\n";
+    }
+
+    TransportConfig config;
+    auto status = LoadTransportConfig(kConfigPath, config);
+    std::remove(kConfigPath);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(config.maxErrorCount, std::uint32_t{7});
+}
+
+TEST(TransportConfigParserTest, LoadsCompletionPollSpinLimit)
+{
+    constexpr const char* kConfigPath = "asu_transport_completion_poll_spin_limit_test.conf";
+    {
+        std::ofstream configFile{kConfigPath};
+        ASSERT_TRUE(configFile.is_open());
+        configFile << "completion_poll_spin_limit=23\n"
+                   << "kernel_count=1\n"
+                   << "quiet_count=1\n";
+    }
+
+    TransportConfig config;
+    const auto status = LoadTransportConfig(kConfigPath, config);
+    std::remove(kConfigPath);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(config.completionPollSpinLimit, std::size_t{23});
+}
+
+CacheKey MakeCacheKey(std::string_view text)
+{
+    CacheKey key{};
+    const auto size = std::min(text.size(), key.size());
+    if (size > 0) { std::memcpy(key.data(), text.data(), size); }
+    return key;
+}
+
+class StubTransProvider : public TransProvider {
+public:
+    Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t, uint32_t,
+                            std::vector<ConnectionHandle>&) override
+    {
+        return Status::OK();
+    }
+    std::vector<Status> DeleteConnections(const std::vector<ConnectionHandle>&) override
+    {
+        return {};
+    }
+    std::vector<Status> Send(const std::vector<TransProvider::SendIoBatch>&, uint32_t,
+                             uint32_t) override
+    {
+        return {};
+    }
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>&,
+                          std::vector<MRHandle>& handles) override
+    {
+        handles.push_back(reinterpret_cast<MRHandle>(static_cast<uintptr_t>(1)));
+        return Status::OK();
+    }
+    std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>&) override
+    {
+        return {};
+    }
+    Status AllocThread(uint32_t, const std::vector<uint32_t>&, std::vector<ThreadHandle>&) override
+    {
+        return Status::OK();
+    }
+    std::vector<Status> FreeThread(const std::vector<ThreadHandle>&) override { return {}; }
+    Status GetMemTokenId(MRHandle, uint32_t& tokenId) override
+    {
+        tokenId = 1;
+        return Status::OK();
+    }
+};
+
+void CreateTaskExecutor(AsuTransportImpl& transport)
+{
+    transport.taskExecutor_ = std::make_unique<TransportTaskExecutor>(
+        transport.config_, transport.transProvider_, transport.connManager_);
+}
+
+constexpr std::size_t kFlagBufferHeaderSize = 16;
+constexpr std::size_t kTestSendBufferSlotSize = 4096;
+constexpr std::size_t kTestSendBufferSlotNum = 1;
+constexpr std::size_t kFlagBufferSlotSize = 128;
+constexpr std::size_t kFlagBufferSlotNum = 16;
+
+std::unordered_map<std::string, std::string> DefaultAttrs()
+{
+    return {
+        {"kv_ns_id",     "3"   },
+        {"dtype",        "2"   },
+        {"dspec",        "10"  },
+        {"lr",           "true"},
+        {"sc",           "true"},
+        {"kernel_count", "1"   },
+        {"quiet_count",  "5"   },
+    };
+}
+
+std::vector<KVBuffer> MakeEntries(std::size_t count)
+{
+    std::vector<KVBuffer> entries(count);
+    for (std::size_t index = 0; index < count; ++index) {
+        entries[index].key = MakeCacheKey("key_" + std::to_string(index));
+        entries[index].buffer.region.addr = 0x100000 + index * 0x1000;
+        entries[index].buffer.region.size = 4096;
+        entries[index].buffer.handle = 0x20 + index;
+    }
+    return entries;
+}
+
+void SetMrKeys(std::vector<KVBuffer>& entries, std::uint32_t tokenBase)
+{
+    for (std::size_t index = 0; index < entries.size(); ++index) {
+        entries[index].mrKey = tokenBase + static_cast<std::uint32_t>(index);
+    }
+}
+
+std::uint32_t PackedBatchEntryMrKey(const std::uint32_t* sqe, std::size_t entryIndex)
+{
+    const auto base = kSqeDwordCount + entryIndex * kBatchEntryDwordCount;
+    return ((sqe[base + 7] >> 24) & 0xFF) | ((sqe[base + 8] & 0xFFFFFF) << 8);
+}
+
+}  // namespace
+
+class SqeRequestTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        transport_ = std::make_unique<AsuTransportImpl>();
+        transport_->SetTransProvider(std::make_unique<StubTransProvider>());
+        transport_->config_.attrs = DefaultAttrs();
+        CreateTaskExecutor(*transport_);
+        auto status = transport_->taskExecutor_->flagBufferManager_.Init(
+            "test flag buffer", MemoryType::HOST_PINNED, kFlagBufferSlotSize, kFlagBufferSlotNum);
+        ASSERT_TRUE(status.ok()) << status.message;
+        status = transport_->taskExecutor_->sendBufferManager_.Init(
+            "test send buffer", MemoryType::HOST_PINNED, kTestSendBufferSlotSize,
+            kTestSendBufferSlotNum);
+        ASSERT_TRUE(status.ok()) << status.message;
+        status = transport_->taskExecutor_->RegisterBufferMemory(
+            transport_->taskExecutor_->sendBufferManager_,
+            transport_->taskExecutor_->sendBufferMrHandle_);
+        ASSERT_TRUE(status.ok()) << status.message;
+        status = transport_->taskExecutor_->RegisterBufferMemory(
+            transport_->taskExecutor_->flagBufferManager_,
+            transport_->taskExecutor_->flagBufferMrHandle_);
+        ASSERT_TRUE(status.ok()) << status.message;
+    }
+
+    std::unique_ptr<AsuTransportImpl> transport_;
+};
+
+TEST_F(SqeRequestTest, ValidateSqeRequestAttrsRejectsMalformedValues)
+{
+    EXPECT_TRUE(ValidateSqeRequestAttrs(DefaultAttrs()).ok());
+
+    auto attrs = DefaultAttrs();
+    attrs["dtype"] = "256";
+    EXPECT_EQ(ValidateSqeRequestAttrs(attrs).code, StatusCode::INVALID_ARGUMENT);
+
+    attrs = DefaultAttrs();
+    attrs["lr"] = "maybe";
+    EXPECT_EQ(ValidateSqeRequestAttrs(attrs).code, StatusCode::INVALID_ARGUMENT);
+
+    attrs = DefaultAttrs();
+    attrs.erase("kernel_count");
+    EXPECT_EQ(ValidateSqeRequestAttrs(attrs).code, StatusCode::INVALID_ARGUMENT);
+
+    attrs = DefaultAttrs();
+    attrs["quiet_count"] = "0";
+    EXPECT_EQ(ValidateSqeRequestAttrs(attrs).code, StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(SqeRequestTest, SubmitBatchStoreAllocatesFlagBufferAndBuildsRequest)
+{
+    auto entries = MakeEntries(3);
+    entries[0].offset = kAlignmentBytes;
+    entries[1].offset = kAlignmentBytes * 2;
+    entries[2].offset = kAlignmentBytes * 3;
+    SetMrKeys(entries, 0xABCD0000);
+    IoScheduler::ScheduledIoBatch subBatch{
+        BatchView<KVBuffer>{entries.data(), entries.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+    transport_->taskExecutor_->nextRequestCid_.store(41, std::memory_order_relaxed);
+    const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
+        AsuOpType::BATCH_STORE, subBatch, subBatchContext);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.flagBuffer.length, kFlagBufferHeaderSize + (entries.size() + 1) / 2);
+    EXPECT_EQ(subBatchContext.cid, std::uint32_t{41});
+    EXPECT_EQ(subBatchContext.opType, AsuOpType::BATCH_STORE);
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
+    EXPECT_TRUE(subBatchContext.status.ok());
+    EXPECT_NE(subBatchContext.sendSge.local_addr, std::uint64_t{0});
+    EXPECT_NE(subBatchContext.sendSge.device_addr, std::uint64_t{0});
+    EXPECT_NE(subBatchContext.flagBuffer.local_addr, std::uint64_t{0});
+    EXPECT_NE(subBatchContext.flagBuffer.device_addr, std::uint64_t{0});
+
+    const auto* packedSqe =
+        reinterpret_cast<const std::uint32_t*>(subBatchContext.sendSge.local_addr);
+    const auto packedResponseAddr =
+        static_cast<std::uint64_t>(packedSqe[3]) | (static_cast<std::uint64_t>(packedSqe[4]) << 32);
+    EXPECT_EQ(packedResponseAddr, subBatchContext.flagBuffer.device_addr);
+    ASSERT_EQ(subBatchContext.entryStatus.size(), entries.size());
+    for (const auto& entryStatus : subBatchContext.entryStatus) { EXPECT_TRUE(entryStatus.ok()); }
+    const auto* sqe = reinterpret_cast<const std::uint32_t*>(subBatchContext.sendSge.local_addr);
+    EXPECT_EQ(sqe[kSqeDwordCount], entries[0].offset);
+    EXPECT_EQ(sqe[kSqeDwordCount + kBatchEntryDwordCount], entries[1].offset);
+    EXPECT_EQ(sqe[kSqeDwordCount + 2 * kBatchEntryDwordCount], entries[2].offset);
+    EXPECT_EQ(PackedBatchEntryMrKey(sqe, 0), std::uint32_t{0xABCD0000});
+    EXPECT_EQ(PackedBatchEntryMrKey(sqe, 1), std::uint32_t{0xABCD0001});
+    EXPECT_EQ(PackedBatchEntryMrKey(sqe, 2), std::uint32_t{0xABCD0002});
+}
+
+TEST_F(SqeRequestTest, SubmitStoreUsesStoreOpcodeAndRequest)
+{
+    auto entries = MakeEntries(1);
+    entries[0].offset = kAlignmentBytes;
+    SetMrKeys(entries, 0xABCD0000);
+    IoScheduler::ScheduledIoBatch subBatch{
+        BatchView<KVBuffer>{entries.data(), entries.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+    const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
+        AsuOpType::STORE, subBatch, subBatchContext);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.opType, AsuOpType::STORE);
+    const auto* sqe = reinterpret_cast<const std::uint32_t*>(subBatchContext.sendSge.local_addr);
+    EXPECT_EQ(sqe[0] & 0xFF, static_cast<std::uint32_t>(KvOpcode::Store));
+    EXPECT_EQ(static_cast<std::uint64_t>(sqe[6]) | (static_cast<std::uint64_t>(sqe[7]) << 32),
+              entries[0].buffer.region.addr);
+    EXPECT_EQ(sqe[8] & 0xFFFFFF, entries[0].buffer.region.size);
+    EXPECT_EQ(sqe[10], entries[0].offset);
+    EXPECT_EQ(sqe[11] & 0xFFFFFF, entries[0].buffer.region.size);
+}
+
+TEST_F(SqeRequestTest, SubmitBatchRetrieveUsesRetrieveOpcodeAndRequest)
+{
+    auto entries = MakeEntries(2);
+    entries[0].offset = kAlignmentBytes * 4;
+    entries[1].offset = kAlignmentBytes * 5;
+    SetMrKeys(entries, 0x76540000);
+    IoScheduler::ScheduledIoBatch subBatch{
+        BatchView<KVBuffer>{entries.data(), entries.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+    transport_->taskExecutor_->nextRequestCid_.store(9, std::memory_order_relaxed);
+    const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
+        AsuOpType::BATCH_LOAD, subBatch, subBatchContext);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.opType, AsuOpType::BATCH_LOAD);
+    EXPECT_EQ(subBatchContext.cid, std::uint16_t{9});
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
+    EXPECT_TRUE(subBatchContext.status.ok());
+    EXPECT_NE(subBatchContext.sendSge.local_addr, std::uint64_t{0});
+    const auto* sqe = reinterpret_cast<const std::uint32_t*>(subBatchContext.sendSge.local_addr);
+    EXPECT_EQ(sqe[kSqeDwordCount], entries[0].offset);
+    EXPECT_EQ(sqe[kSqeDwordCount + kBatchEntryDwordCount], entries[1].offset);
+    EXPECT_EQ(PackedBatchEntryMrKey(sqe, 0), std::uint32_t{0x76540000});
+    EXPECT_EQ(PackedBatchEntryMrKey(sqe, 1), std::uint32_t{0x76540001});
+}
+
+TEST_F(SqeRequestTest, SubmitLoadUsesRetrieveOpcodeAndRequest)
+{
+    auto entries = MakeEntries(1);
+    entries[0].offset = kAlignmentBytes * 4;
+    SetMrKeys(entries, 0x76540000);
+    IoScheduler::ScheduledIoBatch subBatch{
+        BatchView<KVBuffer>{entries.data(), entries.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+    const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
+        AsuOpType::LOAD, subBatch, subBatchContext);
+
+    ASSERT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.opType, AsuOpType::LOAD);
+    const auto* sqe = reinterpret_cast<const std::uint32_t*>(subBatchContext.sendSge.local_addr);
+    EXPECT_EQ(sqe[0] & 0xFF, static_cast<std::uint32_t>(KvOpcode::Retrieve));
+    EXPECT_EQ(sqe[10], entries[0].offset);
+    EXPECT_EQ(sqe[11] & 0xFFFFFF, entries[0].buffer.region.size);
+}
+
+TEST_F(SqeRequestTest, SubmitBatchStoreRejectsUnregisteredEntryBuffer)
+{
+    auto entries = MakeEntries(1);
+    IoScheduler::ScheduledIoBatch subBatch{
+        BatchView<KVBuffer>{entries.data(), entries.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+    const auto status = transport_->taskExecutor_->BuildEntrySubBatchRequest(
+        AsuOpType::BATCH_STORE, subBatch, subBatchContext);
+
+    EXPECT_EQ(status.code, StatusCode::BUFFER_NOT_REGISTERED);
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
+    EXPECT_EQ(subBatchContext.status.code, StatusCode::BUFFER_NOT_REGISTERED);
+    ASSERT_EQ(subBatchContext.entryStatus.size(), entries.size());
+    EXPECT_EQ(subBatchContext.entryStatus[0].code, StatusCode::BUFFER_NOT_REGISTERED);
+    EXPECT_EQ(subBatchContext.flagBuffer.local_addr, std::uint64_t{0});
+    EXPECT_EQ(subBatchContext.sendSge.local_addr, std::uint64_t{0});
+}
+
+TEST_F(SqeRequestTest, SubmitDeleteCopiesKeysAndBuildsFlagBackedRequest)
+{
+    std::vector<CacheKey> keys = {MakeCacheKey("k0"), MakeCacheKey("k1"), MakeCacheKey("k2"),
+                                  MakeCacheKey("k3"), MakeCacheKey("k4"), MakeCacheKey("k5"),
+                                  MakeCacheKey("k6"), MakeCacheKey("k7"), MakeCacheKey("k8")};
+    IoScheduler::ScheduledKeyBatch subBatch{
+        BatchView<CacheKey>{keys.data(), keys.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+    transport_->taskExecutor_->nextRequestCid_.store(55, std::memory_order_relaxed);
+
+    const auto status = transport_->taskExecutor_->SubmitKeySubBatchRequest(
+        AsuOpType::DELETE, subBatch, subBatchContext);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.opType, AsuOpType::DELETE);
+    EXPECT_EQ(subBatchContext.cid, std::uint16_t{55});
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
+    EXPECT_TRUE(subBatchContext.status.ok());
+    EXPECT_EQ(subBatchContext.flagBuffer.length, kFlagBufferHeaderSize + (keys.size() + 7) / 8);
+    EXPECT_NE(subBatchContext.sendSge.local_addr, std::uint64_t{0});
+    ASSERT_EQ(subBatchContext.entryStatus.size(), keys.size());
+    for (const auto& entryStatus : subBatchContext.entryStatus) { EXPECT_TRUE(entryStatus.ok()); }
+}
+
+TEST_F(SqeRequestTest, SubmitExistReadsScAttribute)
+{
+    std::vector<CacheKey> keys = {MakeCacheKey("k0"), MakeCacheKey("k1"), MakeCacheKey("k2"),
+                                  MakeCacheKey("k3"), MakeCacheKey("k4"), MakeCacheKey("k5"),
+                                  MakeCacheKey("k6"), MakeCacheKey("k7"), MakeCacheKey("k8")};
+    IoScheduler::ScheduledKeyBatch subBatch{
+        BatchView<CacheKey>{keys.data(), keys.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+    transport_->taskExecutor_->nextRequestCid_.store(13, std::memory_order_relaxed);
+
+    const auto status = transport_->taskExecutor_->SubmitKeySubBatchRequest(
+        AsuOpType::QUERY, subBatch, subBatchContext);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.opType, AsuOpType::QUERY);
+    EXPECT_EQ(subBatchContext.cid, std::uint16_t{13});
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
+    EXPECT_TRUE(subBatchContext.status.ok());
+    EXPECT_TRUE(subBatchContext.useSeekControl);
+    EXPECT_EQ(subBatchContext.flagBuffer.length, kFlagBufferHeaderSize + (keys.size() + 7) / 8);
+}
+
+TEST_F(SqeRequestTest, SubmitExistDisablesSeekControlWhenScDisabled)
+{
+    auto attrs = DefaultAttrs();
+    attrs["sc"] = "false";
+    transport_->config_.attrs = attrs;
+    transport_->taskExecutor_->nextRequestCid_.store(13, std::memory_order_relaxed);
+
+    std::vector<CacheKey> keys = {MakeCacheKey("k0")};
+    IoScheduler::ScheduledKeyBatch subBatch{
+        BatchView<CacheKey>{keys.data(), keys.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+
+    const auto status = transport_->taskExecutor_->SubmitKeySubBatchRequest(
+        AsuOpType::QUERY, subBatch, subBatchContext);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_FALSE(subBatchContext.useSeekControl);
+}
+
+TEST_F(SqeRequestTest, AllocationFailureMarksWholeSubBatchFailed)
+{
+    auto entries = MakeEntries(2);
+    SetMrKeys(entries, 0x45670000);
+    IoScheduler::ScheduledIoBatch subBatch{
+        BatchView<KVBuffer>{entries.data(), entries.size()}
+    };
+    TransportSubBatchContext subBatchContext;
+    AsuTransportImpl uninitializedFlagTransport;
+    uninitializedFlagTransport.SetTransProvider(std::make_unique<StubTransProvider>());
+    uninitializedFlagTransport.config_.attrs = DefaultAttrs();
+    CreateTaskExecutor(uninitializedFlagTransport);
+    ASSERT_TRUE(uninitializedFlagTransport.taskExecutor_->sendBufferManager_
+                    .Init("test send buffer", MemoryType::HOST, kTestSendBufferSlotSize,
+                          kTestSendBufferSlotNum)
+                    .ok());
+    uninitializedFlagTransport.taskExecutor_->nextRequestCid_.store(3, std::memory_order_relaxed);
+    const auto status = uninitializedFlagTransport.taskExecutor_->BuildEntrySubBatchRequest(
+        AsuOpType::BATCH_STORE, subBatch, subBatchContext);
+
+    EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
+    EXPECT_EQ(subBatchContext.status.code, StatusCode::NOT_INITIALIZED);
+    EXPECT_EQ(subBatchContext.flagBuffer.local_addr, std::uint64_t{0});
+    EXPECT_EQ(subBatchContext.sendSge.local_addr, std::uint64_t{0});
+    ASSERT_EQ(subBatchContext.entryStatus.size(), entries.size());
+    for (const auto& entryStatus : subBatchContext.entryStatus) {
+        EXPECT_EQ(entryStatus.code, StatusCode::NOT_INITIALIZED);
+    }
+}
+
+TEST_F(SqeRequestTest, SubmitKeepAliveBuildsFlagBackedRequest)
+{
+    TransportSubBatchContext subBatchContext;
+    transport_->taskExecutor_->nextRequestCid_.store(77, std::memory_order_relaxed);
+
+    const auto status = transport_->taskExecutor_->SubmitKeepAliveRequest(subBatchContext);
+
+    EXPECT_TRUE(status.ok()) << status.message;
+    EXPECT_EQ(subBatchContext.cid, std::uint16_t{77});
+    EXPECT_EQ(subBatchContext.opType, AsuOpType::KEEP_ALIVE);
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::PENDING);
+    EXPECT_TRUE(subBatchContext.status.ok());
+    EXPECT_EQ(subBatchContext.flagBuffer.length, kFlagBufferHeaderSize + 1);
+    EXPECT_NE(subBatchContext.sendSge.local_addr, std::uint64_t{0});
+    ASSERT_EQ(subBatchContext.entryStatus.size(), 1);
+    EXPECT_TRUE(subBatchContext.entryStatus[0].ok());
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/test/transport/transport_task_completion_test.cpp
+++ b/ucm/transport/kv/asu/test/transport/transport_task_completion_test.cpp
@@ -1,0 +1,673 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <gtest/gtest.h>
+#include <vector>
+#define private public
+#include "asu_transport_impl.h"
+#undef private
+#include "asu_transport/trans_provider.h"
+#include "buffer_manager.h"
+#include "connection_internal.h"
+
+namespace UC::ASU {
+namespace {
+
+constexpr std::size_t kTestBufferSlotSize = 512;
+constexpr std::size_t kTestBufferSlotNum = 16;
+
+class StubTransProvider : public TransProvider {
+public:
+    Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t qpNum,
+                            uint32_t, std::vector<ConnectionHandle>& handles) override
+    {
+        handles.clear();
+        handles.resize(qpNum, nullptr);
+        return Status::OK();
+    }
+    std::vector<Status> DeleteConnections(const std::vector<ConnectionHandle>& handles) override
+    {
+        return std::vector<Status>(handles.size(), Status::OK());
+    }
+    std::vector<Status> Send(const std::vector<TransProvider::SendIoBatch>&, uint32_t,
+                             uint32_t) override
+    {
+        return {};
+    }
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>&,
+                          std::vector<MRHandle>& handles) override
+    {
+        handles.push_back(reinterpret_cast<MRHandle>(static_cast<uintptr_t>(1)));
+        return Status::OK();
+    }
+    std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>&) override
+    {
+        return {};
+    }
+    Status AllocThread(uint32_t, const std::vector<uint32_t>&, std::vector<ThreadHandle>&) override
+    {
+        return Status::OK();
+    }
+    std::vector<Status> FreeThread(const std::vector<ThreadHandle>&) override { return {}; }
+    Status GetMemTokenId(MRHandle, uint32_t& tokenId) override
+    {
+        tokenId = 1;
+        return Status::OK();
+    }
+};
+
+void CreateTaskExecutor(AsuTransportImpl& transport)
+{
+    transport.taskExecutor_ = std::make_unique<TransportTaskExecutor>(
+        transport.config_, transport.transProvider_, transport.connManager_);
+}
+
+class TransportTaskCompletionTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        transport_ = std::make_unique<AsuTransportImpl>();
+        transport_->SetTransProvider(std::make_unique<StubTransProvider>());
+        CreateTaskExecutor(*transport_);
+        auto status = transport_->taskExecutor_->sendBufferManager_.Init(
+            "test send buffer", MemoryType::HOST, kTestBufferSlotSize, kTestBufferSlotNum);
+        ASSERT_TRUE(status.ok()) << status.message;
+        status = transport_->taskExecutor_->flagBufferManager_.Init(
+            "test flag buffer", MemoryType::HOST, kTestBufferSlotSize, kTestBufferSlotNum);
+        ASSERT_TRUE(status.ok()) << status.message;
+        status = transport_->taskExecutor_->RegisterBufferMemory(
+            transport_->taskExecutor_->sendBufferManager_,
+            transport_->taskExecutor_->sendBufferMrHandle_);
+        ASSERT_TRUE(status.ok()) << status.message;
+        status = transport_->taskExecutor_->RegisterBufferMemory(
+            transport_->taskExecutor_->flagBufferManager_,
+            transport_->taskExecutor_->flagBufferMrHandle_);
+        ASSERT_TRUE(status.ok()) << status.message;
+    }
+
+    std::unique_ptr<AsuTransportImpl> transport_;
+};
+
+TEST_F(TransportTaskCompletionTest, InitRejectsZeroMaxErrorCount)
+{
+    TransportConfig config;
+    config.maxErrorCount = 0;
+
+    const auto status = transport_->Init(config, transport_->transProvider_);
+
+    EXPECT_EQ(status.code, StatusCode::INVALID_ARGUMENT);
+}
+
+TEST_F(TransportTaskCompletionTest, TaskExecutorSupportsExplicitLifecycle)
+{
+    AsuTransportImpl transport;
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+    transport.SetTransProvider(std::make_unique<StubTransProvider>());
+
+    CreateTaskExecutor(transport);
+    ASSERT_TRUE(transport.taskExecutor_->Init().ok());
+    EXPECT_NE(transport.taskExecutor_, nullptr);
+
+    EXPECT_TRUE(transport.taskExecutor_->Shutdown().ok());
+    transport.taskExecutor_.reset();
+    EXPECT_EQ(transport.taskExecutor_, nullptr);
+}
+
+TEST_F(TransportTaskCompletionTest, InitializeCountsOnlyPendingSubBatches)
+{
+    TransportTask ctx;
+    ctx.subBatchContexts->resize(3);
+    (*ctx.subBatchContexts)[0].state = TransportSubBatchState::PENDING;
+    (*ctx.subBatchContexts)[1].state = TransportSubBatchState::COMPLETED;
+    (*ctx.subBatchContexts)[2].state = TransportSubBatchState::COMPLETED;
+    (*ctx.subBatchContexts)[2].status = Status::Error(StatusCode::IO_ERROR, "fake error");
+
+    ctx.InitializeRemainingSubBatchCount();
+
+    EXPECT_EQ(ctx.remainingSubBatchCount, std::uint32_t{1});
+}
+
+TEST_F(TransportTaskCompletionTest, CompleteSubBatchCompletesPendingSubBatch)
+{
+    TransportTask ctx;
+    TransportSubBatchContext subBatchContext;
+    const auto status = Status::Error(StatusCode::IO_ERROR, "fake error");
+    ctx.remainingSubBatchCount = 1;
+
+    transport_->taskExecutor_->CompleteSubBatch(ctx, subBatchContext, status);
+
+    EXPECT_EQ(ctx.remainingSubBatchCount, std::uint32_t{0});
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
+    EXPECT_EQ(subBatchContext.status.code, StatusCode::IO_ERROR);
+}
+
+TEST_F(TransportTaskCompletionTest, ReleaseSubBatchResourcesClearsAllocatedSlots)
+{
+    TransportSubBatchContext subBatchContext;
+    ASSERT_TRUE(
+        transport_->taskExecutor_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
+
+    transport_->taskExecutor_->ReleaseSubBatchResources(subBatchContext);
+
+    EXPECT_EQ(subBatchContext.sendSge.slot_index, UINT32_MAX);
+    EXPECT_EQ(subBatchContext.flagBuffer.slot_index, UINT32_MAX);
+    EXPECT_EQ(subBatchContext.sendSge.local_addr, std::uint64_t{0});
+    EXPECT_EQ(subBatchContext.flagBuffer.local_addr, std::uint64_t{0});
+}
+
+TEST_F(TransportTaskCompletionTest, FailureCqeAccumulatesWithoutSuccessReset)
+{
+    auto* provider = transport_->transProvider_.get();
+    transport_->connManager_ = std::make_unique<ConnectionManager>(*provider, "", 5000, 3);
+    ASSERT_TRUE(transport_->connManager_->AddGroup(AsuEndpoint{}, 1).ok());
+    auto channel = transport_->connManager_->SelectConnection();
+    ASSERT_NE(channel, nullptr);
+    transport_->connManager_->ReportFailure(channel);
+    ASSERT_EQ(channel->GetErrorCount(), std::uint32_t{1});
+
+    auto ctx = std::make_shared<TransportTask>();
+    ctx->state.store(TransportTaskState::INFLIGHT, std::memory_order_release);
+    ctx->subBatchContexts->resize(1);
+
+    auto& subBatchContext = (*ctx->subBatchContexts)[0];
+    subBatchContext.cid = 123;
+    subBatchContext.opType = AsuOpType::BATCH_STORE;
+    subBatchContext.entryStatus.assign(1, Status::OK());
+    subBatchContext.channel = channel;
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_
+            .Allocate((kCqeDwordCount + 1) * sizeof(std::uint32_t), subBatchContext.flagBuffer)
+            .ok());
+
+    auto* cqe = reinterpret_cast<std::uint32_t*>(subBatchContext.flagBuffer.local_addr);
+    cqe[3] = subBatchContext.cid | (0x716U << 17);
+
+    transport_->taskExecutor_->Poll(ctx);
+
+    EXPECT_EQ(channel->GetErrorCount(), std::uint32_t{2});
+    EXPECT_EQ(channel->GetState(), ChannelState::ACTIVE);
+    EXPECT_EQ(subBatchContext.status.code, StatusCode::ASU_CQE_IO_TIMEOUT);
+}
+
+TEST_F(TransportTaskCompletionTest, PollTaskCompletionsTimesOutAndReleasesResources)
+{
+    auto* provider = transport_->transProvider_.get();
+    transport_->connManager_ = std::make_unique<ConnectionManager>(*provider, "", 5000, 2);
+    ASSERT_TRUE(transport_->connManager_->AddGroup(AsuEndpoint{}, 1).ok());
+    auto channel = transport_->connManager_->SelectConnection();
+    ASSERT_NE(channel, nullptr);
+
+    auto ctx = std::make_shared<TransportTask>();
+    ctx->taskId = 1;
+    ctx->state.store(TransportTaskState::INFLIGHT, std::memory_order_release);
+    ctx->deadline = std::chrono::steady_clock::now();
+    ctx->entryStatus.assign(2, Status::OK());
+    ctx->subBatchContexts->resize(1);
+
+    auto& subBatchContext = (*ctx->subBatchContexts)[0];
+    subBatchContext.opType = AsuOpType::BATCH_STORE;
+    subBatchContext.entryStatus.assign(2, Status::OK());
+    subBatchContext.channel = channel;
+    ASSERT_TRUE(
+        transport_->taskExecutor_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
+
+    std::size_t callbackCount = 0;
+    TaskResult callbackResult;
+    ctx->onComplete = [&](TaskResult result) {
+        ++callbackCount;
+        callbackResult = std::move(result);
+    };
+
+    if (transport_->taskExecutor_->Poll(ctx)) { transport_->taskManager_.NotifyCompletion(ctx); }
+
+    EXPECT_EQ(callbackCount, std::size_t{1});
+    EXPECT_EQ(ctx->state.load(std::memory_order_acquire), TransportTaskState::COMPLETED);
+    EXPECT_EQ(callbackResult.status.code, StatusCode::TIMEOUT);
+    ASSERT_EQ(callbackResult.entryStatus.size(), std::size_t{2});
+    EXPECT_EQ(callbackResult.entryStatus[0].code, StatusCode::TIMEOUT);
+    EXPECT_EQ(callbackResult.entryStatus[1].code, StatusCode::TIMEOUT);
+    EXPECT_EQ(subBatchContext.sendSge.slot_index, UINT32_MAX);
+    EXPECT_EQ(subBatchContext.flagBuffer.slot_index, UINT32_MAX);
+    EXPECT_EQ(channel->GetErrorCount(), std::uint32_t{1});
+    EXPECT_EQ(channel->GetState(), ChannelState::ACTIVE);
+}
+
+TEST_F(TransportTaskCompletionTest, ExecutionTimeoutCountsEachSubBatch)
+{
+    auto* provider = transport_->transProvider_.get();
+    transport_->connManager_ = std::make_unique<ConnectionManager>(*provider, "", 5000, 2);
+    ASSERT_TRUE(transport_->connManager_->AddGroup(AsuEndpoint{}, 1).ok());
+    auto channel = transport_->connManager_->SelectConnection();
+    ASSERT_NE(channel, nullptr);
+    auto sameChannel = transport_->connManager_->SelectConnection();
+    ASSERT_EQ(sameChannel, channel);
+
+    auto ctx = std::make_shared<TransportTask>();
+    ctx->state.store(TransportTaskState::INFLIGHT, std::memory_order_release);
+    ctx->deadline = std::chrono::steady_clock::now();
+    ctx->entryStatus.assign(2, Status::OK());
+    ctx->subBatchContexts->resize(2);
+    for (auto& subBatchContext : *ctx->subBatchContexts) {
+        subBatchContext.channel = channel;
+        subBatchContext.entryStatus.assign(1, Status::OK());
+    }
+
+    transport_->taskExecutor_->Poll(ctx);
+
+    EXPECT_EQ(channel->GetErrorCount(), std::uint32_t{2});
+    EXPECT_EQ(channel->GetState(), ChannelState::DRAINING);
+    EXPECT_EQ(channel->GetInflightCount(), std::uint32_t{0});
+}
+
+TEST_F(TransportTaskCompletionTest, ReleaseSubBatchResourcesPreservesSubBatchStatus)
+{
+    TransportSubBatchContext subBatchContext;
+    subBatchContext.state = TransportSubBatchState::COMPLETED;
+    subBatchContext.status = Status::Error(StatusCode::IO_ERROR, "send failed");
+    ASSERT_TRUE(
+        transport_->taskExecutor_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
+
+    transport_->taskExecutor_->ReleaseSubBatchResources(subBatchContext);
+
+    EXPECT_EQ(subBatchContext.state, TransportSubBatchState::COMPLETED);
+    EXPECT_EQ(subBatchContext.status.code, StatusCode::IO_ERROR);
+}
+
+TEST_F(TransportTaskCompletionTest, ReleaseSubBatchResourcesClearsSlotsAfterFreeFailure)
+{
+    TransportSubBatchContext subBatchContext;
+    subBatchContext.sendSge.slot_index = kTestBufferSlotNum;
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
+
+    transport_->taskExecutor_->ReleaseSubBatchResources(subBatchContext);
+
+    EXPECT_EQ(subBatchContext.sendSge.slot_index, UINT32_MAX);
+    EXPECT_EQ(subBatchContext.flagBuffer.slot_index, UINT32_MAX);
+}
+
+TEST_F(TransportTaskCompletionTest, ReleaseSubBatchResourcesReleasesChannelInflight)
+{
+    StubTransProvider provider;
+    ConnectionManager connManager(provider, "", 5000);
+    ASSERT_TRUE(connManager.AddGroup(AsuEndpoint{}, 1).ok());
+    auto channel = connManager.SelectConnection();
+    ASSERT_NE(channel, nullptr);
+    ASSERT_EQ(channel->GetInflightCount(), std::uint32_t{1});
+
+    TransportSubBatchContext subBatchContext;
+    subBatchContext.channel = channel;
+
+    transport_->taskExecutor_->ReleaseSubBatchResources(subBatchContext);
+
+    EXPECT_EQ(channel->GetInflightCount(), std::uint32_t{0});
+    EXPECT_EQ(subBatchContext.channel.get(), nullptr);
+}
+
+TEST_F(TransportTaskCompletionTest, TryFinalizeEmptyTaskMarksPartialFailed)
+{
+    TransportTask ctx;
+    ctx.finalStatus = Status::OK();
+
+    ctx.TryFinalizeFromSubBatches();
+
+    EXPECT_EQ(ctx.state.load(std::memory_order_acquire), TransportTaskState::COMPLETED);
+    EXPECT_EQ(ctx.finalStatus.code, StatusCode::PARTIAL_FAILED);
+
+    ctx.state.store(TransportTaskState::PENDING, std::memory_order_release);
+    ctx.finalStatus = Status::Error(StatusCode::UNSUPPORTED, "unsupported");
+
+    ctx.TryFinalizeFromSubBatches();
+
+    EXPECT_EQ(ctx.state.load(std::memory_order_acquire), TransportTaskState::COMPLETED);
+    EXPECT_EQ(ctx.finalStatus.code, StatusCode::PARTIAL_FAILED);
+}
+
+TEST_F(TransportTaskCompletionTest, TryFinalizeWaitsUntilAllSubBatchesFinish)
+{
+    TransportTask ctx;
+    ctx.subBatchContexts->resize(2);
+    ctx.remainingSubBatchCount = 1;
+    ctx.state.store(TransportTaskState::INFLIGHT, std::memory_order_release);
+
+    ctx.TryFinalizeFromSubBatches();
+
+    EXPECT_EQ(ctx.state.load(std::memory_order_acquire), TransportTaskState::INFLIGHT);
+}
+
+TEST_F(TransportTaskCompletionTest, TryFinalizeAggregatesSuccessAndFailure)
+{
+    TransportTask ctx;
+    ctx.subBatchContexts->resize(2);
+    (*ctx.subBatchContexts)[0].state = TransportSubBatchState::COMPLETED;
+    (*ctx.subBatchContexts)[0].status = Status::OK();
+    (*ctx.subBatchContexts)[1].state = TransportSubBatchState::COMPLETED;
+    (*ctx.subBatchContexts)[1].status = Status::Error(StatusCode::IO_ERROR, "sub-batch failed");
+    ctx.remainingSubBatchCount = 0;
+
+    ctx.TryFinalizeFromSubBatches();
+
+    EXPECT_EQ(ctx.state.load(std::memory_order_acquire), TransportTaskState::COMPLETED);
+    EXPECT_EQ(ctx.finalStatus.code, StatusCode::PARTIAL_FAILED);
+
+    TransportTask successCtx;
+    successCtx.subBatchContexts->resize(1);
+    (*successCtx.subBatchContexts)[0].state = TransportSubBatchState::COMPLETED;
+    (*successCtx.subBatchContexts)[0].status = Status::OK();
+    successCtx.remainingSubBatchCount = 0;
+
+    successCtx.TryFinalizeFromSubBatches();
+
+    EXPECT_EQ(successCtx.state.load(std::memory_order_acquire), TransportTaskState::COMPLETED);
+    EXPECT_TRUE(successCtx.finalStatus.ok());
+}
+
+TEST_F(TransportTaskCompletionTest, NotifyCompletionPassesResultOnce)
+{
+    TransportTask ctx;
+    std::uint32_t callbackCount = 0;
+    TaskResult callbackResult;
+    ctx.onComplete = [&callbackCount, &callbackResult](TaskResult result) {
+        ++callbackCount;
+        callbackResult = std::move(result);
+    };
+    TaskResult result;
+    result.status = Status::Error(StatusCode::IO_ERROR, "fake completion error");
+    result.entryStatus = {Status::Error(StatusCode::NOT_FOUND, "fake entry error")};
+
+    EXPECT_TRUE(ctx.NotifyCompletion(result));
+    EXPECT_FALSE(ctx.NotifyCompletion(std::move(result)));
+
+    EXPECT_EQ(callbackCount, std::uint32_t{1});
+    EXPECT_EQ(callbackResult.status.code, StatusCode::IO_ERROR);
+    ASSERT_EQ(callbackResult.entryStatus.size(), std::size_t{1});
+    EXPECT_EQ(callbackResult.entryStatus[0].code, StatusCode::NOT_FOUND);
+    EXPECT_TRUE(ctx.completionNotified.load(std::memory_order_acquire));
+}
+
+TEST_F(TransportTaskCompletionTest, TaskManagerNotifyCompletionRemovesTaskAfterCallback)
+{
+    TaskId taskId = kInvalidTaskId;
+    bool callbackInvoked = false;
+    bool taskPresentDuringCallback = false;
+    auto ctx = std::make_unique<TransportTask>();
+    ctx->onComplete = [&](TaskResult) {
+        callbackInvoked = true;
+        taskPresentDuringCallback = transport_->taskManager_.Get(taskId) != nullptr;
+    };
+    ASSERT_TRUE(transport_->taskManager_.Submit(std::move(ctx), taskId).ok());
+    auto submittedCtx = transport_->taskManager_.Get(taskId);
+    ASSERT_NE(submittedCtx, nullptr);
+
+    transport_->taskManager_.NotifyCompletion(submittedCtx);
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_TRUE(taskPresentDuringCallback);
+    EXPECT_EQ(transport_->taskManager_.Get(taskId), nullptr);
+}
+
+TEST_F(TransportTaskCompletionTest, TaskManagerNotifyCompletionRemovesTaskWithoutCallback)
+{
+    TaskId taskId = kInvalidTaskId;
+    auto ctx = std::make_unique<TransportTask>();
+    ctx->finalStatus = Status::OK();
+    ctx->entryStatus = {Status::OK()};
+    ASSERT_TRUE(transport_->taskManager_.Submit(std::move(ctx), taskId).ok());
+    auto submittedCtx = transport_->taskManager_.Get(taskId);
+    ASSERT_NE(submittedCtx, nullptr);
+    submittedCtx->state.store(TransportTaskState::COMPLETED, std::memory_order_release);
+
+    transport_->taskManager_.NotifyCompletion(submittedCtx);
+
+    TaskResult result;
+    TransportTaskManager::BuildResult(*submittedCtx, result);
+    EXPECT_TRUE(result.status.ok());
+    ASSERT_EQ(result.entryStatus.size(), std::size_t{1});
+    EXPECT_TRUE(result.entryStatus[0].ok());
+    EXPECT_EQ(transport_->taskManager_.Get(taskId), nullptr);
+}
+
+TEST_F(TransportTaskCompletionTest, CancelInvokesCallbackOutsideTaskLock)
+{
+    TaskId taskId = kInvalidTaskId;
+    bool callbackInvoked = false;
+    bool taskLockAvailable = false;
+    bool terminalState = false;
+    auto ctx = std::make_unique<TransportTask>();
+    auto* rawCtx = ctx.get();
+    ctx->onComplete = [&](TaskResult result) {
+        callbackInvoked = result.status.code == StatusCode::CANCELED;
+        terminalState =
+            rawCtx->state.load(std::memory_order_acquire) == TransportTaskState::COMPLETED;
+        taskLockAvailable = rawCtx->mutex.try_lock();
+        if (taskLockAvailable) { rawCtx->mutex.unlock(); }
+    };
+    ASSERT_TRUE(transport_->taskManager_.Submit(std::move(ctx), taskId).ok());
+
+    EXPECT_TRUE(transport_->Cancel(taskId).ok());
+
+    EXPECT_TRUE(callbackInvoked);
+    EXPECT_TRUE(taskLockAvailable);
+    EXPECT_TRUE(terminalState);
+    EXPECT_EQ(transport_->taskManager_.Get(taskId), nullptr);
+}
+
+TEST_F(TransportTaskCompletionTest, CancelMarksOnlyUnfinishedEntriesCanceled)
+{
+    TaskId taskId = kInvalidTaskId;
+    TaskResult callbackResult;
+    bool completedSubBatchPreserved = false;
+    bool pendingSubBatchCanceled = false;
+    auto ctx = std::make_unique<TransportTask>();
+    auto* rawCtx = ctx.get();
+    ctx->entryStatus.assign(2, Status::OK());
+    ctx->subBatchContexts->resize(2);
+    (*ctx->subBatchContexts)[0].state = TransportSubBatchState::COMPLETED;
+    (*ctx->subBatchContexts)[0].entryStatus = {Status::OK()};
+    (*ctx->subBatchContexts)[1].state = TransportSubBatchState::PENDING;
+    (*ctx->subBatchContexts)[1].entryStatus = {Status::OK()};
+    ctx->onComplete = [&](TaskResult result) {
+        const auto& completedSubBatch = (*rawCtx->subBatchContexts)[0];
+        const auto& canceledSubBatch = (*rawCtx->subBatchContexts)[1];
+        completedSubBatchPreserved = completedSubBatch.state == TransportSubBatchState::COMPLETED &&
+                                     completedSubBatch.status.ok();
+        pendingSubBatchCanceled = canceledSubBatch.state == TransportSubBatchState::COMPLETED &&
+                                  canceledSubBatch.status.code == StatusCode::CANCELED;
+        callbackResult = std::move(result);
+    };
+    ASSERT_TRUE(transport_->taskManager_.Submit(std::move(ctx), taskId).ok());
+
+    ASSERT_TRUE(transport_->Cancel(taskId).ok());
+
+    EXPECT_EQ(callbackResult.status.code, StatusCode::CANCELED);
+    ASSERT_EQ(callbackResult.entryStatus.size(), std::size_t{2});
+    EXPECT_TRUE(callbackResult.entryStatus[0].ok());
+    EXPECT_EQ(callbackResult.entryStatus[1].code, StatusCode::CANCELED);
+    EXPECT_TRUE(completedSubBatchPreserved);
+    EXPECT_TRUE(pendingSubBatchCanceled);
+}
+
+TEST_F(TransportTaskCompletionTest, FailedSubmissionDoesNotInvokeCallback)
+{
+    std::vector<KVBuffer> entries(1);
+    std::uint32_t callbackCount = 0;
+
+    auto task = std::make_shared<TransportTask>();
+    task->taskId = 123;
+    task->opType = AsuOpType::BATCH_LOAD;
+    task->entries = entries;
+    task->onComplete = [&callbackCount](TaskResult) { ++callbackCount; };
+    const auto status = transport_->Submit(task);
+
+    EXPECT_EQ(status.code, StatusCode::NOT_INITIALIZED);
+    EXPECT_EQ(task->taskId, kInvalidTaskId);
+    EXPECT_EQ(callbackCount, std::uint32_t{0});
+}
+
+TEST_F(TransportTaskCompletionTest, ShutdownCallbackCannotSubmitNewTask)
+{
+    std::uint32_t callbackCount = 0;
+    std::uint32_t nestedCallbackCount = 0;
+    Status nestedSubmitStatus = Status::OK();
+    auto ctx = std::make_unique<TransportTask>();
+    ctx->onComplete = [&](TaskResult result) {
+        ++callbackCount;
+        EXPECT_EQ(result.status.code, StatusCode::CANCELED);
+        auto nestedTask = std::make_shared<TransportTask>();
+        nestedTask->opType = AsuOpType::BATCH_LOAD;
+        nestedTask->entries.resize(1);
+        nestedTask->onComplete = [&nestedCallbackCount](TaskResult) { ++nestedCallbackCount; };
+        nestedSubmitStatus = transport_->Submit(nestedTask);
+        EXPECT_EQ(nestedTask->taskId, kInvalidTaskId);
+    };
+
+    TaskId taskId = kInvalidTaskId;
+    ASSERT_TRUE(transport_->taskManager_.Submit(std::move(ctx), taskId).ok());
+
+    EXPECT_TRUE(transport_->Shutdown().ok());
+
+    EXPECT_EQ(callbackCount, std::uint32_t{1});
+    EXPECT_EQ(nestedSubmitStatus.code, StatusCode::NOT_INITIALIZED);
+    EXPECT_EQ(nestedCallbackCount, std::uint32_t{0});
+}
+
+TEST_F(TransportTaskCompletionTest, ShutdownDrainsInflightTaskBeforeCanceling)
+{
+    auto ctx = std::make_unique<TransportTask>();
+    ctx->entryStatus.assign(1, Status::OK());
+    ctx->subBatchContexts->resize(1);
+    ctx->remainingSubBatchCount = 1;
+    auto& subBatchContext = (*ctx->subBatchContexts)[0];
+    subBatchContext.cid = 123;
+    subBatchContext.opType = AsuOpType::BATCH_STORE;
+    subBatchContext.entryStatus.assign(1, Status::OK());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
+    auto* cqe = reinterpret_cast<std::uint32_t*>(subBatchContext.flagBuffer.local_addr);
+    cqe[3] = subBatchContext.cid;
+
+    std::uint32_t callbackCount = 0;
+    Status callbackStatus = Status::Error(StatusCode::INTERNAL_ERROR, "callback not invoked");
+    ctx->onComplete = [&](TaskResult result) {
+        ++callbackCount;
+        callbackStatus = std::move(result.status);
+    };
+
+    TaskId taskId = kInvalidTaskId;
+    ASSERT_TRUE(transport_->taskManager_.Submit(std::move(ctx), taskId).ok());
+    auto submittedCtx = transport_->taskManager_.Get(taskId);
+    ASSERT_NE(submittedCtx, nullptr);
+    submittedCtx->state.store(TransportTaskState::INFLIGHT, std::memory_order_release);
+    transport_->completionWorker_ =
+        std::thread(&AsuTransportImpl::CompletionLoop, transport_.get());
+
+    EXPECT_TRUE(transport_->Shutdown().ok());
+
+    EXPECT_EQ(callbackCount, std::uint32_t{1});
+    EXPECT_TRUE(callbackStatus.ok()) << callbackStatus.message;
+}
+
+TEST_F(TransportTaskCompletionTest, CancelReleasesResourcesBeforeInvokingCallbackOnce)
+{
+    TaskId taskId = kInvalidTaskId;
+    std::uint32_t callbackCount = 0;
+    bool resourcesReleased = false;
+    auto ctx = std::make_unique<TransportTask>();
+    ctx->subBatchContexts->resize(1);
+    auto& subBatchContext = (*ctx->subBatchContexts)[0];
+    ASSERT_TRUE(
+        transport_->taskExecutor_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
+    auto* rawCtx = ctx.get();
+    ctx->onComplete = [&](TaskResult result) {
+        ++callbackCount;
+        resourcesReleased = result.status.code == StatusCode::CANCELED &&
+                            (*rawCtx->subBatchContexts)[0].sendSge.slot_index == UINT32_MAX &&
+                            (*rawCtx->subBatchContexts)[0].flagBuffer.slot_index == UINT32_MAX;
+    };
+    ASSERT_TRUE(transport_->taskManager_.Submit(std::move(ctx), taskId).ok());
+
+    EXPECT_TRUE(transport_->Cancel(taskId).ok());
+    EXPECT_EQ(transport_->Cancel(taskId).code, StatusCode::TASK_NOT_FOUND);
+
+    EXPECT_EQ(callbackCount, std::uint32_t{1});
+    EXPECT_TRUE(resourcesReleased);
+    EXPECT_EQ(transport_->taskManager_.Get(taskId), nullptr);
+}
+
+TEST_F(TransportTaskCompletionTest, ShutdownReleasesResourcesBeforeInvokingCallbackOnce)
+{
+    TaskId taskId = kInvalidTaskId;
+    std::uint32_t callbackCount = 0;
+    bool resourcesReleased = false;
+    bool entryCanceled = false;
+    auto ctx = std::make_unique<TransportTask>();
+    ctx->entryStatus = {Status::OK()};
+    ctx->subBatchContexts->resize(1);
+    auto& subBatchContext = (*ctx->subBatchContexts)[0];
+    subBatchContext.entryStatus = {Status::OK()};
+    ASSERT_TRUE(
+        transport_->taskExecutor_->sendBufferManager_.Allocate(64, subBatchContext.sendSge).ok());
+    ASSERT_TRUE(
+        transport_->taskExecutor_->flagBufferManager_.Allocate(64, subBatchContext.flagBuffer)
+            .ok());
+    auto* rawCtx = ctx.get();
+    ctx->onComplete = [&](TaskResult result) {
+        ++callbackCount;
+        resourcesReleased = result.status.code == StatusCode::CANCELED &&
+                            (*rawCtx->subBatchContexts)[0].sendSge.slot_index == UINT32_MAX &&
+                            (*rawCtx->subBatchContexts)[0].flagBuffer.slot_index == UINT32_MAX;
+        entryCanceled =
+            result.entryStatus.size() == 1 && result.entryStatus[0].code == StatusCode::CANCELED;
+    };
+    ASSERT_TRUE(transport_->taskManager_.Submit(std::move(ctx), taskId).ok());
+
+    EXPECT_TRUE(transport_->Shutdown().ok());
+    EXPECT_TRUE(transport_->Shutdown().ok());
+
+    EXPECT_EQ(callbackCount, std::uint32_t{1});
+    EXPECT_TRUE(resourcesReleased);
+    EXPECT_TRUE(entryCanceled);
+    EXPECT_EQ(transport_->taskManager_.Get(taskId), nullptr);
+}
+
+}  // namespace
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/include/aiv_transport/aiv_transport.h
+++ b/ucm/transport/kv/asu/trans/include/aiv_transport/aiv_transport.h
@@ -1,0 +1,95 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+#include "asu_transport/types.h"
+
+namespace UC::ASU {
+
+class AIVTransport {
+public:
+    using ConnectionHandle = void*;
+
+    virtual ~AIVTransport() = default;
+
+    virtual Status CreateConnection(const std::string& localIp, const std::string& remoteIp,
+                                    uint32_t port, uint32_t qpNum, uint32_t timeout,
+                                    std::vector<ConnectionHandle>& connectionHandles) = 0;
+
+    virtual std::vector<Status> DeleteConnections(
+        const std::vector<ConnectionHandle>& connectionHandles) = 0;
+
+    struct SendIoBatch {
+        ConnectionHandle connectionHandle;
+        void* sendBuffer;
+        void* flagBuffer;
+        uint64_t len;
+    };
+
+    virtual std::vector<Status> Send(const std::vector<SendIoBatch>& ioBatches,
+                                     uint32_t kernelCount, uint32_t quietCount) = 0;
+
+    enum class MemType { MEM_DEVICE, MEM_HOST };
+
+    struct RegisterMemoryDesc {
+        MemType memoryType;
+        uintptr_t addr;
+        size_t size;
+    };
+
+    virtual Status RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
+                                  std::vector<MRHandle>& mrHandles) = 0;
+
+    struct BindMemoryDesc {
+        MemType memoryType;
+        uintptr_t addr;
+        size_t size;
+        uint32_t tokenId;
+    };
+
+    virtual Status BindMemory(const std::vector<BindMemoryDesc>& memoryDescs,
+                              std::vector<MRHandle>& mrHandles) = 0;
+
+    struct UnregisterMemoryDesc {
+        MRHandle mrHandle;
+    };
+
+    virtual std::vector<Status> UnregisterMemory(
+        const std::vector<UnregisterMemoryDesc>& memoryDescs) = 0;
+
+    virtual Status GetMemTokenId(MRHandle mrHandle, uint32_t& tokenId) = 0;
+
+    virtual Status GetServerCapabilities(ConnectionHandle connectionHandle,
+                                         ServerKvCapabilities& capabilities) = 0;
+};
+
+std::unique_ptr<AIVTransport> CreateAIVTransProvider();
+std::unique_ptr<AIVTransport> CreateAIVTransProvider(uint32_t deviceId);
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/asu_transport.h
@@ -1,0 +1,118 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "asu_transport/trans_provider.h"
+#include "asu_transport/types.h"
+
+namespace UC::ASU {
+
+struct TransportTask;
+
+struct AsuEndpoint {
+    std::string ip;
+    std::uint16_t port{0};
+    Protocol protocol{Protocol::ROCE};
+    std::int32_t numaNode{-1};
+    std::string hcaName;
+    std::uint8_t hcaPort{1};
+    std::unordered_map<std::string, std::string> attrs;
+};
+
+struct TransportConfig {
+    // TODO: 拆分Config，按逻辑模块细化
+    std::string asuName;
+    AsuId asuId{0};
+    // Local logical device ID used by the transport provider.
+    std::int32_t deviceId{-1};
+    std::vector<AsuEndpoint> endpoints;
+
+    TransProviderType providerType{TransProviderType::AICPU};
+
+    std::uint32_t qpNum{1};
+
+    std::uint32_t maxInflightTasks{1024};
+    std::uint64_t maxInflightBytes{1ULL << 30};
+
+    std::uint64_t timeoutMs{100};
+    std::uint32_t maxErrorCount{2};
+    std::size_t completionPollSpinLimit{16};
+
+    bool enableDeviceDirect{true};
+    bool enableHostFallback{false};
+    bool preconnect{true};
+    bool bindCqPoller{true};
+
+    // Slot sizes are caller-visible capacities; BufferManager computes the
+    // aligned physical stride used for allocation and memory registration.
+    std::size_t sendBufferSlotSize{4160};
+    std::size_t sendBufferSlotNum{128};
+    // Maximum memory required by a batch store/retrieve response flag buffer.
+    std::size_t flagBufferSlotSize{71};
+    std::size_t flagBufferSlotNum{4096};
+    std::size_t asuBatchLoadIoNum{110};
+    std::size_t asuBatchStoreIoNum{110};
+    std::size_t asuDeleteIoNum{254};
+    std::size_t asuQueryIoNum{256};
+
+    // Transport attrs loaded from config, including SQE request attrs
+    // (kv_ns_id, dtype, dspec, lr, sc) and send attrs (kernel_count, quiet_count).
+    std::unordered_map<std::string, std::string> attrs;
+};
+
+template <typename T>
+struct BatchView {
+    const T* data{nullptr};
+    std::size_t size{0};
+
+    const T& operator[](std::size_t i) const noexcept { return data[i]; }
+    bool empty() const noexcept { return size == 0; }
+};
+
+class AsuTransport {
+public:
+    virtual ~AsuTransport() = default;
+
+    virtual Status Init(const TransportConfig& config,
+                        std::shared_ptr<TransProvider> transProvider) = 0;
+    virtual Status Init(const std::string& configPath,
+                        std::shared_ptr<TransProvider> transProvider) = 0;
+    virtual Status Shutdown() = 0;
+    virtual Status CheckHealth() = 0;
+
+    virtual Status Submit(const std::shared_ptr<TransportTask>& task) = 0;
+
+    // Best-effort cancellation, does not interrupt underlying UB/RoCE IO
+    virtual Status Cancel(TaskId taskId) = 0;
+};
+
+std::unique_ptr<AsuTransport> CreateAsuTransport();
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/include/asu_transport/trans_provider.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/trans_provider.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+#include "asu_transport/types.h"
+
+namespace UC::ASU {
+
+struct TransportConfig;
+
+class TransProvider {
+public:
+    using ConnectionHandle = void*;
+    using ThreadHandle = void*;
+
+    virtual ~TransProvider() = default;
+
+    // On success, connectionHandles contains exactly qpNum handles. On failure, it is empty.
+    virtual Status CreateConnection(const std::string& localIp, const std::string& remoteIp,
+                                    uint32_t port, uint32_t qpNum, uint32_t timeout,
+                                    std::vector<ConnectionHandle>& connectionHandles) = 0;
+
+    virtual std::vector<Status> DeleteConnections(
+        const std::vector<ConnectionHandle>& connectionHandles) = 0;
+
+    // Returns provider-neutral KV limits for the server behind this connection. Providers that
+    // do not support capability discovery keep the default UNSUPPORTED result.
+    virtual Status GetServerCapabilities(ConnectionHandle connectionHandle,
+                                         ServerKvCapabilities& capabilities)
+    {
+        (void)connectionHandle;
+        capabilities = {};
+        return Status::Error(StatusCode::UNSUPPORTED, "server capability query is not supported");
+    }
+
+    struct SendIoBatch {
+        ConnectionHandle connectionHandle;
+        void* sendBuffer;
+        void* flagBuffer;
+        uint64_t len;
+    };
+
+    virtual std::vector<Status> Send(const std::vector<SendIoBatch>& ioBatches,
+                                     uint32_t kernelCount, uint32_t quietCount) = 0;
+
+    enum class MemType { MEM_DEVICE, MEM_HOST };
+
+    struct RegisterMemoryDesc {
+        MemType memoryType;
+        uintptr_t addr;
+        size_t size;
+        uintptr_t localAddr{0};
+    };
+
+    virtual Status RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
+                                  std::vector<MRHandle>& mrHandles) = 0;
+
+    struct BindMemoryDesc {
+        MemType memoryType;
+        uintptr_t addr;
+        size_t size;
+        std::uint32_t tokenId;
+    };
+
+    // Creates a provider-local handle for an existing shared registration.
+    virtual Status BindMemory(const std::vector<BindMemoryDesc>& memoryDescs,
+                              std::vector<MRHandle>& mrHandles)
+    {
+        (void)memoryDescs;
+        mrHandles.clear();
+        return Status::Error(StatusCode::UNSUPPORTED, "memory binding is not supported");
+    }
+
+    struct UnregisterMemoryDesc {
+        MRHandle mrHandle;
+    };
+
+    virtual std::vector<Status> UnregisterMemory(
+        const std::vector<UnregisterMemoryDesc>& memoryDescs) = 0;
+
+    virtual Status AllocThread(uint32_t threadNum, const std::vector<uint32_t>& notifyNumPerThread,
+                               std::vector<ThreadHandle>& threads) = 0;
+
+    virtual std::vector<Status> FreeThread(const std::vector<ThreadHandle>& threads) = 0;
+
+    virtual Status GetMemTokenId(MRHandle mrHandle, uint32_t& tokenId) = 0;
+};
+
+Status CreateTransProvider(const TransportConfig& config,
+                           std::shared_ptr<TransProvider>& transProvider);
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/include/asu_transport/types.h
+++ b/ucm/transport/kv/asu/trans/include/asu_transport/types.h
@@ -1,0 +1,187 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace UC::ASU {
+
+using TaskId = std::uint64_t;
+using MRHandle = std::uint64_t;
+constexpr std::size_t kCacheKeySizeBytes = 8;
+using CacheKey = std::array<std::byte, kCacheKeySizeBytes>;
+using AsuId = std::uint64_t;
+
+inline std::string_view CacheKeyView(const CacheKey& key)
+{
+    return {reinterpret_cast<const char*>(key.data()), key.size()};
+}
+
+inline std::string CacheKeyToHex(const CacheKey& key)
+{
+    static constexpr char kHex[] = "0123456789abcdef";
+    std::string text;
+    text.reserve(key.size() * 2);
+    for (auto byte : key) {
+        const auto value = static_cast<unsigned char>(std::to_integer<unsigned char>(byte));
+        text.push_back(kHex[value >> 4]);
+        text.push_back(kHex[value & 0x0F]);
+    }
+    return text;
+}
+
+enum class TransProviderType { AICPU, FAKE, AIV, UNSUPPORTED };
+
+constexpr TaskId kInvalidTaskId = 0;
+constexpr MRHandle kInvalidMRHandle = 0;
+constexpr std::uint32_t kAsuAlignmentBytes = 512;  // KV protocol requires 512B alignment
+
+enum class StatusCode {
+    OK = 0,
+    INVALID_ARGUMENT,
+    NOT_INITIALIZED,
+    TIMEOUT,
+    NOT_FOUND,
+    PARTIAL_FAILED,
+    CONNECTION_ERROR,
+    IO_ERROR,
+    BUFFER_NOT_REGISTERED,
+    BUFFER_NOT_SUPPORTED,
+    TASK_NOT_FOUND,
+    RESOURCE_BUSY,
+    UNSUPPORTED,
+    IN_PROGRESS,
+    INTERNAL_ERROR,
+    CANCELED,
+
+    // ASU entry status codes keep raw entry result values in the low byte.
+    ASU_ENTRY_RETRY_ADVISED = 0x0100 | 0x01,
+    ASU_ENTRY_NO_RETRY_ADVISED = 0x0100 | 0x02,
+    ASU_ENTRY_KEY_NOT_FOUND = 0x0100 | 0x03,
+    ASU_ENTRY_DATA_NOT_EXIST = 0x0100 | 0x04,
+    ASU_ENTRY_DELETE_FAILED = 0x0200 | 0x01,
+    ASU_ENTRY_KEY_NOT_EXIST = 0x0300 | 0x00,
+    ASU_ENTRY_KEY_EXIST = 0x0300 | 0x01,
+
+    ASU_CQE_INVALID_COMMAND_OPCODE = 0x10000 | 0x001,
+    ASU_CQE_INVALID_FIELD_IN_COMMAND = 0x10000 | 0x002,
+    ASU_CQE_INTERNAL_ERROR = 0x10000 | 0x006,
+    ASU_CQE_WRITE_FAULT = 0x10000 | 0x280,
+    ASU_CQE_UNRECOVERED_READ_ERROR = 0x10000 | 0x281,
+    ASU_CQE_KEY_NOT_EXIST = 0x10000 | 0x701,
+    ASU_CQE_OUT_OF_CREATE_SIZE = 0x10000 | 0x712,
+    ASU_CQE_IO_TIMEOUT = 0x10000 | 0x716,
+    ASU_CQE_KEY_ALREADY_EXISTED = 0x10000 | 0x723,
+    ASU_CQE_RESOURCE_BUSY = 0x10000 | 0x731,
+    ASU_CQE_CHECK_RESULT_BUFFER = 0x10000 | 0x732,
+};
+
+struct Status {
+    StatusCode code{StatusCode::OK};
+    std::string message;
+
+    bool ok() const noexcept { return code == StatusCode::OK; }
+
+    static Status OK() { return {}; }
+    static Status Error(StatusCode c, std::string msg) { return Status{c, std::move(msg)}; }
+};
+
+enum class Protocol {
+    UB = 0,
+    ROCE = 1,
+    TCP = 2,
+};
+
+struct ServerKvCapabilities {
+    // A zero limit means that the provider did not advertise that capability.
+    std::uint32_t queueNum{0};
+    std::uint32_t ioQueueDepth{0};
+    std::uint32_t ioQueueKeyConcurrency{0};     // Placeholder
+    std::uint32_t connectionKeyConcurrency{0};  // Placeholder
+    std::uint64_t singleValueMaxBytes{0};
+    std::uint64_t batchValueMaxBytes{0};
+    std::uint32_t batchStoreKeys{0};
+    std::uint32_t batchLoadKeys{0};
+    std::uint32_t deleteKeys{0};
+    std::uint32_t queryKeys{0};
+    std::uint32_t keyLength{0};
+    std::uint32_t kvCapabilities{0};  // Placeholder
+};
+
+struct QueryResult {
+    std::vector<std::uint8_t> exists;
+    std::uint32_t prefixHitKeys{0};
+};
+
+enum class MemoryType {
+    HOST = 0,
+    HOST_PINNED = 1,
+    DEVICE = 2,
+};
+
+struct MemoryRegion {  // 地址范围抽象
+    MemoryType memoryType{MemoryType::HOST};
+    std::uint64_t addr{0};
+    std::uint64_t size{0};
+    std::int32_t deviceId{-1};
+    std::int32_t numaNode{-1};
+};
+
+struct Buffer {  // 单个IO
+    MemoryRegion region;
+    MRHandle handle{kInvalidMRHandle};
+};
+
+struct KVBuffer {
+    CacheKey key;
+    Buffer buffer;
+    std::uint32_t offset{0};  // target buffer offset
+    // Resolved by AsuClient from buffer.handle before the entry reaches the transport.
+    std::optional<std::uint32_t> mrKey;
+};
+
+// Describes a registered memory region returned by registration or reused for binding.
+struct RegisteredMemory {
+    MemoryRegion region;
+    MRHandle handle{kInvalidMRHandle};
+    std::uint32_t tokenId{0};
+};
+
+struct TaskResult {
+    Status status;
+    std::vector<Status> entryStatus;
+    std::optional<QueryResult> queryResult;
+};
+
+using TaskCompletionCallback = std::function<void(TaskResult)>;
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/aicpu_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/aicpu_trans_provider.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "asu_transport/trans_provider.h"
+
+namespace UC::ASU {
+
+class AICPUTransProvider : public TransProvider {
+public:
+    Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t, uint32_t,
+                            std::vector<ConnectionHandle>&) override
+    {
+        return Status::OK();
+    }
+
+    std::vector<Status> DeleteConnections(const std::vector<ConnectionHandle>& handles) override
+    {
+        return std::vector<Status>(handles.size(), Status::OK());
+    }
+
+    std::vector<Status> Send(const std::vector<SendIoBatch>& ioBatches, uint32_t, uint32_t) override
+    {
+        return std::vector<Status>(ioBatches.size(), Status::OK());
+    }
+
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>&, std::vector<MRHandle>&) override
+    {
+        return Status::OK();
+    }
+
+    Status BindMemory(const std::vector<BindMemoryDesc>& memoryDescs,
+                      std::vector<MRHandle>& mrHandles) override
+    {
+        mrHandles.assign(memoryDescs.size(), kInvalidMRHandle);
+        return Status::OK();
+    }
+
+    std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& handles) override
+    {
+        return std::vector<Status>(handles.size(), Status::OK());
+    }
+
+    Status AllocThread(uint32_t, const std::vector<uint32_t>&, std::vector<ThreadHandle>&) override
+    {
+        return Status::OK();
+    }
+
+    std::vector<Status> FreeThread(const std::vector<ThreadHandle>& threads) override
+    {
+        return std::vector<Status>(threads.size(), Status::OK());
+    }
+
+    Status GetMemTokenId(MRHandle, uint32_t& tokenId) override
+    {
+        tokenId = 0;
+        return Status::OK();
+    }
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/aiv_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/aiv_trans_provider.h
@@ -1,0 +1,133 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <memory>
+#include "aiv_transport/aiv_transport.h"
+#include "asu_transport/trans_provider.h"
+
+namespace UC::ASU {
+
+class AIVTransProviderAdapter : public TransProvider {
+public:
+    AIVTransProviderAdapter() : impl_(CreateAIVTransProvider()) {}
+    explicit AIVTransProviderAdapter(uint32_t deviceId) : impl_(CreateAIVTransProvider(deviceId)) {}
+
+    Status CreateConnection(const std::string& localIp, const std::string& remoteIp, uint32_t port,
+                            uint32_t qpNum, uint32_t timeout,
+                            std::vector<ConnectionHandle>& connectionHandles) override
+    {
+        return FromImpl(
+            impl_->CreateConnection(localIp, remoteIp, port, qpNum, timeout, connectionHandles));
+    }
+
+    std::vector<Status> DeleteConnections(
+        const std::vector<ConnectionHandle>& connectionHandles) override
+    {
+        return FromImpl(impl_->DeleteConnections(connectionHandles));
+    }
+
+    Status GetServerCapabilities(ConnectionHandle connectionHandle,
+                                 ServerKvCapabilities& capabilities) override
+    {
+        return FromImpl(impl_->GetServerCapabilities(connectionHandle, capabilities));
+    }
+
+    std::vector<Status> Send(const std::vector<SendIoBatch>& ioBatches, uint32_t kernelCount,
+                             uint32_t quietCount) override
+    {
+        std::vector<AIVTransport::SendIoBatch> batches;
+        batches.reserve(ioBatches.size());
+        for (const auto& io : ioBatches) {
+            batches.push_back({io.connectionHandle, io.sendBuffer, io.flagBuffer, io.len});
+        }
+        return FromImpl(impl_->Send(batches, kernelCount, quietCount));
+    }
+
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
+                          std::vector<MRHandle>& mrHandles) override
+    {
+        std::vector<AIVTransport::RegisterMemoryDesc> descs;
+        descs.reserve(memoryDescs.size());
+        for (const auto& desc : memoryDescs) {
+            descs.push_back(
+                {static_cast<AIVTransport::MemType>(desc.memoryType), desc.addr, desc.size});
+        }
+        return FromImpl(impl_->RegisterMemory(descs, mrHandles));
+    }
+
+    Status BindMemory(const std::vector<BindMemoryDesc>& memoryDescs,
+                      std::vector<MRHandle>& mrHandles) override
+    {
+        std::vector<AIVTransport::BindMemoryDesc> descs;
+        descs.reserve(memoryDescs.size());
+        for (const auto& desc : memoryDescs) {
+            descs.push_back({static_cast<AIVTransport::MemType>(desc.memoryType), desc.addr,
+                             desc.size, desc.tokenId});
+        }
+        return FromImpl(impl_->BindMemory(descs, mrHandles));
+    }
+
+    std::vector<Status> UnregisterMemory(
+        const std::vector<UnregisterMemoryDesc>& memoryDescs) override
+    {
+        std::vector<AIVTransport::UnregisterMemoryDesc> descs;
+        descs.reserve(memoryDescs.size());
+        for (const auto& desc : memoryDescs) { descs.push_back({desc.mrHandle}); }
+        return FromImpl(impl_->UnregisterMemory(descs));
+    }
+
+    Status AllocThread(uint32_t, const std::vector<uint32_t>&, std::vector<ThreadHandle>&) override
+    {
+        return Status::OK();
+    }
+
+    std::vector<Status> FreeThread(const std::vector<ThreadHandle>& threads) override
+    {
+        return std::vector<Status>(threads.size(), Status::OK());
+    }
+
+    Status GetMemTokenId(MRHandle mrHandle, uint32_t& tokenId) override
+    {
+        return FromImpl(impl_->GetMemTokenId(mrHandle, tokenId));
+    }
+
+private:
+    static Status FromImpl(const Status& status)
+    {
+        return status.ok() ? Status::OK() : Status::Error(status.code, status.message);
+    }
+
+    static std::vector<Status> FromImpl(const std::vector<Status>& statuses)
+    {
+        std::vector<Status> out;
+        out.reserve(statuses.size());
+        for (const auto& status : statuses) { out.push_back(FromImpl(status)); }
+        return out;
+    }
+
+    std::unique_ptr<AIVTransport> impl_;
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/asu_response_status.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_response_status.cpp
@@ -1,0 +1,189 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "asu_response_status.h"
+#include <algorithm>
+#include <string>
+
+namespace UC::ASU {
+
+namespace {
+
+constexpr int kAsuBatchEntryStatusBase = 0x0100;
+constexpr int kAsuDeleteEntryStatusBase = 0x0200;
+constexpr int kAsuExistEntryStatusBase = 0x0300;
+constexpr int kAsuCqeStatusBase = 0x10000;
+
+StatusCode EntryStatusCode(AsuOpType opType, std::uint8_t rawResult)
+{
+    if (opType == AsuOpType::BATCH_STORE || opType == AsuOpType::BATCH_LOAD) {
+        return static_cast<StatusCode>(kAsuBatchEntryStatusBase | rawResult);
+    }
+    if (opType == AsuOpType::DELETE) {
+        return static_cast<StatusCode>(kAsuDeleteEntryStatusBase | rawResult);
+    }
+    if (opType == AsuOpType::QUERY) {
+        return static_cast<StatusCode>(kAsuExistEntryStatusBase | rawResult);
+    }
+    return rawResult == 0 ? StatusCode::OK : StatusCode::IO_ERROR;
+}
+
+StatusCode CqeStatusCode(std::uint16_t rawStatus)
+{
+    return static_cast<StatusCode>(kAsuCqeStatusBase | rawStatus);
+}
+
+Status ResultBufferEntryToStatus(AsuOpType opType, std::uint8_t rawResult)
+{
+    if (opType != AsuOpType::QUERY && rawResult == 0x00) { return Status::OK(); }
+
+    if (opType == AsuOpType::BATCH_STORE || opType == AsuOpType::BATCH_LOAD) {
+        switch (EntryStatusCode(opType, rawResult)) {
+            case StatusCode::ASU_ENTRY_RETRY_ADVISED:
+                return Status::Error(StatusCode::ASU_ENTRY_RETRY_ADVISED,
+                                     "general error, retry advised");
+            case StatusCode::ASU_ENTRY_NO_RETRY_ADVISED:
+                return Status::Error(StatusCode::ASU_ENTRY_NO_RETRY_ADVISED,
+                                     "general error, no retry advised");
+            case StatusCode::ASU_ENTRY_KEY_NOT_FOUND:
+                return Status::Error(StatusCode::ASU_ENTRY_KEY_NOT_FOUND, "key not found");
+            case StatusCode::ASU_ENTRY_DATA_NOT_EXIST:
+                return Status::Error(StatusCode::ASU_ENTRY_DATA_NOT_EXIST, "data not exist");
+            default:
+                return Status::Error(StatusCode::IO_ERROR, "unknown ASU entry key result is " +
+                                                               std::to_string(rawResult));
+        }
+    }
+
+    if (opType == AsuOpType::DELETE) {
+        switch (EntryStatusCode(opType, rawResult)) {
+            case StatusCode::ASU_ENTRY_DELETE_FAILED:
+                return Status::Error(StatusCode::ASU_ENTRY_DELETE_FAILED, "delete failed");
+            default:
+                return Status::Error(StatusCode::IO_ERROR,
+                                     "unknown ASU delete result is " + std::to_string(rawResult));
+        }
+    }
+
+    if (opType == AsuOpType::QUERY) {
+        switch (EntryStatusCode(opType, rawResult)) {
+            case StatusCode::ASU_ENTRY_KEY_NOT_EXIST:
+                return Status::Error(StatusCode::ASU_ENTRY_KEY_NOT_EXIST, "key not exist");
+            case StatusCode::ASU_ENTRY_KEY_EXIST:
+                return Status::Error(StatusCode::ASU_ENTRY_KEY_EXIST, "key exist");
+            default:
+                return Status::Error(StatusCode::IO_ERROR,
+                                     "unknown ASU exist result is " + std::to_string(rawResult));
+        }
+    }
+
+    return Status::Error(StatusCode::IO_ERROR, "entry CQE status is " + std::to_string(rawResult));
+}
+
+}  // namespace
+
+Status KvResponseStatusToSubBatchStatus(std::uint16_t rawStatus)
+{
+    if (rawStatus == 0x00) { return Status::OK(); }
+
+    switch (CqeStatusCode(rawStatus)) {
+        case StatusCode::ASU_CQE_INVALID_COMMAND_OPCODE:
+            return Status::Error(StatusCode::ASU_CQE_INVALID_COMMAND_OPCODE,
+                                 "Invalid Command Opcode");
+        case StatusCode::ASU_CQE_INVALID_FIELD_IN_COMMAND:
+            return Status::Error(StatusCode::ASU_CQE_INVALID_FIELD_IN_COMMAND,
+                                 "Invalid Field in Command");
+        case StatusCode::ASU_CQE_INTERNAL_ERROR:
+            return Status::Error(StatusCode::ASU_CQE_INTERNAL_ERROR, "Internal Error");
+        case StatusCode::ASU_CQE_WRITE_FAULT:
+            return Status::Error(StatusCode::ASU_CQE_WRITE_FAULT, "Write fault");
+        case StatusCode::ASU_CQE_UNRECOVERED_READ_ERROR:
+            return Status::Error(StatusCode::ASU_CQE_UNRECOVERED_READ_ERROR,
+                                 "Unrecovered Read Error");
+        case StatusCode::ASU_CQE_KEY_NOT_EXIST:
+            return Status::Error(StatusCode::ASU_CQE_KEY_NOT_EXIST, "Key Not Exist");
+        case StatusCode::ASU_CQE_OUT_OF_CREATE_SIZE:
+            return Status::Error(StatusCode::ASU_CQE_OUT_OF_CREATE_SIZE, "Out of Create Size");
+        case StatusCode::ASU_CQE_IO_TIMEOUT:
+            return Status::Error(StatusCode::ASU_CQE_IO_TIMEOUT, "IO TimeOut");
+        case StatusCode::ASU_CQE_KEY_ALREADY_EXISTED:
+            return Status::Error(StatusCode::ASU_CQE_KEY_ALREADY_EXISTED, "Key already Existed");
+        case StatusCode::ASU_CQE_RESOURCE_BUSY:
+            return Status::Error(StatusCode::ASU_CQE_RESOURCE_BUSY, "Resource Busy");
+        case StatusCode::ASU_CQE_CHECK_RESULT_BUFFER:
+            return Status::Error(StatusCode::ASU_CQE_CHECK_RESULT_BUFFER,
+                                 "Batched Result, check result buffer for entry errors");
+        default:
+            return Status::Error(StatusCode::IO_ERROR,
+                                 "unknown ASU sub-batch status is " + std::to_string(rawStatus));
+    }
+}
+
+void FillEntryStatusFromCqeResult(const KvResponse& response,
+                                  TransportSubBatchContext& subBatchContext)
+{
+    auto& entryStatus = subBatchContext.entryStatus;
+    const auto keyExist = Status::Error(StatusCode::ASU_ENTRY_KEY_EXIST, "key exist");
+    const auto keyNotExist = Status::Error(StatusCode::ASU_ENTRY_KEY_NOT_EXIST, "key not exist");
+    const bool isQuery = subBatchContext.opType == AsuOpType::QUERY;
+
+    if (subBatchContext.status.ok()) {
+        std::fill(entryStatus.begin(), entryStatus.end(), isQuery ? keyExist : Status::OK());
+        return;
+    }
+
+    if (isQuery && !subBatchContext.useSeekControl &&
+        subBatchContext.status.code == StatusCode::ASU_CQE_CHECK_RESULT_BUFFER) {
+        const auto existingKeyCount =
+            std::min(entryStatus.size(), static_cast<std::size_t>(response.existing_key_number));
+        std::fill(entryStatus.begin(), entryStatus.end(), keyNotExist);
+        std::fill_n(entryStatus.begin(), existingKeyCount, keyExist);
+        return;
+    }
+
+    if (subBatchContext.status.code != StatusCode::ASU_CQE_CHECK_RESULT_BUFFER ||
+        response.result_buffer.empty()) {
+        std::fill(entryStatus.begin(), entryStatus.end(), subBatchContext.status);
+        return;
+    }
+
+    for (std::size_t index = 0; index < entryStatus.size(); ++index) {
+        entryStatus[index] =
+            ResultBufferEntryToStatus(subBatchContext.opType, response.result_buffer[index]);
+    }
+}
+
+QueryResult BuildQueryResultFromEntryStatus(const std::vector<Status>& entryStatus)
+{
+    QueryResult queryResult;
+    queryResult.exists.assign(entryStatus.size(), 0);
+    for (std::size_t index = 0; index < entryStatus.size(); ++index) {
+        queryResult.exists[index] = entryStatus[index].code == StatusCode::ASU_ENTRY_KEY_EXIST;
+        if (queryResult.prefixHitKeys == index && queryResult.exists[index] != 0) {
+            ++queryResult.prefixHitKeys;
+        }
+    }
+    return queryResult;
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/asu_response_status.h
+++ b/ucm/transport/kv/asu/trans/src/asu_response_status.h
@@ -1,0 +1,41 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include "asu_transport/types.h"
+#include "connection_manager.h"
+#include "transport_task_manager.h"
+
+namespace UC::ASU {
+
+Status KvResponseStatusToSubBatchStatus(std::uint16_t rawStatus);
+
+void FillEntryStatusFromCqeResult(const KvResponse& response,
+                                  TransportSubBatchContext& subBatchContext);
+
+QueryResult BuildQueryResultFromEntryStatus(const std::vector<Status>& entryStatus);
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_submit_flow.cpp
@@ -1,0 +1,163 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <algorithm>
+#include <cstdint>
+#include <utility>
+#include "connection_internal.h"
+#include "logger.h"
+#include "transport_task_executor.h"
+
+namespace UC::ASU {
+
+namespace {
+
+std::uint32_t GetSendCountAttr(const std::unordered_map<std::string, std::string>& attrs,
+                               const std::string& name)
+{
+    auto it = attrs.find(name);
+    if (it == attrs.end()) { return 0; }
+    return static_cast<std::uint32_t>(std::stoull(it->second, nullptr, 0));
+}
+
+void SetSubBatchSendFailed(TransportSubBatchContext& subBatchContext, const Status& status)
+{
+    std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(), status);
+    subBatchContext.state = TransportSubBatchState::COMPLETED;
+    subBatchContext.status = status;
+}
+
+}  // namespace
+
+Status TransportTaskExecutor::PrepareTaskSubBatches(
+    const TransportTask& ctx, std::vector<TransportSubBatchContext>& subBatchContexts)
+{
+    if (IsEntryBatchOp(ctx.opType)) {
+        const auto opType = ctx.opType;
+        if (ctx.entries.empty()) {
+            UC_ERROR("Submit entry batch failed: entry batch is empty");
+            return Status::Error(StatusCode::INVALID_ARGUMENT, "entry batch is empty");
+        }
+        const auto entries = BatchView<KVBuffer>{ctx.entries.data(), ctx.entries.size()};
+        const auto subBatches = ioScheduler_.SplitForAsu(entries, opType);
+        subBatchContexts.reserve(subBatches.size());
+        for (std::size_t index = 0; index < subBatches.size(); ++index) {
+            const auto& subBatch = subBatches[index];
+            auto& subBatchContext = subBatchContexts.emplace_back();
+            const auto subBatchStatus =
+                BuildEntrySubBatchRequest(opType, subBatch, subBatchContext);
+            if (!subBatchStatus.ok()) {
+                UC_ERROR(
+                    "Build entry sub-batch request failed index={} batch_size={} code={} "
+                    "message={}",
+                    index, subBatch.entries.size, static_cast<int>(subBatchStatus.code),
+                    subBatchStatus.message);
+                return subBatchStatus;
+            }
+        }
+    } else if (IsKeyBatchOp(ctx.opType)) {
+        if (ctx.keys.empty()) {
+            UC_ERROR("Submit key batch failed: key batch is empty");
+            return Status::Error(StatusCode::INVALID_ARGUMENT, "key batch is empty");
+        }
+        const auto keys = BatchView<CacheKey>{ctx.keys.data(), ctx.keys.size()};
+        const auto subBatches = ioScheduler_.SplitForAsu(keys, ctx.opType);
+        subBatchContexts.reserve(subBatches.size());
+        for (std::size_t index = 0; index < subBatches.size(); ++index) {
+            const auto& subBatch = subBatches[index];
+            auto& subBatchContext = subBatchContexts.emplace_back();
+            const auto subBatchStatus =
+                SubmitKeySubBatchRequest(ctx.opType, subBatch, subBatchContext);
+            if (!subBatchStatus.ok()) {
+                UC_ERROR("Submit key sub-batch failed index={} batch_size={} code={} message={}",
+                         index, subBatch.keys.size, static_cast<int>(subBatchStatus.code),
+                         subBatchStatus.message);
+                return subBatchStatus;
+            }
+        }
+    } else if (IsKeepAliveOp(ctx.opType)) {
+        auto& subBatchContext = subBatchContexts.emplace_back();
+        const auto subBatchStatus = SubmitKeepAliveRequest(subBatchContext);
+        if (!subBatchStatus.ok()) {
+            UC_ERROR("Submit keep-alive request failed code={} message={}",
+                     static_cast<int>(subBatchStatus.code), subBatchStatus.message);
+            return subBatchStatus;
+        }
+    } else {
+        UC_ERROR("Unsupported transport operation op_type={}", static_cast<int>(ctx.opType));
+        return Status::Error(StatusCode::UNSUPPORTED, "transport operation is unsupported");
+    }
+    return Status::OK();
+}
+
+void TransportTaskExecutor::BuildSubBatchSendBuffers(
+    std::vector<TransportSubBatchContext>& subBatchContexts,
+    std::vector<TransProvider::SendIoBatch>& ioBatches)
+{
+    ioBatches.reserve(subBatchContexts.size());
+
+    for (auto& subBatchContext : subBatchContexts) {
+        ioBatches.push_back(TransProvider::SendIoBatch{
+            subBatchContext.channel->GetConnection(),
+            reinterpret_cast<void*>(subBatchContext.sendSge.device_addr),
+            reinterpret_cast<void*>(subBatchContext.flagBuffer.device_addr),
+            subBatchContext.sendSge.length});
+    }
+}
+
+void TransportTaskExecutor::SendSubBatchBuffers(
+    std::vector<TransportSubBatchContext>& subBatchContexts,
+    const std::vector<TransProvider::SendIoBatch>& ioBatches)
+{
+    if (ioBatches.empty()) { return; }
+
+    const auto kernelCount = GetSendCountAttr(config_.attrs, "kernel_count");
+    const auto quietCount = GetSendCountAttr(config_.attrs, "quiet_count");
+    const auto sendStatuses = transProvider_->Send(ioBatches, kernelCount, quietCount);
+    if (sendStatuses.size() != ioBatches.size()) {
+        const auto status = Status::Error(StatusCode::INTERNAL_ERROR,
+                                          "transport send returned unexpected status count");
+        UC_ERROR("Transport send returned unexpected status count expected={} actual={}",
+                 ioBatches.size(), sendStatuses.size());
+        for (auto& subBatchContext : subBatchContexts) {
+            SetSubBatchSendFailed(subBatchContext, status);
+            ReleaseSubBatchResources(subBatchContext);
+        }
+        return;
+    }
+
+    for (std::size_t index = 0; index < sendStatuses.size(); ++index) {
+        auto& subBatchContext = subBatchContexts[index];
+        const auto& subBatchStatus = sendStatuses[index];
+        if (subBatchStatus.ok()) { continue; }
+
+        UC_ERROR("Send sub-batch failed sub_batch_index={} cid={} code={} message={}", index,
+                 subBatchContext.cid, static_cast<int>(subBatchStatus.code),
+                 subBatchStatus.message);
+        SetSubBatchSendFailed(subBatchContext, subBatchStatus);
+        connManager_->ReportFailure(subBatchContext.channel);
+        ReleaseSubBatchResources(subBatchContext);
+    }
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.cpp
@@ -1,0 +1,321 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "asu_transport_impl.h"
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <thread>
+#include <utility>
+#include "asu_transport/asu_transport.h"
+#include "asu_transport/trans_provider.h"
+#include "connection_manager.h"
+#include "logger.h"
+#include "transport_config_parser.h"
+
+namespace UC::ASU {
+
+namespace {
+
+std::chrono::steady_clock::time_point TaskDeadline(std::uint64_t timeoutMs)
+{
+    if (timeoutMs == 0) { return std::chrono::steady_clock::time_point::max(); }
+    return std::chrono::steady_clock::now() + std::chrono::milliseconds(timeoutMs);
+}
+
+}  // namespace
+
+AsuTransportImpl::AsuTransportImpl() = default;
+
+AsuTransportImpl::~AsuTransportImpl() { Shutdown(); }
+
+Status AsuTransportImpl::Init(const std::string& configPath,
+                              std::shared_ptr<TransProvider> transProvider)
+{
+    TransportConfig config;
+    auto status = LoadTransportConfig(configPath, config);
+    if (!status.ok()) { return status; }
+    return Init(config, std::move(transProvider));
+}
+
+Status AsuTransportImpl::Init(const TransportConfig& config,
+                              std::shared_ptr<TransProvider> transProvider)
+{
+    UC_DEBUG("AsuTransportImpl::Init start");
+    if (worker_.joinable()) {
+        UC_DEBUG("AsuTransportImpl::Init already initialized");
+        return Status::OK();
+    }
+    config_ = config;
+    transProvider_ = std::move(transProvider);
+    if (config_.maxErrorCount == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "maxErrorCount must be greater than 0");
+    }
+    if (config_.completionPollSpinLimit == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "completionPollSpinLimit must be greater than 0");
+    }
+
+    if (!transProvider_) {
+        UC_ERROR("AsuTransportImpl::Init: TransProvider is null");
+        return Status::Error(StatusCode::NOT_INITIALIZED, "TransProvider is null");
+    }
+
+    std::string localIp;
+    auto it = config_.attrs.find("localIp");
+    if (it != config_.attrs.end()) { localIp = it->second; }
+
+    std::uint32_t timeout = 5000;
+    auto tit = config_.attrs.find("timeout");
+    if (tit != config_.attrs.end()) {
+        timeout = static_cast<std::uint32_t>(std::stoul(tit->second));
+    }
+
+    connManager_.reset();
+    connManager_ = std::make_unique<ConnectionManager>(*transProvider_, localIp, timeout,
+                                                       config_.maxErrorCount);
+
+    const std::uint32_t qp_num = config_.qpNum;
+    UC_DEBUG("AsuTransportImpl::Init endpoints={} qp_num={}", config_.endpoints.size(), qp_num);
+    for (const auto& ep : config_.endpoints) {
+        auto s = connManager_->AddGroup(ep, qp_num);
+        if (!s.ok()) {
+            UC_DEBUG("AsuTransportImpl::Init AddGroup FAILED: {}", s.message);
+            const auto shutdownStatus = Shutdown();
+            if (!shutdownStatus.ok()) {
+                UC_WARN(
+                    "AsuTransportImpl::Init cleanup failed after AddGroup failure: code={} "
+                    "message={}",
+                    static_cast<int>(shutdownStatus.code), shutdownStatus.message);
+            }
+            return s;
+        }
+    }
+
+    const auto serverCapabilities = connManager_->GetServerCapabilities();
+    for (std::size_t index = 0; index < serverCapabilities.size(); ++index) {
+        const auto& capabilities = serverCapabilities[index];
+        UC_INFO(
+            "AsuTransportImpl::Init ServerKvCapabilities group={} queueNum={} ioQueueDepth={} "
+            "ioQueueKeyConcurrency={} connectionKeyConcurrency={} singleValueMaxBytes={} "
+            "batchValueMaxBytes={} batchStoreKeys={} batchLoadKeys={} deleteKeys={} "
+            "queryKeys={} keyLength={} kvCapabilities={}",
+            index, capabilities.queueNum, capabilities.ioQueueDepth,
+            capabilities.ioQueueKeyConcurrency, capabilities.connectionKeyConcurrency,
+            capabilities.singleValueMaxBytes, capabilities.batchValueMaxBytes,
+            capabilities.batchStoreKeys, capabilities.batchLoadKeys, capabilities.deleteKeys,
+            capabilities.queryKeys, capabilities.keyLength, capabilities.kvCapabilities);
+        auto applyCapLimit = [](auto& cfgField, auto capValue) {
+            if (capValue != 0) {
+                cfgField = std::min(cfgField, static_cast<std::size_t>(capValue));
+            }
+        };
+        applyCapLimit(config_.asuBatchStoreIoNum, capabilities.batchStoreKeys);
+        applyCapLimit(config_.asuBatchLoadIoNum, capabilities.batchLoadKeys);
+        applyCapLimit(config_.asuDeleteIoNum, capabilities.deleteKeys);
+        applyCapLimit(config_.asuQueryIoNum, capabilities.queryKeys);
+    }
+    UC_INFO("AsuTransportImpl::Init effective batch limits: store={} load={} delete={} query={}",
+            config_.asuBatchStoreIoNum, config_.asuBatchLoadIoNum, config_.asuDeleteIoNum,
+            config_.asuQueryIoNum);
+
+    connManager_->StartRecoverLoop();
+
+    taskExecutor_ = std::make_unique<TransportTaskExecutor>(config_, transProvider_, connManager_);
+    auto status = taskExecutor_->Init();
+    if (!status.ok()) {
+        const auto shutdownStatus = Shutdown();
+        if (!shutdownStatus.ok()) {
+            UC_WARN(
+                "AsuTransportImpl::Init cleanup failed after task executor initialization "
+                "failure: code={} message={}",
+                static_cast<int>(shutdownStatus.code), shutdownStatus.message);
+        }
+        return status;
+    }
+    auto queueDepth = std::max<std::size_t>(2, static_cast<std::size_t>(config_.maxInflightTasks));
+    executeQueue_.Setup(queueDepth + 1);
+    stopWorker_.store(false, std::memory_order_release);
+    stopCompletionWorker_.store(false, std::memory_order_release);
+    worker_ = std::thread(&AsuTransportImpl::WorkerLoop, this);
+    completionWorker_ = std::thread(&AsuTransportImpl::CompletionLoop, this);
+    UC_DEBUG("AsuTransportImpl::Init OK: queueDepth={}", queueDepth);
+    return Status::OK();
+}
+
+Status AsuTransportImpl::Shutdown()
+{
+    Status finalStatus = Status::OK();
+    {
+        std::lock_guard<std::mutex> lock(producerMu_);
+        stopWorker_.store(true, std::memory_order_release);
+    }
+
+    if (worker_.joinable()) { worker_.join(); }
+
+    if (completionWorker_.joinable() && config_.timeoutMs != 0) {
+        bool hasInflightTask = false;
+        for (const auto& ctx : taskManager_.GetAll()) {
+            if (ctx != nullptr &&
+                ctx->state.load(std::memory_order_acquire) == TransportTaskState::INFLIGHT) {
+                hasInflightTask = true;
+                break;
+            }
+        }
+        if (hasInflightTask) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(config_.timeoutMs));
+        }
+    }
+
+    stopCompletionWorker_.store(true, std::memory_order_release);
+    if (completionWorker_.joinable()) { completionWorker_.join(); }
+
+    for (const auto& ctx : taskManager_.GetAll()) {
+        if (ctx == nullptr) { continue; }
+        if (!taskExecutor_->Cancel(ctx)) { continue; }
+        taskManager_.NotifyCompletion(ctx);
+    }
+    for (const auto& ctx : taskManager_.GetAll()) {
+        if (ctx != nullptr) { (void)taskManager_.Remove(ctx->taskId); }
+    }
+    if (taskExecutor_) {
+        const auto status = taskExecutor_->Shutdown();
+        if (!status.ok()) {
+            if (finalStatus.ok()) { finalStatus = status; }
+        } else {
+            taskExecutor_.reset();
+        }
+    }
+
+    if (connManager_) {
+        auto status = connManager_->Shutdown();
+        if (!status.ok() && finalStatus.ok()) { finalStatus = status; }
+        connManager_.reset();
+    }
+
+    UC_DEBUG("AsuTransportImpl::Shutdown OK");
+    return finalStatus;
+}
+
+Status AsuTransportImpl::CheckHealth()
+{
+    if (!worker_.joinable() || !completionWorker_.joinable()) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "transport worker is not running");
+    }
+    return Status::OK();
+}
+
+Status AsuTransportImpl::Submit(const TransportTaskPtr& task)
+{
+    if (!task) { return Status::Error(StatusCode::INVALID_ARGUMENT, "transport task is null"); }
+    const auto entryCount = IsEntryBatchOp(task->opType) ? task->entries.size() : task->keys.size();
+    task->entryStatus.assign(entryCount, Status::OK());
+    task->deadline = TaskDeadline(config_.timeoutMs);
+    return SubmitTask(task);
+}
+
+Status AsuTransportImpl::Cancel(TaskId taskId)
+{
+    auto ctx = taskManager_.Get(taskId);
+    if (!ctx) { return Status::Error(StatusCode::TASK_NOT_FOUND, "transport task not found"); }
+
+    if (!taskExecutor_->Cancel(ctx)) { return Status::OK(); }
+    taskManager_.NotifyCompletion(ctx);
+    return Status::OK();
+}
+
+Status AsuTransportImpl::SubmitTask(const TransportTaskPtr& task)
+{
+    std::lock_guard<std::mutex> lock(producerMu_);
+    if (stopWorker_.load(std::memory_order_acquire) || !worker_.joinable()) {
+        task->taskId = kInvalidTaskId;
+        return Status::Error(StatusCode::NOT_INITIALIZED, "transport is not accepting tasks");
+    }
+
+    TaskId taskId = kInvalidTaskId;
+    auto status = taskManager_.Submit(task, taskId);
+    if (!status.ok()) { return status; }
+
+    auto submittedTask = taskManager_.Get(taskId);
+    if (!submittedTask) {
+        task->taskId = kInvalidTaskId;
+        return Status::Error(StatusCode::INTERNAL_ERROR, "transport task disappeared after submit");
+    }
+
+    if (!executeQueue_.TryPush(std::move(submittedTask))) {
+        taskManager_.Remove(taskId);
+        task->taskId = kInvalidTaskId;
+        return Status::Error(StatusCode::RESOURCE_BUSY, "transport task queue is full");
+    }
+    return Status::OK();
+}
+
+void AsuTransportImpl::WorkerLoop()
+{
+    executeQueue_.ConsumerLoop(stopWorker_, [this](TransportTaskPtr task) {
+        if (!task) { return; }
+        if (taskExecutor_->Execute(task)) { taskManager_.NotifyCompletion(task); }
+    });
+}
+
+void AsuTransportImpl::CompletionLoop()
+{
+    std::size_t noCompletionRounds = 0;
+
+    while (!stopCompletionWorker_.load(std::memory_order_acquire)) {
+        const auto tasks = taskManager_.GetAll();
+        if (tasks.empty()) {
+            noCompletionRounds = 0;
+            std::this_thread::sleep_for(std::chrono::microseconds(50));
+            continue;
+        }
+
+        bool completedTask = false;
+        for (const auto& ctx : tasks) {
+            if (taskExecutor_->Poll(ctx)) {
+                taskManager_.NotifyCompletion(ctx);
+                completedTask = true;
+            }
+        }
+
+        if (completedTask) {
+            noCompletionRounds = 0;
+        } else if (++noCompletionRounds >= config_.completionPollSpinLimit) {
+            noCompletionRounds = 0;
+            std::this_thread::yield();
+        }
+    }
+}
+
+void AsuTransportImpl::SetTransProvider(std::shared_ptr<TransProvider> provider)
+{
+    transProvider_ = std::move(provider);
+}
+
+std::unique_ptr<AsuTransport> CreateAsuTransport() { return std::make_unique<AsuTransportImpl>(); }
+
+extern "C" std::unique_ptr<AsuTransport> UcmAsuCreateAsuTransport() { return CreateAsuTransport(); }
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
+++ b/ucm/transport/kv/asu/trans/src/asu_transport_impl.h
@@ -1,0 +1,81 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+#include "asu_transport/asu_transport.h"
+#include "asu_transport/trans_provider.h"
+#include "connection_manager.h"
+#include "template/spsc_ring_queue.h"
+#include "transport_task_executor.h"
+#include "transport_task_manager.h"
+
+namespace UC::ASU {
+
+class AsuTransportImpl final : public AsuTransport {
+public:
+    AsuTransportImpl();
+    ~AsuTransportImpl() override;
+
+    Status Init(const TransportConfig& config,
+                std::shared_ptr<TransProvider> transProvider) override;
+    Status Init(const std::string& configPath,
+                std::shared_ptr<TransProvider> transProvider) override;
+    Status Shutdown() override;
+
+    Status CheckHealth() override;
+
+    Status Submit(const TransportTaskPtr& task) override;
+
+    Status Cancel(TaskId taskId) override;
+
+private:
+    Status SubmitTask(const TransportTaskPtr& task);
+    void WorkerLoop();
+    void CompletionLoop();
+
+    void SetTransProvider(std::shared_ptr<TransProvider> provider);
+
+    TransportConfig config_;
+    std::shared_ptr<TransProvider> transProvider_;
+    std::unique_ptr<ConnectionManager> connManager_;
+
+    std::unique_ptr<TransportTaskExecutor> taskExecutor_;
+    TransportTaskManager taskManager_;
+    UC::SpscRingQueue<TransportTaskPtr> executeQueue_;
+    std::mutex producerMu_;
+
+    std::thread worker_;
+    std::thread completionWorker_;
+    std::atomic_bool stopWorker_{false};
+    std::atomic_bool stopCompletionWorker_{false};
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/buffer_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/buffer_manager.cpp
@@ -1,0 +1,221 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "buffer_manager.h"
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include "logger.h"
+#include "trans/detail/reserved_buffer.h"
+#include "trans/device.h"
+
+namespace UC::ASU {
+
+constexpr std::size_t kSlotAddressAlignment = 64;
+
+bool GetSlotStride(std::size_t capacity, std::size_t& stride)
+{
+    // NOTE: Ascend ACL documents an aclrtMallocHost large-block suballocation
+    // layout of ALIGN_UP(len, 32) + 32 bytes with 64-byte-aligned segment
+    // starts. Current HCOMM/RDMA validation did not reproduce failures without
+    // the extra 32-byte tail room, so ASU keeps only the 64-byte slot-start
+    // alignment for now.
+    // Keep one layout for every memory type by aligning each slot start to a
+    // 64-byte boundary.
+    constexpr auto kMaxSize = std::numeric_limits<std::size_t>::max();
+    if (capacity > kMaxSize - (kSlotAddressAlignment - 1)) { return false; }
+
+    stride = (capacity + kSlotAddressAlignment - 1) / kSlotAddressAlignment * kSlotAddressAlignment;
+    return true;
+}
+
+Status BufferManager::BufferRegion::Create(MemoryType type, std::size_t size, BufferRegion& region)
+{
+    auto buffer = Trans::Device{}.MakeBuffer();
+    if (!buffer) {
+        return Status::Error(StatusCode::INTERNAL_ERROR, "failed to create runtime buffer");
+    }
+
+    switch (type) {
+        case MemoryType::HOST: {
+            auto owner = buffer->MakeHostBuffer(size);
+            if (!owner) {
+                return Status::Error(StatusCode::INTERNAL_ERROR, "failed to allocate host memory");
+            }
+            // HOST has one CPU-visible address, which is also passed to the
+            // provider when it registers the region as MEM_HOST.
+            region = {owner, owner.get(), owner.get(), TransProvider::MemType::MEM_HOST};
+            return Status::OK();
+        }
+        case MemoryType::HOST_PINNED: {
+            if (!buffer->SupportsHostMappedDeviceBuffer()) {
+                return Status::Error(StatusCode::UNSUPPORTED,
+                                     "host-mapped device buffer not supported by runtime");
+            }
+            void* deviceAddr = nullptr;
+            auto owner = buffer->MakeHostMappedDeviceBuffer(size, &deviceAddr);
+            if (!owner) {
+                return Status::Error(StatusCode::INTERNAL_ERROR,
+                                     "failed to allocate host-pinned memory");
+            }
+            region = {owner, owner.get(), deviceAddr, TransProvider::MemType::MEM_DEVICE};
+            return Status::OK();
+        }
+        case MemoryType::DEVICE: {
+            auto owner = buffer->MakeDeviceBuffer(size);
+            if (!owner) {
+                return Status::Error(StatusCode::INTERNAL_ERROR,
+                                     "failed to allocate device memory");
+            }
+            region = {owner, owner.get(), owner.get(), TransProvider::MemType::MEM_DEVICE};
+            return Status::OK();
+        }
+        default: return Status::Error(StatusCode::INVALID_ARGUMENT, "unsupported memory type");
+    }
+}
+
+void BufferManager::BufferRegion::Reset()
+{
+    owner.reset();
+    localAddr = nullptr;
+    deviceAddr = nullptr;
+    providerMemType = TransProvider::MemType::MEM_HOST;
+}
+
+BufferManager::~BufferManager() { Shutdown(); }
+
+void BufferManager::Shutdown()
+{
+    tokenId_ = 0;
+    region_.Reset();
+    slot_capacity_ = 0;
+    slot_stride_ = 0;
+    slot_num_ = 0;
+}
+
+Status BufferManager::Init(std::string name, MemoryType type, std::size_t slot_capacity,
+                           std::size_t slot_num)
+{
+    if (region_) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, name + " already initialized");
+    }
+    if (slot_capacity == 0 || slot_num == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             name + ": slot_capacity and slot_num must be non-zero");
+    }
+    std::size_t slotStride = 0;
+    if (!GetSlotStride(slot_capacity, slotStride) ||
+        slot_num > std::numeric_limits<std::size_t>::max() / slotStride) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, name + ": slot layout size overflow");
+    }
+
+    name_ = std::move(name);
+    memory_type_ = type;
+    slot_capacity_ = slot_capacity;
+    slot_stride_ = slotStride;
+    slot_num_ = slot_num;
+
+    std::size_t total = slot_stride_ * slot_num_;
+
+    auto allocStatus = BufferRegion::Create(memory_type_, total, region_);
+    if (!allocStatus.ok()) { return allocStatus; }
+
+    if (memory_type_ == MemoryType::DEVICE) {
+        if (const auto memStatus = UC::Trans::Memset(region_.localAddr, total, 0);
+            memStatus.Failure()) {
+            region_.Reset();
+            return Status::Error(StatusCode::INTERNAL_ERROR, name_ + ": failed to zero memory");
+        }
+    } else {
+        std::memset(region_.localAddr, 0, total);
+    }
+
+    index_pool_.Setup(static_cast<IndexPool::Index>(slot_num));
+    tokenId_ = 0;
+
+    return Status::OK();
+}
+
+Status BufferManager::GetRegisterMemoryDesc(TransProvider::RegisterMemoryDesc& desc) const
+{
+    if (!region_) { return Status::Error(StatusCode::NOT_INITIALIZED, name_ + " not initialized"); }
+    desc = {region_.providerMemType, reinterpret_cast<uintptr_t>(region_.deviceAddr),
+            slot_stride_ * slot_num_, reinterpret_cast<uintptr_t>(region_.localAddr)};
+    return Status::OK();
+}
+
+Status BufferManager::Allocate(std::size_t size, ScatterGatherEntry& sge)
+{
+    if (!region_) { return Status::Error(StatusCode::NOT_INITIALIZED, name_ + " not initialized"); }
+    if (size == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, name_ + ": size must be non-zero");
+    }
+    if (size > slot_capacity_) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, name_ + ": size exceeds slot_capacity");
+    }
+
+    auto idx = index_pool_.Acquire();
+    if (idx == IndexPool::npos) {
+        return Status::Error(StatusCode::RESOURCE_BUSY, name_ + ": no free slots");
+    }
+    const auto offset = idx * slot_stride_;
+    sge.local_addr =
+        reinterpret_cast<std::uint64_t>(static_cast<char*>(region_.localAddr) + offset);
+    sge.device_addr =
+        reinterpret_cast<std::uint64_t>(static_cast<char*>(region_.deviceAddr) + offset);
+    sge.length = static_cast<std::uint32_t>(size);
+    sge.tokenId = tokenId_;
+    sge.slot_index = idx;
+    sge.memory_type = memory_type_;
+    return Status::OK();
+}
+
+Status BufferManager::Free(std::uint32_t slot_index)
+{
+    if (!region_) { return Status::Error(StatusCode::NOT_INITIALIZED, name_ + " not initialized"); }
+    if (slot_index >= slot_num_) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, name_ + ": slot_index out of range");
+    }
+    auto* p = static_cast<char*>(region_.localAddr) + slot_index * slot_stride_;
+    if (memory_type_ == MemoryType::DEVICE) {
+        if (const auto memStatus = UC::Trans::Memset(p, slot_stride_, 0); memStatus.Failure()) {
+            return Status::Error(StatusCode::INTERNAL_ERROR, name_ + ": failed to zero memory");
+        }
+    } else {
+        std::memset(p, 0, slot_stride_);
+    }
+    index_pool_.Release(static_cast<IndexPool::Index>(slot_index));
+    return Status::OK();
+}
+
+bool BufferManager::IsValidPointer(const void* ptr) const
+{
+    if (!ptr || !region_) { return false; }
+    auto* base = static_cast<const char*>(region_.localAddr);
+    auto* p = static_cast<const char*>(ptr);
+    if (p < base || p >= base + slot_stride_ * slot_num_) { return false; }
+    auto offset = static_cast<std::size_t>(p - base);
+    return (offset % slot_stride_) == 0;
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/buffer_manager.h
+++ b/ucm/transport/kv/asu/trans/src/buffer_manager.h
@@ -1,0 +1,93 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include "asu_transport/trans_provider.h"
+#include "asu_transport/types.h"
+#include "thread/index_pool.h"
+
+namespace UC::ASU {
+
+struct ScatterGatherEntry {
+    // Local-side address. CPU-accessible for HOST/HOST_PINNED and a local
+    // device address for DEVICE.
+    std::uint64_t local_addr{0};
+    // Device-visible address used by HCOMM/HIXL and remote RDMA operations.
+    std::uint64_t device_addr{0};
+    std::uint32_t length{0};
+    std::uint32_t tokenId{0};
+    std::uint32_t slot_index{UINT32_MAX};
+    MemoryType memory_type{MemoryType::HOST};
+};
+
+class BufferManager {
+public:
+    BufferManager() = default;
+    ~BufferManager();
+
+    BufferManager(const BufferManager&) = delete;
+    BufferManager& operator=(const BufferManager&) = delete;
+
+    Status Init(std::string name, MemoryType type, std::size_t slot_capacity, std::size_t slot_num);
+    void Shutdown();
+
+    Status Allocate(std::size_t size, ScatterGatherEntry& sge);
+    Status Free(std::uint32_t slot_index);
+
+    bool IsValidPointer(const void* ptr) const;
+
+    std::uint32_t GetTokenId() const { return tokenId_; }
+    void SetTokenId(std::uint32_t tokenId) { tokenId_ = tokenId; }
+    Status GetRegisterMemoryDesc(TransProvider::RegisterMemoryDesc& desc) const;
+
+private:
+    struct BufferRegion {
+        static Status Create(MemoryType type, std::size_t size, BufferRegion& region);
+
+        explicit operator bool() const { return owner != nullptr; }
+        void Reset();
+
+        std::shared_ptr<void> owner;
+        void* localAddr{nullptr};
+        void* deviceAddr{nullptr};
+        TransProvider::MemType providerMemType{TransProvider::MemType::MEM_HOST};
+    };
+
+    std::string name_;
+    std::size_t slot_capacity_{0};
+    std::size_t slot_stride_{0};
+    std::size_t slot_num_{0};
+    MemoryType memory_type_{MemoryType::HOST};
+
+    BufferRegion region_;
+    IndexPool index_pool_;
+
+    std::uint32_t tokenId_{0};
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/connection_internal.cpp
+++ b/ucm/transport/kv/asu/trans/src/connection_internal.cpp
@@ -1,0 +1,129 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "connection_internal.h"
+#include <algorithm>
+#include "logger.h"
+
+namespace UC::ASU {
+
+// ─── ConnectionChannel ───
+
+ConnectionChannel::ConnectionChannel(std::uint32_t id, ConnectionGroup* grp,
+                                     TransProvider::ConnectionHandle handle,
+                                     TransProvider* provider)
+    : channelId(id), group(grp), handle_(handle), provider_(provider)
+{
+    state.store(ChannelState::ACTIVE, std::memory_order_release);
+    inflightCount.store(0, std::memory_order_release);
+    errorCount.store(0, std::memory_order_release);
+}
+
+ConnectionChannel::~ConnectionChannel()
+{
+    if (handle_ && provider_) {
+        provider_->DeleteConnections({handle_});
+        handle_ = nullptr;
+    }
+}
+
+std::uint32_t ConnectionChannel::FetchAddErrorCount(std::uint32_t val)
+{
+    return errorCount.fetch_add(val, std::memory_order_relaxed);
+}
+
+std::uint32_t ConnectionChannel::GetErrorCount() const
+{
+    return errorCount.load(std::memory_order_relaxed);
+}
+
+void ConnectionChannel::ResetErrorCount() { errorCount.store(0, std::memory_order_relaxed); }
+
+void ConnectionChannel::IncrementInflight()
+{
+    inflightCount.fetch_add(1, std::memory_order_acq_rel);
+}
+
+void ConnectionChannel::ReleaseInflight()
+{
+    auto current = inflightCount.load(std::memory_order_acquire);
+    while (current > 0) {
+        if (inflightCount.compare_exchange_weak(current, current - 1, std::memory_order_acq_rel)) {
+            return;
+        }
+    }
+}
+
+bool ConnectionChannel::MarkForDrain()
+{
+    ChannelState expected = ChannelState::ACTIVE;
+    if (!state.compare_exchange_strong(expected, ChannelState::DRAINING,
+                                       std::memory_order_acq_rel)) {
+        UC_DEBUG("ConnectionChannel::MarkForDrain CAS FAILED: current_state={} (expected ACTIVE=0)",
+                 static_cast<int>(expected));
+        return false;
+    }
+    UC_DEBUG("ConnectionChannel::MarkForDrain CAS OK: ch_id={} ACTIVE->DRAINING", channelId);
+    return true;
+}
+
+// ─── ConnectionGroup ───
+
+ConnectionGroup::ConnectionGroup(std::uint32_t id, const AsuEndpoint& ep,
+                                 const ServerKvCapabilities& capabilities)
+    : groupId(id), endpoint(ep), serverCapabilities(capabilities)
+{
+}
+
+std::shared_ptr<ConnectionChannel> ConnectionGroup::AddChannel(ConnectionHandle handle,
+                                                               TransProvider* provider)
+{
+    auto id = nextChannelId_.fetch_add(1, std::memory_order_relaxed);
+    auto channel = std::make_shared<ConnectionChannel>(id, this, handle, provider);
+    channels.push_back(channel);
+    UC_DEBUG("ConnectionGroup::AddChannel groupId={} ch_id={} totalChannels={}", groupId,
+             channel->GetChannelId(), channels.size());
+    return channel;
+}
+
+void ConnectionGroup::RemoveChannel(ConnectionChannel* channel)
+{
+    auto it = std::find_if(
+        channels.begin(), channels.end(),
+        [channel](const std::shared_ptr<ConnectionChannel>& p) { return p.get() == channel; });
+    if (it != channels.end()) {
+        UC_DEBUG("ConnectionGroup::RemoveChannel groupId={} ch_id={} removed, totalChannels={}",
+                 groupId, channel->GetChannelId(), channels.size() - 1);
+        channels.erase(it);
+    }
+}
+
+bool ConnectionGroup::HasActiveChannel() const
+{
+    for (auto& channel : channels) {
+        if (channel->GetState() == ChannelState::ACTIVE) { return true; }
+    }
+    return false;
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/connection_internal.h
+++ b/ucm/transport/kv/asu/trans/src/connection_internal.h
@@ -1,0 +1,105 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+#include "asu_transport/asu_transport.h"
+#include "asu_transport/trans_provider.h"
+#include "asu_transport/types.h"
+#include "connection_manager.h"
+
+namespace UC::ASU {
+
+enum class ChannelState : std::uint8_t {
+    ACTIVE,
+    DRAINING,
+    FAILED,
+};
+
+class ConnectionChannel {
+public:
+    ConnectionChannel(std::uint32_t id, ConnectionGroup* grp,
+                      TransProvider::ConnectionHandle handle, TransProvider* provider);
+    ~ConnectionChannel();
+
+    std::uint32_t GetChannelId() const { return channelId; }
+    ChannelState GetState() const { return state.load(std::memory_order_acquire); }
+    std::uint32_t GetInflightCount() const { return inflightCount.load(std::memory_order_acquire); }
+    ConnectionGroup* GetGroup() const { return group; }
+    TransProvider::ConnectionHandle GetConnection() const { return handle_; }
+
+    std::uint32_t FetchAddErrorCount(std::uint32_t val);
+    std::uint32_t GetErrorCount() const;
+    void ResetErrorCount();
+
+    // Test helper to set state directly
+    void SetState(ChannelState s) { state.store(s, std::memory_order_release); }
+    void SetInflightCount(std::uint32_t c) { inflightCount.store(c, std::memory_order_release); }
+
+    void IncrementInflight();
+    void ReleaseInflight();
+    bool MarkForDrain();
+
+private:
+    // inflightCount: Maintained by upper-level users, it records the number of requests currently
+    // being processed on the channel
+    alignas(64) std::atomic<std::uint32_t> inflightCount{0};
+    alignas(64) std::atomic<ChannelState> state{ChannelState::ACTIVE};
+
+    std::uint32_t channelId{0};
+    ConnectionGroup* group{nullptr};
+    TransProvider::ConnectionHandle handle_{nullptr};
+    TransProvider* provider_{nullptr};
+
+    // Cold path
+    std::atomic<std::uint32_t> errorCount{0};
+};
+
+class ConnectionGroup {
+public:
+    ConnectionGroup(std::uint32_t id, const AsuEndpoint& ep,
+                    const ServerKvCapabilities& capabilities = {});
+
+    std::uint32_t GetGroupId() const { return groupId; }
+    const AsuEndpoint& GetEndpoint() const { return endpoint; }
+    const ServerKvCapabilities& GetServerCapabilities() const { return serverCapabilities; }
+    const std::vector<std::shared_ptr<ConnectionChannel>>& GetChannels() const { return channels; }
+
+    std::shared_ptr<ConnectionChannel> AddChannel(ConnectionHandle handle, TransProvider* provider);
+    void RemoveChannel(ConnectionChannel* channel);
+    bool HasActiveChannel() const;
+
+private:
+    std::uint32_t groupId{0};
+    AsuEndpoint endpoint;
+    ServerKvCapabilities serverCapabilities;
+    std::vector<std::shared_ptr<ConnectionChannel>> channels;
+    std::atomic<std::uint32_t> nextChannelId_{0};
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/connection_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/connection_manager.cpp
@@ -1,0 +1,345 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include "connection_internal.h"
+#include "logger.h"
+
+namespace UC::ASU {
+
+ConnectionManager::ConnectionManager(TransProvider& provider, const std::string& localIp,
+                                     std::uint32_t timeout, std::uint32_t maxErrorCount)
+    : provider_(provider), localIp_(localIp), timeout_(timeout), maxErrorCount_(maxErrorCount)
+{
+}
+
+ConnectionManager::~ConnectionManager() { Shutdown(); }
+
+Status ConnectionManager::AddGroup(const AsuEndpoint& endpoint, std::uint32_t qp_num)
+{
+    if (shuttingDown_.load(std::memory_order_acquire)) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "connection manager shutting down");
+    }
+    UC_DEBUG("ConnectionManager::AddGroup endpoint={} qp_num={}", endpoint.ip, qp_num);
+
+    std::vector<TransProvider::ConnectionHandle> handles;
+    auto createStatus =
+        provider_.CreateConnection(localIp_, endpoint.ip, endpoint.port, qp_num, timeout_, handles);
+    if (!createStatus.ok()) { return createStatus; }
+    if (handles.empty()) {
+        return Status::Error(StatusCode::INTERNAL_ERROR, "provider returned no connection handles");
+    }
+
+    ServerKvCapabilities capabilities;
+    auto capabilityStatus = provider_.GetServerCapabilities(handles.front(), capabilities);
+    if (!capabilityStatus.ok() && capabilityStatus.code != StatusCode::UNSUPPORTED) {
+        const auto deleteStatuses = provider_.DeleteConnections(handles);
+        for (const auto& deleteStatus : deleteStatuses) {
+            if (!deleteStatus.ok()) {
+                UC_WARN(
+                    "ConnectionManager::AddGroup cleanup failed after capability query failure: "
+                    "code={} message={}",
+                    static_cast<int>(deleteStatus.code), deleteStatus.message);
+            }
+        }
+        return capabilityStatus;
+    }
+    if (capabilityStatus.code == StatusCode::UNSUPPORTED) {
+        capabilities = {};
+        UC_DEBUG(
+            "ConnectionManager::AddGroup server capability query is not supported. Use default "
+            "configurations instead");
+    }
+    if (capabilities.ioQueueDepth != 0) {
+        maxInflightPerChannel_ = std::min(maxInflightPerChannel_, capabilities.ioQueueDepth);
+    }
+
+    {
+        std::lock_guard<std::mutex> cacheLock(channelCacheMu_);
+        std::unique_lock<std::shared_mutex> lock(structureMu_);
+        auto gid = static_cast<std::uint32_t>(groups_.size());
+        auto group = std::make_unique<ConnectionGroup>(gid, endpoint, capabilities);
+        for (auto handle : handles) { group->AddChannel(handle, &provider_); }
+        groups_.push_back(std::move(group));
+
+        for (const auto& channel : groups_.back()->GetChannels()) {
+            channelCache_.push_back(channel);
+        }
+    }
+    cacheDirty_.store(false, std::memory_order_release);
+    UC_DEBUG("ConnectionManager::AddGroup OK");
+    return Status::OK();
+}
+
+Status ConnectionManager::Shutdown()
+{
+    UC_DEBUG("ConnectionManager::Shutdown start");
+    shuttingDown_.store(true, std::memory_order_release);
+    StopRecoverLoop();
+
+    channelCache_.clear();
+    {
+        std::unique_lock<std::shared_mutex> lock(drainMu_);
+        drainList_.clear();
+    }
+
+    // Now safe to destroy ConnectionGroup objects
+    {
+        std::unique_lock<std::shared_mutex> lock(structureMu_);
+        groups_.clear();
+    }
+
+    UC_DEBUG("ConnectionManager::Shutdown done");
+    return Status::OK();
+}
+
+std::shared_ptr<ConnectionChannel> ConnectionManager::SelectConnection()
+{
+    if (shuttingDown_.load(std::memory_order_acquire)) { return nullptr; }
+    auto policy = routingPolicy_;
+    auto channel =
+        policy == RoutingPolicy::LEAST_LOADED ? SelectByLeastLoaded() : SelectByRoundRobin();
+    if (channel) {
+        UC_DEBUG("ConnectionManager::SelectConnection policy={} ch_id={} group_id={} inflight={}",
+                 policy == RoutingPolicy::LEAST_LOADED ? "LEAST_LOADED" : "ROUND_ROBIN",
+                 channel->GetChannelId(), channel->GetGroup()->GetGroupId(),
+                 channel->GetInflightCount());
+    } else {
+        UC_DEBUG("ConnectionManager::SelectConnection policy={} NO available channel",
+                 policy == RoutingPolicy::LEAST_LOADED ? "LEAST_LOADED" : "ROUND_ROBIN");
+    }
+    return channel;
+}
+
+std::shared_ptr<ConnectionChannel> ConnectionManager::GetActiveConnection()
+{
+    if (shuttingDown_.load(std::memory_order_acquire)) { return nullptr; }
+
+    std::lock_guard<std::mutex> cacheLock(channelCacheMu_);
+    if (cacheDirty_.load(std::memory_order_acquire)) { RebuildChannelCache(); }
+
+    for (const auto& channel : channelCache_) {
+        if (channel->GetState() == ChannelState::ACTIVE) { return channel; }
+    }
+    return nullptr;
+}
+
+void ConnectionManager::SetRoutingPolicy(RoutingPolicy policy) { routingPolicy_ = policy; }
+
+void ConnectionManager::ReportFailure(const std::shared_ptr<ConnectionChannel>& channel)
+{
+    if (channel == nullptr) { return; }
+    if (shuttingDown_.load(std::memory_order_acquire)) { return; }
+    auto oldCount = channel->FetchAddErrorCount(1);
+    UC_DEBUG("ConnectionManager::ReportFailure ch_id={} group_id={} error_count={} threshold={}",
+             channel->GetChannelId(), channel->GetGroup()->GetGroupId(), oldCount + 1,
+             maxErrorCount_);
+    if (oldCount + 1 < maxErrorCount_) {
+        UC_DEBUG("ConnectionManager::ReportFailure below threshold, skip drain");
+        return;
+    }
+
+    if (!channel->MarkForDrain()) {
+        UC_DEBUG(
+            "ConnectionManager::ReportFailure MarkForDrain CAS failed "
+            "(already draining/failed)");
+        return;
+    }
+
+    UC_DEBUG("ConnectionManager::ReportFailure MarkForDrain OK, ch_id={} state=DRAINING",
+             channel->GetChannelId());
+    cacheDirty_.store(true, std::memory_order_release);
+
+    {
+        std::unique_lock<std::shared_mutex> lock(drainMu_);
+        for (const auto& existing : drainList_) {
+            if (existing.get() == channel.get()) return;
+        }
+        drainList_.push_back(channel);
+    }
+}
+
+void ConnectionManager::ReportSuccess(const std::shared_ptr<ConnectionChannel>& channel)
+{
+    if (channel == nullptr) { return; }
+    channel->ResetErrorCount();
+}
+
+void ConnectionManager::StartRecoverLoop()
+{
+    UC_DEBUG("ConnectionManager::StartRecoverLoop start");
+    if (recoverWorker_.joinable()) { return; }
+    stopRecover_.store(false, std::memory_order_release);
+    recoverWorker_ = std::thread(&ConnectionManager::RecoverLoop, this);
+}
+
+void ConnectionManager::StopRecoverLoop()
+{
+    UC_DEBUG("ConnectionManager::StopRecoverLoop start");
+    stopRecover_.store(true, std::memory_order_release);
+    if (recoverWorker_.joinable()) { recoverWorker_.join(); }
+}
+
+void ConnectionManager::RecoverLoop()
+{
+    UC_DEBUG("ConnectionManager::RecoverLoop started");
+    while (!stopRecover_.load(std::memory_order_acquire)) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(kRecoverIntervalMs));
+        if (stopRecover_.load(std::memory_order_acquire)) { break; }
+
+        std::vector<std::shared_ptr<ConnectionChannel>> to_recover;
+        {
+            std::unique_lock<std::shared_mutex> lock(drainMu_);
+            to_recover.swap(drainList_);
+        }
+
+        for (auto& channel : to_recover) {
+            ConnectionGroup* grp = channel->GetGroup();
+            AsuEndpoint ep = grp->GetEndpoint();
+            std::uint32_t gid = grp->GetGroupId();
+
+            std::vector<TransProvider::ConnectionHandle> new_handles;
+            auto createStatus =
+                provider_.CreateConnection(localIp_, ep.ip, ep.port, 1, timeout_, new_handles);
+
+            if (!createStatus.ok()) {
+                UC_DEBUG(
+                    "ConnectionManager::RecoverLoop RebuildChannel FAILED, keep in drain_list for "
+                    "retry group_id={}",
+                    gid);
+                std::unique_lock<std::shared_mutex> lock(drainMu_);
+                drainList_.push_back(std::move(channel));
+                continue;
+            }
+
+            {
+                std::unique_lock<std::shared_mutex> lock(structureMu_);
+                grp->RemoveChannel(channel.get());
+                auto new_ch = grp->AddChannel(new_handles[0], &provider_);
+                UC_DEBUG(
+                    "ConnectionManager::RecoverLoop RebuildChannel OK: new_ch_id={} group_id={}",
+                    new_ch->GetChannelId(), gid);
+                cacheDirty_.store(true, std::memory_order_release);
+            }
+        }
+    }
+    UC_DEBUG("ConnectionManager::RecoverLoop stopped");
+}
+
+void ConnectionManager::RebuildChannelCache()
+{
+    if (!cacheDirty_.load(std::memory_order_acquire)) { return; }
+    std::shared_lock<std::shared_mutex> struct_lock(structureMu_);
+    std::vector<std::shared_ptr<ConnectionChannel>> new_cache;
+    for (const auto& g : groups_) {
+        for (const auto& channel : g->GetChannels()) {
+            if (channel->GetState() == ChannelState::ACTIVE) { new_cache.push_back(channel); }
+        }
+    }
+    channelCache_ = std::move(new_cache);
+    cacheDirty_.store(false, std::memory_order_release);
+}
+
+std::shared_ptr<ConnectionChannel> ConnectionManager::SelectByRoundRobin()
+{
+    std::lock_guard<std::mutex> cacheLock(channelCacheMu_);
+    if (cacheDirty_.load(std::memory_order_acquire)) { RebuildChannelCache(); }
+
+    if (channelCache_.empty()) { return nullptr; }
+
+    auto idx = rrIndex_.fetch_add(1, std::memory_order_relaxed);
+    std::size_t total = channelCache_.size();
+    std::size_t start = idx % total;
+    const auto maxInflightPerChannel = maxInflightPerChannel_;
+
+    for (std::size_t i = 0; i < total; ++i) {
+        std::size_t pos = (start + i) % total;
+        const auto& channel = channelCache_[pos];
+        if (channel->GetState() != ChannelState::ACTIVE) { continue; }
+        if (channel->GetInflightCount() < maxInflightPerChannel) {
+            channel->IncrementInflight();
+            return channel;
+        }
+    }
+    UC_DEBUG(
+        "ConnectionManager::SelectByRoundRobin no available channel: all ACTIVE channels "
+        "reached maximum inflight limit, max_inflight_per_channel={}",
+        maxInflightPerChannel);
+    return nullptr;
+}
+
+std::shared_ptr<ConnectionChannel> ConnectionManager::SelectByLeastLoaded()
+{
+    std::lock_guard<std::mutex> cacheLock(channelCacheMu_);
+    if (cacheDirty_.load(std::memory_order_acquire)) { RebuildChannelCache(); }
+
+    if (channelCache_.empty()) { return nullptr; }
+
+    std::shared_ptr<ConnectionChannel> selected;
+    std::uint32_t min_inflight = std::numeric_limits<std::uint32_t>::max();
+    const auto maxInflightPerChannel = maxInflightPerChannel_;
+
+    for (const auto& channel : channelCache_) {
+        auto inflight = channel->GetInflightCount();
+        if (channel->GetState() == ChannelState::ACTIVE && inflight < maxInflightPerChannel &&
+            inflight < min_inflight) {
+            min_inflight = inflight;
+            selected = channel;
+            if (min_inflight == 0) break;
+        }
+    }
+
+    if (selected) {
+        selected->IncrementInflight();
+        return selected;
+    }
+    UC_DEBUG(
+        "ConnectionManager::SelectByLeastLoaded no available channel: all ACTIVE channels "
+        "reached maximum inflight limit, max_inflight_per_channel={}",
+        maxInflightPerChannel);
+    return nullptr;
+}
+
+std::int64_t ConnectionManager::TotalInflightCount()
+{
+    if (shuttingDown_.load(std::memory_order_acquire)) { return 0; }
+    std::int64_t sum = 0;
+    std::shared_lock<std::shared_mutex> lock(structureMu_);
+    for (const auto& group : groups_) {
+        for (const auto& channel : group->GetChannels()) { sum += channel->GetInflightCount(); }
+    }
+    return sum;
+}
+
+std::vector<ServerKvCapabilities> ConnectionManager::GetServerCapabilities()
+{
+    std::vector<ServerKvCapabilities> capabilities;
+    std::shared_lock<std::shared_mutex> lock(structureMu_);
+    capabilities.reserve(groups_.size());
+    for (const auto& group : groups_) { capabilities.push_back(group->GetServerCapabilities()); }
+    return capabilities;
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/connection_manager.h
+++ b/ucm/transport/kv/asu/trans/src/connection_manager.h
@@ -1,0 +1,106 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <thread>
+#include <vector>
+#include "asu_transport/asu_transport.h"
+#include "asu_transport/trans_provider.h"
+#include "asu_transport/types.h"
+#include "kv_protocol.h"
+
+namespace UC::ASU {
+
+using ConnectionHandle = void*;
+
+enum class RoutingPolicy : std::uint8_t {
+    ROUND_ROBIN,
+    LEAST_LOADED,
+};
+
+class ConnectionChannel;
+class ConnectionGroup;
+struct ScatterGatherEntry;
+
+class ConnectionManager {
+public:
+    ConnectionManager(TransProvider& provider, const std::string& localIp, std::uint32_t timeout,
+                      std::uint32_t maxErrorCount = 2);
+    ~ConnectionManager();
+
+    Status AddGroup(const AsuEndpoint& endpoint, std::uint32_t qp_num);
+    Status Shutdown();
+
+    std::shared_ptr<ConnectionChannel> SelectConnection();
+    std::shared_ptr<ConnectionChannel> GetActiveConnection();
+    void SetRoutingPolicy(RoutingPolicy policy);
+    void ReportFailure(const std::shared_ptr<ConnectionChannel>& channel);
+    void ReportSuccess(const std::shared_ptr<ConnectionChannel>& channel);
+
+    void StartRecoverLoop();
+    void StopRecoverLoop();
+
+    std::int64_t TotalInflightCount();
+    std::vector<ServerKvCapabilities> GetServerCapabilities();
+
+private:
+    std::vector<std::unique_ptr<ConnectionGroup>> groups_;
+    std::shared_mutex structureMu_;  // shared_mutex allows concurrent reads
+
+    std::vector<std::shared_ptr<ConnectionChannel>> channelCache_;
+    std::mutex channelCacheMu_;
+    std::atomic<bool> cacheDirty_{false};
+
+    std::atomic<bool> shuttingDown_{false};
+
+    std::atomic<std::uint32_t> rrIndex_{0};
+    RoutingPolicy routingPolicy_{RoutingPolicy::ROUND_ROBIN};
+    static constexpr std::uint64_t kRecoverIntervalMs = 100;
+
+    std::thread recoverWorker_;
+    std::atomic<bool> stopRecover_{false};
+
+    std::shared_mutex drainMu_;
+    std::vector<std::shared_ptr<ConnectionChannel>> drainList_;
+
+    TransProvider& provider_;
+    std::string localIp_;
+    std::uint32_t timeout_;
+    std::uint32_t maxErrorCount_;
+    std::uint32_t maxInflightPerChannel_{256};
+
+    void RecoverLoop();
+    void RebuildChannelCache();
+    std::shared_ptr<ConnectionChannel> SelectByRoundRobin();
+    std::shared_ptr<ConnectionChannel> SelectByLeastLoaded();
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.cpp
@@ -1,0 +1,791 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "fake_trans_provider.h"
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <shared_mutex>
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+#include <vector>
+#include "kv_protocol.h"
+#include "logger.h"
+
+namespace UC::ASU {
+namespace {
+
+constexpr std::uint16_t kCqeSuccess = 0x000;
+constexpr std::uint16_t kCqeInternalError = 0x006;
+constexpr std::uint16_t kCqeCheckResultBuffer = 0x732;
+constexpr std::uint8_t kBatchEntryOk = 0x0;
+constexpr std::uint8_t kBatchEntryKeyNotFound = 0x3;
+constexpr std::uint8_t kDeleteEntryOk = 0x0;
+constexpr std::uint8_t kDeleteEntryFailed = 0x1;
+constexpr std::uint8_t kExistEntryNotExist = 0x0;
+constexpr std::uint8_t kExistEntryExist = 0x1;
+constexpr std::uint32_t kExistSeekControlMask = 1U << 16;
+constexpr std::size_t kKeyLockCount = 256;
+
+std::array<std::shared_mutex, kKeyLockCount> g_keyMutexes;
+
+std::uint64_t ReadU64(std::uint32_t low, std::uint32_t high)
+{
+    return static_cast<std::uint64_t>(low) | (static_cast<std::uint64_t>(high) << 32);
+}
+
+std::uint32_t RequestCid(const std::uint32_t* request) { return request[0] >> 16; }
+
+AsuId RequestAsuId(const std::uint32_t* request) { return request[1]; }
+
+KvOpcode RequestOpcode(const std::uint32_t* request)
+{
+    return static_cast<KvOpcode>(request[0] & 0xFF);
+}
+
+CacheKey ReadKey(const std::uint32_t* data)
+{
+    CacheKey key{};
+    std::memcpy(key.data(), data, kCacheKeySizeBytes);
+    return key;
+}
+
+std::uint64_t KeyHash(const CacheKey& key)
+{
+    std::uint64_t hash = 1469598103934665603ULL;
+    for (auto byte : key) {
+        const auto ch = std::to_integer<unsigned char>(byte);
+        hash ^= ch;
+        hash *= 1099511628211ULL;
+    }
+    return hash;
+}
+
+std::string KeyFileName(const CacheKey& key)
+{
+    std::ostringstream stream;
+    stream << std::hex << std::setw(16) << std::setfill('0') << KeyHash(key) << ".bin";
+    return stream.str();
+}
+
+std::shared_mutex& KeyMutex(const CacheKey& key)
+{
+    return g_keyMutexes[KeyHash(key) % kKeyLockCount];
+}
+
+std::filesystem::path AsuRoot(const std::string& storePath, AsuId asuId)
+{
+    return std::filesystem::path(storePath) / ("asu-" + std::to_string(asuId));
+}
+
+std::filesystem::path KeyPath(const std::string& storePath, AsuId asuId, const CacheKey& key)
+{
+    return AsuRoot(storePath, asuId) / KeyFileName(key);
+}
+
+void PackCqeHeader(std::uint32_t* flagBuffer, std::uint16_t cid, std::uint16_t status)
+{
+    flagBuffer[0] = 0;
+    flagBuffer[1] = 0;
+    flagBuffer[2] = 0;
+    flagBuffer[3] = static_cast<std::uint32_t>(cid) | (static_cast<std::uint32_t>(status) << 17);
+}
+
+void PackResultBuffer4Bit(std::uint32_t* resultData, const std::vector<std::uint8_t>& results)
+{
+    const auto dwordCount = (results.size() + 7) / 8;
+    std::fill(resultData, resultData + dwordCount, 0);
+    for (std::size_t index = 0; index < results.size(); ++index) {
+        resultData[index / 8] |= static_cast<std::uint32_t>(results[index] & 0xF)
+                                 << ((index % 8) * 4);
+    }
+}
+
+void PackResultBuffer1Bit(std::uint32_t* resultData, const std::vector<std::uint8_t>& results)
+{
+    const auto dwordCount = (results.size() + 31) / 32;
+    std::fill(resultData, resultData + dwordCount, 0);
+    for (std::size_t index = 0; index < results.size(); ++index) {
+        resultData[index / 32] |= static_cast<std::uint32_t>(results[index] & 0x1) << (index % 32);
+    }
+}
+
+struct BatchEntry {
+    CacheKey key{};
+    std::uint32_t offset{0};
+    std::uint64_t bufferAddr{0};
+    std::uint32_t length{0};
+};
+
+std::vector<BatchEntry> ReadBatchEntries(const std::uint32_t* request, std::uint16_t batchNumber)
+{
+    std::vector<BatchEntry> entries;
+    entries.reserve(batchNumber);
+    for (std::uint16_t index = 0; index < batchNumber; ++index) {
+        const auto* entry = request + kSqeDwordCount + index * kBatchEntryDwordCount;
+        BatchEntry parsed;
+        parsed.offset = entry[0];
+        parsed.key = ReadKey(entry + 1);
+        parsed.bufferAddr = ReadU64(entry[5], entry[6]);
+        parsed.length = entry[7] & 0xFFFFFF;
+        entries.emplace_back(std::move(parsed));
+    }
+    return entries;
+}
+
+std::vector<CacheKey> ReadKeyEntries(const std::uint32_t* request, std::uint16_t batchNumber)
+{
+    std::vector<CacheKey> keys;
+    keys.reserve(batchNumber);
+    for (std::uint16_t index = 0; index < batchNumber; ++index) {
+        const auto* entry = request + kSqeDwordCount + index * kKeyEntryDwordCount;
+        keys.emplace_back(ReadKey(entry));
+    }
+    return keys;
+}
+
+std::size_t CompletionDwordCount(const std::uint32_t* request)
+{
+    const auto opcode = RequestOpcode(request);
+    if (opcode == KvOpcode::KeepAlive) { return kCqeDwordCount; }
+    if (opcode == KvOpcode::Store || opcode == KvOpcode::Retrieve) { return kCqeDwordCount; }
+
+    const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
+    const auto resultDwordCount =
+        opcode == KvOpcode::BatchStore || opcode == KvOpcode::BatchRetrieve
+            ? (static_cast<std::size_t>(batchNumber) + 7) / 8
+            : (static_cast<std::size_t>(batchNumber) + 31) / 32;
+    return kCqeDwordCount + resultDwordCount;
+}
+
+std::size_t RequestDwordCount(const std::uint32_t* request)
+{
+    const auto opcode = RequestOpcode(request);
+    if (opcode == KvOpcode::Store || opcode == KvOpcode::Retrieve ||
+        opcode == KvOpcode::KeepAlive) {
+        return kSqeDwordCount;
+    }
+
+    const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
+    const auto entryDwordCount = opcode == KvOpcode::BatchStore || opcode == KvOpcode::BatchRetrieve
+                                     ? kBatchEntryDwordCount
+                                     : kKeyEntryDwordCount;
+    return kSqeDwordCount + static_cast<std::size_t>(batchNumber) * entryDwordCount;
+}
+
+void PublishCompletion(std::uint32_t* flagBuffer, const std::vector<std::uint32_t>& completion)
+{
+    std::memcpy(flagBuffer, completion.data(), 3 * sizeof(std::uint32_t));
+    if (completion.size() > kCqeDwordCount) {
+        std::memcpy(flagBuffer + kCqeDwordCount, completion.data() + kCqeDwordCount,
+                    (completion.size() - kCqeDwordCount) * sizeof(std::uint32_t));
+    }
+    __atomic_store_n(flagBuffer + 3, completion[3], __ATOMIC_RELEASE);
+}
+
+}  // namespace
+
+class FakeTransProvider::WorkerPool {
+public:
+    WorkerPool(FakeTransProvider& provider, std::size_t workerCount) : provider_(provider)
+    {
+        if (workerCount == 0) { throw std::invalid_argument("fake backend worker count is zero"); }
+        workers_.reserve(workerCount);
+        try {
+            for (std::size_t index = 0; index < workerCount; ++index) {
+                workers_.emplace_back(&WorkerPool::WorkerLoop, this);
+            }
+        } catch (...) {
+            StopAndJoin();
+            throw;
+        }
+    }
+
+    ~WorkerPool() { StopAndJoin(); }
+
+    WorkerPool(const WorkerPool&) = delete;
+    WorkerPool& operator=(const WorkerPool&) = delete;
+
+    bool Push(IoTask task)
+    {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            if (stopping_) { return false; }
+            tasks_.emplace_back(std::move(task));
+            ++pendingTaskCount_;
+        }
+        workReady_.notify_one();
+        return true;
+    }
+
+    void WaitUntilIdle()
+    {
+        std::unique_lock<std::mutex> lock(mutex_);
+        idle_.wait(lock, [this] { return pendingTaskCount_ == 0; });
+    }
+
+private:
+    void WorkerLoop()
+    {
+        while (true) {
+            IoTask task;
+            {
+                std::unique_lock<std::mutex> lock(mutex_);
+                workReady_.wait(lock, [this] { return stopping_ || !tasks_.empty(); });
+                if (stopping_ && tasks_.empty()) { return; }
+                task = std::move(tasks_.front());
+                tasks_.pop_front();
+            }
+
+            provider_.ProcessIoTask(task);
+
+            {
+                std::lock_guard<std::mutex> lock(mutex_);
+                --pendingTaskCount_;
+                if (pendingTaskCount_ == 0) { idle_.notify_all(); }
+            }
+        }
+    }
+
+    void StopAndJoin()
+    {
+        {
+            std::lock_guard<std::mutex> lock(mutex_);
+            stopping_ = true;
+        }
+        workReady_.notify_all();
+        for (auto& worker : workers_) {
+            if (worker.joinable()) { worker.join(); }
+        }
+        workers_.clear();
+    }
+
+    FakeTransProvider& provider_;
+    std::mutex mutex_;
+    std::condition_variable workReady_;
+    std::condition_variable idle_;
+    std::deque<IoTask> tasks_;
+    std::vector<std::thread> workers_;
+    std::size_t pendingTaskCount_{0};
+    bool stopping_{false};
+};
+
+FakeTransProviderConfig MakeFakeTransProviderConfig(const TransportConfig& config)
+{
+    FakeTransProviderConfig fakeConfig;
+    fakeConfig.deviceId = config.deviceId < 0 ? 0 : config.deviceId;
+    auto pathIter = config.attrs.find("fake_backend.path");
+    if (pathIter != config.attrs.end() && !pathIter->second.empty()) {
+        fakeConfig.storePath = pathIter->second;
+    }
+    auto latencyIter = config.attrs.find("fake_backend.latency_ms");
+    if (latencyIter != config.attrs.end()) {
+        fakeConfig.latencyMs = static_cast<std::uint64_t>(std::stoull(latencyIter->second));
+    }
+    auto deviceIter = config.attrs.find("fake_backend.device_id");
+    if (deviceIter != config.attrs.end()) {
+        fakeConfig.deviceId = static_cast<std::int32_t>(std::stol(deviceIter->second));
+    }
+    auto workerIter = config.attrs.find("fake_backend.worker_threads");
+    if (workerIter != config.attrs.end()) {
+        fakeConfig.workerThreads = static_cast<std::size_t>(std::stoull(workerIter->second));
+    }
+    return fakeConfig;
+}
+
+FakeTransProvider::FakeTransProvider(FakeTransProviderConfig config)
+    : config_(std::move(config)),
+      workerPool_(std::make_unique<WorkerPool>(*this, config_.workerThreads))
+{
+    if (SetupDeviceRuntime().ok()) { stream_ = device_.MakeStream(); }
+}
+
+FakeTransProvider::~FakeTransProvider() = default;
+
+Status FakeTransProvider::SetupDeviceRuntime()
+{
+    const auto deviceId = config_.deviceId < 0 ? 0 : config_.deviceId;
+    thread_local std::int32_t readyDeviceId = -1;
+    if (readyDeviceId == deviceId) { return Status::OK(); }
+
+    const auto initStatus = device_.Init();
+    if (initStatus.Failure() && initStatus != UC::Status::DuplicateKey()) {
+        return Status::Error(StatusCode::INTERNAL_ERROR,
+                             "ASU fake backend Device::Init failed: " + initStatus.ToString());
+    }
+
+    const auto setupStatus = device_.Setup(deviceId);
+    if (setupStatus.Failure()) {
+        return Status::Error(StatusCode::INTERNAL_ERROR,
+                             "ASU fake backend Device::Setup failed: device_id=" +
+                                 std::to_string(deviceId) + " message=" + setupStatus.ToString());
+    }
+    readyDeviceId = deviceId;
+    return Status::OK();
+}
+
+Status FakeTransProvider::ResolveLocalAddress(const void* providerAddr, std::size_t size,
+                                              void*& localAddr)
+{
+    const auto address = reinterpret_cast<std::uintptr_t>(providerAddr);
+    std::lock_guard<std::mutex> lock(registeredMemoryMu_);
+    for (const auto& item : registeredMemories_) {
+        const auto& memory = item.second;
+        if (address < memory.providerAddr) { continue; }
+        const auto offset = address - memory.providerAddr;
+        if (offset > memory.size || size > memory.size - offset) { continue; }
+        localAddr = reinterpret_cast<void*>(memory.localAddr + offset);
+        return Status::OK();
+    }
+    localAddr = nullptr;
+    return Status::Error(StatusCode::BUFFER_NOT_REGISTERED,
+                         "fake backend IO buffer is not registered");
+}
+
+bool FakeTransProvider::StoreBytes(AsuId asuId, const CacheKey& key, std::uint32_t offset,
+                                   std::uint64_t addr, std::uint32_t length)
+{
+    std::unique_lock<std::shared_mutex> keyLock(KeyMutex(key));
+    if (stream_ == nullptr) {
+        UC_ERROR("ASU fake backend stream not initialized asuId={} key={} addr={} length={}.",
+                 asuId, CacheKeyToHex(key), addr, length);
+        return false;
+    }
+    std::vector<char> buffer(length);
+    const auto copyStatus =
+        stream_->DeviceToHost(reinterpret_cast<void*>(addr), buffer.data(), length);
+    if (copyStatus.Failure()) {
+        UC_ERROR(
+            "ASU fake backend device-to-host copy failed asuId={} key={} addr={} length={} "
+            "message={}.",
+            asuId, CacheKeyToHex(key), addr, length, copyStatus.ToString());
+        return false;
+    }
+
+    std::filesystem::create_directories(AsuRoot(config_.storePath, asuId));
+    const auto path = KeyPath(config_.storePath, asuId, key);
+    std::fstream output(path, std::ios::binary | std::ios::in | std::ios::out);
+    if (!output) {
+        std::ofstream create(path, std::ios::binary);
+        create.close();
+        output.open(path, std::ios::binary | std::ios::in | std::ios::out);
+    }
+    if (!output) {
+        UC_ERROR("ASU fake backend failed to open store file asuId={} key={} path={}.", asuId,
+                 CacheKeyToHex(key), path.string());
+        return false;
+    }
+    output.seekp(static_cast<std::streamoff>(offset), std::ios::beg);
+    if (!output) {
+        UC_ERROR("ASU fake backend failed to seek store file asuId={} key={} path={} offset={}.",
+                 asuId, CacheKeyToHex(key), path.string(), offset);
+        return false;
+    }
+    output.write(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+    return output.good();
+}
+
+bool FakeTransProvider::LoadBytes(AsuId asuId, const CacheKey& key, std::uint32_t offset,
+                                  std::uint64_t addr, std::uint32_t length)
+{
+    std::shared_lock<std::shared_mutex> keyLock(KeyMutex(key));
+    if (stream_ == nullptr) {
+        UC_ERROR("ASU fake backend stream not initialized asuId={} key={} addr={} length={}.",
+                 asuId, CacheKeyToHex(key), addr, length);
+        return false;
+    }
+    const auto path = KeyPath(config_.storePath, asuId, key);
+    std::ifstream input(path, std::ios::binary);
+    if (!input) {
+        UC_ERROR("ASU fake backend failed to open load file asuId={} key={} path={}.", asuId,
+                 CacheKeyToHex(key), path.string());
+        return false;
+    }
+    std::vector<char> buffer(length, 0);
+    input.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
+    if (input) {
+        input.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        const auto readCount = input.gcount();
+        if (readCount < static_cast<std::streamsize>(length)) {
+            std::fill(buffer.begin() + readCount, buffer.end(), 0);
+        }
+    }
+    const auto copyStatus =
+        stream_->HostToDevice(buffer.data(), reinterpret_cast<void*>(addr), length);
+    if (copyStatus.Failure()) {
+        UC_ERROR(
+            "ASU fake backend host-to-device copy failed asuId={} key={} addr={} length={} "
+            "message={}.",
+            asuId, CacheKeyToHex(key), addr, length, copyStatus.ToString());
+        return false;
+    }
+    return true;
+}
+
+bool FakeTransProvider::DeleteKey(AsuId asuId, const CacheKey& key)
+{
+    std::unique_lock<std::shared_mutex> keyLock(KeyMutex(key));
+    std::error_code errorCode;
+    std::filesystem::remove(KeyPath(config_.storePath, asuId, key), errorCode);
+    return !errorCode;
+}
+
+bool FakeTransProvider::ExistsKey(AsuId asuId, const CacheKey& key)
+{
+    std::shared_lock<std::shared_mutex> keyLock(KeyMutex(key));
+    std::error_code errorCode;
+    return std::filesystem::exists(KeyPath(config_.storePath, asuId, key), errorCode);
+}
+
+Status FakeTransProvider::CompleteStore(AsuId asuId, const std::uint32_t* request,
+                                        std::uint32_t* flagBuffer)
+{
+    const auto cid = static_cast<std::uint16_t>(RequestCid(request));
+    const auto bufferAddr = ReadU64(request[6], request[7]);
+    const auto bufferLength = request[8] & 0xFFFFFF;
+    const auto offset = request[10];
+    const auto key = ReadKey(request + 12);
+    const auto status = StoreBytes(asuId, key, offset, bufferAddr, bufferLength)
+                            ? kCqeSuccess
+                            : kCqeCheckResultBuffer;
+    PackCqeHeader(flagBuffer, cid, status);
+    return Status::OK();
+}
+
+Status FakeTransProvider::CompleteRetrieve(AsuId asuId, const std::uint32_t* request,
+                                           std::uint32_t* flagBuffer)
+{
+    const auto cid = static_cast<std::uint16_t>(RequestCid(request));
+    const auto bufferAddr = ReadU64(request[6], request[7]);
+    const auto bufferLength = request[8] & 0xFFFFFF;
+    const auto offset = request[10];
+    const auto key = ReadKey(request + 12);
+    const auto status = LoadBytes(asuId, key, offset, bufferAddr, bufferLength)
+                            ? kCqeSuccess
+                            : kCqeCheckResultBuffer;
+    PackCqeHeader(flagBuffer, cid, status);
+    return Status::OK();
+}
+
+Status FakeTransProvider::CompleteBatchStore(AsuId asuId, const std::uint32_t* request,
+                                             std::uint32_t* flagBuffer)
+{
+    const auto cid = static_cast<std::uint16_t>(RequestCid(request));
+    const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
+    std::vector<std::uint8_t> results(batchNumber, kBatchEntryOk);
+
+    const auto entries = ReadBatchEntries(request, batchNumber);
+    for (std::size_t index = 0; index < entries.size(); ++index) {
+        const auto& entry = entries[index];
+        if (!StoreBytes(asuId, entry.key, entry.offset, entry.bufferAddr, entry.length)) {
+            results[index] = kBatchEntryKeyNotFound;
+        }
+    }
+
+    const auto allOk = std::all_of(results.begin(), results.end(),
+                                   [](std::uint8_t result) { return result == kBatchEntryOk; });
+    const auto cqeStatus = allOk ? kCqeSuccess : kCqeCheckResultBuffer;
+    PackCqeHeader(flagBuffer, cid, cqeStatus);
+    if (!allOk) { PackResultBuffer4Bit(flagBuffer + kCqeDwordCount, results); }
+    return Status::OK();
+}
+
+Status FakeTransProvider::CompleteBatchRetrieve(AsuId asuId, const std::uint32_t* request,
+                                                std::uint32_t* flagBuffer)
+{
+    const auto cid = static_cast<std::uint16_t>(RequestCid(request));
+    const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
+    std::vector<std::uint8_t> results(batchNumber, kBatchEntryOk);
+
+    const auto entries = ReadBatchEntries(request, batchNumber);
+    for (std::size_t index = 0; index < entries.size(); ++index) {
+        const auto& entry = entries[index];
+        if (!LoadBytes(asuId, entry.key, entry.offset, entry.bufferAddr, entry.length)) {
+            results[index] = kBatchEntryKeyNotFound;
+        }
+    }
+
+    const auto allOk = std::all_of(results.begin(), results.end(),
+                                   [](std::uint8_t result) { return result == kBatchEntryOk; });
+    const auto cqeStatus = allOk ? kCqeSuccess : kCqeCheckResultBuffer;
+    PackCqeHeader(flagBuffer, cid, cqeStatus);
+    if (!allOk) { PackResultBuffer4Bit(flagBuffer + kCqeDwordCount, results); }
+    return Status::OK();
+}
+
+Status FakeTransProvider::CompleteDelete(AsuId asuId, const std::uint32_t* request,
+                                         std::uint32_t* flagBuffer)
+{
+    const auto cid = static_cast<std::uint16_t>(RequestCid(request));
+    const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
+    std::vector<std::uint8_t> results(batchNumber, kDeleteEntryOk);
+
+    const auto keys = ReadKeyEntries(request, batchNumber);
+    for (std::size_t index = 0; index < keys.size(); ++index) {
+        if (!DeleteKey(asuId, keys[index])) { results[index] = kDeleteEntryFailed; }
+    }
+
+    const auto allOk = std::all_of(results.begin(), results.end(),
+                                   [](std::uint8_t result) { return result == kDeleteEntryOk; });
+    const auto cqeStatus = allOk ? kCqeSuccess : kCqeCheckResultBuffer;
+    PackCqeHeader(flagBuffer, cid, cqeStatus);
+    if (!allOk) { PackResultBuffer1Bit(flagBuffer + kCqeDwordCount, results); }
+    return Status::OK();
+}
+
+Status FakeTransProvider::CompleteExist(AsuId asuId, const std::uint32_t* request,
+                                        std::uint32_t* flagBuffer)
+{
+    const auto cid = static_cast<std::uint16_t>(RequestCid(request));
+    const auto batchNumber = static_cast<std::uint16_t>(request[10] & 0xFFFF);
+    std::vector<std::uint8_t> results(batchNumber, kExistEntryNotExist);
+    std::uint16_t existingKeyNumber = 0;
+    const bool useSeekControl = (request[10] & kExistSeekControlMask) != 0;
+
+    const auto keys = ReadKeyEntries(request, batchNumber);
+    for (std::size_t index = 0; index < keys.size(); ++index) {
+        if (ExistsKey(asuId, keys[index])) {
+            results[index] = kExistEntryExist;
+            ++existingKeyNumber;
+        } else if (!useSeekControl) {
+            break;
+        }
+    }
+
+    const auto allExist = existingKeyNumber == batchNumber;
+    const auto cqeStatus = allExist ? kCqeSuccess : kCqeCheckResultBuffer;
+    PackCqeHeader(flagBuffer, cid, cqeStatus);
+    flagBuffer[0] = existingKeyNumber;
+    if (!allExist) { PackResultBuffer1Bit(flagBuffer + kCqeDwordCount, results); }
+    return Status::OK();
+}
+
+Status FakeTransProvider::CompleteFakeBackendRequest(const void* sendBuffer, std::uint64_t len,
+                                                     std::vector<std::uint32_t>& completion)
+{
+    if (config_.latencyMs > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(config_.latencyMs));
+    }
+
+    if (sendBuffer == nullptr || len < kSqeDwordCount * sizeof(std::uint32_t)) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "fake backend send buffer is empty");
+    }
+
+    const auto* request = reinterpret_cast<const std::uint32_t*>(sendBuffer);
+    completion.assign(CompletionDwordCount(request), 0);
+    auto* flagBuffer = completion.data();
+    const auto asuId = RequestAsuId(request);
+    switch (RequestOpcode(request)) {
+        case KvOpcode::Store: return CompleteStore(asuId, request, flagBuffer);
+        case KvOpcode::Retrieve: return CompleteRetrieve(asuId, request, flagBuffer);
+        case KvOpcode::BatchStore: return CompleteBatchStore(asuId, request, flagBuffer);
+        case KvOpcode::BatchRetrieve: return CompleteBatchRetrieve(asuId, request, flagBuffer);
+        case KvOpcode::Delete: return CompleteDelete(asuId, request, flagBuffer);
+        case KvOpcode::Exist: return CompleteExist(asuId, request, flagBuffer);
+        case KvOpcode::KeepAlive: {
+            PackCqeHeader(flagBuffer, static_cast<std::uint16_t>(RequestCid(request)), kCqeSuccess);
+            return Status::OK();
+        }
+        default:
+            return Status::Error(StatusCode::UNSUPPORTED,
+                                 "fake backend does not support this ASU operation");
+    }
+}
+
+Status FakeTransProvider::CreateConnection(const std::string&, const std::string&, uint32_t,
+                                           uint32_t qpNum, uint32_t,
+                                           std::vector<ConnectionHandle>& handles)
+{
+    auto status = SetupDeviceRuntime();
+    if (!status.ok()) { return status; }
+    handles.clear();
+    handles.reserve(qpNum);
+    for (uint32_t index = 0; index < qpNum; ++index) {
+        handles.push_back(reinterpret_cast<ConnectionHandle>(static_cast<std::uintptr_t>(index) +
+                                                             static_cast<std::uintptr_t>(1)));
+    }
+    return Status::OK();
+}
+
+std::vector<Status> FakeTransProvider::DeleteConnections(
+    const std::vector<ConnectionHandle>& handles)
+{
+    return std::vector<Status>(handles.size(), Status::OK());
+}
+
+std::vector<Status> FakeTransProvider::Send(const std::vector<SendIoBatch>& ioBatches,
+                                            uint32_t kernelCount, uint32_t quietCount)
+{
+    (void)kernelCount;
+    (void)quietCount;
+    std::vector<Status> statuses;
+    statuses.reserve(ioBatches.size());
+    for (const auto& ioBatch : ioBatches) {
+        if (ioBatch.sendBuffer == nullptr || ioBatch.flagBuffer == nullptr ||
+            ioBatch.len < kSqeDwordCount * sizeof(std::uint32_t) ||
+            ioBatch.len > std::numeric_limits<std::size_t>::max()) {
+            statuses.emplace_back(
+                Status::Error(StatusCode::INVALID_ARGUMENT, "fake backend IO buffer is invalid"));
+            continue;
+        }
+
+        void* localSendBuffer = nullptr;
+        auto status = ResolveLocalAddress(ioBatch.sendBuffer, static_cast<std::size_t>(ioBatch.len),
+                                          localSendBuffer);
+        if (!status.ok()) {
+            statuses.emplace_back(std::move(status));
+            continue;
+        }
+
+        const auto* request = static_cast<const std::uint32_t*>(localSendBuffer);
+        const auto requestSize = RequestDwordCount(request) * sizeof(std::uint32_t);
+        if (requestSize > ioBatch.len) {
+            statuses.emplace_back(Status::Error(StatusCode::INVALID_ARGUMENT,
+                                                "fake backend send buffer is truncated"));
+            continue;
+        }
+
+        const auto completionSize = CompletionDwordCount(request) * sizeof(std::uint32_t);
+        void* localFlagBuffer = nullptr;
+        status = ResolveLocalAddress(ioBatch.flagBuffer, completionSize, localFlagBuffer);
+        if (!status.ok()) {
+            statuses.emplace_back(std::move(status));
+            continue;
+        }
+
+        IoTask task;
+        task.request.resize(ioBatch.len / sizeof(std::uint32_t) +
+                            (ioBatch.len % sizeof(std::uint32_t) != 0));
+        std::memcpy(task.request.data(), localSendBuffer, static_cast<std::size_t>(ioBatch.len));
+        task.requestLength = ioBatch.len;
+        task.flagBuffer = static_cast<std::uint32_t*>(localFlagBuffer);
+        if (!workerPool_->Push(std::move(task))) {
+            statuses.emplace_back(
+                Status::Error(StatusCode::NOT_INITIALIZED, "fake backend worker pool is stopping"));
+            continue;
+        }
+        statuses.emplace_back(Status::OK());
+    }
+    return statuses;
+}
+
+void FakeTransProvider::ProcessIoTask(IoTask& task)
+{
+    std::vector<std::uint32_t> completion;
+    Status status;
+    try {
+        status = SetupDeviceRuntime();
+        if (status.ok()) {
+            status =
+                CompleteFakeBackendRequest(task.request.data(), task.requestLength, completion);
+        }
+    } catch (const std::exception& error) {
+        status = Status::Error(StatusCode::INTERNAL_ERROR,
+                               "fake backend worker exception: " + std::string(error.what()));
+    } catch (...) {
+        status = Status::Error(StatusCode::INTERNAL_ERROR,
+                               "fake backend worker raised an unknown exception");
+    }
+    if (!status.ok()) {
+        completion.assign(kCqeDwordCount, 0);
+        PackCqeHeader(completion.data(),
+                      static_cast<std::uint16_t>(RequestCid(task.request.data())),
+                      kCqeInternalError);
+        UC_ERROR("ASU fake backend worker failed code={} message={}", static_cast<int>(status.code),
+                 status.message);
+    }
+    PublishCompletion(task.flagBuffer, completion);
+}
+
+Status FakeTransProvider::RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
+                                         std::vector<MRHandle>& mrHandles)
+{
+    mrHandles.clear();
+    mrHandles.reserve(memoryDescs.size());
+    std::lock_guard<std::mutex> lock(registeredMemoryMu_);
+    for (const auto& desc : memoryDescs) {
+        auto handle = nextMrHandle_.fetch_add(1, std::memory_order_relaxed);
+        if (handle == 0) { handle = nextMrHandle_.fetch_add(1, std::memory_order_relaxed); }
+        auto mrHandle = reinterpret_cast<MRHandle>(handle);
+        if (desc.localAddr != 0) {
+            registeredMemories_[mrHandle] = RegisteredMemory{desc.addr, desc.localAddr, desc.size};
+        }
+        mrHandles.push_back(mrHandle);
+    }
+    return Status::OK();
+}
+
+Status FakeTransProvider::BindMemory(const std::vector<BindMemoryDesc>& memoryDescs,
+                                     std::vector<MRHandle>& mrHandles)
+{
+    mrHandles.clear();
+    mrHandles.reserve(memoryDescs.size());
+    std::lock_guard<std::mutex> lock(registeredMemoryMu_);
+    for (const auto& desc : memoryDescs) {
+        auto handle = nextMrHandle_.fetch_add(1, std::memory_order_relaxed);
+        if (handle == 0) { handle = nextMrHandle_.fetch_add(1, std::memory_order_relaxed); }
+        const auto mrHandle = reinterpret_cast<MRHandle>(handle);
+        registeredMemories_[mrHandle] = RegisteredMemory{desc.addr, desc.addr, desc.size};
+        mrHandles.emplace_back(mrHandle);
+    }
+    return Status::OK();
+}
+
+std::vector<Status> FakeTransProvider::UnregisterMemory(
+    const std::vector<UnregisterMemoryDesc>& handles)
+{
+    workerPool_->WaitUntilIdle();
+    std::lock_guard<std::mutex> lock(registeredMemoryMu_);
+    for (const auto& desc : handles) { registeredMemories_.erase(desc.mrHandle); }
+    return std::vector<Status>(handles.size(), Status::OK());
+}
+
+Status FakeTransProvider::AllocThread(uint32_t, const std::vector<uint32_t>&,
+                                      std::vector<ThreadHandle>&)
+{
+    return Status::OK();
+}
+
+std::vector<Status> FakeTransProvider::FreeThread(const std::vector<ThreadHandle>& threads)
+{
+    return std::vector<Status>(threads.size(), Status::OK());
+}
+
+Status FakeTransProvider::GetMemTokenId(MRHandle, uint32_t& tokenId)
+{
+    tokenId = 1;
+    return Status::OK();
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
+++ b/ucm/transport/kv/asu/trans/src/fake_trans_provider.h
@@ -1,0 +1,120 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+#include "asu_transport/asu_transport.h"
+#include "asu_transport/trans_provider.h"
+#include "trans/device.h"
+#include "trans/stream.h"
+
+namespace UC::ASU {
+
+struct FakeTransProviderConfig {
+    std::string storePath{"./asu-fake-backend-store"};
+    std::uint64_t latencyMs{1};
+    std::int32_t deviceId{0};
+    std::size_t workerThreads{4};
+};
+
+class FakeTransProvider : public TransProvider {
+public:
+    explicit FakeTransProvider(FakeTransProviderConfig config);
+    ~FakeTransProvider() override;
+
+    Status CreateConnection(const std::string&, const std::string&, uint32_t, uint32_t qpNum,
+                            uint32_t, std::vector<ConnectionHandle>& handles) override;
+
+    std::vector<Status> DeleteConnections(const std::vector<ConnectionHandle>& handles) override;
+
+    std::vector<Status> Send(const std::vector<SendIoBatch>& ioBatches, uint32_t kernelCount,
+                             uint32_t quietCount) override;
+
+    Status RegisterMemory(const std::vector<RegisterMemoryDesc>& memoryDescs,
+                          std::vector<MRHandle>& mrHandles) override;
+
+    Status BindMemory(const std::vector<BindMemoryDesc>& memoryDescs,
+                      std::vector<MRHandle>& mrHandles) override;
+
+    std::vector<Status> UnregisterMemory(const std::vector<UnregisterMemoryDesc>& handles) override;
+
+    Status AllocThread(uint32_t, const std::vector<uint32_t>&, std::vector<ThreadHandle>&) override;
+
+    std::vector<Status> FreeThread(const std::vector<ThreadHandle>& threads) override;
+
+    Status GetMemTokenId(MRHandle, uint32_t& tokenId) override;
+
+private:
+    struct IoTask {
+        std::vector<std::uint32_t> request;
+        std::uint64_t requestLength{0};
+        std::uint32_t* flagBuffer{nullptr};
+    };
+
+    class WorkerPool;
+
+    struct RegisteredMemory {
+        std::uintptr_t providerAddr{0};
+        std::uintptr_t localAddr{0};
+        std::size_t size{0};
+    };
+
+    Status SetupDeviceRuntime();
+    Status ResolveLocalAddress(const void* providerAddr, std::size_t size, void*& localAddr);
+    void ProcessIoTask(IoTask& task);
+
+    bool StoreBytes(AsuId asuId, const CacheKey& key, std::uint32_t offset, std::uint64_t addr,
+                    std::uint32_t length);
+    bool LoadBytes(AsuId asuId, const CacheKey& key, std::uint32_t offset, std::uint64_t addr,
+                   std::uint32_t length);
+    bool DeleteKey(AsuId asuId, const CacheKey& key);
+    bool ExistsKey(AsuId asuId, const CacheKey& key);
+    Status CompleteStore(AsuId asuId, const std::uint32_t* request, std::uint32_t* flagBuffer);
+    Status CompleteRetrieve(AsuId asuId, const std::uint32_t* request, std::uint32_t* flagBuffer);
+    Status CompleteBatchStore(AsuId asuId, const std::uint32_t* request, std::uint32_t* flagBuffer);
+    Status CompleteBatchRetrieve(AsuId asuId, const std::uint32_t* request,
+                                 std::uint32_t* flagBuffer);
+    Status CompleteDelete(AsuId asuId, const std::uint32_t* request, std::uint32_t* flagBuffer);
+    Status CompleteExist(AsuId asuId, const std::uint32_t* request, std::uint32_t* flagBuffer);
+    Status CompleteFakeBackendRequest(const void* sendBuffer, std::uint64_t len,
+                                      std::vector<std::uint32_t>& completion);
+
+    FakeTransProviderConfig config_;
+    Trans::Device device_;
+    std::unique_ptr<Trans::Stream> stream_;
+    std::atomic<std::uintptr_t> nextMrHandle_{1};
+    std::mutex registeredMemoryMu_;
+    std::unordered_map<MRHandle, RegisteredMemory> registeredMemories_;
+    std::unique_ptr<WorkerPool> workerPool_;
+};
+
+FakeTransProviderConfig MakeFakeTransProviderConfig(const TransportConfig& config);
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/io_scheduler.cpp
+++ b/ucm/transport/kv/asu/trans/src/io_scheduler.cpp
@@ -1,0 +1,92 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "io_scheduler.h"
+#include <algorithm>
+
+namespace UC::ASU {
+
+namespace {
+
+std::size_t GetSubBatchCount(std::size_t total, std::size_t ioNum)
+{
+    return 1 + (total - 1) / ioNum;
+}
+
+template <typename Value, typename ScheduledBatch, typename SetView>
+std::vector<ScheduledBatch> SplitBatchView(const BatchView<Value>& view, std::size_t ioNum,
+                                           SetView setView)
+{
+    std::vector<ScheduledBatch> result;
+    const std::size_t subBatchCount = GetSubBatchCount(view.size, ioNum);
+    result.reserve(subBatchCount);
+
+    for (std::size_t offset = 0; offset < view.size; offset += ioNum) {
+        const std::size_t end = std::min(offset + ioNum, view.size);
+
+        auto& batch = result.emplace_back();
+        setView(batch, BatchView<Value>{view.data + offset, end - offset});
+    }
+
+    return result;
+}
+
+}  // namespace
+
+IoScheduler::IoScheduler(const TransportConfig& config)
+    : batchLoadIoNum_(config.asuBatchLoadIoNum),
+      batchStoreIoNum_(config.asuBatchStoreIoNum),
+      deleteIoNum_(config.asuDeleteIoNum),
+      queryIoNum_(config.asuQueryIoNum)
+{
+}
+
+std::vector<IoScheduler::ScheduledIoBatch> IoScheduler::SplitForAsu(
+    const BatchView<KVBuffer>& entries, AsuOpType opType) const
+{
+    return SplitBatchView<KVBuffer, ScheduledIoBatch>(
+        entries, GetSqeIoNum(opType),
+        [](ScheduledIoBatch& batch, BatchView<KVBuffer> view) { batch.entries = view; });
+}
+
+std::vector<IoScheduler::ScheduledKeyBatch> IoScheduler::SplitForAsu(
+    const BatchView<CacheKey>& keys, AsuOpType opType) const
+{
+    return SplitBatchView<CacheKey, ScheduledKeyBatch>(
+        keys, GetSqeIoNum(opType),
+        [](ScheduledKeyBatch& batch, BatchView<CacheKey> view) { batch.keys = view; });
+}
+
+std::size_t IoScheduler::GetSqeIoNum(AsuOpType opType) const
+{
+    if (opType == AsuOpType::LOAD || opType == AsuOpType::STORE) { return 1; }
+    switch (opType) {
+        case AsuOpType::BATCH_LOAD: return batchLoadIoNum_;
+        case AsuOpType::BATCH_STORE: return batchStoreIoNum_;
+        case AsuOpType::DELETE: return deleteIoNum_;
+        case AsuOpType::QUERY: return queryIoNum_;
+        default: return 0;
+    }
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/io_scheduler.h
+++ b/ucm/transport/kv/asu/trans/src/io_scheduler.h
@@ -1,0 +1,60 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+#include "asu_transport/asu_transport.h"
+#include "transport_task_manager.h"
+
+namespace UC::ASU {
+
+class IoScheduler {
+public:
+    IoScheduler() = default;
+    explicit IoScheduler(const TransportConfig& config);
+
+    struct ScheduledIoBatch {
+        BatchView<KVBuffer> entries;
+    };
+
+    struct ScheduledKeyBatch {
+        BatchView<CacheKey> keys;
+    };
+
+    std::vector<ScheduledIoBatch> SplitForAsu(const BatchView<KVBuffer>& entries,
+                                              AsuOpType opType) const;
+    std::vector<ScheduledKeyBatch> SplitForAsu(const BatchView<CacheKey>& keys,
+                                               AsuOpType opType) const;
+    std::size_t GetSqeIoNum(AsuOpType opType) const;
+
+private:
+    std::size_t batchLoadIoNum_{110};
+    std::size_t batchStoreIoNum_{110};
+    std::size_t deleteIoNum_{254};
+    std::size_t queryIoNum_{256};
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/kv_protocol.cpp
+++ b/ucm/transport/kv/asu/trans/src/kv_protocol.cpp
@@ -1,0 +1,1271 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "kv_protocol.h"
+#include <algorithm>
+#include <cstring>
+
+namespace UC::ASU {
+
+static void UnpackCqeBase(const std::uint32_t* data, KvResponse& out)
+{
+    out.cid = data[3] & 0xFFFF;
+    out.status = (data[3] >> 17) & 0x7FFF;
+}
+
+static void UnpackResultBuffer4Bit(const std::uint32_t* result_data, std::uint16_t batch_number,
+                                   std::vector<std::uint8_t>& result_buffer)
+{
+    result_buffer.resize(batch_number);
+    for (std::uint16_t i = 0; i < batch_number; ++i) {
+        std::uint32_t dword_idx = i / 8;
+        std::uint32_t slot = (i % 8) * 4;
+        result_buffer[i] = (result_data[dword_idx] >> slot) & 0xF;
+    }
+}
+
+static void UnpackResultBuffer1Bit(const std::uint32_t* result_data, std::uint16_t batch_number,
+                                   std::vector<std::uint8_t>& result_buffer)
+{
+    result_buffer.resize(batch_number);
+    for (std::uint16_t i = 0; i < batch_number; ++i) {
+        std::uint32_t dword_idx = i / 32;
+        std::uint32_t bit = i % 32;
+        result_buffer[i] = (result_data[dword_idx] >> bit) & 0x1;
+    }
+}
+
+static Status VerifyFixedBits(const std::uint32_t* data, const char* log_prefix)
+{
+    if (((data[0] >> 14) & 0x3) != kFixedBits) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             std::string(log_prefix) + ": fixed bits mismatch");
+    }
+    return Status::OK();
+}
+
+static Status VerifyRflagConsistency(const std::uint32_t* data, const char* log_prefix)
+{
+    bool rflag = (data[0] >> 13) & 0x1;
+    std::uint64_t resp_addr =
+        static_cast<std::uint64_t>(data[3]) | (static_cast<std::uint64_t>(data[4]) << 32);
+    std::uint32_t resp_mr_key = data[5];
+    if (rflag) {
+        if (resp_addr == 0) {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                std::string(log_prefix) + ": rflag set but response_buffer_addr is zero");
+        }
+        if (resp_mr_key == 0) {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                std::string(log_prefix) + ": rflag set but response_mr_key is zero");
+        }
+    } else {
+        if (resp_addr != 0) {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                std::string(log_prefix) + ": rflag false but response_buffer_addr non-zero");
+        }
+        if (resp_mr_key != 0) {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                std::string(log_prefix) + ": rflag false but response_mr_key non-zero");
+        }
+    }
+    return Status::OK();
+}
+
+static Status VerifyCacheKeyEntry(const std::uint32_t* key_dwords, const std::string& log_prefix)
+{
+    const auto* bytes = reinterpret_cast<const std::byte*>(key_dwords);
+    const auto keyAllZero = std::all_of(bytes, bytes + kCacheKeySizeBytes,
+                                        [](std::byte value) { return value == std::byte{0}; });
+    if (keyAllZero) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, log_prefix + ": key is all zeros");
+    }
+    const auto tailAllZero = std::all_of(bytes + kCacheKeySizeBytes, bytes + kKeyEntrySizeBytes,
+                                         [](std::byte value) { return value == std::byte{0}; });
+    if (!tailAllZero) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             log_prefix + ": reserved key bytes are non-zero");
+    }
+    return Status::OK();
+}
+
+static bool IsCacheKeyAllZero(const CacheKey& key)
+{
+    return std::all_of(key.begin(), key.end(),
+                       [](std::byte value) { return value == std::byte{0}; });
+}
+
+static Status VerifyBatchEntry(const std::uint32_t* base, const std::string& log_prefix,
+                               std::uint16_t i)
+{
+    if (base[0] % kAlignmentBytes != 0) {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            log_prefix + ": entry[" + std::to_string(i) + "] offset not 512B aligned");
+    }
+
+    auto key_status =
+        VerifyCacheKeyEntry(&base[1], log_prefix + ": entry[" + std::to_string(i) + "]");
+    if (!key_status.ok()) { return key_status; }
+
+    std::uint64_t entry_addr =
+        static_cast<std::uint64_t>(base[5]) | (static_cast<std::uint64_t>(base[6]) << 32);
+    if (entry_addr == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             log_prefix + ": entry[" + std::to_string(i) + "] buffer_addr is zero");
+    }
+
+    std::uint32_t entry_length = base[7] & 0xFFFFFF;
+    if (entry_length == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             log_prefix + ": entry[" + std::to_string(i) + "] length is zero");
+    }
+    if (entry_length % kAlignmentBytes != 0) {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            log_prefix + ": entry[" + std::to_string(i) + "] length not 512B aligned");
+    }
+
+    if ((base[8] >> 24) != static_cast<std::uint32_t>(DptrType::Standard)) {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            log_prefix + ": entry[" + std::to_string(i) + "] DptrType != Standard");
+    }
+
+    return Status::OK();
+}
+
+Status KvStoreProtocol::PackSqe(const SqeRequest& req, std::uint32_t* target)
+{
+    auto& r = static_cast<const KvStoreRequest&>(req);
+    auto status = ValidateRequest(r);
+    if (!status.ok()) { return status; }
+
+    target[0] = (r.cid << 16) | (kFixedBits << 14) | static_cast<std::uint32_t>(KvOpcode::Store);
+    target[1] = r.kv_ns_id;
+    target[2] = ((r.dtype & 0x7) << 13) | ((r.dspec & 0x1F) << 8);
+    target[6] = r.buffer_addr & 0xFFFFFFFFULL;
+    target[7] = (r.buffer_addr >> 32) & 0xFFFFFFFFULL;
+    target[8] = ((r.mr_key & 0xFF) << 24) | (r.buffer_length & 0xFFFFFF);
+    target[9] =
+        (static_cast<std::uint32_t>(DptrType::Standard) << 24) | ((r.mr_key >> 8) & 0xFFFFFF);
+    target[10] = r.offset;
+    target[11] = (r.lr ? (1U << 31) : 0) | (r.length & 0xFFFFFF);
+
+    std::memcpy(&target[12], r.key.data(), kCacheKeySizeBytes);
+    return Status::OK();
+}
+
+Status KvStoreProtocol::ValidateRequest(const KvStoreRequest& r) const
+{
+    if (r.buffer_addr == 0) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "buffer_addr is zero in Store request");
+    }
+    if (r.buffer_length == 0) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "buffer_length is zero in Store request");
+    }
+    if (r.buffer_length % kAlignmentBytes != 0) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "buffer_length(" + std::to_string(r.buffer_length) +
+                                 ") must be 512B aligned in Store request");
+    }
+    if (r.buffer_length > 0xFFFFFF) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "buffer_length(" + std::to_string(r.buffer_length) +
+                                 ") exceeds 24-bit limit in Store request");
+    }
+    if (r.offset % kAlignmentBytes != 0) [[unlikely]] {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            "offset(" + std::to_string(r.offset) + ") must be 512B aligned in Store request");
+    }
+    if (r.length == 0) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "length is 1-based, must be non-zero in Store request");
+    }
+    if (r.length > 0xFFFFFF) [[unlikely]] {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            "length(" + std::to_string(r.length) + ") exceeds 24-bit limit in Store request");
+    }
+    if (IsCacheKeyAllZero(r.key)) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "key is all zeros in Store request");
+    }
+    if (r.dtype > 0x7) [[unlikely]] {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            "dtype(" + std::to_string(r.dtype) + ") exceeds 3-bit limit in Store request");
+    }
+    if (r.dspec > 0x1F) [[unlikely]] {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            "dspec(" + std::to_string(r.dspec) + ") exceeds 5-bit limit in Store request");
+    }
+    return Status::OK();
+}
+
+Status KvStoreProtocol::UnpackCqe(const std::uint32_t* data, std::uint16_t, KvResponse& out) const
+{
+    UnpackCqeBase(data, out);
+    return Status::OK();
+}
+
+Status KvStoreProtocol::VerifyPackedBuffer(const std::uint32_t* data, std::size_t length) const
+{
+    constexpr std::size_t kExpectedLength = kSqeDwordCount * sizeof(std::uint32_t);
+    if (length != kExpectedLength) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Store: length(" + std::to_string(length) + ") != expected(" +
+                                 std::to_string(kExpectedLength) + ")");
+    }
+
+    auto status = VerifyFixedBits(data, "Store");
+    if (!status.ok()) { return status; }
+    if ((data[0] >> 8) & 0x3F) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Store: reserved bits non-zero in data[0] bit8-13");
+    }
+
+    if (data[2] & 0xFFFF00FFU) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Store: reserved bits non-zero in data[2] bit0-7,bit16-31");
+    }
+
+    if (data[3] || data[4] || data[5]) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Store: reserved bits non-zero in data[3-5]");
+    }
+
+    std::uint64_t buffer_addr =
+        static_cast<std::uint64_t>(data[6]) | (static_cast<std::uint64_t>(data[7]) << 32);
+    if (buffer_addr == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Store: buffer_addr is zero");
+    }
+
+    std::uint32_t buffer_length = data[8] & 0xFFFFFF;
+    if (buffer_length == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Store: buffer_length is zero");
+    }
+    if (buffer_length % kAlignmentBytes != 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Store: buffer_length not 512B aligned");
+    }
+
+    if ((data[9] >> 24) != static_cast<std::uint32_t>(DptrType::Standard)) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Store: DptrType != Standard");
+    }
+
+    std::uint32_t offset = data[10];
+    if (offset % kAlignmentBytes != 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Store: offset not 512B aligned");
+    }
+
+    std::uint32_t kv_length = data[11] & 0xFFFFFF;
+    if (kv_length == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Store: length is zero");
+    }
+    if (data[11] & 0x7F000000U) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Store: reserved bits non-zero in data[11] bit24-30");
+    }
+
+    status = VerifyCacheKeyEntry(&data[12], "Store");
+    if (!status.ok()) { return status; }
+
+    return Status::OK();
+}
+
+Status KvRetrieveProtocol::PackSqe(const SqeRequest& req, std::uint32_t* target)
+{
+    auto& r = static_cast<const KvRetrieveRequest&>(req);
+    auto status = ValidateRequest(r);
+    if (!status.ok()) { return status; }
+
+    target[0] = (r.cid << 16) | (kFixedBits << 14) | static_cast<std::uint32_t>(KvOpcode::Retrieve);
+    target[1] = r.kv_ns_id;
+    target[6] = r.buffer_addr & 0xFFFFFFFFULL;
+    target[7] = (r.buffer_addr >> 32) & 0xFFFFFFFFULL;
+    target[8] = ((r.mr_key & 0xFF) << 24) | (r.buffer_length & 0xFFFFFF);
+    target[9] =
+        (static_cast<std::uint32_t>(DptrType::Standard) << 24) | ((r.mr_key >> 8) & 0xFFFFFF);
+    target[10] = r.offset;
+    target[11] = (r.lr ? (1U << 31) : 0) | (r.length & 0xFFFFFF);
+
+    std::memcpy(&target[12], r.key.data(), kCacheKeySizeBytes);
+    return Status::OK();
+}
+
+Status KvRetrieveProtocol::ValidateRequest(const KvRetrieveRequest& r) const
+{
+    if (r.buffer_addr == 0) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "buffer_addr is zero in Retrieve request");
+    }
+    if (r.buffer_length == 0) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "buffer_length is zero in Retrieve request");
+    }
+    if (r.buffer_length % kAlignmentBytes != 0) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "buffer_length(" + std::to_string(r.buffer_length) +
+                                 ") must be 512B aligned in Retrieve request");
+    }
+    if (r.buffer_length > 0xFFFFFF) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "buffer_length(" + std::to_string(r.buffer_length) +
+                                 ") exceeds 24-bit limit in Retrieve request");
+    }
+    if (r.offset % kAlignmentBytes != 0) [[unlikely]] {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            "offset(" + std::to_string(r.offset) + ") must be 512B aligned in Retrieve request");
+    }
+    if (r.length == 0) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "length is 1-based, must be non-zero in Retrieve request");
+    }
+    if (r.length > 0xFFFFFF) [[unlikely]] {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            "length(" + std::to_string(r.length) + ") exceeds 24-bit limit in Retrieve request");
+    }
+    if (IsCacheKeyAllZero(r.key)) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "key is all zeros in Retrieve request");
+    }
+    return Status::OK();
+}
+
+Status KvRetrieveProtocol::UnpackCqe(const std::uint32_t* data, std::uint16_t,
+                                     KvResponse& out) const
+{
+    UnpackCqeBase(data, out);
+    return Status::OK();
+}
+
+Status KvRetrieveProtocol::VerifyPackedBuffer(const std::uint32_t* data, std::size_t length) const
+{
+    constexpr std::size_t kExpectedLength = kSqeDwordCount * sizeof(std::uint32_t);
+    if (length != kExpectedLength) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Retrieve: length(" + std::to_string(length) + ") != expected(" +
+                                 std::to_string(kExpectedLength) + ")");
+    }
+
+    auto status = VerifyFixedBits(data, "Retrieve");
+    if (!status.ok()) { return status; }
+    if ((data[0] >> 8) & 0x3F) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Retrieve: reserved bits non-zero in data[0] bit8-13");
+    }
+
+    if (data[2] != 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Retrieve: reserved bits non-zero in data[2]");
+    }
+
+    if (data[3] || data[4] || data[5]) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Retrieve: reserved bits non-zero in data[3-5]");
+    }
+
+    std::uint64_t buffer_addr =
+        static_cast<std::uint64_t>(data[6]) | (static_cast<std::uint64_t>(data[7]) << 32);
+    if (buffer_addr == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Retrieve: buffer_addr is zero");
+    }
+
+    std::uint32_t buffer_length = data[8] & 0xFFFFFF;
+    if (buffer_length == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Retrieve: buffer_length is zero");
+    }
+    if (buffer_length % kAlignmentBytes != 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Retrieve: buffer_length not 512B aligned");
+    }
+
+    if ((data[9] >> 24) != static_cast<std::uint32_t>(DptrType::Standard)) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Retrieve: DptrType != Standard");
+    }
+
+    std::uint32_t offset = data[10];
+    if (offset % kAlignmentBytes != 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Retrieve: offset not 512B aligned");
+    }
+
+    std::uint32_t kv_length = data[11] & 0xFFFFFF;
+    if (kv_length == 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "Retrieve: length is zero");
+    }
+    if (data[11] & 0x7F000000U) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Retrieve: reserved bits non-zero in data[11] bit24-30");
+    }
+
+    status = VerifyCacheKeyEntry(&data[12], "Retrieve");
+    if (!status.ok()) { return status; }
+
+    return Status::OK();
+}
+
+std::size_t KvBatchStoreProtocol::PackedSize(const SqeRequest& req) const
+{
+    auto& r = static_cast<const KvBatchStoreRequest&>(req);
+    return (kSqeDwordCount + r.batch_number * kBatchEntryDwordCount) * sizeof(std::uint32_t);
+}
+
+Status KvBatchStoreProtocol::PackSqe(const SqeRequest& req, std::uint32_t* target)
+{
+    auto& r = static_cast<const KvBatchStoreRequest&>(req);
+    auto status = ValidateRequest(r);
+    if (!status.ok()) { return status; }
+
+    target[0] =
+        (r.cid << 16) | (kFixedBits << 14) | static_cast<std::uint32_t>(KvOpcode::BatchStore);
+    if (r.rflag) { target[0] |= (1U << 13); }
+    target[1] = r.kv_ns_id;
+    target[2] = ((r.dtype & 0x7) << 13) | ((r.dspec & 0x1F) << 8);
+    target[3] = r.response_buffer_addr & 0xFFFFFFFFULL;
+    target[4] = (r.response_buffer_addr >> 32) & 0xFFFFFFFFULL;
+    target[5] = r.response_mr_key;
+    target[8] = r.batch_number * kBatchEntrySizeBytes;
+    target[9] = static_cast<std::uint32_t>(DptrType::Batch) << 24;
+    target[10] = r.batch_number;
+    if (r.lr) { target[11] |= (1U << 31); }
+
+    for (std::size_t i = 0; i < r.batch_number; ++i) {
+        PackEntry(r.entries[i], target + kSqeDwordCount + i * kBatchEntryDwordCount);
+    }
+    return Status::OK();
+}
+
+Status KvBatchStoreProtocol::ValidateRequest(const KvBatchStoreRequest& r) const
+{
+    if (r.batch_number == 0 || r.batch_number > kMaxBatchNumber) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "batch_number(" + std::to_string(r.batch_number) +
+                                 ") must be in range [1, 110] in BatchStore request");
+    }
+    if (r.batch_number != r.entries.size()) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "batch_number(" + std::to_string(r.batch_number) +
+                                 ") must equal entries.size()(" + std::to_string(r.entries.size()) +
+                                 ") in BatchStore request");
+    }
+    if (r.rflag) {
+        if (r.response_buffer_addr == 0) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "response_buffer_addr is zero in BatchStore request");
+        }
+        if (r.response_mr_key == 0) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "response_mr_key is zero in BatchStore request");
+        }
+    } else {
+        if (r.response_buffer_addr != 0) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "response_buffer_addr must be zero when rflag is false in BatchStore request");
+        }
+        if (r.response_mr_key != 0) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "response_mr_key must be zero when rflag is false in BatchStore request");
+        }
+    }
+    if (r.dtype > 0x7) [[unlikely]] {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            "dtype(" + std::to_string(r.dtype) + ") exceeds 3-bit limit in BatchStore request");
+    }
+    if (r.dspec > 0x1F) [[unlikely]] {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            "dspec(" + std::to_string(r.dspec) + ") exceeds 5-bit limit in BatchStore request");
+    }
+    for (std::size_t i = 0; i < r.batch_number; ++i) {
+        const auto& entry = r.entries[i];
+        if (entry.offset % kAlignmentBytes != 0) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "entry[" + std::to_string(i) + "] offset(" +
+                                     std::to_string(entry.offset) +
+                                     ") must be 512B aligned in BatchStore request");
+        }
+        if (IsCacheKeyAllZero(entry.key)) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "entry[" + std::to_string(i) + "] key is all zeros in BatchStore request");
+        }
+        if (entry.buffer_addr == 0) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "entry[" + std::to_string(i) + "] buffer_addr is zero in BatchStore request");
+        }
+        if (entry.length == 0) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "entry[" + std::to_string(i) + "] length is zero in BatchStore request");
+        }
+        if (entry.length % kAlignmentBytes != 0) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "entry[" + std::to_string(i) + "] length(" +
+                                     std::to_string(entry.length) +
+                                     ") must be 512B aligned in BatchStore request");
+        }
+        if (entry.length > 0xFFFFFF) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "entry[" + std::to_string(i) + "] length(" +
+                                     std::to_string(entry.length) +
+                                     ") exceeds 24-bit limit in BatchStore request");
+        }
+    }
+    return Status::OK();
+}
+
+void KvBatchStoreProtocol::PackEntry(const KvBatchStoreEntry& entry, std::uint32_t* base)
+{
+    base[0] = entry.offset;
+
+    std::memcpy(&base[1], entry.key.data(), kCacheKeySizeBytes);
+
+    base[5] = entry.buffer_addr & 0xFFFFFFFFULL;
+    base[6] = (entry.buffer_addr >> 32) & 0xFFFFFFFFULL;
+    base[7] = ((entry.mr_key & 0xFF) << 24) | (entry.length & 0xFFFFFF);
+    base[8] =
+        (static_cast<std::uint32_t>(DptrType::Standard) << 24) | ((entry.mr_key >> 8) & 0xFFFFFF);
+}
+
+Status KvBatchStoreProtocol::UnpackCqe(const std::uint32_t* data, std::uint16_t batch_number,
+                                       KvResponse& out) const
+{
+    UnpackCqeBase(data, out);
+    UnpackResultBuffer4Bit(data + kCqeDwordCount, batch_number, out.result_buffer);
+    return Status::OK();
+}
+
+Status KvBatchStoreProtocol::VerifyPackedBuffer(const std::uint32_t* data, std::size_t length) const
+{
+    auto status = VerifyFixedBits(data, "BatchStore");
+    if (!status.ok()) { return status; }
+    if ((data[0] >> 8) & 0x1F) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchStore: reserved bits non-zero in data[0] bit8-12");
+    }
+
+    if (data[2] & 0xFFFF00FFU) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchStore: reserved bits non-zero in data[2] bit0-7,bit16-31");
+    }
+
+    if (data[6] || data[7]) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchStore: reserved bits non-zero in data[6-7]");
+    }
+
+    status = VerifyRflagConsistency(data, "BatchStore");
+    if (!status.ok()) { return status; }
+
+    if (data[9] != (static_cast<std::uint32_t>(DptrType::Batch) << 24)) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchStore: data[9] DptrType or reserved bits mismatch");
+    }
+
+    if (data[10] >> 16) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchStore: reserved bits non-zero in data[10] bit16-31");
+    }
+    std::uint16_t batch_number = data[10] & 0xFFFF;
+    if (batch_number == 0 || batch_number > kMaxBatchNumber) {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            "BatchStore: batch_number(" + std::to_string(batch_number) + ") out of range [1, 110]");
+    }
+
+    if (data[8] != static_cast<std::uint32_t>(batch_number) * kBatchEntrySizeBytes) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchStore: data[8](" + std::to_string(data[8]) +
+                                 ") != batch_number * " + std::to_string(kBatchEntrySizeBytes));
+    }
+
+    std::size_t expected_length =
+        (kSqeDwordCount + batch_number * kBatchEntryDwordCount) * sizeof(std::uint32_t);
+    if (length != expected_length) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchStore: length(" + std::to_string(length) + ") != expected(" +
+                                 std::to_string(expected_length) + ")");
+    }
+
+    if ((data[11] & 0x7FFFFFFFU) || data[12] || data[13] || data[14] || data[15]) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchStore: reserved bits non-zero in data[11-15]");
+    }
+
+    for (std::uint16_t i = 0; i < batch_number; ++i) {
+        const std::uint32_t* base = data + kSqeDwordCount + i * kBatchEntryDwordCount;
+        auto entry_status = VerifyBatchEntry(base, "BatchStore", i);
+        if (!entry_status.ok()) { return entry_status; }
+    }
+
+    return Status::OK();
+}
+
+std::size_t KvBatchRetrieveProtocol::PackedSize(const SqeRequest& req) const
+{
+    auto& r = static_cast<const KvBatchRetrieveRequest&>(req);
+    return (kSqeDwordCount + r.batch_number * kBatchEntryDwordCount) * sizeof(std::uint32_t);
+}
+
+Status KvBatchRetrieveProtocol::PackSqe(const SqeRequest& req, std::uint32_t* target)
+{
+    auto& r = static_cast<const KvBatchRetrieveRequest&>(req);
+    auto status = ValidateRequest(r);
+    if (!status.ok()) { return status; }
+
+    target[0] =
+        (r.cid << 16) | (kFixedBits << 14) | static_cast<std::uint32_t>(KvOpcode::BatchRetrieve);
+    if (r.rflag) { target[0] |= (1U << 13); }
+    target[1] = r.kv_ns_id;
+    target[3] = r.response_buffer_addr & 0xFFFFFFFFULL;
+    target[4] = (r.response_buffer_addr >> 32) & 0xFFFFFFFFULL;
+    target[5] = r.response_mr_key;
+    target[8] = r.batch_number * kBatchEntrySizeBytes;
+    target[9] = static_cast<std::uint32_t>(DptrType::Batch) << 24;
+    target[10] = r.batch_number;
+    if (r.lr) { target[11] |= (1U << 31); }
+
+    for (std::size_t i = 0; i < r.batch_number; ++i) {
+        PackEntry(r.entries[i], target + kSqeDwordCount + i * kBatchEntryDwordCount);
+    }
+    return Status::OK();
+}
+
+Status KvBatchRetrieveProtocol::ValidateRequest(const KvBatchRetrieveRequest& r) const
+{
+    if (r.batch_number == 0 || r.batch_number > kMaxBatchNumber) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "batch_number(" + std::to_string(r.batch_number) +
+                                 ") must be in range [1, 110] in BatchRetrieve request");
+    }
+    if (r.batch_number != r.entries.size()) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "batch_number(" + std::to_string(r.batch_number) +
+                                 ") must equal entries.size()(" + std::to_string(r.entries.size()) +
+                                 ") in BatchRetrieve request");
+    }
+    if (r.rflag) {
+        if (r.response_buffer_addr == 0) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "response_buffer_addr is zero in BatchRetrieve request");
+        }
+        if (r.response_mr_key == 0) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "response_mr_key is zero in BatchRetrieve request");
+        }
+    } else {
+        if (r.response_buffer_addr != 0) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "response_buffer_addr must be zero when rflag is false in BatchRetrieve request");
+        }
+        if (r.response_mr_key != 0) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "response_mr_key must be zero when rflag is false in BatchRetrieve request");
+        }
+    }
+    for (std::size_t i = 0; i < r.batch_number; ++i) {
+        const auto& entry = r.entries[i];
+        if (entry.offset % kAlignmentBytes != 0) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "entry[" + std::to_string(i) + "] offset(" +
+                                     std::to_string(entry.offset) +
+                                     ") must be 512B aligned in BatchRetrieve request");
+        }
+        if (IsCacheKeyAllZero(entry.key)) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "entry[" + std::to_string(i) + "] key is all zeros in BatchRetrieve request");
+        }
+        if (entry.buffer_addr == 0) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "entry[" + std::to_string(i) + "] buffer_addr is zero in BatchRetrieve request");
+        }
+        if (entry.length == 0) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "entry[" + std::to_string(i) + "] length is zero in BatchRetrieve request");
+        }
+        if (entry.length % kAlignmentBytes != 0) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "entry[" + std::to_string(i) + "] length(" +
+                                     std::to_string(entry.length) +
+                                     ") must be 512B aligned in BatchRetrieve request");
+        }
+        if (entry.length > 0xFFFFFF) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "entry[" + std::to_string(i) + "] length(" +
+                                     std::to_string(entry.length) +
+                                     ") exceeds 24-bit limit in BatchRetrieve request");
+        }
+    }
+    return Status::OK();
+}
+
+void KvBatchRetrieveProtocol::PackEntry(const KvBatchRetrieveEntry& entry, std::uint32_t* base)
+{
+    base[0] = entry.offset;
+
+    std::memcpy(&base[1], entry.key.data(), kCacheKeySizeBytes);
+
+    base[5] = entry.buffer_addr & 0xFFFFFFFFULL;
+    base[6] = (entry.buffer_addr >> 32) & 0xFFFFFFFFULL;
+    base[7] = ((entry.mr_key & 0xFF) << 24) | (entry.length & 0xFFFFFF);
+    base[8] =
+        (static_cast<std::uint32_t>(DptrType::Standard) << 24) | ((entry.mr_key >> 8) & 0xFFFFFF);
+}
+
+Status KvBatchRetrieveProtocol::UnpackCqe(const std::uint32_t* data, std::uint16_t batch_number,
+                                          KvResponse& out) const
+{
+    UnpackCqeBase(data, out);
+    UnpackResultBuffer4Bit(data + kCqeDwordCount, batch_number, out.result_buffer);
+    return Status::OK();
+}
+
+Status KvBatchRetrieveProtocol::VerifyPackedBuffer(const std::uint32_t* data,
+                                                   std::size_t length) const
+{
+    auto status = VerifyFixedBits(data, "BatchRetrieve");
+    if (!status.ok()) { return status; }
+    if ((data[0] >> 8) & 0x1F) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchRetrieve: reserved bits non-zero in data[0] bit8-12");
+    }
+
+    if (data[2] != 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchRetrieve: reserved bits non-zero in data[2]");
+    }
+
+    if (data[6] || data[7]) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchRetrieve: reserved bits non-zero in data[6-7]");
+    }
+
+    status = VerifyRflagConsistency(data, "BatchRetrieve");
+    if (!status.ok()) { return status; }
+
+    if (data[9] != (static_cast<std::uint32_t>(DptrType::Batch) << 24)) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchRetrieve: data[9] DptrType or reserved bits mismatch");
+    }
+
+    if (data[10] >> 16) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchRetrieve: reserved bits non-zero in data[10] bit16-31");
+    }
+    std::uint16_t batch_number = data[10] & 0xFFFF;
+    if (batch_number == 0 || batch_number > kMaxBatchNumber) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "BatchRetrieve: batch_number(" +
+                                                               std::to_string(batch_number) +
+                                                               ") out of range [1, 110]");
+    }
+
+    if (data[8] != static_cast<std::uint32_t>(batch_number) * kBatchEntrySizeBytes) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchRetrieve: data[8](" + std::to_string(data[8]) +
+                                 ") != batch_number * " + std::to_string(kBatchEntrySizeBytes));
+    }
+
+    std::size_t expected_length =
+        (kSqeDwordCount + batch_number * kBatchEntryDwordCount) * sizeof(std::uint32_t);
+    if (length != expected_length) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchRetrieve: length(" + std::to_string(length) + ") != expected(" +
+                                 std::to_string(expected_length) + ")");
+    }
+
+    if ((data[11] & 0x7FFFFFFFU) || data[12] || data[13] || data[14] || data[15]) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "BatchRetrieve: reserved bits non-zero in data[11-15]");
+    }
+
+    for (std::uint16_t i = 0; i < batch_number; ++i) {
+        const std::uint32_t* base = data + kSqeDwordCount + i * kBatchEntryDwordCount;
+        auto entry_status = VerifyBatchEntry(base, "BatchRetrieve", i);
+        if (!entry_status.ok()) { return entry_status; }
+    }
+
+    return Status::OK();
+}
+
+std::size_t KvDeleteProtocol::PackedSize(const SqeRequest& req) const
+{
+    auto& r = static_cast<const KvDeleteRequest&>(req);
+    return (kSqeDwordCount + r.batch_number * kKeyEntryDwordCount) * sizeof(std::uint32_t);
+}
+
+Status KvDeleteProtocol::PackSqe(const SqeRequest& req, std::uint32_t* target)
+{
+    auto& r = static_cast<const KvDeleteRequest&>(req);
+    auto status = ValidateRequest(r);
+    if (!status.ok()) { return status; }
+
+    target[0] = (r.cid << 16) | (kFixedBits << 14) | static_cast<std::uint32_t>(KvOpcode::Delete);
+    if (r.rflag) { target[0] |= (1U << 13); }
+    target[1] = r.kv_ns_id;
+    target[3] = r.response_buffer_addr & 0xFFFFFFFFULL;
+    target[4] = (r.response_buffer_addr >> 32) & 0xFFFFFFFFULL;
+    target[5] = r.response_mr_key;
+    target[8] = r.batch_number * kKeyEntrySizeBytes;
+    target[9] = static_cast<std::uint32_t>(DptrType::Batch) << 24;
+    target[10] = r.batch_number;
+
+    for (std::size_t i = 0; i < r.batch_number; ++i) {
+        PackEntry(r.keys[i], target + kSqeDwordCount + i * kKeyEntryDwordCount);
+    }
+    return Status::OK();
+}
+
+Status KvDeleteProtocol::ValidateRequest(const KvDeleteRequest& r) const
+{
+    if (r.batch_number == 0 || r.batch_number > kMaxDeleteBatchNumber) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "batch_number(" + std::to_string(r.batch_number) +
+                                 ") must be in range [1, 254] in Delete request");
+    }
+    if (r.batch_number != r.keys.size()) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "batch_number(" + std::to_string(r.batch_number) +
+                                 ") must equal keys.size()(" + std::to_string(r.keys.size()) +
+                                 ") in Delete request");
+    }
+    if (r.rflag) {
+        if (r.response_buffer_addr == 0) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "response_buffer_addr is zero in Delete request");
+        }
+        if (r.response_mr_key == 0) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "response_mr_key is zero in Delete request");
+        }
+    } else {
+        if (r.response_buffer_addr != 0) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "response_buffer_addr must be zero when rflag is false in Delete request");
+        }
+        if (r.response_mr_key != 0) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "response_mr_key must be zero when rflag is false in Delete request");
+        }
+    }
+    for (std::size_t i = 0; i < r.batch_number; ++i) {
+        if (IsCacheKeyAllZero(r.keys[i])) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "key[" + std::to_string(i) + "] is all zeros in Delete request");
+        }
+    }
+    return Status::OK();
+}
+
+void KvDeleteProtocol::PackEntry(const CacheKey& key, std::uint32_t* base)
+{
+    std::memcpy(&base[0], key.data(), kCacheKeySizeBytes);
+}
+
+Status KvDeleteProtocol::UnpackCqe(const std::uint32_t* data, std::uint16_t batch_number,
+                                   KvResponse& out) const
+{
+    UnpackCqeBase(data, out);
+    UnpackResultBuffer1Bit(data + kCqeDwordCount, batch_number, out.result_buffer);
+    return Status::OK();
+}
+
+Status KvDeleteProtocol::VerifyPackedBuffer(const std::uint32_t* data, std::size_t length) const
+{
+    auto status = VerifyFixedBits(data, "Delete");
+    if (!status.ok()) { return status; }
+    if ((data[0] >> 8) & 0x1F) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Delete: reserved bits non-zero in data[0] bit8-12");
+    }
+
+    if (data[2] != 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Delete: reserved bits non-zero in data[2]");
+    }
+
+    if (data[6] || data[7]) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Delete: reserved bits non-zero in data[6-7]");
+    }
+
+    status = VerifyRflagConsistency(data, "Delete");
+    if (!status.ok()) { return status; }
+
+    if (data[9] != (static_cast<std::uint32_t>(DptrType::Batch) << 24)) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Delete: data[9] DptrType or reserved bits mismatch");
+    }
+
+    if (data[10] >> 16) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Delete: reserved bits non-zero in data[10] bit16-31");
+    }
+    std::uint16_t batch_number = data[10] & 0xFFFF;
+    if (batch_number == 0 || batch_number > kMaxDeleteBatchNumber) {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            "Delete: batch_number(" + std::to_string(batch_number) + ") out of range [1, 254]");
+    }
+
+    if (data[8] != static_cast<std::uint32_t>(batch_number) * kKeyEntrySizeBytes) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Delete: data[8](" + std::to_string(data[8]) + ") != batch_number * " +
+                                 std::to_string(kKeyEntrySizeBytes));
+    }
+
+    std::size_t expected_length =
+        (kSqeDwordCount + batch_number * kKeyEntryDwordCount) * sizeof(std::uint32_t);
+    if (length != expected_length) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Delete: length(" + std::to_string(length) + ") != expected(" +
+                                 std::to_string(expected_length) + ")");
+    }
+
+    if (data[11] || data[12] || data[13] || data[14] || data[15]) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Delete: reserved bits non-zero in data[11-15]");
+    }
+
+    for (std::uint16_t i = 0; i < batch_number; ++i) {
+        const std::uint32_t* base = data + kSqeDwordCount + i * kKeyEntryDwordCount;
+        auto key_status = VerifyCacheKeyEntry(base, "Delete: entry[" + std::to_string(i) + "]");
+        if (!key_status.ok()) { return key_status; }
+    }
+
+    return Status::OK();
+}
+
+std::size_t KvExistProtocol::PackedSize(const SqeRequest& req) const
+{
+    auto& r = static_cast<const KvExistRequest&>(req);
+    return (kSqeDwordCount + r.batch_number * kKeyEntryDwordCount) * sizeof(std::uint32_t);
+}
+
+Status KvExistProtocol::PackSqe(const SqeRequest& req, std::uint32_t* target)
+{
+    auto& r = static_cast<const KvExistRequest&>(req);
+    auto status = ValidateRequest(r);
+    if (!status.ok()) { return status; }
+
+    target[0] = (r.cid << 16) | (kFixedBits << 14) | static_cast<std::uint32_t>(KvOpcode::Exist);
+    if (r.rflag) { target[0] |= (1U << 13); }
+    target[1] = r.kv_ns_id;
+    target[3] = r.response_buffer_addr & 0xFFFFFFFFULL;
+    target[4] = (r.response_buffer_addr >> 32) & 0xFFFFFFFFULL;
+    target[5] = r.response_mr_key;
+    target[8] = r.batch_number * kKeyEntrySizeBytes;
+    target[9] = static_cast<std::uint32_t>(DptrType::Batch) << 24;
+    target[10] = r.batch_number;
+    if (r.sc) { target[10] |= (1U << 16); }
+
+    for (std::size_t i = 0; i < r.batch_number; ++i) {
+        PackEntry(r.keys[i], target + kSqeDwordCount + i * kKeyEntryDwordCount);
+    }
+    return Status::OK();
+}
+
+Status KvExistProtocol::ValidateRequest(const KvExistRequest& r) const
+{
+    if (r.batch_number == 0 || r.batch_number > kMaxExistBatchNumber) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "batch_number(" + std::to_string(r.batch_number) +
+                                 ") must be in range [1, 256] in Exist request");
+    }
+    if (r.batch_number != r.keys.size()) [[unlikely]] {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "batch_number(" + std::to_string(r.batch_number) +
+                                 ") must equal keys.size()(" + std::to_string(r.keys.size()) +
+                                 ") in Exist request");
+    }
+    if (r.rflag) {
+        if (r.response_buffer_addr == 0) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "response_buffer_addr is zero in Exist request");
+        }
+        if (r.response_mr_key == 0) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "response_mr_key is zero in Exist request");
+        }
+    } else {
+        if (r.response_buffer_addr != 0) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "response_buffer_addr must be zero when rflag is false in Exist request");
+        }
+        if (r.response_mr_key != 0) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "response_mr_key must be zero when rflag is false in Exist request");
+        }
+    }
+    for (std::size_t i = 0; i < r.batch_number; ++i) {
+        if (IsCacheKeyAllZero(r.keys[i])) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "key[" + std::to_string(i) + "] is all zeros in Exist request");
+        }
+    }
+    return Status::OK();
+}
+
+void KvExistProtocol::PackEntry(const CacheKey& key, std::uint32_t* base)
+{
+    std::memcpy(&base[0], key.data(), kCacheKeySizeBytes);
+}
+
+Status KvExistProtocol::UnpackCqe(const std::uint32_t* data, std::uint16_t batch_number,
+                                  KvResponse& out) const
+{
+    UnpackCqeBase(data, out);
+    out.existing_key_number = data[0] & 0xFFFF;
+    UnpackResultBuffer1Bit(data + kCqeDwordCount, batch_number, out.result_buffer);
+    return Status::OK();
+}
+
+Status KvExistProtocol::VerifyPackedBuffer(const std::uint32_t* data, std::size_t length) const
+{
+    auto status = VerifyFixedBits(data, "Exist");
+    if (!status.ok()) { return status; }
+    if ((data[0] >> 8) & 0x1F) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Exist: reserved bits non-zero in data[0] bit8-12");
+    }
+
+    if (data[2] != 0) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Exist: reserved bits non-zero in data[2]");
+    }
+
+    if (data[6] || data[7]) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Exist: reserved bits non-zero in data[6-7]");
+    }
+
+    status = VerifyRflagConsistency(data, "Exist");
+    if (!status.ok()) { return status; }
+
+    if (data[9] != (static_cast<std::uint32_t>(DptrType::Batch) << 24)) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Exist: data[9] DptrType or reserved bits mismatch");
+    }
+
+    if (data[10] >> 17) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Exist: reserved bits non-zero in data[10] bit17-31");
+    }
+    std::uint16_t batch_number = data[10] & 0xFFFF;
+    if (batch_number == 0 || batch_number > kMaxExistBatchNumber) {
+        return Status::Error(
+            StatusCode::INVALID_ARGUMENT,
+            "Exist: batch_number(" + std::to_string(batch_number) + ") out of range [1, 256]");
+    }
+
+    if (data[8] != static_cast<std::uint32_t>(batch_number) * kKeyEntrySizeBytes) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Exist: data[8](" + std::to_string(data[8]) + ") != batch_number * " +
+                                 std::to_string(kKeyEntrySizeBytes));
+    }
+
+    std::size_t expected_length =
+        (kSqeDwordCount + batch_number * kKeyEntryDwordCount) * sizeof(std::uint32_t);
+    if (length != expected_length) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Exist: length(" + std::to_string(length) + ") != expected(" +
+                                 std::to_string(expected_length) + ")");
+    }
+
+    if (data[11] || data[12] || data[13] || data[14] || data[15]) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "Exist: reserved bits non-zero in data[11-15]");
+    }
+
+    for (std::uint16_t i = 0; i < batch_number; ++i) {
+        const std::uint32_t* base = data + kSqeDwordCount + i * kKeyEntryDwordCount;
+        auto key_status = VerifyCacheKeyEntry(base, "Exist: entry[" + std::to_string(i) + "]");
+        if (!key_status.ok()) { return key_status; }
+    }
+
+    return Status::OK();
+}
+
+Status KvKeepAliveProtocol::PackSqe(const SqeRequest& req, std::uint32_t* target)
+{
+    auto& r = static_cast<const KvKeepAliveRequest&>(req);
+    auto status = ValidateRequest(r);
+    if (!status.ok()) { return status; }
+
+    target[0] = (r.cid << 16) | static_cast<std::uint32_t>(KvOpcode::KeepAlive);
+    if (r.rflag) { target[0] |= (1U << 13); }
+    target[3] = r.response_buffer_addr & 0xFFFFFFFFULL;
+    target[4] = (r.response_buffer_addr >> 32) & 0xFFFFFFFFULL;
+    target[5] = r.response_mr_key;
+    return Status::OK();
+}
+
+Status KvKeepAliveProtocol::ValidateRequest(const KvKeepAliveRequest& r) const
+{
+    if (r.rflag) {
+        if (r.response_buffer_addr == 0) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "response_buffer_addr is zero in KeepAlive request");
+        }
+        if (r.response_mr_key == 0) [[unlikely]] {
+            return Status::Error(StatusCode::INVALID_ARGUMENT,
+                                 "response_mr_key is zero in KeepAlive request");
+        }
+    } else {
+        if (r.response_buffer_addr != 0) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "response_buffer_addr must be zero when rflag is false in KeepAlive request");
+        }
+        if (r.response_mr_key != 0) [[unlikely]] {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "response_mr_key must be zero when rflag is false in KeepAlive request");
+        }
+    }
+    return Status::OK();
+}
+
+Status KvKeepAliveProtocol::VerifyPackedBuffer(const std::uint32_t* data, std::size_t length) const
+{
+    constexpr std::size_t kExpectedLength = kSqeDwordCount * sizeof(std::uint32_t);
+    if (length != kExpectedLength) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "KeepAlive: length(" + std::to_string(length) + ") != expected(" +
+                                 std::to_string(kExpectedLength) + ")");
+    }
+
+    if (data[0] & 0xDF00U) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "KeepAlive: reserved bits non-zero in data[0] bit8-12 or bit14-15");
+    }
+
+    if (data[1] || data[2]) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "KeepAlive: reserved bits non-zero in data[1-2]");
+    }
+
+    auto status = VerifyRflagConsistency(data, "KeepAlive");
+    if (!status.ok()) { return status; }
+
+    for (std::size_t i = 6; i < kSqeDwordCount; ++i) {
+        if (data[i] != 0) {
+            return Status::Error(
+                StatusCode::INVALID_ARGUMENT,
+                "KeepAlive: reserved bits non-zero in data[" + std::to_string(i) + "]");
+        }
+    }
+
+    return Status::OK();
+}
+
+ProtocolManager::ProtocolManager()
+{
+    protocols_[KvOpcode::Store] = std::make_unique<KvStoreProtocol>();
+    protocols_[KvOpcode::Retrieve] = std::make_unique<KvRetrieveProtocol>();
+    protocols_[KvOpcode::BatchStore] = std::make_unique<KvBatchStoreProtocol>();
+    protocols_[KvOpcode::BatchRetrieve] = std::make_unique<KvBatchRetrieveProtocol>();
+    protocols_[KvOpcode::Delete] = std::make_unique<KvDeleteProtocol>();
+    protocols_[KvOpcode::Exist] = std::make_unique<KvExistProtocol>();
+    protocols_[KvOpcode::KeepAlive] = std::make_unique<KvKeepAliveProtocol>();
+}
+
+std::size_t ProtocolManager::GetPackedSize(KvOpcode opcode, const SqeRequest& req) const
+{
+    KvProtocol* proto = GetProtocol(opcode);
+    if (!proto) { return 0; }
+    return proto->PackedSize(req);
+}
+
+Status ProtocolManager::PackRequest(void* data_ptr, KvOpcode opcode, const SqeRequest& req)
+{
+    KvProtocol* proto = GetProtocol(opcode);
+    if (!proto) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "unknown opcode in PackRequest");
+    }
+    return proto->PackSqe(req, static_cast<std::uint32_t*>(data_ptr));
+}
+
+Status ProtocolManager::UnpackResponse(const void* data_ptr, KvOpcode opcode,
+                                       std::uint16_t batch_number, KvResponse& out)
+{
+    KvProtocol* proto = GetProtocol(opcode);
+    if (!proto) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "unknown opcode in UnpackResponse");
+    }
+    auto* data = static_cast<const std::uint32_t*>(data_ptr);
+    return proto->UnpackCqe(data, batch_number, out);
+}
+
+Status ProtocolManager::PollResponseCid(const void* data_ptr, std::uint16_t& cid) const
+{
+    auto* data = static_cast<const std::uint32_t*>(data_ptr);
+    cid = __atomic_load_n(data + 3, __ATOMIC_ACQUIRE) & 0xFFFF;
+    return Status::OK();
+}
+
+Status ProtocolManager::VerifyPackedBuffer(const void* data_ptr, std::size_t length)
+{
+    if (!data_ptr || length < kSqeDwordCount * sizeof(std::uint32_t)) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "VerifyPackedBuffer: invalid data_ptr or length too small");
+    }
+
+    auto* data = static_cast<const std::uint32_t*>(data_ptr);
+    auto opcode = static_cast<KvOpcode>(data[0] & 0xFF);
+
+    KvProtocol* proto = GetProtocol(opcode);
+    if (!proto) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT,
+                             "VerifyPackedBuffer: unknown opcode " +
+                                 std::to_string(static_cast<std::uint8_t>(opcode)));
+    }
+    return proto->VerifyPackedBuffer(data, length);
+}
+
+KvProtocol* ProtocolManager::GetProtocol(KvOpcode opcode) const
+{
+    auto it = protocols_.find(opcode);
+    return it != protocols_.end() ? it->second.get() : nullptr;
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/kv_protocol.h
+++ b/ucm/transport/kv/asu/trans/src/kv_protocol.h
@@ -1,0 +1,309 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include "asu_transport/types.h"
+
+namespace UC::ASU {
+
+enum class KvOpcode : std::uint8_t {
+    Store = 0x1,
+    Retrieve = 0x2,
+    BatchStore = 0x45,
+    BatchRetrieve = 0x46,
+    Delete = 0x8,
+    Exist = 0xC,
+    KeepAlive = 0xF4
+};
+
+enum class DptrType : std::uint8_t { Standard = 0x40, Batch = 0x1 };
+
+constexpr std::size_t kSqeDwordCount = 16;
+constexpr std::uint32_t kFixedBits = 0x3;
+constexpr std::uint32_t kAlignmentBytes = kAsuAlignmentBytes;
+constexpr std::size_t kBatchEntrySizeBytes = 36;
+constexpr std::size_t kBatchEntryDwordCount = 9;
+constexpr std::size_t kKeyEntrySizeBytes = 16;
+constexpr std::size_t kKeyEntryDwordCount = 4;
+constexpr std::size_t kMaxBatchNumber = 110;
+constexpr std::size_t kMaxDeleteBatchNumber = 254;
+constexpr std::size_t kMaxExistBatchNumber = 256;
+constexpr std::size_t kCqeDwordCount = 4;
+
+class SqeRequest {
+public:
+    virtual ~SqeRequest() = default;
+};
+
+class KvStoreRequest : public SqeRequest {
+public:
+    std::uint16_t cid{0};
+    std::uint32_t kv_ns_id{0};
+    std::uint8_t dtype{0};
+    std::uint8_t dspec{0};
+    std::uint64_t buffer_addr{0};
+    std::uint32_t buffer_length{0};
+    std::uint32_t mr_key{0};
+    std::uint32_t offset{0};
+    bool lr{false};
+    std::uint32_t length{0};
+    CacheKey key{};
+};
+
+class KvRetrieveRequest : public SqeRequest {
+public:
+    std::uint16_t cid{0};
+    std::uint32_t kv_ns_id{0};
+    std::uint64_t buffer_addr{0};
+    std::uint32_t buffer_length{0};
+    std::uint32_t mr_key{0};
+    std::uint32_t offset{0};
+    bool lr{false};
+    std::uint32_t length{0};
+    CacheKey key{};
+};
+
+class KvBatchStoreEntry {
+public:
+    std::uint32_t offset{0};
+    CacheKey key{};
+    std::uint64_t buffer_addr{0};
+    std::uint32_t mr_key{0};
+    std::uint32_t length{0};
+};
+
+class KvBatchStoreRequest : public SqeRequest {
+public:
+    std::uint16_t cid{0};
+    std::uint32_t kv_ns_id{0};
+    std::uint8_t dtype{0};
+    std::uint8_t dspec{0};
+    std::uint64_t response_buffer_addr{0};
+    std::uint32_t response_mr_key{0};
+    bool lr{false};
+    bool rflag{false};
+    std::uint16_t batch_number{0};
+    std::vector<KvBatchStoreEntry> entries;
+};
+
+class KvBatchRetrieveEntry {
+public:
+    std::uint32_t offset{0};
+    CacheKey key{};
+    std::uint64_t buffer_addr{0};
+    std::uint32_t mr_key{0};
+    std::uint32_t length{0};
+};
+
+class KvBatchRetrieveRequest : public SqeRequest {
+public:
+    std::uint16_t cid{0};
+    std::uint32_t kv_ns_id{0};
+    std::uint64_t response_buffer_addr{0};
+    std::uint32_t response_mr_key{0};
+    bool lr{false};
+    bool rflag{false};
+    std::uint16_t batch_number{0};
+    std::vector<KvBatchRetrieveEntry> entries;
+};
+
+class KvDeleteRequest : public SqeRequest {
+public:
+    std::uint16_t cid{0};
+    std::uint32_t kv_ns_id{0};
+    std::uint64_t response_buffer_addr{0};
+    std::uint32_t response_mr_key{0};
+    bool rflag{false};
+    std::uint16_t batch_number{0};
+    std::vector<CacheKey> keys;
+};
+
+class KvExistRequest : public SqeRequest {
+public:
+    std::uint16_t cid{0};
+    std::uint32_t kv_ns_id{0};
+    std::uint64_t response_buffer_addr{0};
+    std::uint32_t response_mr_key{0};
+    bool rflag{false};
+    bool sc{true};
+    std::uint16_t batch_number{0};
+    std::vector<CacheKey> keys;
+};
+
+class KvKeepAliveRequest : public SqeRequest {
+public:
+    std::uint16_t cid{0};
+    std::uint64_t response_buffer_addr{0};
+    std::uint32_t response_mr_key{0};
+    bool rflag{false};
+};
+
+class KvResponse {
+public:
+    virtual ~KvResponse() = default;
+    std::uint16_t cid{0};
+    std::uint16_t status{0};
+    std::uint16_t existing_key_number{0};
+    std::vector<std::uint8_t> result_buffer;
+};
+
+class KvProtocol {
+public:
+    virtual ~KvProtocol() = default;
+
+    virtual Status PackSqe(const SqeRequest& req, std::uint32_t* target) = 0;
+    virtual std::size_t PackedSize(const SqeRequest& req) const = 0;
+
+    virtual Status UnpackCqe(const std::uint32_t* data, std::uint16_t batch_number,
+                             KvResponse& out) const
+    {
+        return Status::Error(StatusCode::UNSUPPORTED, "CQE unpack not supported for this opcode");
+    }
+
+    virtual Status VerifyPackedBuffer(const std::uint32_t* data, std::size_t length) const = 0;
+};
+
+class KvStoreProtocol : public KvProtocol {
+public:
+    Status PackSqe(const SqeRequest& req, std::uint32_t* target) override;
+    std::size_t PackedSize(const SqeRequest& req) const override
+    {
+        return kSqeDwordCount * sizeof(std::uint32_t);
+    }
+    Status UnpackCqe(const std::uint32_t* data, std::uint16_t batch_number,
+                     KvResponse& out) const override;
+    Status VerifyPackedBuffer(const std::uint32_t* data, std::size_t length) const override;
+
+private:
+    Status ValidateRequest(const KvStoreRequest& r) const;
+};
+
+class KvRetrieveProtocol : public KvProtocol {
+public:
+    Status PackSqe(const SqeRequest& req, std::uint32_t* target) override;
+    std::size_t PackedSize(const SqeRequest& req) const override
+    {
+        return kSqeDwordCount * sizeof(std::uint32_t);
+    }
+    Status UnpackCqe(const std::uint32_t* data, std::uint16_t batch_number,
+                     KvResponse& out) const override;
+    Status VerifyPackedBuffer(const std::uint32_t* data, std::size_t length) const override;
+
+private:
+    Status ValidateRequest(const KvRetrieveRequest& r) const;
+};
+
+class KvBatchStoreProtocol : public KvProtocol {
+public:
+    Status PackSqe(const SqeRequest& req, std::uint32_t* target) override;
+    std::size_t PackedSize(const SqeRequest& req) const override;
+    Status UnpackCqe(const std::uint32_t* data, std::uint16_t batch_number,
+                     KvResponse& out) const override;
+    Status VerifyPackedBuffer(const std::uint32_t* data, std::size_t length) const override;
+
+private:
+    Status ValidateRequest(const KvBatchStoreRequest& r) const;
+    static void PackEntry(const KvBatchStoreEntry& entry, std::uint32_t* base);
+};
+
+class KvBatchRetrieveProtocol : public KvProtocol {
+public:
+    Status PackSqe(const SqeRequest& req, std::uint32_t* target) override;
+    std::size_t PackedSize(const SqeRequest& req) const override;
+    Status UnpackCqe(const std::uint32_t* data, std::uint16_t batch_number,
+                     KvResponse& out) const override;
+    Status VerifyPackedBuffer(const std::uint32_t* data, std::size_t length) const override;
+
+private:
+    Status ValidateRequest(const KvBatchRetrieveRequest& r) const;
+    static void PackEntry(const KvBatchRetrieveEntry& entry, std::uint32_t* base);
+};
+
+class KvDeleteProtocol : public KvProtocol {
+public:
+    Status PackSqe(const SqeRequest& req, std::uint32_t* target) override;
+    std::size_t PackedSize(const SqeRequest& req) const override;
+    Status UnpackCqe(const std::uint32_t* data, std::uint16_t batch_number,
+                     KvResponse& out) const override;
+    Status VerifyPackedBuffer(const std::uint32_t* data, std::size_t length) const override;
+
+private:
+    Status ValidateRequest(const KvDeleteRequest& r) const;
+    static void PackEntry(const CacheKey& key, std::uint32_t* base);
+};
+
+class KvExistProtocol : public KvProtocol {
+public:
+    Status PackSqe(const SqeRequest& req, std::uint32_t* target) override;
+    std::size_t PackedSize(const SqeRequest& req) const override;
+    Status UnpackCqe(const std::uint32_t* data, std::uint16_t batch_number,
+                     KvResponse& out) const override;
+    Status VerifyPackedBuffer(const std::uint32_t* data, std::size_t length) const override;
+
+private:
+    Status ValidateRequest(const KvExistRequest& r) const;
+    static void PackEntry(const CacheKey& key, std::uint32_t* base);
+};
+
+class KvKeepAliveProtocol : public KvProtocol {
+public:
+    Status PackSqe(const SqeRequest& req, std::uint32_t* target) override;
+    std::size_t PackedSize(const SqeRequest& req) const override
+    {
+        return kSqeDwordCount * sizeof(std::uint32_t);
+    }
+    Status VerifyPackedBuffer(const std::uint32_t* data, std::size_t length) const override;
+
+private:
+    Status ValidateRequest(const KvKeepAliveRequest& r) const;
+};
+
+class ProtocolManager {
+public:
+    ProtocolManager();
+    ~ProtocolManager() = default;
+
+    ProtocolManager(const ProtocolManager&) = delete;
+    ProtocolManager& operator=(const ProtocolManager&) = delete;
+
+    std::size_t GetPackedSize(KvOpcode opcode, const SqeRequest& req) const;
+    Status PackRequest(void* data_ptr, KvOpcode opcode, const SqeRequest& req);
+    Status UnpackResponse(const void* data_ptr, KvOpcode opcode, std::uint16_t batch_number,
+                          KvResponse& out);
+    Status PollResponseCid(const void* data_ptr, std::uint16_t& cid) const;
+    Status VerifyPackedBuffer(const void* data_ptr, std::size_t length);
+
+private:
+    std::unordered_map<KvOpcode, std::unique_ptr<KvProtocol>> protocols_;
+
+    KvProtocol* GetProtocol(KvOpcode opcode) const;
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/link_protocol.cpp
+++ b/ucm/transport/kv/asu/trans/src/link_protocol.cpp
@@ -1,0 +1,156 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "link_protocol.h"
+#include <cstring>
+
+namespace UC::ASU {
+
+Status NegotiateSqe::Pack(const NegotiateRequest& req)
+{
+    buffer.assign(kMsgHeaderSize + kNegotiatePayloadSize, 0);
+
+    MsgHeader header;
+    header.cmd = LinkProtocolCmd::Negotiate;
+    header.len = kNegotiatePayloadSize;
+    header.Pack(buffer);
+
+    // Offset 16: cap[31:0]
+    std::memcpy(&buffer[16], &req.cap, 4);
+
+    // Offset 20: rsv[23:0] (zero)
+
+    // Offset 44: private_len[31:0]
+    std::memcpy(&buffer[44], &req.private_len, 4);
+
+    // Offset 48: major_version
+    buffer[48] = req.major_version;
+
+    // Offset 49: minor_version
+    buffer[49] = req.minor_version;
+
+    // Offset 50: kato[15:0]
+    std::memcpy(&buffer[50], &req.kato, 2);
+
+    // Offset 52: reserved[123:0] (zero)
+    return Status::OK();
+}
+
+Status NegotiateSqe::Validate() const
+{
+    if (buffer.size() < kMsgHeaderSize + kNegotiatePayloadSize) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "buffer too small");
+    }
+    return Status::OK();
+}
+
+Status HandshakeSqe::Pack(const HandshakeRequest& req)
+{
+    buffer.assign(kMsgHeaderSize + kHandshakePayloadSize, 0);
+
+    MsgHeader header;
+    header.cmd = LinkProtocolCmd::Handshake;
+    header.len = kHandshakePayloadSize;
+    header.Pack(buffer);
+
+    // Offset 16: gid[15:0]
+    std::memcpy(&buffer[16], req.gid, 16);
+
+    // Offset 32: lid[15:0]
+    std::memcpy(&buffer[32], &req.lid, 2);
+
+    // Offset 34: mtu
+    buffer[34] = req.mtu;
+
+    // Offset 35: total_qp_num
+    buffer[35] = req.total_qp_num;
+
+    // Offset 36: sl
+    buffer[36] = req.sl;
+
+    // Offset 37: traffic_class
+    buffer[37] = req.traffic_class;
+
+    // Offset 38: rnr_timer
+    buffer[38] = req.rnr_timer;
+
+    // Offset 39: rnr_retry_cnt
+    buffer[39] = req.rnr_retry_cnt;
+
+    // Offset 40: timeout
+    buffer[40] = req.timeout;
+
+    // Offset 41: retry_cnt
+    buffer[41] = req.retry_cnt;
+
+    // Offset 42: qp_rd_atom
+    buffer[42] = req.qp_rd_atom;
+
+    // Offset 43: rsv
+    buffer[43] = req.rsv;
+
+    // Offset 44: start_psn[31:0]
+    std::memcpy(&buffer[44], &req.start_psn, 4);
+
+    // Offset 48: qpn[32] (128 bytes)
+    std::memcpy(&buffer[48], req.qpn, 128);
+    return Status::OK();
+}
+
+Status HandshakeSqe::Validate() const
+{
+    if (buffer.size() < kMsgHeaderSize + kHandshakePayloadSize) {
+        return Status::Error(StatusCode::INVALID_ARGUMENT, "buffer too small");
+    }
+    return Status::OK();
+}
+
+Status HandshakeDoneSqe::Pack()
+{
+    buffer.assign(kMsgHeaderSize, 0);
+
+    MsgHeader header;
+    header.cmd = LinkProtocolCmd::HandshakeDone;
+    header.len = 0;
+    header.Pack(buffer);
+    return Status::OK();
+}
+
+Status DisconnectSqe::Pack(const DisconnectRequest& req)
+{
+    buffer.assign(kMsgHeaderSize + kDisconnectPayloadSize, 0);
+
+    MsgHeader header;
+    header.cmd = LinkProtocolCmd::Disconnect;
+    header.len = kDisconnectPayloadSize;
+    header.Pack(buffer);
+
+    // Offset 16: local_qpn[31:0]
+    std::memcpy(&buffer[16], &req.local_qpn, 4);
+
+    // Offset 20: remote_qpn[31:0]
+    std::memcpy(&buffer[20], &req.remote_qpn, 4);
+    return Status::OK();
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/link_protocol.h
+++ b/ucm/transport/kv/asu/trans/src/link_protocol.h
@@ -1,0 +1,163 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+#include "asu_transport/types.h"
+
+namespace UC::ASU {
+
+constexpr std::uint32_t kMsgHeaderSize = 16;
+constexpr std::uint32_t kMsgVersion = 1;
+
+// LinkProtocolCmd defines the message types for the KV connection protocol.
+enum class LinkProtocolCmd : std::uint8_t {
+    Negotiate = 0,
+    Handshake = 1,
+    HandshakeDone = 3,
+    Disconnect = 4
+};
+
+constexpr std::size_t kNegotiatePayloadSize = 160;  // 32 + 128
+constexpr std::size_t kHandshakePayloadSize = 160;
+constexpr std::size_t kDisconnectPayloadSize = 8;
+
+class MsgHeader {
+public:
+    std::uint32_t crc{0};
+    std::uint8_t ver{kMsgVersion};
+    LinkProtocolCmd cmd{LinkProtocolCmd::Negotiate};
+    std::uint8_t pad[6]{0};
+    std::uint32_t len{0};
+
+    void Pack(std::vector<std::uint8_t>& buffer) const
+    {
+        std::memcpy(&buffer[0], &crc, 4);
+        buffer[4] = ver;
+        buffer[5] = static_cast<std::uint8_t>(cmd);
+        std::memcpy(&buffer[12], &len, 4);
+    }
+
+    static MsgHeader Unpack(const std::uint8_t* data)
+    {
+        MsgHeader h;
+        std::memcpy(&h.crc, &data[0], 4);
+        h.ver = data[4];
+        h.cmd = static_cast<LinkProtocolCmd>(data[5]);
+        std::memcpy(&h.len, &data[12], 4);
+        return h;
+    }
+};
+
+class NegotiateRequest {
+public:
+    std::uint32_t cap{0};
+    std::uint32_t private_len{4};
+    std::uint8_t major_version{1};
+    std::uint8_t minor_version{0};
+    std::uint16_t kato{0};
+};
+
+class HandshakeRequest {
+public:
+    std::uint8_t gid[16]{0};
+    std::uint16_t lid{0};
+    std::uint8_t mtu{0};
+    std::uint8_t total_qp_num{0};
+    std::uint8_t sl{0};
+    std::uint8_t traffic_class{0};
+    std::uint8_t rnr_timer{0};
+    std::uint8_t rnr_retry_cnt{0};
+    std::uint8_t timeout{0};
+    std::uint8_t retry_cnt{0};
+    std::uint8_t qp_rd_atom{0};
+    std::uint8_t rsv{0};
+    std::uint32_t start_psn{0};
+    std::uint32_t qpn[32]{0};
+};
+
+class DisconnectRequest {
+public:
+    std::uint32_t local_qpn{0};
+    std::uint32_t remote_qpn{0};
+};
+
+class NegotiateSqe {
+public:
+    NegotiateSqe() = default;
+
+    const void* Data() const { return buffer.data(); }
+    std::size_t Size() const { return buffer.size(); }
+
+    Status Pack(const NegotiateRequest& req);
+    Status Validate() const;
+
+private:
+    std::vector<std::uint8_t> buffer;
+};
+
+class HandshakeSqe {
+public:
+    HandshakeSqe() = default;
+
+    const void* Data() const { return buffer.data(); }
+    std::size_t Size() const { return buffer.size(); }
+
+    Status Pack(const HandshakeRequest& req);
+    Status Validate() const;
+
+private:
+    std::vector<std::uint8_t> buffer;
+};
+
+class HandshakeDoneSqe {
+public:
+    HandshakeDoneSqe() = default;
+
+    const void* Data() const { return buffer.data(); }
+    std::size_t Size() const { return buffer.size(); }
+
+    Status Pack();
+
+private:
+    std::vector<std::uint8_t> buffer;
+};
+
+class DisconnectSqe {
+public:
+    DisconnectSqe() = default;
+
+    const void* Data() const { return buffer.data(); }
+    std::size_t Size() const { return buffer.size(); }
+
+    Status Pack(const DisconnectRequest& req);
+
+private:
+    std::vector<std::uint8_t> buffer;
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/sqe_request.cpp
+++ b/ucm/transport/kv/asu/trans/src/sqe_request.cpp
@@ -1,0 +1,417 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+#include "buffer_manager.h"
+#include "connection_manager.h"
+#include "kv_protocol.h"
+#include "logger.h"
+#include "transport_task_executor.h"
+
+namespace UC::ASU {
+
+namespace {
+
+constexpr std::size_t kFlagBufferHeaderSize = 16;
+
+Status ValidateSqeMrKeys(const BatchView<KVBuffer>& entries)
+{
+    for (std::size_t index = 0; index < entries.size; ++index) {
+        if (!entries[index].mrKey.has_value()) {
+            return Status::Error(
+                StatusCode::BUFFER_NOT_REGISTERED,
+                "entry buffer is not registered, entryIndex=" + std::to_string(index));
+        }
+    }
+    return Status::OK();
+}
+
+std::string ToLower(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
+template <typename T>
+T GetTransportConfigAttr(const std::unordered_map<std::string, std::string>& attrs,
+                         const std::string& name, T fallback = {})
+{
+    auto iter = attrs.find(name);
+    if (iter == attrs.end()) { return fallback; }
+
+    if constexpr (std::is_same_v<T, bool>) {
+        const auto value = ToLower(iter->second);
+        return value == "1" || value == "true";
+    } else {
+        return static_cast<T>(std::stoull(iter->second, nullptr, 0));
+    }
+}
+
+std::size_t GetFlagBufferSize(KvOpcode opcode, std::size_t batchNum)
+{
+    switch (opcode) {
+        case KvOpcode::BatchStore:
+        case KvOpcode::BatchRetrieve: return kFlagBufferHeaderSize + (batchNum + 1) / 2;
+        case KvOpcode::Delete:
+        case KvOpcode::Exist: return kFlagBufferHeaderSize + (batchNum + 7) / 8;
+        default: return kFlagBufferHeaderSize + 1;
+    }
+}
+
+Status AllocateSubBatchFlagBuffer(KvOpcode opcode, std::size_t batchNum,
+                                  BufferManager& flagBufferManager,
+                                  TransportSubBatchContext& subBatchContext)
+{
+    const auto flagBufferSize = GetFlagBufferSize(opcode, batchNum);
+    auto status = flagBufferManager.Allocate(flagBufferSize, subBatchContext.flagBuffer);
+    if (!status.ok()) {
+        UC_ERROR(
+            "Allocate sub-batch flag buffer failed opcode={} batch_num={} size={} code={} "
+            "message={}",
+            static_cast<int>(opcode), batchNum, flagBufferSize, static_cast<int>(status.code),
+            status.message);
+        subBatchContext.flagBuffer = {};
+        return status;
+    }
+    return Status::OK();
+}
+
+void SetSubBatchBuildFailed(TransportSubBatchContext& subBatchContext, const Status& status)
+{
+    subBatchContext.state = TransportSubBatchState::COMPLETED;
+    subBatchContext.status = status;
+    std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(), status);
+}
+
+struct SubBatchRequestSource {
+    const BatchView<KVBuffer>* entries{nullptr};
+    const BatchView<CacheKey>* keys{nullptr};
+
+    static SubBatchRequestSource FromEntries(const BatchView<KVBuffer>& value)
+    {
+        return SubBatchRequestSource{&value, nullptr};
+    }
+
+    static SubBatchRequestSource FromKeys(const BatchView<CacheKey>& value)
+    {
+        return SubBatchRequestSource{nullptr, &value};
+    }
+
+    static SubBatchRequestSource KeepAlive() { return SubBatchRequestSource{}; }
+};
+
+Status PrepareSubBatchRequest(AsuOpType opType, KvOpcode opcode, std::uint16_t cid,
+                              std::size_t batchNum, BufferManager& flagBufferManager,
+                              TransportSubBatchContext& subBatchContext)
+{
+    subBatchContext.opType = opType;
+    subBatchContext.cid = cid;
+    auto status = AllocateSubBatchFlagBuffer(opcode, batchNum, flagBufferManager, subBatchContext);
+    if (!status.ok()) {
+        SetSubBatchBuildFailed(subBatchContext, status);
+        return status;
+    }
+    return Status::OK();
+}
+
+Status PackSubBatchRequest(ProtocolManager& protocolManager, BufferManager& sendBufferManager,
+                           KvOpcode opcode, const SqeRequest& request,
+                           TransportSubBatchContext& subBatchContext)
+{
+    auto packedSize = protocolManager.GetPackedSize(opcode, request);
+    auto status = sendBufferManager.Allocate(packedSize, subBatchContext.sendSge);
+    if (!status.ok()) {
+        UC_ERROR(
+            "Allocate sub-batch send buffer failed opcode={} cid={} packed_size={} code={} "
+            "message={}",
+            static_cast<int>(opcode), subBatchContext.cid, packedSize,
+            static_cast<int>(status.code), status.message);
+        SetSubBatchBuildFailed(subBatchContext, status);
+        return status;
+    }
+
+    status = protocolManager.PackRequest(
+        reinterpret_cast<void*>(subBatchContext.sendSge.local_addr), opcode, request);
+    if (!status.ok()) {
+        UC_ERROR("Pack sub-batch request failed opcode={} cid={} code={} message={}",
+                 static_cast<int>(opcode), subBatchContext.cid, static_cast<int>(status.code),
+                 status.message);
+        SetSubBatchBuildFailed(subBatchContext, status);
+        return status;
+    }
+
+    subBatchContext.status = status;
+    return status;
+}
+
+KvBatchStoreRequest BuildBatchStoreRequest(
+    const BatchView<KVBuffer>& entries, const std::unordered_map<std::string, std::string>& attrs,
+    std::uint16_t cid, const ScatterGatherEntry& flagBuffer)
+{
+    KvBatchStoreRequest request;
+    request.cid = cid;
+    request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
+    request.dtype = GetTransportConfigAttr<std::uint8_t>(attrs, "dtype");
+    request.dspec = GetTransportConfigAttr<std::uint8_t>(attrs, "dspec");
+    request.response_buffer_addr = flagBuffer.device_addr;
+    request.response_mr_key = flagBuffer.tokenId;
+    request.lr = GetTransportConfigAttr<bool>(attrs, "lr");
+    request.rflag = true;
+    request.batch_number = static_cast<std::uint16_t>(entries.size);
+    request.entries.reserve(entries.size);
+    for (std::size_t index = 0; index < entries.size; ++index) {
+        KvBatchStoreEntry entry;
+        entry.key = entries[index].key;
+        entry.offset = entries[index].offset;
+        entry.buffer_addr = entries[index].buffer.region.addr;
+        entry.mr_key = *entries[index].mrKey;
+        entry.length = static_cast<std::uint32_t>(entries[index].buffer.region.size);
+        request.entries.emplace_back(std::move(entry));
+    }
+    return request;
+}
+
+KvStoreRequest BuildStoreRequest(const KVBuffer& entry,
+                                 const std::unordered_map<std::string, std::string>& attrs,
+                                 std::uint16_t cid)
+{
+    KvStoreRequest request;
+    request.cid = cid;
+    request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
+    request.dtype = GetTransportConfigAttr<std::uint8_t>(attrs, "dtype");
+    request.dspec = GetTransportConfigAttr<std::uint8_t>(attrs, "dspec");
+    request.buffer_addr = entry.buffer.region.addr;
+    request.buffer_length = static_cast<std::uint32_t>(entry.buffer.region.size);
+    request.mr_key = *entry.mrKey;
+    request.offset = entry.offset;
+    request.lr = GetTransportConfigAttr<bool>(attrs, "lr");
+    request.length = request.buffer_length;
+    request.key = entry.key;
+    return request;
+}
+
+KvRetrieveRequest BuildRetrieveRequest(const KVBuffer& entry,
+                                       const std::unordered_map<std::string, std::string>& attrs,
+                                       std::uint16_t cid)
+{
+    KvRetrieveRequest request;
+    request.cid = cid;
+    request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
+    request.buffer_addr = entry.buffer.region.addr;
+    request.buffer_length = static_cast<std::uint32_t>(entry.buffer.region.size);
+    request.mr_key = *entry.mrKey;
+    request.offset = entry.offset;
+    request.lr = GetTransportConfigAttr<bool>(attrs, "lr");
+    request.length = request.buffer_length;
+    request.key = entry.key;
+    return request;
+}
+
+KvBatchRetrieveRequest BuildBatchRetrieveRequest(
+    const BatchView<KVBuffer>& entries, const std::unordered_map<std::string, std::string>& attrs,
+    std::uint16_t cid, const ScatterGatherEntry& flagBuffer)
+{
+    KvBatchRetrieveRequest request;
+    request.cid = cid;
+    request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
+    request.response_buffer_addr = flagBuffer.device_addr;
+    request.response_mr_key = flagBuffer.tokenId;
+    request.lr = GetTransportConfigAttr<bool>(attrs, "lr");
+    request.rflag = true;
+    request.batch_number = static_cast<std::uint16_t>(entries.size);
+    request.entries.reserve(entries.size);
+    for (std::size_t index = 0; index < entries.size; ++index) {
+        KvBatchRetrieveEntry entry;
+        entry.key = entries[index].key;
+        entry.offset = entries[index].offset;
+        entry.buffer_addr = entries[index].buffer.region.addr;
+        entry.mr_key = *entries[index].mrKey;
+        entry.length = static_cast<std::uint32_t>(entries[index].buffer.region.size);
+        request.entries.emplace_back(std::move(entry));
+    }
+    return request;
+}
+
+std::vector<CacheKey> CopyKeys(const BatchView<CacheKey>& keys)
+{
+    std::vector<CacheKey> requestKeys;
+    requestKeys.reserve(keys.size);
+    for (std::size_t index = 0; index < keys.size; ++index) {
+        requestKeys.emplace_back(keys[index]);
+    }
+    return requestKeys;
+}
+
+KvDeleteRequest BuildDeleteRequest(const BatchView<CacheKey>& keys,
+                                   const std::unordered_map<std::string, std::string>& attrs,
+                                   std::uint16_t cid, const ScatterGatherEntry& flagBuffer)
+{
+    KvDeleteRequest request;
+    request.cid = cid;
+    request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
+    request.response_buffer_addr = flagBuffer.device_addr;
+    request.response_mr_key = flagBuffer.tokenId;
+    request.rflag = true;
+    request.keys = CopyKeys(keys);
+    request.batch_number = static_cast<std::uint16_t>(request.keys.size());
+    return request;
+}
+
+KvExistRequest BuildExistRequest(const BatchView<CacheKey>& keys,
+                                 const std::unordered_map<std::string, std::string>& attrs,
+                                 std::uint16_t cid, const ScatterGatherEntry& flagBuffer)
+{
+    KvExistRequest request;
+    request.cid = cid;
+    request.kv_ns_id = GetTransportConfigAttr<std::uint32_t>(attrs, "kv_ns_id");
+    request.response_buffer_addr = flagBuffer.device_addr;
+    request.response_mr_key = flagBuffer.tokenId;
+    request.rflag = true;
+    request.sc = GetTransportConfigAttr<bool>(attrs, "sc", true);
+    request.keys = CopyKeys(keys);
+    request.batch_number = static_cast<std::uint16_t>(request.keys.size());
+    return request;
+}
+
+KvKeepAliveRequest BuildKeepAliveRequest(std::uint16_t cid, const ScatterGatherEntry& flagBuffer)
+{
+    KvKeepAliveRequest request;
+    request.cid = cid;
+    request.response_buffer_addr = flagBuffer.device_addr;
+    request.response_mr_key = flagBuffer.tokenId;
+    request.rflag = true;
+    return request;
+}
+
+std::unique_ptr<SqeRequest> BuildSqeRequest(
+    KvOpcode opcode, const SubBatchRequestSource& source,
+    const std::unordered_map<std::string, std::string>& attrs, std::uint16_t cid,
+    const ScatterGatherEntry& flagBuffer, TransportSubBatchContext& subBatchContext)
+{
+    switch (opcode) {
+        case KvOpcode::Store:
+            if (source.entries == nullptr || source.entries->size != 1) { return nullptr; }
+            return std::make_unique<KvStoreRequest>(
+                BuildStoreRequest(source.entries->data[0], attrs, cid));
+        case KvOpcode::Retrieve:
+            if (source.entries == nullptr || source.entries->size != 1) { return nullptr; }
+            return std::make_unique<KvRetrieveRequest>(
+                BuildRetrieveRequest(source.entries->data[0], attrs, cid));
+        case KvOpcode::BatchRetrieve:
+            if (source.entries == nullptr) { return nullptr; }
+            return std::make_unique<KvBatchRetrieveRequest>(
+                BuildBatchRetrieveRequest(*source.entries, attrs, cid, flagBuffer));
+        case KvOpcode::BatchStore:
+            if (source.entries == nullptr) { return nullptr; }
+            return std::make_unique<KvBatchStoreRequest>(
+                BuildBatchStoreRequest(*source.entries, attrs, cid, flagBuffer));
+        case KvOpcode::Delete:
+            if (source.keys == nullptr) { return nullptr; }
+            return std::make_unique<KvDeleteRequest>(
+                BuildDeleteRequest(*source.keys, attrs, cid, flagBuffer));
+        case KvOpcode::Exist: {
+            if (source.keys == nullptr) { return nullptr; }
+            auto request = BuildExistRequest(*source.keys, attrs, cid, flagBuffer);
+            subBatchContext.useSeekControl = request.sc;
+            return std::make_unique<KvExistRequest>(std::move(request));
+        }
+        case KvOpcode::KeepAlive:
+            return std::make_unique<KvKeepAliveRequest>(BuildKeepAliveRequest(cid, flagBuffer));
+        default:
+            UC_ERROR("Build SQE request failed: unsupported opcode={} cid={}",
+                     static_cast<int>(opcode), cid);
+            return nullptr;
+    }
+}
+
+}  // namespace
+
+Status TransportTaskExecutor::BuildEntrySubBatchRequest(
+    AsuOpType opType, const IoScheduler::ScheduledIoBatch& subBatch,
+    TransportSubBatchContext& subBatchContext)
+{
+    const auto source = SubBatchRequestSource::FromEntries(subBatch.entries);
+    subBatchContext.entryStatus.assign(subBatch.entries.size, Status::OK());
+    const auto opcode = ToKvOpcode(opType);
+
+    auto validationStatus = ValidateSqeMrKeys(subBatch.entries);
+    if (!validationStatus.ok()) {
+        SetSubBatchBuildFailed(subBatchContext, validationStatus);
+        return validationStatus;
+    }
+
+    const auto cid = AllocateRequestCid();
+    auto status = PrepareSubBatchRequest(opType, opcode, cid, subBatch.entries.size,
+                                         flagBufferManager_, subBatchContext);
+    if (!status.ok()) { return status; }
+
+    auto request = BuildSqeRequest(opcode, source, config_.attrs, subBatchContext.cid,
+                                   subBatchContext.flagBuffer, subBatchContext);
+    return PackSubBatchRequest(protocolManager_, sendBufferManager_, opcode, *request,
+                               subBatchContext);
+}
+
+Status TransportTaskExecutor::SubmitKeySubBatchRequest(
+    AsuOpType opType, const IoScheduler::ScheduledKeyBatch& subBatch,
+    TransportSubBatchContext& subBatchContext)
+{
+    const auto source = SubBatchRequestSource::FromKeys(subBatch.keys);
+    subBatchContext.entryStatus.assign(subBatch.keys.size, Status::OK());
+    const auto opcode = ToKvOpcode(opType);
+
+    auto status = PrepareSubBatchRequest(opType, opcode, AllocateRequestCid(), subBatch.keys.size,
+                                         flagBufferManager_, subBatchContext);
+    if (!status.ok()) { return status; }
+
+    auto request = BuildSqeRequest(opcode, source, config_.attrs, subBatchContext.cid,
+                                   subBatchContext.flagBuffer, subBatchContext);
+    return PackSubBatchRequest(protocolManager_, sendBufferManager_, opcode, *request,
+                               subBatchContext);
+}
+
+Status TransportTaskExecutor::SubmitKeepAliveRequest(TransportSubBatchContext& subBatchContext)
+{
+    const auto opType = AsuOpType::KEEP_ALIVE;
+    const auto source = SubBatchRequestSource::KeepAlive();
+    subBatchContext.entryStatus.assign(1, Status::OK());
+    const auto opcode = ToKvOpcode(opType);
+
+    auto status = PrepareSubBatchRequest(opType, opcode, AllocateRequestCid(), 1,
+                                         flagBufferManager_, subBatchContext);
+    if (!status.ok()) { return status; }
+
+    auto request = BuildSqeRequest(opcode, source, config_.attrs, subBatchContext.cid,
+                                   subBatchContext.flagBuffer, subBatchContext);
+    return PackSubBatchRequest(protocolManager_, sendBufferManager_, opcode, *request,
+                               subBatchContext);
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/trans_provider.cpp
+++ b/ucm/transport/kv/asu/trans/src/trans_provider.cpp
@@ -1,0 +1,64 @@
+#include "asu_transport/trans_provider.h"
+#include <exception>
+#include <memory>
+#ifdef UCM_ASU_ENABLE_AICPU_PROVIDER
+#include "aicpu_trans_provider.h"
+#endif
+#ifdef UCM_ASU_ENABLE_AIV_PROVIDER
+#include "aiv_trans_provider.h"
+#endif
+#include "asu_transport/asu_transport.h"
+#ifdef UCM_ASU_ENABLE_FAKE_PROVIDER
+#include "fake_trans_provider.h"
+#endif
+
+namespace UC::ASU {
+
+Status CreateTransProvider(const TransportConfig& config,
+                           std::shared_ptr<TransProvider>& transProvider)
+{
+    transProvider.reset();
+    switch (config.providerType) {
+        case TransProviderType::AICPU:
+#ifdef UCM_ASU_ENABLE_AICPU_PROVIDER
+            transProvider = std::make_shared<AICPUTransProvider>();
+            return Status::OK();
+#else
+            return Status::Error(
+                StatusCode::UNSUPPORTED,
+                "AICPU trans provider is not built; enable BUILD_UCM_ASU_PROVIDER_AICPU");
+#endif
+        case TransProviderType::FAKE:
+#ifdef UCM_ASU_ENABLE_FAKE_PROVIDER
+            try {
+                transProvider =
+                    std::make_shared<FakeTransProvider>(MakeFakeTransProviderConfig(config));
+                return Status::OK();
+            } catch (const std::exception& error) {
+                return Status::Error(
+                    StatusCode::INTERNAL_ERROR,
+                    "failed to create fake provider: " + std::string(error.what()));
+            }
+#else
+            return Status::Error(
+                StatusCode::UNSUPPORTED,
+                "FAKE trans provider is not built; enable BUILD_UCM_ASU_PROVIDER_FAKE");
+#endif
+        case TransProviderType::AIV:
+#ifdef UCM_ASU_ENABLE_AIV_PROVIDER
+            transProvider = std::make_shared<AIVTransProviderAdapter>(config.deviceId);
+            return Status::OK();
+#else
+            return Status::Error(
+                StatusCode::UNSUPPORTED,
+                "AIV trans provider is not built; enable BUILD_UCM_ASU_PROVIDER_AIV and set "
+                "ASU_AIV_PROVIDER_ROOT");
+#endif
+        case TransProviderType::UNSUPPORTED:
+            return Status::Error(StatusCode::UNSUPPORTED,
+                                 "ASU trans provider backend is not supported");
+    }
+    return Status::Error(StatusCode::UNSUPPORTED, "ASU trans provider backend is not supported");
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/transport_config_parser.cpp
+++ b/ucm/transport/kv/asu/trans/src/transport_config_parser.cpp
@@ -1,0 +1,177 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "transport_config_parser.h"
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <limits>
+#include <utility>
+#include "asu_transport/asu_transport.h"
+#include "config_parser_common.h"
+#include "logger.h"
+
+namespace UC::ASU {
+
+namespace {
+
+std::string ToLower(std::string value)
+{
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    return value;
+}
+
+}  // namespace
+
+Status ValidateSqeRequestAttrs(const std::unordered_map<std::string, std::string>& attrs)
+{
+    const auto parseInteger = [&attrs](const std::string& name, auto maxValue,
+                                       std::uint64_t& out) -> Status {
+        auto iter = attrs.find(name);
+        if (iter == attrs.end()) { return Status::Error(StatusCode::NOT_FOUND, ""); }
+        try {
+            out = std::stoull(iter->second, nullptr, 0);
+            if (out > maxValue) {
+                UC_ERROR("Validate SQE attr failed name={} value={} reason=exceeds_range", name,
+                         iter->second);
+                return Status::Error(StatusCode::INVALID_ARGUMENT, name + " exceeds valid range");
+            }
+        } catch (const std::exception&) {
+            UC_ERROR("Validate SQE attr failed name={} value={} reason=invalid_integer", name,
+                     iter->second);
+            return Status::Error(StatusCode::INVALID_ARGUMENT, name + " is not a valid integer");
+        }
+        return Status::OK();
+    };
+
+    const auto validateInteger = [&](const std::string& name, auto maxValue) -> Status {
+        std::uint64_t dummy;
+        auto s = parseInteger(name, maxValue, dummy);
+        if (s.code == StatusCode::NOT_FOUND) { return Status::OK(); }
+        return s;
+    };
+
+    const auto validateRequiredPositiveInteger = [&](const std::string& name,
+                                                     auto maxValue) -> Status {
+        std::uint64_t parsed;
+        auto s = parseInteger(name, maxValue, parsed);
+        if (s.code == StatusCode::NOT_FOUND) {
+            UC_ERROR("Validate SQE attr failed name={} reason=missing_required", name);
+            return Status::Error(StatusCode::INVALID_ARGUMENT, name + " is required");
+        }
+        if (!s.ok()) { return s; }
+        if (parsed == 0) {
+            UC_ERROR("Validate SQE attr failed name={} reason=must_be_positive", name);
+            return Status::Error(StatusCode::INVALID_ARGUMENT, name + " must be greater than zero");
+        }
+        return Status::OK();
+    };
+
+    const auto validateBool = [&attrs](const std::string& name) -> Status {
+        auto iter = attrs.find(name);
+        if (iter == attrs.end()) { return Status::OK(); }
+        const auto value = ToLower(iter->second);
+        if (value == "1" || value == "0" || value == "true" || value == "false") {
+            return Status::OK();
+        }
+        UC_ERROR("Validate SQE attr failed name={} value={} reason=invalid_bool", name,
+                 iter->second);
+        return Status::Error(StatusCode::INVALID_ARGUMENT, name + " is not a valid bool");
+    };
+
+    auto status = validateInteger("kv_ns_id", std::numeric_limits<std::uint32_t>::max());
+    if (!status.ok()) { return status; }
+    status = validateInteger("timeout", std::numeric_limits<std::uint32_t>::max());
+    if (!status.ok()) { return status; }
+    status = validateInteger("dtype", std::numeric_limits<std::uint8_t>::max());
+    if (!status.ok()) { return status; }
+    status = validateInteger("dspec", std::numeric_limits<std::uint8_t>::max());
+    if (!status.ok()) { return status; }
+    status = validateBool("sc");
+    if (!status.ok()) { return status; }
+    status = validateBool("lr");
+    if (!status.ok()) { return status; }
+    status =
+        validateRequiredPositiveInteger("kernel_count", std::numeric_limits<std::uint32_t>::max());
+    if (!status.ok()) { return status; }
+    status =
+        validateRequiredPositiveInteger("quiet_count", std::numeric_limits<std::uint32_t>::max());
+    if (!status.ok()) { return status; }
+    return Status::OK();
+}
+
+Status LoadTransportConfig(const std::string& configPath, TransportConfig& config)
+{
+    std::ifstream configFile{configPath};
+    if (!configFile.is_open()) {
+        return Status::Error(StatusCode::NOT_FOUND,
+                             "failed to open asu transport config, path=" + configPath);
+    }
+
+    config = TransportConfig{};
+    std::string line;
+    while (std::getline(configFile, line)) {
+        line = TrimConfigValue(line);
+        if (line.empty() || line[0] == '#') { continue; }
+
+        const auto pos = line.find('=');
+        if (pos == std::string::npos) { continue; }
+
+        const auto key = TrimConfigValue(line.substr(0, pos));
+        const auto value = TrimConfigValue(line.substr(pos + 1));
+        if (key == "asuName" || key == "asu_name") {
+            config.asuName = value;
+        } else if (key == "asuId" || key == "asu_id") {
+            config.asuId = ParseConfigUint64(value);
+        } else if (key == "endpoint" || key == "endpoints") {
+            config.endpoints.clear();
+            for (const auto& endpointValue : SplitConfigValue(value, ';')) {
+                config.endpoints.emplace_back(ParseTransportEndpoint(endpointValue));
+            }
+        } else if (key == "timeoutMs" || key == "timeout_ms") {
+            config.timeoutMs = ParseConfigUint64(value);
+        } else if (key == "maxErrorCount" || key == "max_error_count") {
+            config.maxErrorCount = static_cast<std::uint32_t>(ParseConfigUint64(value));
+        } else if (key == "maxInflightTasks" || key == "max_inflight_tasks") {
+            config.maxInflightTasks = static_cast<std::uint32_t>(ParseConfigUint64(value));
+        } else if (key == "maxInflightBytes" || key == "max_inflight_bytes") {
+            config.maxInflightBytes = ParseConfigUint64(value);
+        } else if (ApplyTransportCompletionConfigField(config, key, value)) {
+            continue;
+        } else if (ApplyTransportBufferConfigField(config, key, value)) {
+            continue;
+        } else if (ApplyTransportIoNumConfigField(config, key, value)) {
+            continue;
+        } else if (ApplyTransportProviderConfigField(config, key, value)) {
+            continue;
+        } else if (ApplyTransportDeviceConfigField(config, key, value)) {
+            continue;
+        } else {
+            config.attrs[key] = value;
+        }
+    }
+    return ValidateSqeRequestAttrs(config.attrs);
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/transport_config_parser.h
+++ b/ucm/transport/kv/asu/trans/src/transport_config_parser.h
@@ -1,0 +1,37 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include "asu_transport/types.h"
+
+namespace UC::ASU {
+
+struct TransportConfig;
+
+Status LoadTransportConfig(const std::string& configPath, TransportConfig& config);
+Status ValidateSqeRequestAttrs(const std::unordered_map<std::string, std::string>& attrs);
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/transport_task_executor.cpp
+++ b/ucm/transport/kv/asu/trans/src/transport_task_executor.cpp
@@ -1,0 +1,427 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#include "transport_task_executor.h"
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include "asu_response_status.h"
+#include "connection_internal.h"
+#include "logger.h"
+
+namespace UC::ASU {
+
+TransportTaskExecutor::TransportTaskExecutor(
+    const TransportConfig& config, const std::shared_ptr<TransProvider>& transProvider,
+    const std::unique_ptr<ConnectionManager>& connectionManager)
+    : config_(config),
+      ioScheduler_(config),
+      transProvider_(transProvider),
+      connManager_(connectionManager)
+{
+}
+
+TransportTaskExecutor::~TransportTaskExecutor()
+{
+    const auto status = Shutdown();
+    if (!status.ok()) {
+        UC_WARN("TransportTaskExecutor destructor cleanup failed: code={} message={}",
+                static_cast<int>(status.code), status.message);
+    }
+}
+
+Status TransportTaskExecutor::Init()
+{
+    auto status = sendBufferManager_.Init("asu send buffer", MemoryType::HOST_PINNED,
+                                          config_.sendBufferSlotSize, config_.sendBufferSlotNum);
+    if (!status.ok()) {
+        (void)Shutdown();
+        return status;
+    }
+
+    status = flagBufferManager_.Init("asu flag buffer", MemoryType::HOST_PINNED,
+                                     config_.flagBufferSlotSize, config_.flagBufferSlotNum);
+    if (!status.ok()) {
+        (void)Shutdown();
+        return status;
+    }
+
+    status = RegisterBufferMemory(sendBufferManager_, sendBufferMrHandle_);
+    if (!status.ok()) {
+        const auto registerStatus =
+            Status::Error(status.code, "failed to register send buffer: " + status.message);
+        const auto shutdownStatus = Shutdown();
+        if (!shutdownStatus.ok()) {
+            UC_WARN(
+                "TransportTaskExecutor::Init cleanup failed after send buffer registration "
+                "failure: code={} message={}",
+                static_cast<int>(shutdownStatus.code), shutdownStatus.message);
+        }
+        return registerStatus;
+    }
+
+    status = RegisterBufferMemory(flagBufferManager_, flagBufferMrHandle_);
+    if (!status.ok()) {
+        const auto registerStatus =
+            Status::Error(status.code, "failed to register flag buffer: " + status.message);
+        const auto shutdownStatus = Shutdown();
+        if (!shutdownStatus.ok()) {
+            UC_WARN(
+                "TransportTaskExecutor::Init cleanup failed after flag buffer registration "
+                "failure: code={} message={}",
+                static_cast<int>(shutdownStatus.code), shutdownStatus.message);
+        }
+        return registerStatus;
+    }
+    return Status::OK();
+}
+
+Status TransportTaskExecutor::Shutdown()
+{
+    Status finalStatus = Status::OK();
+    auto status = UnregisterBufferMemory(flagBufferMrHandle_);
+    if (!status.ok()) {
+        UC_WARN("Failed to unregister flag buffer: code={} message={}",
+                static_cast<int>(status.code), status.message);
+        finalStatus =
+            Status::Error(status.code, "failed to unregister flag buffer: " + status.message);
+    }
+
+    status = UnregisterBufferMemory(sendBufferMrHandle_);
+    if (!status.ok()) {
+        UC_WARN("Failed to unregister send buffer: code={} message={}",
+                static_cast<int>(status.code), status.message);
+        if (finalStatus.ok()) {
+            finalStatus =
+                Status::Error(status.code, "failed to unregister send buffer: " + status.message);
+        }
+    }
+
+    if (flagBufferMrHandle_ == kInvalidMRHandle) { flagBufferManager_.Shutdown(); }
+    if (sendBufferMrHandle_ == kInvalidMRHandle) { sendBufferManager_.Shutdown(); }
+    return finalStatus;
+}
+
+Status TransportTaskExecutor::RegisterBufferMemory(BufferManager& bufferManager, MRHandle& mrHandle)
+{
+    if (!transProvider_) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "TransProvider is null");
+    }
+
+    TransProvider::RegisterMemoryDesc desc;
+    auto status = bufferManager.GetRegisterMemoryDesc(desc);
+    if (!status.ok()) { return status; }
+
+    std::vector<MRHandle> mrHandles;
+    status = transProvider_->RegisterMemory({desc}, mrHandles);
+    if (!status.ok()) {
+        return Status::Error(StatusCode::INTERNAL_ERROR,
+                             "provider memory registration failed: " + status.message);
+    }
+    if (mrHandles.empty() || mrHandles[0] == kInvalidMRHandle) {
+        return Status::Error(StatusCode::INTERNAL_ERROR, "provider returned no valid MR handle");
+    }
+
+    mrHandle = mrHandles[0];
+    std::uint32_t tokenId = 0;
+    status = transProvider_->GetMemTokenId(mrHandle, tokenId);
+    if (!status.ok()) {
+        const auto unregisterStatus = UnregisterBufferMemory(mrHandle);
+        if (!unregisterStatus.ok()) {
+            UC_WARN("Failed to unregister memory after token lookup failure: {}",
+                    unregisterStatus.message);
+        }
+        return Status::Error(StatusCode::INTERNAL_ERROR,
+                             "memory token lookup failed: " + status.message);
+    }
+
+    bufferManager.SetTokenId(tokenId);
+    return Status::OK();
+}
+
+Status TransportTaskExecutor::UnregisterBufferMemory(MRHandle& mrHandle)
+{
+    if (mrHandle == kInvalidMRHandle) { return Status::OK(); }
+    if (!transProvider_) {
+        return Status::Error(StatusCode::NOT_INITIALIZED, "TransProvider is null");
+    }
+
+    const auto statuses =
+        transProvider_->UnregisterMemory({TransProvider::UnregisterMemoryDesc{mrHandle}});
+    for (const auto& status : statuses) {
+        if (!status.ok()) {
+            return Status::Error(status.code,
+                                 "provider memory unregistration failed: " + status.message);
+        }
+    }
+    mrHandle = kInvalidMRHandle;
+    return Status::OK();
+}
+
+void TransportTaskExecutor::ReleaseSubBatchResources(TransportSubBatchContext& subBatchContext)
+{
+    if (subBatchContext.sendSge.slot_index != UINT32_MAX) {
+        const auto slotIndex = subBatchContext.sendSge.slot_index;
+        auto status = sendBufferManager_.Free(slotIndex);
+        if (!status.ok()) {
+            UC_ERROR("Failed to release sub-batch send buffer slot({}): {}", slotIndex,
+                     status.message);
+        }
+        subBatchContext.sendSge = {};
+    }
+
+    if (subBatchContext.flagBuffer.slot_index != UINT32_MAX) {
+        const auto slotIndex = subBatchContext.flagBuffer.slot_index;
+        auto status = flagBufferManager_.Free(slotIndex);
+        if (!status.ok()) {
+            UC_ERROR("Failed to release sub-batch flag buffer slot({}): {}", slotIndex,
+                     status.message);
+        }
+        subBatchContext.flagBuffer = {};
+    }
+
+    if (subBatchContext.channel != nullptr) {
+        subBatchContext.channel->ReleaseInflight();
+        subBatchContext.channel = nullptr;
+    }
+}
+
+void TransportTaskExecutor::ReleaseAllSubBatchResources(
+    std::vector<TransportSubBatchContext>& subBatchContexts)
+{
+    for (auto& subBatchContext : subBatchContexts) { ReleaseSubBatchResources(subBatchContext); }
+}
+
+void TransportTaskExecutor::AbortSubBatchesBeforeSend(
+    TransportTask& task, std::vector<TransportSubBatchContext>& subBatchContexts)
+{
+    const auto canceledStatus =
+        Status::Error(StatusCode::CANCELED, "sub-batch canceled after pre-send failure");
+    std::fill(task.entryStatus.begin(), task.entryStatus.end(), canceledStatus);
+
+    bool hasFailedSubBatch = false;
+    for (auto& subBatchContext : subBatchContexts) {
+        ReleaseSubBatchResources(subBatchContext);
+        if (!subBatchContext.status.ok()) {
+            hasFailedSubBatch = true;
+        } else if (hasFailedSubBatch) {
+            std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(),
+                      canceledStatus);
+            subBatchContext.status = canceledStatus;
+        }
+        subBatchContext.state = TransportSubBatchState::COMPLETED;
+    }
+}
+
+void TransportTaskExecutor::CompleteSubBatch(TransportTask& task,
+                                             TransportSubBatchContext& subBatchContext,
+                                             const Status& status)
+{
+    ReleaseSubBatchResources(subBatchContext);
+    subBatchContext.state = TransportSubBatchState::COMPLETED;
+    subBatchContext.status = status;
+    --task.remainingSubBatchCount;
+}
+
+bool TransportTaskExecutor::Cancel(const TransportTaskPtr& task)
+{
+    if (!task) { return false; }
+
+    std::lock_guard<std::mutex> lock(task->mutex);
+    if (task->Done()) { return false; }
+    const auto canceledStatus = Status::Error(StatusCode::CANCELED, "transport task canceled");
+    std::fill(task->entryStatus.begin(), task->entryStatus.end(), canceledStatus);
+    for (auto& subBatchContext : *task->subBatchContexts) {
+        if (subBatchContext.state == TransportSubBatchState::COMPLETED) { continue; }
+        std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(),
+                  canceledStatus);
+        subBatchContext.status = canceledStatus;
+        subBatchContext.state = TransportSubBatchState::COMPLETED;
+    }
+    task->finalStatus = canceledStatus;
+    ReleaseAllSubBatchResources(*task->subBatchContexts);
+    task->state.store(TransportTaskState::COMPLETED, std::memory_order_release);
+    return true;
+}
+
+std::uint16_t TransportTaskExecutor::AllocateRequestCid()
+{
+    auto requestCid = nextRequestCid_.fetch_add(1, std::memory_order_relaxed);
+    if (requestCid == 0) { requestCid = nextRequestCid_.fetch_add(1, std::memory_order_relaxed); }
+    return requestCid;
+}
+
+Status TransportTaskExecutor::AssignSubBatchConnections(
+    std::vector<TransportSubBatchContext>& subBatchContexts)
+{
+    for (auto& subBatchContext : subBatchContexts) {
+        auto channel = connManager_->SelectConnection();
+        if (!channel) {
+            const auto subBatchStatus =
+                Status::Error(StatusCode::CONNECTION_ERROR, "no available connection channel");
+            std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(),
+                      subBatchStatus);
+            subBatchContext.state = TransportSubBatchState::COMPLETED;
+            subBatchContext.status = subBatchStatus;
+            return subBatchStatus;
+        }
+
+        subBatchContext.channel = channel;
+    }
+    return Status::OK();
+}
+
+bool TransportTaskExecutor::Execute(const TransportTaskPtr& task)
+{
+    TransportTaskState expected = TransportTaskState::PENDING;
+    if (!task->state.compare_exchange_strong(expected, TransportTaskState::INFLIGHT,
+                                             std::memory_order_acq_rel)) {
+        return false;
+    }
+
+    std::vector<TransportSubBatchContext> subBatchContexts;
+    auto status = PrepareTaskSubBatches(*task, subBatchContexts);
+
+    if (status.ok()) { status = AssignSubBatchConnections(subBatchContexts); }
+
+    std::vector<TransProvider::SendIoBatch> ioBatches;
+    if (status.ok()) { BuildSubBatchSendBuffers(subBatchContexts, ioBatches); }
+
+    if (!status.ok()) {
+        UC_ERROR("Abort transport task before send task_id={} code={} message={}", task->taskId,
+                 static_cast<int>(status.code), status.message);
+    } else {
+        SendSubBatchBuffers(subBatchContexts, ioBatches);
+    }
+
+    bool done = false;
+    {
+        std::lock_guard<std::mutex> lock(task->mutex);
+        if (task->Done()) {
+            UC_DEBUG(
+                "TransportTaskExecutor::Execute canceled during process task_id={} sub_batches={}",
+                task->taskId, subBatchContexts.size());
+            ReleaseAllSubBatchResources(subBatchContexts);
+            return false;
+        }
+
+        if (!status.ok()) { AbortSubBatchesBeforeSend(*task, subBatchContexts); }
+        *task->subBatchContexts = std::move(subBatchContexts);
+        task->InitializeRemainingSubBatchCount();
+        task->TryFinalizeFromSubBatches();
+        UC_DEBUG(
+            "TransportTaskExecutor::Execute submitted task_id={} op_type={} entries={} keys={} "
+            "sub_batches={} done={} code={} message={}",
+            task->taskId, static_cast<int>(task->opType), task->entries.size(), task->keys.size(),
+            task->subBatchContexts->size(), task->Done(), static_cast<int>(task->finalStatus.code),
+            task->finalStatus.message);
+
+        done = task->Done();
+    }
+    return done;
+}
+
+bool TransportTaskExecutor::Poll(const TransportTaskPtr& task)
+{
+    if (!task) { return false; }
+
+    bool done = false;
+    {
+        std::lock_guard<std::mutex> lock(task->mutex);
+        if (task->state.load(std::memory_order_acquire) != TransportTaskState::INFLIGHT) {
+            return false;
+        }
+        if (task->subBatchContexts->empty()) { return false; }
+
+        if (std::chrono::steady_clock::now() >= task->deadline) {
+            const auto timeoutStatus =
+                Status::Error(StatusCode::TIMEOUT, "transport task execution timeout");
+            std::fill(task->entryStatus.begin(), task->entryStatus.end(), timeoutStatus);
+            for (auto& subBatchContext : *task->subBatchContexts) {
+                if (subBatchContext.state == TransportSubBatchState::COMPLETED) { continue; }
+
+                std::fill(subBatchContext.entryStatus.begin(), subBatchContext.entryStatus.end(),
+                          timeoutStatus);
+                connManager_->ReportFailure(subBatchContext.channel);
+                CompleteSubBatch(*task, subBatchContext, timeoutStatus);
+            }
+            task->finalStatus = timeoutStatus;
+            task->state.store(TransportTaskState::COMPLETED, std::memory_order_release);
+        } else {
+            for (auto& subBatchContext : *task->subBatchContexts) {
+                if (subBatchContext.state == TransportSubBatchState::COMPLETED) { continue; }
+
+                auto completeWithError = [this, &task, &subBatchContext](const Status& status) {
+                    std::fill(subBatchContext.entryStatus.begin(),
+                              subBatchContext.entryStatus.end(), status);
+                    CompleteSubBatch(*task, subBatchContext, status);
+                };
+
+                std::uint16_t completedCid = 0;
+                const void* responseData =
+                    reinterpret_cast<void*>(subBatchContext.flagBuffer.local_addr);
+
+                if (const auto status =
+                        protocolManager_.PollResponseCid(responseData, completedCid);
+                    !status.ok()) {
+                    continue;
+                }
+                if (completedCid == 0 || completedCid != subBatchContext.cid) { continue; }
+
+                KvResponse response;
+                const auto batchNumber =
+                    static_cast<std::uint16_t>(subBatchContext.entryStatus.size());
+                if (const auto status = protocolManager_.UnpackResponse(
+                        responseData, ToKvOpcode(subBatchContext.opType), batchNumber, response);
+                    !status.ok()) {
+                    completeWithError(status);
+                    continue;
+                }
+
+                subBatchContext.status = KvResponseStatusToSubBatchStatus(response.status);
+                FillEntryStatusFromCqeResult(response, subBatchContext);
+
+                const bool queryResultBufferStatus =
+                    subBatchContext.opType == AsuOpType::QUERY &&
+                    subBatchContext.status.code == StatusCode::ASU_CQE_CHECK_RESULT_BUFFER;
+                const auto status = subBatchContext.status.ok() || queryResultBufferStatus
+                                        ? Status::OK()
+                                        : subBatchContext.status;
+                if (status.code == StatusCode::ASU_CQE_INTERNAL_ERROR ||
+                    status.code == StatusCode::ASU_CQE_IO_TIMEOUT) {
+                    connManager_->ReportFailure(subBatchContext.channel);
+                } else {
+                    connManager_->ReportSuccess(subBatchContext.channel);
+                }
+                CompleteSubBatch(*task, subBatchContext, status);
+            }
+            task->TryFinalizeFromSubBatches();
+        }
+        done = task->Done();
+    }
+    return done;
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/transport_task_executor.h
+++ b/ucm/transport/kv/asu/trans/src/transport_task_executor.h
@@ -1,0 +1,110 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+#include "asu_transport/trans_provider.h"
+#include "buffer_manager.h"
+#include "connection_manager.h"
+#include "io_scheduler.h"
+#include "kv_protocol.h"
+#include "transport_task_manager.h"
+
+namespace UC::ASU {
+
+inline KvOpcode ToKvOpcode(AsuOpType opType)
+{
+    switch (opType) {
+        case AsuOpType::LOAD: return KvOpcode::Retrieve;
+        case AsuOpType::STORE: return KvOpcode::Store;
+        case AsuOpType::BATCH_LOAD: return KvOpcode::BatchRetrieve;
+        case AsuOpType::BATCH_STORE: return KvOpcode::BatchStore;
+        case AsuOpType::DELETE: return KvOpcode::Delete;
+        case AsuOpType::QUERY: return KvOpcode::Exist;
+        case AsuOpType::KEEP_ALIVE: return KvOpcode::KeepAlive;
+    }
+    return KvOpcode::KeepAlive;
+}
+
+// Owns the transport data path for one task and all of its sub-batches.
+// Task lookup, waiting, and callback delivery remain TransportTaskManager concerns.
+class TransportTaskExecutor {
+public:
+    TransportTaskExecutor(const TransportConfig& config,
+                          const std::shared_ptr<TransProvider>& transProvider,
+                          const std::unique_ptr<ConnectionManager>& connectionManager);
+    ~TransportTaskExecutor();
+
+    Status Init();
+    Status Shutdown();
+
+    bool Execute(const TransportTaskPtr& task);
+    bool Poll(const TransportTaskPtr& task);
+    bool Cancel(const TransportTaskPtr& task);
+
+private:
+    Status RegisterBufferMemory(BufferManager& bufferManager, MRHandle& mrHandle);
+    Status UnregisterBufferMemory(MRHandle& mrHandle);
+    std::uint16_t AllocateRequestCid();
+
+    Status PrepareTaskSubBatches(const TransportTask& task,
+                                 std::vector<TransportSubBatchContext>& subBatchContexts);
+    Status BuildEntrySubBatchRequest(AsuOpType opType,
+                                     const IoScheduler::ScheduledIoBatch& subBatch,
+                                     TransportSubBatchContext& subBatchContext);
+    Status SubmitKeySubBatchRequest(AsuOpType opType,
+                                    const IoScheduler::ScheduledKeyBatch& subBatch,
+                                    TransportSubBatchContext& subBatchContext);
+    Status SubmitKeepAliveRequest(TransportSubBatchContext& subBatchContext);
+
+    Status AssignSubBatchConnections(std::vector<TransportSubBatchContext>& subBatchContexts);
+    void BuildSubBatchSendBuffers(std::vector<TransportSubBatchContext>& subBatchContexts,
+                                  std::vector<TransProvider::SendIoBatch>& ioBatches);
+    void SendSubBatchBuffers(std::vector<TransportSubBatchContext>& subBatchContexts,
+                             const std::vector<TransProvider::SendIoBatch>& ioBatches);
+
+    void AbortSubBatchesBeforeSend(TransportTask& task,
+                                   std::vector<TransportSubBatchContext>& subBatchContexts);
+    void CompleteSubBatch(TransportTask& task, TransportSubBatchContext& subBatchContext,
+                          const Status& status);
+    void ReleaseSubBatchResources(TransportSubBatchContext& subBatchContext);
+    void ReleaseAllSubBatchResources(std::vector<TransportSubBatchContext>& subBatchContexts);
+
+    const TransportConfig& config_;
+    IoScheduler ioScheduler_;
+    const std::shared_ptr<TransProvider>& transProvider_;
+    BufferManager sendBufferManager_;
+    BufferManager flagBufferManager_;
+    MRHandle sendBufferMrHandle_{kInvalidMRHandle};
+    MRHandle flagBufferMrHandle_{kInvalidMRHandle};
+    ProtocolManager protocolManager_;
+    const std::unique_ptr<ConnectionManager>& connManager_;
+    std::atomic<std::uint16_t> nextRequestCid_{1};
+};
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/transport_task_manager.cpp
+++ b/ucm/transport/kv/asu/trans/src/transport_task_manager.cpp
@@ -1,0 +1,84 @@
+#include "transport_task_manager.h"
+#include <utility>
+#include "asu_response_status.h"
+
+namespace UC::ASU {
+
+TransportTask::TransportTask() : subBatchContexts(std::make_shared<TransportSubBatchList>()) {}
+
+bool TransportTask::Done() const
+{
+    return state.load(std::memory_order_acquire) == TransportTaskState::COMPLETED;
+}
+
+bool TransportTask::NotifyCompletion(TaskResult result)
+{
+    if (!onComplete || completionNotified.exchange(true, std::memory_order_acq_rel)) {
+        return false;
+    }
+    onComplete(std::move(result));
+    return true;
+}
+
+Status TransportTask::BuildFinalStatus() const
+{
+    for (const auto& subBatchContext : *subBatchContexts) {
+        if (!subBatchContext.status.ok()) {
+            return Status::Error(StatusCode::PARTIAL_FAILED, "transport task partially failed");
+        }
+    }
+
+    return Status::OK();
+}
+
+void TransportTask::InitializeRemainingSubBatchCount()
+{
+    remainingSubBatchCount = 0;
+    for (const auto& subBatchContext : *subBatchContexts) {
+        if (subBatchContext.state == TransportSubBatchState::PENDING) { ++remainingSubBatchCount; }
+    }
+}
+
+void TransportTask::TryFinalizeFromSubBatches()
+{
+    if (subBatchContexts->empty()) {
+        finalStatus = Status::Error(StatusCode::PARTIAL_FAILED, "transport task partially failed");
+        state.store(TransportTaskState::COMPLETED, std::memory_order_release);
+        return;
+    }
+
+    if (remainingSubBatchCount != 0) { return; }
+
+    finalStatus = BuildFinalStatus();
+    state.store(TransportTaskState::COMPLETED, std::memory_order_release);
+}
+
+void TransportTaskManager::NotifyCompletion(const TransportTaskPtr& task)
+{
+    TaskResult result;
+    BuildResult(*task, result);
+    (void)task->NotifyCompletion(std::move(result));
+    (void)Remove(task->taskId);
+}
+
+void TransportTaskManager::BuildResult(const TransportTask& task, TaskResult& result)
+{
+    result.status = task.finalStatus;
+    result.entryStatus = task.entryStatus;
+    if (!task.subBatchContexts->empty()) {
+        std::size_t resultIndex = 0;
+        for (const auto& subBatchContext : *task.subBatchContexts) {
+            for (const auto& status : subBatchContext.entryStatus) {
+                if (resultIndex >= result.entryStatus.size()) { break; }
+                result.entryStatus[resultIndex++] = status;
+            }
+        }
+    }
+
+    result.queryResult.reset();
+    if (task.opType == AsuOpType::QUERY) {
+        result.queryResult = BuildQueryResultFromEntryStatus(result.entryStatus);
+    }
+}
+
+}  // namespace UC::ASU

--- a/ucm/transport/kv/asu/trans/src/transport_task_manager.h
+++ b/ucm/transport/kv/asu/trans/src/transport_task_manager.h
@@ -1,0 +1,58 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Huawei Technologies Co., Ltd. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * */
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+#include "asu_transport/asu_transport.h"
+#include "buffer_manager.h"
+#include "connection_manager.h"
+#include "task_context.h"
+#include "task_manager_base.h"
+
+namespace UC::ASU {
+
+struct TransportSubBatchContext {
+    std::uint16_t cid{0};
+    AsuOpType opType{AsuOpType::QUERY};
+    TransportSubBatchState state{TransportSubBatchState::PENDING};
+    Status status{Status::OK()};
+    std::shared_ptr<ConnectionChannel> channel;
+    bool useSeekControl{false};
+    ScatterGatherEntry sendSge;
+    ScatterGatherEntry flagBuffer;
+    std::vector<Status> entryStatus;
+};
+
+class TransportTaskManager : public TaskManagerBase<TransportTask, TransportTaskState> {
+public:
+    TransportTaskManager() : TaskManagerBase(TransportTaskState::PENDING, "transport") {}
+
+    void NotifyCompletion(const TransportTaskPtr& task);
+    static void BuildResult(const TransportTask& task, TaskResult& result);
+};
+
+}  // namespace UC::ASU


### PR DESCRIPTION
## Purpose

This PR introduces the ASU client and transport modules under `ucm/transport/kv/asu`.

ASU provides an asynchronous KV transport layer between upper-level stores/connectors and different transport providers. It includes client-side routing and configuration, task lifecycle management, connection and buffer management, KV/SQE protocol handling, and transport provider abstraction.

This is the first PR of the `feature_26h1` staged merge. `kv-test`, `asu-store`, connectors, and other upper-level modules will be merged in subsequent PRs.

## Modifications

### ASU module and client APIs

Add the ASU module skeleton, public client/transport APIs, configuration parsing, view management, and client-side routing.

Corresponding PR

* [https://github.com/ModelEngine-Group/unified-cache-management/pull/962](https://github.com/ModelEngine-Group/unified-cache-management/pull/962)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/967](https://github.com/ModelEngine-Group/unified-cache-management/pull/967)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/971](https://github.com/ModelEngine-Group/unified-cache-management/pull/971)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1000](https://github.com/ModelEngine-Group/unified-cache-management/pull/1000)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1287](https://github.com/ModelEngine-Group/unified-cache-management/pull/1287)

### Client task management

Add asynchronous client task management, task completion handling, SPSC task queues, and single STORE/LOAD operations.

Corresponding PR

* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1167](https://github.com/ModelEngine-Group/unified-cache-management/pull/1167)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1182](https://github.com/ModelEngine-Group/unified-cache-management/pull/1182)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1191](https://github.com/ModelEngine-Group/unified-cache-management/pull/1191)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1194](https://github.com/ModelEngine-Group/unified-cache-management/pull/1194)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1229](https://github.com/ModelEngine-Group/unified-cache-management/pull/1229)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1235](https://github.com/ModelEngine-Group/unified-cache-management/pull/1235)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1240](https://github.com/ModelEngine-Group/unified-cache-management/pull/1240)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1306](https://github.com/ModelEngine-Group/unified-cache-management/pull/1306)

### KV transport protocols

Add ASU KV/SQE protocols, request packing, submit flow, I/O scheduling, transport task execution, and response status handling.

Corresponding PR

* [https://github.com/ModelEngine-Group/unified-cache-management/pull/977](https://github.com/ModelEngine-Group/unified-cache-management/pull/977)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/991](https://github.com/ModelEngine-Group/unified-cache-management/pull/991)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/997](https://github.com/ModelEngine-Group/unified-cache-management/pull/997)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/998](https://github.com/ModelEngine-Group/unified-cache-management/pull/998)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/999](https://github.com/ModelEngine-Group/unified-cache-management/pull/999)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1002](https://github.com/ModelEngine-Group/unified-cache-management/pull/1002)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1010](https://github.com/ModelEngine-Group/unified-cache-management/pull/1010)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1023](https://github.com/ModelEngine-Group/unified-cache-management/pull/1023)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1034](https://github.com/ModelEngine-Group/unified-cache-management/pull/1034)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1048](https://github.com/ModelEngine-Group/unified-cache-management/pull/1048)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1056](https://github.com/ModelEngine-Group/unified-cache-management/pull/1056)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1173](https://github.com/ModelEngine-Group/unified-cache-management/pull/1173)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1202](https://github.com/ModelEngine-Group/unified-cache-management/pull/1202)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1291](https://github.com/ModelEngine-Group/unified-cache-management/pull/1291)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1312](https://github.com/ModelEngine-Group/unified-cache-management/pull/1312)

### Connection and memory management

Add connection lifecycle management, endpoint recovery, buffer registration, shared transport providers, buffer-pool support, and memory-key propagation.

Corresponding PR

* [https://github.com/ModelEngine-Group/unified-cache-management/pull/978](https://github.com/ModelEngine-Group/unified-cache-management/pull/978)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/988](https://github.com/ModelEngine-Group/unified-cache-management/pull/988)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1014](https://github.com/ModelEngine-Group/unified-cache-management/pull/1014)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1024](https://github.com/ModelEngine-Group/unified-cache-management/pull/1024)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1051](https://github.com/ModelEngine-Group/unified-cache-management/pull/1051)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1101](https://github.com/ModelEngine-Group/unified-cache-management/pull/1101)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1171](https://github.com/ModelEngine-Group/unified-cache-management/pull/1171)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1200](https://github.com/ModelEngine-Group/unified-cache-management/pull/1200)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1222](https://github.com/ModelEngine-Group/unified-cache-management/pull/1222)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1244](https://github.com/ModelEngine-Group/unified-cache-management/pull/1244)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1271](https://github.com/ModelEngine-Group/unified-cache-management/pull/1271)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1294](https://github.com/ModelEngine-Group/unified-cache-management/pull/1294)

### Transport providers

Add provider selection and integration for AICPU, externally supplied AIV libraries, and FakeBackend. Optimize concurrent FakeBackend task processing.

Corresponding PR

* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1008](https://github.com/ModelEngine-Group/unified-cache-management/pull/1008)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1028](https://github.com/ModelEngine-Group/unified-cache-management/pull/1028)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1200](https://github.com/ModelEngine-Group/unified-cache-management/pull/1200)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1222](https://github.com/ModelEngine-Group/unified-cache-management/pull/1222)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1317](https://github.com/ModelEngine-Group/unified-cache-management/pull/1317)

### ASU-side integration APIs

Incorporate ASU-side API changes required by later `kv-test`, `asu-store`, and connector integration, without including those upper-level modules in this PR.

Corresponding PR

* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1018](https://github.com/ModelEngine-Group/unified-cache-management/pull/1018)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1031](https://github.com/ModelEngine-Group/unified-cache-management/pull/1031)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1050](https://github.com/ModelEngine-Group/unified-cache-management/pull/1050)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1127](https://github.com/ModelEngine-Group/unified-cache-management/pull/1127)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1147](https://github.com/ModelEngine-Group/unified-cache-management/pull/1147)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1175](https://github.com/ModelEngine-Group/unified-cache-management/pull/1175)

### Unit tests and build integration

Add ASU client and transport unit tests, reorganize the test suites, reduce test runtime, and enable ASU tests in CI.

Add the `BUILD_UCM_ASU` CMake option and wire the ASU module into the transport build.

Corresponding PR

* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1202](https://github.com/ModelEngine-Group/unified-cache-management/pull/1202)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1291](https://github.com/ModelEngine-Group/unified-cache-management/pull/1291)
* [https://github.com/ModelEngine-Group/unified-cache-management/pull/1318](https://github.com/ModelEngine-Group/unified-cache-management/pull/1318)

## Test

Only ASU unit tests are required for this staged PR.
All unit tests passed.