### PR TITLE
[Fix][CI] Harden release publication policy and Builder promotion

### DIFF
--- a/.github/release/README.md
+++ b/.github/release/README.md
@@ -87,13 +87,13 @@ never consume a mutable Builder Tag.
 
 The workflow accepts:
 
-| Git Tag | Wheel version | Chart version | GitHub Release |
-| --- | --- | --- | --- |
-| `vX.Y.Z` | `X.Y.Z` | `X.Y.Z` | public Release |
-| `vX.Y.ZrcN` | `X.Y.ZrcN` | `X.Y.Z-rc.N` | public prerelease |
-| `draft/vX.Y.Z` | `X.Y.Z.dev0` | `X.Y.Z-draft.0` | Draft |
-| `draft/vX.Y.Z-N` | `X.Y.Z.devN` | `X.Y.Z-draft.N` | Draft |
-| `nightly/vX.Y.Z-YYYYMMDD-N` | `X.Y.Z.devYYYYMMDDNNN` | `X.Y.Z-nightly.YYYYMMDD.N` | public prerelease after success |
+| Git Tag | Selected Profile | Wheel version | Chart version | GitHub Release mode when enabled |
+| --- | --- | --- | --- | --- |
+| `vX.Y.Z` | Stable | `X.Y.Z` | `X.Y.Z` | public Release |
+| `vX.Y.ZrcN` | Prerelease | `X.Y.ZrcN` | `X.Y.Z-rc.N` | public prerelease |
+| `draft/vX.Y.Z` | Draft | `X.Y.Z.dev0` | `X.Y.Z-draft.0` | Draft |
+| `draft/vX.Y.Z-N` | Draft | `X.Y.Z.devN` | `X.Y.Z-draft.N` | Draft |
+| `nightly/vX.Y.Z-YYYYMMDD-N` | Nightly | `X.Y.Z.devYYYYMMDDNNN` | `X.Y.Z-nightly.YYYYMMDD.N` | public prerelease after success |
 
 The tagged source owns the package model, and public versions must be canonical
 and non-local. Before opening or reusing a Release, the reusable core requires
@@ -111,13 +111,18 @@ recursively trigger another workflow, the same scheduled Run calls the common
 `release-ucm.yml` reusable core directly. Manual `nightly/*` Tag pushes use the
 same core through `release-tag.yml`.
 
-Official and fork `v*` Tags invoke that same Release Core. The two mutually
-exclusive callers isolate production secrets: the official caller inherits
-production credentials, while the fork uses only its `fork-preview` environment.
-A fork still publishes its own GitHub Release, GHCR images, and Chart OCI
-artifacts.
+Supported Release Tags in both the official repository and Forks invoke that
+same Release Core. The two mutually exclusive callers isolate production
+secrets: the official caller inherits production credentials, while Fork
+publication jobs bind to the `fork-preview` Environment. The Fork Tag caller
+explicitly forwards its TestPyPI and Docker Hub Secrets; it never forwards
+`PYPI_API_TOKEN`.
 
-Publication then updates the same Release in stages:
+A fork publishes any Profile-enabled GitHub Release, GHCR, and Chart OCI outputs
+under its own identity.
+
+When `github_release` is enabled, publication updates the same Release in
+stages:
 
 1. version, Tag, Profile, and Fork target preflight passes, then every configured
    Runtime selector resolves to published Registry Tags;
@@ -137,14 +142,18 @@ succeed, a compact public `release-manifest.json` schema 6 is uploaded and read
 back. It records only the Tag/type/Actions Run, Chart OCI reference, Runtime
 member/index references, and GitHub Release asset names needed for cleanup.
 
-If image publication is disabled, Tag Releases stop after Wheels, the example
-config, and Chart publication. If requested image publication fails, those
+If image publication is disabled while other channels remain enabled, the image
+stages are skipped and publication continues only through those enabled
+channels. If every channel is disabled, validation completes without an
+external write. If requested image publication fails, already published
 artifacts remain usable and the public Release is marked `images-failed`. OCI
 archives are not uploaded to GitHub Release. PyPI and Docker Hub follow the
-selected Release Profile. Official releases use only production targets. Forks
-use TestPyPI when `TEST_PYPI_API_TOKEN` exists, and a custom Docker Hub namespace
-when both Docker Hub credentials exist; absent Fork credentials remain
-`scope-skipped`, while a Profile-disabled channel stays disabled.
+selected Release Profile in `release.yaml`, which is the sole authority for
+channel switches. Official releases use production targets. Forks use TestPyPI
+when `TEST_PYPI_API_TOKEN` exists. Docker Hub publication in either scope
+requires `DOCKERHUB_NAMESPACE` plus both Docker Hub credentials. Missing
+requested Docker Hub configuration fails preflight, while a Profile-disabled
+channel stays disabled.
 Missing backend Wheels are uploaded and read back first, the meta Wheel is
 uploaded last, and exact extras metadata plus all filenames, versions, and
 SHA256 digests are persisted in the internal `pypi-receipt.json` Actions
@@ -162,46 +171,149 @@ credentials are present. For example, `SuperMarioYL` builds
 `supermarioyl-uc-manager` and `supermarioyl-uc-manager-cuda-cu130`. The Python
 import remains `ucm`.
 
+## Official release setup
+
+This section applies only to
+`ModelEngine-Group/unified-cache-management`. The Tag workflow identifies that
+repository as `publication_scope=official`.
+
+Publication has two separate inputs:
+
+1. the selected Profile in `release.yaml` requests the channel with
+   `publish.<channel>: true`;
+2. the repository contains the Secret or Variable required by that channel.
+
+A Secret never turns on a Profile-disabled channel. Conversely, an enabled
+official channel does not silently fall back to another target when its
+configuration is missing.
+
+### 1. Configure the official repository
+
+Open **Settings -> Secrets and variables -> Actions** in the official repository.
+Add tokens and credentials under **Repository secrets**, and add the Docker Hub
+target under **Repository variables**:
+
+| Name | GitHub kind | Required when | Value |
+| --- | --- | --- | --- |
+| `PYPI_API_TOKEN` | Repository Secret | Profile has `pypi: true` | Complete production PyPI API token authorized for every planned `uc-manager*` project. |
+| `DOCKERHUB_USERNAME` | Repository Secret | Profile has `dockerhub: true` | Docker ID authorized for the configured namespace. |
+| `DOCKERHUB_TOKEN` | Repository Secret | Profile has `dockerhub: true` | Docker Hub access token with Read & Write permission; add Delete permission when cleanup must remove tags. |
+| `DOCKERHUB_NAMESPACE` | Repository Variable | Profile has `dockerhub: true` | Full namespace such as `docker.io/official-org`, without a repository name or trailing slash. |
+
+The workflow reads the three credentials through `secrets.*` and reads only
+`DOCKERHUB_NAMESPACE` through `vars.*`. Do not store tokens in Variables. Even
+though the Docker Hub username is not sensitive, it must remain a Secret because
+the workflow does not read `vars.DOCKERHUB_USERNAME`.
+
+Under **Settings -> Actions -> General**, allow **Read and write permissions**
+when repository or organization policy otherwise restricts `GITHUB_TOKEN`.
+
+The equivalent GitHub CLI commands are:
+
+```bash
+repo=ModelEngine-Group/unified-cache-management
+gh secret set PYPI_API_TOKEN --repo "${repo}"
+gh secret set DOCKERHUB_USERNAME --repo "${repo}"
+gh secret set DOCKERHUB_TOKEN --repo "${repo}"
+gh variable set DOCKERHUB_NAMESPACE --repo "${repo}" \
+  --body docker.io/official-org
+```
+
+Each command prompts for the value without writing it to the repository. Omit
+the PyPI command while `pypi` is disabled, and omit both Docker Hub commands
+plus the namespace command while `dockerhub` is disabled.
+
+Release jobs still reference the Environment name `release-production`. You do
+not need to create or populate it for repository-level configuration: GitHub
+[creates an unconfigured referenced Environment automatically](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments).
+Create it manually only when deployment reviewers, wait timers, or
+Environment-level isolation are required; do not duplicate the same credential
+at both repository and Environment levels.
+
+### 2. Confirm the official targets
+
+Official PyPI always uses `https://upload.pypi.org/legacy/` and publishes the
+canonical `uc-manager*` distribution names. Never put a TestPyPI token in
+`PYPI_API_TOKEN`.
+
+Docker Hub always uses the exact `DOCKERHUB_NAMESPACE` value. It is not derived
+from the GitHub owner or `DOCKERHUB_USERNAME`, and `release.yaml` contains no
+fallback namespace. Image repository basenames and tags still come from the
+frozen Release Plan.
+
+### 3. Check the effective decision
+
+Before pushing a formal Tag, inspect the selected Profile in `release.yaml`.
+The Plan summary and frozen `release-plan.json` must show the same `requested`
+value.
+
+Official PyPI resolves as follows:
+
+| Profile `pypi` | `PYPI_API_TOKEN` | Result |
+| --- | --- | --- |
+| `false` | absent or present | channel is disabled and the Secret is unused |
+| `true` | present and authorized | publication and public readback run |
+| `true` | absent | the enabled publication job fails |
+
+Official Docker Hub resolves as follows:
+
+| Profile `dockerhub` | Namespace + Secret pair | Result |
+| --- | --- | --- |
+| `false` | absent, partial, or complete | channel is disabled and the values are unused |
+| `true` | all three configured and authorized | preflight passes; member and index publication run |
+| `true` | namespace, username, or token missing | preflight fails before Registry discovery |
+
+An invalid or unauthorized supplied credential can still fail authentication or
+readback; `present` does not mean it has been accepted by the external service.
+
 ## Fork preview setup
 
-Fork publication is opt-in by credential presence. It never reads the official
-PyPI credential and it does not change the publication targets of the canonical
-`ModelEngine-Group/unified-cache-management` repository.
+This section applies to every repository other than the canonical official
+repository. Fork PyPI and Docker Hub publication requires both a request from
+the selected Release Profile and the corresponding Fork credential. It never
+reads the official PyPI credential and it does not change the publication
+targets of `ModelEngine-Group/unified-cache-management`.
 
-### 1. Create the GitHub Environment
+### 1. Configure the Fork repository
 
-In the fork repository, open **Settings -> Environments** and create an
-environment named exactly `fork-preview`. Store the Fork channel Secrets in
-that environment when possible. A repository-level Actions Secret is also
-supported for `TEST_PYPI_API_TOKEN`: the Tag caller forwards only that named
-credential and never forwards `PYPI_API_TOKEN` to the Fork Release call. Keep
-the Docker Hub credential pair in `fork-preview`.
+Open **Settings -> Secrets and variables -> Actions** in the Fork. Add the
+credentials as **Repository secrets** and the Docker Hub target as a
+**Repository variable**:
+
+| Name | GitHub kind | Required when | Value |
+| --- | --- | --- | --- |
+| `TEST_PYPI_API_TOKEN` | Repository Secret | Profile has `pypi: true` and TestPyPI publication is wanted | Account-scoped TestPyPI API token authorized for every Fork-owned `<owner>-uc-manager*` project. |
+| `DOCKERHUB_USERNAME` | Repository Secret | Profile has `dockerhub: true` | Docker ID authorized for the configured namespace. |
+| `DOCKERHUB_TOKEN` | Repository Secret | Profile has `dockerhub: true` | Docker Hub access token with Read & Write permission; add Delete permission when cleanup must remove tags. |
+| `DOCKERHUB_NAMESPACE` | Repository Variable | Profile has `dockerhub: true` | Full namespace such as `docker.io/my-org`, without a repository name or trailing slash. |
+
+The Fork caller explicitly forwards all three Secrets to the reusable Release
+Core. The equivalent GitHub CLI commands are:
+
+```bash
+fork=OWNER/unified-cache-management
+gh secret set TEST_PYPI_API_TOKEN --repo "${fork}"
+gh secret set DOCKERHUB_USERNAME --repo "${fork}"
+gh secret set DOCKERHUB_TOKEN --repo "${fork}"
+gh variable set DOCKERHUB_NAMESPACE --repo "${fork}" \
+  --body docker.io/my-org
+```
+
+Each `gh secret set` command prompts for its value. Omit the TestPyPI command
+when that publication is not wanted, and omit all three Docker Hub settings
+while `dockerhub` is disabled.
+
+Fork jobs still reference the Environment name `fork-preview`, but
+repository-level configuration does not require you to create or populate it.
+GitHub creates an unconfigured referenced Environment automatically. Create it
+manually only when approval or Environment-level isolation is required, and do
+not duplicate the same credential at both levels.
 
 Also open **Settings -> Actions -> General** and make sure Actions is enabled. If
 repository or organization policy restricts `GITHUB_TOKEN` writes, allow
 **Read and write permissions**. The workflow itself requests scoped `contents`
 and `packages` writes for the Fork's Release, GHCR, and Chart OCI.
 See [GitHub's Actions settings guide](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository).
-
-| Name | GitHub kind | Required | Value |
-| --- | --- | --- | --- |
-| `TEST_PYPI_API_TOKEN` | Secret (environment recommended; repository supported) | TestPyPI only | An account-scoped TestPyPI API token that can create or update the Fork-owned `<owner>-uc-manager*` projects. TestPyPI accounts and tokens are separate from production PyPI; follow the [TestPyPI guide](https://packaging.python.org/en/latest/guides/using-testpypi/). |
-| `DOCKERHUB_USERNAME` | Environment Secret | Docker Hub only | The Docker ID whose token can write to the selected personal or organization namespace. |
-| `DOCKERHUB_TOKEN` | Environment Secret | Docker Hub only | A Docker Hub personal access token with Read & Write permission; also grant Delete when retention or `cleanup-ucm-release.yml` must remove Docker Hub tags. Do not use the account password; follow the [Docker access-token guide](https://docs.docker.com/security/access-tokens/). |
-| `FORK_DOCKERHUB_NAMESPACE` | Variable | Optional | Full namespace such as `docker.io/my-org`, without a trailing slash. If omitted, the pipeline uses `docker.io/<DOCKERHUB_USERNAME>`. |
-
-The equivalent GitHub CLI commands are below. Each `gh secret set` command
-prompts for the value without writing it to the repository; omit the channels
-you do not want to enable:
-
-```bash
-fork=OWNER/unified-cache-management
-gh secret set TEST_PYPI_API_TOKEN --env fork-preview --repo "${fork}"
-gh secret set DOCKERHUB_USERNAME --env fork-preview --repo "${fork}"
-gh secret set DOCKERHUB_TOKEN --env fork-preview --repo "${fork}"
-gh variable set FORK_DOCKERHUB_NAMESPACE --env fork-preview \
-  --repo "${fork}" --body docker.io/my-org
-```
 
 The TestPyPI endpoints are fixed by policy: upload uses
 `https://test.pypi.org/legacy/`, package installation uses
@@ -210,38 +322,41 @@ The TestPyPI endpoints are fixed by policy: upload uses
 required; the prefix is derived from `github.repository_owner` through the
 frozen repository identity.
 
-Keep the production `PYPI_API_TOKEN` only in the official
-`release-production` environment. Do not copy it into `fork-preview`.
-
-Docker Hub credentials are a pair. Configuring only the username or only the
-token, or setting `FORK_DOCKERHUB_NAMESPACE` without both credentials, fails the
-Release preflight before Registry discovery or GitHub Release creation. The
-configured user or token must have write access when the namespace names an
-organization.
+Keep the production `PYPI_API_TOKEN` only in the official repository. Do not
+copy it into the Fork or `fork-preview`.
 
 ### 2. Understand what becomes enabled
 
-Credentials only make a Fork target available; the selected Release Profile
-must also request that channel:
+Credentials only make a Fork target available; they do not override the
+selected Release Profile. PyPI resolves as follows:
 
-| `fork-preview` configuration | Stable / Prerelease / Draft | Nightly |
+| Profile `pypi` | `TEST_PYPI_API_TOKEN` | Effective decision |
 | --- | --- | --- |
-| No external credentials | TestPyPI and Docker Hub are `scope-skipped` | Both remain disabled |
-| `TEST_PYPI_API_TOKEN` only | Publish and read back TestPyPI | Disabled by Profile |
-| Docker Hub username + token | Publish and read back Docker Hub | Disabled by Profile |
-| All three Secrets | Publish and read back both targets | Both remain disabled |
+| `false` | absent or present | `requested=false`, `enabled=false`, `disabled` |
+| `true` | absent | `requested=true`, `enabled=false`, `scope-skipped` |
+| `true` | present | `requested=true`, `enabled=true`, `publish` |
 
-GHCR, Chart OCI, and the Fork's own GitHub Release continue to use the Fork's
-GitHub identity in every combination. `FORK_DOCKERHUB_NAMESPACE` changes only
-the Docker Hub destination; image repository basenames and tags still come from
-the frozen Release Plan.
+Docker Hub uses the same explicit three-value contract as official publication:
 
-### 3. Run one Fork Draft validation
+| Profile `dockerhub` | Fork Docker Hub configuration | Result |
+| --- | --- | --- |
+| `false` | absent, partial, or complete | `requested=false`, `enabled=false`, `disabled`; values are unused |
+| `true` | namespace, username, and token all configured | preflight passes and Docker Hub publication runs |
+| `true` | any of the three values missing | preflight fails before Registry discovery |
+
+`DOCKERHUB_NAMESPACE` must match `docker.io/<account-or-org>`. It has no
+`{owner}` or username-derived fallback. Credentials by themselves never change
+a `false` Profile switch to `true`; read the current switch values from
+`release.yaml` rather than inferring them from this setup section.
+
+When requested, GHCR, Chart OCI, and the Fork's own GitHub Release use the
+Fork's GitHub identity and do not depend on the external credentials above.
+
+### 3. Validate Profile decisions with a Fork Draft
 
 First update and commit `version.ini`, including `UCM_VERSION` and both
-supported Runtime selector lists. Use a fresh Draft sequence because Python
-index filenames are immutable and the cleanup workflow does not delete
-TestPyPI releases:
+supported Runtime selector lists. Use a fresh Draft sequence because published
+Tag, Release, and OCI coordinates are immutable:
 
 ```bash
 base="$(PYTHONPATH=.github/release python -c \
@@ -251,33 +366,36 @@ git tag -a "${tag}" -m "Fork publication validation ${tag}"
 git push origin "${tag}"
 ```
 
-In the `Plan Wheels, Images, and Chart` summary, confirm the requested channels
-show the expected effective decisions:
+This run validates only the channels requested by the selected Draft Profile.
+In the currently committed `release.yaml`, Draft disables both PyPI and Docker
+Hub, so this example proves that neither channel writes externally; it does not
+prove that TestPyPI or Docker Hub credentials are valid. Credential validation
+requires a fresh Fork Tag whose selected Profile explicitly requests the target
+channel.
 
-```text
-PyPI: requested=true enabled=true disposition=publish scope=fork
-Docker Hub: requested=true enabled=true disposition=publish scope=fork
-```
+In the `Plan Wheels, Images, and Chart` summary, compare each channel with the
+selected Release Profile in `release.yaml`. Every `requested` value must match
+that Profile exactly. For PyPI and Docker Hub, `enabled` and `disposition` then
+follow the credential table above; the frozen `release-plan.json` records the
+same decisions, the TestPyPI target, and any configured Docker Hub namespace.
 
-If only one credential set was configured, the other channel should remain
-`scope-skipped`. The frozen `release-plan.json` must also record
-`.publish.pypi.target == "testpypi"` and the configured Docker Hub namespace.
 After completion, verify all of the following:
 
-- each owner-prefixed backend project and the final empty owner-prefixed meta
-  package are visible on TestPyPI, and the fresh-environment extra installation
-  job passed;
-- Docker Hub member tags and multi-architecture indexes exist under the planned
-  namespace and match the digests recorded in `release-manifest.json`;
-- the Fork GitHub Release still contains backend Wheels, the Chart, config,
-  and manifest, but not the empty meta Wheel or internal receipt;
+- every channel with `enabled=true` was published and read back at its planned
+  target;
+- every channel with `enabled=false` performed no external write;
+- GHCR member tags and multi-architecture indexes, when enabled, match the
+  references recorded in `release-manifest.json`;
+- the Fork GitHub Release, when enabled, contains backend Wheels, the Chart,
+  config, and manifest, but not the empty meta Wheel or internal receipt;
 - no project or image was written to production PyPI or the official Docker Hub
   namespace.
 
 ### Common setup failures
 
-- Preflight reports an incomplete Docker Hub credential pair: add or remove both
-  `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` together.
+- Preflight reports incomplete Docker Hub configuration while the channel is
+  requested: configure `DOCKERHUB_NAMESPACE`, `DOCKERHUB_USERNAME`, and
+  `DOCKERHUB_TOKEN` together.
 - Preflight rejects the Docker Hub namespace: use exactly
   `docker.io/<account-or-org>` with no repository name or trailing slash.
 - TestPyPI returns an authorization error: use the complete account-scoped
@@ -285,8 +403,7 @@ After completion, verify all of the following:
   planned `<owner>-uc-manager*` project. Production PyPI ownership does not
   grant TestPyPI ownership.
 - TestPyPI reports an existing filename with different bytes: do not reuse or
-  move the Tag; create a new Draft sequence so the derived `.devN` version is
-  new.
+  move the Tag; publish a new version.
 - GitHub Release, GHCR, or Chart writes return `403`: recheck the Fork's Actions
   policy and `GITHUB_TOKEN` Read and write setting before changing external
   credentials.

--- a/.github/release/README.md
+++ b/.github/release/README.md
@@ -321,7 +321,9 @@ The TestPyPI endpoints are fixed by policy: upload uses
 `https://test.pypi.org/simple/`, and normal Python dependencies still come from
 `https://pypi.org/simple/`. No endpoint or distribution-prefix Variable is
 required; the prefix is derived from `github.repository_owner` through the
-frozen repository identity.
+frozen repository identity. TestPyPI file readback waits for up to approximately
+three minutes because upload acceptance can precede JSON/Simple Index visibility;
+production PyPI keeps the shorter one-minute window.
 
 Keep the production `PYPI_API_TOKEN` only in the official repository. Do not
 copy it into the Fork or `fork-preview`.

--- a/.github/release/README.md
+++ b/.github/release/README.md
@@ -112,11 +112,11 @@ recursively trigger another workflow, the same scheduled Run calls the common
 same core through `release-tag.yml`.
 
 Supported Release Tags in both the official repository and Forks invoke that
-same Release Core. The two mutually exclusive callers isolate production
-secrets: the official caller inherits production credentials, while Fork
-publication jobs bind to the `fork-preview` Environment. The Fork Tag caller
-explicitly forwards its TestPyPI and Docker Hub Secrets; it never forwards
-`PYPI_API_TOKEN`.
+same Release Core through one caller. The caller passes the repository-derived
+publication scope and conditionally forwards the matching Python index Secret:
+`PYPI_API_TOKEN` only for the official repository and `TEST_PYPI_API_TOKEN`
+only for Forks. Docker Hub credentials remain explicit for either scope, while
+publication jobs bind to the corresponding Environment.
 
 A fork publishes any Profile-enabled GitHub Release, GHCR, and Chart OCI outputs
 under its own identity.
@@ -287,8 +287,9 @@ credentials as **Repository secrets** and the Docker Hub target as a
 | `DOCKERHUB_TOKEN` | Repository Secret | Profile has `dockerhub: true` | Docker Hub access token with Read & Write permission; add Delete permission when cleanup must remove tags. |
 | `DOCKERHUB_NAMESPACE` | Repository Variable | Profile has `dockerhub: true` | Full namespace such as `docker.io/my-org`, without a repository name or trailing slash. |
 
-The Fork caller explicitly forwards all three Secrets to the reusable Release
-Core. The equivalent GitHub CLI commands are:
+For Fork scope, the shared Tag caller forwards the TestPyPI Secret and both
+Docker Hub Secrets to the reusable Release Core. It does not forward
+`PYPI_API_TOKEN`. The equivalent GitHub CLI commands are:
 
 ```bash
 fork=OWNER/unified-cache-management

--- a/.github/release/README.md
+++ b/.github/release/README.md
@@ -323,7 +323,7 @@ The TestPyPI endpoints are fixed by policy: upload uses
 required; the prefix is derived from `github.repository_owner` through the
 frozen repository identity. TestPyPI file readback waits for up to approximately
 three minutes because upload acceptance can precede JSON/Simple Index visibility;
-production PyPI keeps the shorter one-minute window.
+production PyPI uses the same bounded readback window.
 
 Keep the production `PYPI_API_TOKEN` only in the official repository. Do not
 copy it into the Fork or `fork-preview`.

--- a/.github/release/release.yaml
+++ b/.github/release/release.yaml
@@ -15,15 +15,16 @@ products:
     target_repository: ghcr.io/{owner}/vllm-ascend
 
 publish:
-  # PyPI 固定上传地址，是否发布由 Release Profile 决定。
+  # 正式仓库的 PyPI 上传地址；Fork 会固定改用 TestPyPI。
+  # 是否发布仍由 Release Profile 决定。
   pypi:
     index: https://upload.pypi.org/legacy/
   # GHCR 固定命名空间，是否发布由 Release Profile 决定。
   ghcr:
     namespace: ghcr.io/{owner}
-  # DockerHub 固定命名空间，是否发布由 Release Profile 决定。
-  dockerhub:
-    namespace: docker.io/{owner}
+  # 正式仓库和 Fork 都通过 DOCKERHUB_NAMESPACE 配置发布命名空间。
+  # 此处只声明渠道；是否发布仍由 Release Profile 决定。
+  dockerhub: {}
   # Chart OCI 固定命名空间，是否发布由 Release Profile 决定。
   chart_oci:
     namespace: ghcr.io/{owner}/charts
@@ -56,9 +57,9 @@ release_profiles:
     # 最多保留 7 个新版 Draft。
     max_count: 7
     publish:
-      pypi: true
+      pypi: false
       ghcr: true
-      dockerhub: true
+      dockerhub: false
       chart_oci: true
       github_release: true
 

--- a/.github/release/retry-registry-command.sh
+++ b/.github/release/retry-registry-command.sh
@@ -3,12 +3,17 @@
 set -euo pipefail
 
 if [ "$#" -lt 2 ]; then
-  echo "usage: retry-registry-command.sh LOG_PATH [--rate-limit-marker PATH [--rate-limit-scope TEXT]] COMMAND [ARG ...]" >&2
+  echo "usage: retry-registry-command.sh LOG_PATH [--retry-transport] [--rate-limit-marker PATH [--rate-limit-scope TEXT]] COMMAND [ARG ...]" >&2
   exit 2
 fi
 
 log_path="$1"
 shift
+retry_transport=false
+if [ "${1:-}" = "--retry-transport" ]; then
+  retry_transport=true
+  shift
+fi
 rate_limit_marker=""
 rate_limit_scope=""
 if [ "${1:-}" = "--rate-limit-marker" ]; then
@@ -46,6 +51,7 @@ max_attempts=$(( ${#retry_delays[@]} + 1 ))
 mkdir -p "$(dirname "${log_path}")"
 rate_limit_pattern='TOOMANYREQUESTS|too many requests|retry-after|HTTP 429|(^|[^[:alnum:]])429([^[:alnum:]]|$)'
 scoped_rate_limit_pattern='TOOMANYREQUESTS|too many requests|retry-after|HTTP 429|status[^0-9]*429|429 Too Many Requests'
+transport_pattern='connection reset( by peer)?|(^|[^[:alnum:]_])EOF([^[:alnum:]_]|$)'
 
 for ((attempt = 1; attempt <= max_attempts; attempt++)); do
   if "$@" 2>&1 | tee "${log_path}"; then
@@ -61,12 +67,19 @@ for ((attempt = 1; attempt <= max_attempts; attempt++)); do
     exit "${tee_status}"
   fi
 
-  if ! grep -Eiq "${rate_limit_pattern}" "${log_path}"; then
+  retry_reason=""
+  if grep -Eiq "${rate_limit_pattern}" "${log_path}"; then
+    retry_reason="rate-limit"
+  elif [ "${retry_transport}" = true ] && \
+       grep -Eiq "${transport_pattern}" "${log_path}"; then
+    retry_reason="transport"
+  else
     echo "Registry command failed with a non-retryable error" >&2
     exit "${command_status}"
   fi
   if [ "${attempt}" -eq "${max_attempts}" ]; then
-    if [ -n "${rate_limit_marker}" ]; then
+    if [ "${retry_reason}" = "rate-limit" ] && \
+       [ -n "${rate_limit_marker}" ]; then
       marker_allowed=true
       if [ -n "${rate_limit_scope}" ] && \
          ! grep -Fi -- "${rate_limit_scope}" "${log_path}" \
@@ -85,6 +98,10 @@ for ((attempt = 1; attempt <= max_attempts; attempt++)); do
   fi
 
   sleep_seconds="${retry_delays[$((attempt - 1))]}"
-  echo "Registry command was rate-limited; retrying in ${sleep_seconds}s" >&2
+  if [ "${retry_reason}" = "rate-limit" ]; then
+    echo "Registry command was rate-limited; retrying in ${sleep_seconds}s" >&2
+  else
+    echo "Registry command hit a transient transport error; retrying in ${sleep_seconds}s" >&2
+  fi
   sleep "${sleep_seconds}"
 done

--- a/.github/release/schemas/config.schema.json
+++ b/.github/release/schemas/config.schema.json
@@ -278,6 +278,17 @@
         "namespace": {"type": "string", "minLength": 1}
       }
     },
+    "publishDockerhub": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requested", "enabled", "disposition"],
+      "properties": {
+        "requested": {"type": "boolean"},
+        "enabled": {"type": "boolean"},
+        "disposition": {"enum": ["publish", "scope-skipped", "disabled"]},
+        "namespace": {"type": "string", "minLength": 1}
+      }
+    },
     "publishGithubRelease": {
       "type": "object",
       "additionalProperties": false,
@@ -295,7 +306,7 @@
       "properties": {
         "pypi": {"$ref": "#/$defs/publishPypi"},
         "ghcr": {"$ref": "#/$defs/publishOci"},
-        "dockerhub": {"$ref": "#/$defs/publishOci"},
+        "dockerhub": {"$ref": "#/$defs/publishDockerhub"},
         "chart_oci": {"$ref": "#/$defs/publishOci"},
         "github_release": {"$ref": "#/$defs/publishGithubRelease"}
       }
@@ -328,6 +339,10 @@
         "namespace": {"type": "string", "minLength": 1}
       }
     },
+    "releasePolicyDockerhub": {
+      "type": "object",
+      "additionalProperties": false
+    },
     "releasePolicyGithubRelease": {
       "type": "object",
       "additionalProperties": false
@@ -339,7 +354,7 @@
       "properties": {
         "pypi": {"$ref": "#/$defs/releasePolicyPypi"},
         "ghcr": {"$ref": "#/$defs/releasePolicyOci"},
-        "dockerhub": {"$ref": "#/$defs/releasePolicyOci"},
+        "dockerhub": {"$ref": "#/$defs/releasePolicyDockerhub"},
         "chart_oci": {"$ref": "#/$defs/releasePolicyOci"},
         "github_release": {"$ref": "#/$defs/releasePolicyGithubRelease"}
       }

--- a/.github/release/tests/test_compact_release.py
+++ b/.github/release/tests/test_compact_release.py
@@ -31,6 +31,7 @@ def _fixture_policy(
         repository=repository,
         version_override="0.7.60rc1",
         release_type=release_type,
+        dockerhub_namespace="docker.io/release-test",
     )
     selectors = {
         "vllm": [{"raw": "0.22.1", "keyword": "0.22.1", "tag": None}],
@@ -438,7 +439,10 @@ def test_plan_rejects_repository_scope_or_runtime_prefix_drift() -> None:
         )
 
     wrong_disposition = copy.deepcopy(formal)
-    wrong_disposition["publish"]["dockerhub"]["disposition"] = "publish"
+    wrong_disposition["publish"]["dockerhub"].update(
+        enabled=False,
+        disposition="publish",
+    )
     with pytest.raises(ValueError, match="publication decision does not match"):
         compact.resolve_plan(
             wrong_disposition,
@@ -446,6 +450,49 @@ def test_plan_rejects_repository_scope_or_runtime_prefix_drift() -> None:
             builder_catalog=catalog,
             route="release",
         )
+
+
+@pytest.mark.parametrize(
+    "repository",
+    (policy.OFFICIAL_REPOSITORY, "release-org/unified-cache-management"),
+)
+def test_release_plan_requires_requested_dockerhub_namespace(
+    repository: str,
+) -> None:
+    formal, selection, catalog = _inputs(repository=repository)
+    formal["release_profile"]["publish"]["dockerhub"] = True
+    formal["publish"]["dockerhub"] = {
+        "requested": True,
+        "enabled": False,
+        "disposition": "scope-skipped",
+    }
+
+    with pytest.raises(ValueError, match="publication decision does not match"):
+        compact.resolve_plan(
+            formal,
+            runtime_selection=selection,
+            builder_catalog=catalog,
+            route="release",
+        )
+
+
+def test_pr_plan_does_not_require_release_dockerhub_configuration() -> None:
+    formal, selection, catalog = _inputs()
+    formal["release_profile"]["publish"]["dockerhub"] = True
+    formal["publish"]["dockerhub"] = {
+        "requested": True,
+        "enabled": False,
+        "disposition": "scope-skipped",
+    }
+
+    plan = compact.resolve_plan(
+        formal,
+        runtime_selection=selection,
+        builder_catalog=catalog,
+        route="pr",
+    )
+
+    assert plan["publish"]["dockerhub"] == formal["publish"]["dockerhub"]
 
 
 def test_draft_coordinates_are_owned_by_the_plan_contract() -> None:
@@ -508,20 +555,28 @@ def test_fork_owner_prefix_changes_runtime_and_python_coordinates() -> None:
 
 
 def test_fork_python_coordinates_do_not_depend_on_secret_availability() -> None:
-    disabled = _plan()
     formal, selection, builder_catalog = _inputs()
-    formal = policy.resolve(
-        repository="release-org/unified-cache-management",
-        version_override="0.7.60rc1",
-        release_type="stable",
-        fork_test_pypi=True,
+    formal = copy.deepcopy(formal)
+    # This compact-plan test supplies its own request instead of inheriting defaults.
+    formal["release_profile"]["publish"]["pypi"] = True
+    formal["publish"]["pypi"].update(
+        requested=True,
+        enabled=False,
+        disposition="scope-skipped",
     )
-    selectors = _fixture_policy()["runtime_selectors"]
-    formal["runtime_selectors"] = copy.deepcopy(selectors)
-    for product in formal["products"]:
-        product["runtime_selectors"] = copy.deepcopy(selectors[product["id"]])
-    enabled = compact.resolve_plan(
+    disabled = compact.resolve_plan(
         formal,
+        runtime_selection=selection,
+        builder_catalog=builder_catalog,
+        route="release",
+    )
+    enabled_formal = copy.deepcopy(formal)
+    enabled_formal["publish"]["pypi"].update(
+        enabled=True,
+        disposition="publish",
+    )
+    enabled = compact.resolve_plan(
+        enabled_formal,
         runtime_selection=selection,
         builder_catalog=builder_catalog,
         route="release",
@@ -539,48 +594,20 @@ def test_fork_python_coordinates_do_not_depend_on_secret_availability() -> None:
 
 @pytest.mark.parametrize("release_type", policy.RELEASE_TYPES)
 def test_plan_records_selected_release_profile(release_type: str) -> None:
-    plan = _plan(release_type)
-    shared_requested = release_type != "nightly"
+    formal, selection, builder_catalog = _inputs(release_type)
+    plan = compact.resolve_plan(
+        formal,
+        runtime_selection=selection,
+        builder_catalog=builder_catalog,
+        route="release",
+    )
+    expected_publish = copy.deepcopy(formal["publish"])
+    expected_publish["pypi"]["distributions"] = sorted(
+        {wheel["dist_name"] for wheel in plan["wheels"]}
+    )
 
     assert plan["release_type"] == release_type
-    assert plan["publish"] == {
-        "pypi": {
-            "target": "testpypi",
-            **policy.PYPI_TARGETS["testpypi"],
-            "distribution_prefix": "release-org-",
-            "requested": shared_requested,
-            "enabled": False,
-            "disposition": "scope-skipped" if shared_requested else "disabled",
-            "distributions": [
-                "release-org-uc-manager-cann901-a2",
-                "release-org-uc-manager-cann901-a3",
-                "release-org-uc-manager-cuda-cu129",
-            ],
-        },
-        "ghcr": {
-            "namespace": "ghcr.io/release-org",
-            "requested": True,
-            "enabled": True,
-            "disposition": "publish",
-        },
-        "dockerhub": {
-            "namespace": "docker.io/release-org",
-            "requested": shared_requested,
-            "enabled": False,
-            "disposition": "scope-skipped" if shared_requested else "disabled",
-        },
-        "chart_oci": {
-            "namespace": "ghcr.io/release-org/charts",
-            "requested": True,
-            "enabled": True,
-            "disposition": "publish",
-        },
-        "github_release": {
-            "requested": True,
-            "enabled": True,
-            "disposition": "publish",
-        },
-    }
+    assert plan["publish"] == expected_publish
 
 
 def test_family_members_are_the_authority_for_index_inputs() -> None:

--- a/.github/release/tests/test_compact_workflows.py
+++ b/.github/release/tests/test_compact_workflows.py
@@ -139,9 +139,7 @@ def test_release_core_is_input_driven_and_uses_crane_before_plan() -> None:
     assert jobs["release-preflight"]["env"]["DOCKERHUB_NAMESPACE"] == (
         "${{ vars.DOCKERHUB_NAMESPACE }}"
     )
-    assert jobs["release-preflight"]["outputs"]["dockerhub_namespace"] == (
-        "${{ steps.profile.outputs.dockerhub_namespace }}"
-    )
+    assert "dockerhub_namespace" not in jobs["release-preflight"]["outputs"]
     assert "refs/tags/${RELEASE_TAG}^{commit}" in profile_run
     assert 'test "${head_sha}" = "${SOURCE_SHA}"' in profile_run
     assert 'test "${tag_sha}" = "${SOURCE_SHA}"' in profile_run
@@ -159,7 +157,9 @@ def test_release_core_is_input_driven_and_uses_crane_before_plan() -> None:
     assert "'{include:[.families[]" in plan_text
     assert "--publication-context" in plan_run
     assert "needs.release-preflight.outputs.fork_test_pypi" in plan_text
-    assert "needs.release-preflight.outputs.dockerhub_namespace" in plan_text
+    assert "needs.release-preflight.outputs.dockerhub_namespace" not in plan_text
+    plan_step = next(step for step in jobs["plan"]["steps"] if step.get("id") == "plan")
+    assert plan_step["env"]["DOCKERHUB_NAMESPACE"] == "${{ vars.DOCKERHUB_NAMESPACE }}"
     assert "dockerhub_namespace" in plan_run
     assert "FORK_DOCKERHUB_NAMESPACE" not in text
     assert "docker.io/${DOCKERHUB_USERNAME,,}" not in text

--- a/.github/release/tests/test_compact_workflows.py
+++ b/.github/release/tests/test_compact_workflows.py
@@ -530,13 +530,12 @@ def test_image_failure_notes_are_not_overwritten_by_the_fallback() -> None:
     assert "-F draft=true -F prerelease=true" in fallback["run"]
 
 
-def test_tag_entry_only_classifies_four_release_types_and_calls_core() -> None:
+def test_tag_entry_only_classifies_four_release_types_and_calls_one_core() -> None:
     workflow = _load("release-tag.yml")
     assert workflow["on"] == {"push": {"tags": ["v*", "draft/v*", "nightly/v*"]}}
     assert set(workflow["jobs"]) == {
         "classify-tag",
-        "release-official",
-        "release-fork",
+        "release",
     }
     classify = workflow["jobs"]["classify-tag"]
     assert set(classify["outputs"]) == {
@@ -559,30 +558,35 @@ def test_tag_entry_only_classifies_four_release_types_and_calls_core() -> None:
     assert "${GITHUB_REPOSITORY,,}" in classify_run
     assert "modelengine-group/unified-cache-management" in classify_run
 
-    for job_name, scope in (
-        ("release-official", "official"),
-        ("release-fork", "fork"),
-    ):
-        release = workflow["jobs"][job_name]
-        assert release["needs"] == "classify-tag"
-        assert release["uses"] == "./.github/workflows/release-ucm.yml"
-        assert set(release["with"]) == {
-            "git_tag",
-            "release_type",
-            "version",
-            "chart_version",
-            "image_version",
-            "release_kind",
-            "is_prerelease",
-            "source_sha",
-            "publication_scope",
-        }
-        assert release["with"]["source_sha"] == "${{ github.sha }}"
-        assert release["with"]["publication_scope"] == scope
-        assert scope in release["if"]
-    assert workflow["jobs"]["release-official"]["secrets"] == "inherit"
-    assert workflow["jobs"]["release-fork"]["secrets"] == {
-        "TEST_PYPI_API_TOKEN": "${{ secrets.TEST_PYPI_API_TOKEN }}",
+    release = workflow["jobs"]["release"]
+    assert release["name"] == "Run Release core"
+    assert release["needs"] == "classify-tag"
+    assert "if" not in release
+    assert release["uses"] == "./.github/workflows/release-ucm.yml"
+    assert set(release["with"]) == {
+        "git_tag",
+        "release_type",
+        "version",
+        "chart_version",
+        "image_version",
+        "release_kind",
+        "is_prerelease",
+        "source_sha",
+        "publication_scope",
+    }
+    assert release["with"]["source_sha"] == "${{ github.sha }}"
+    assert release["with"]["publication_scope"] == (
+        "${{ needs.classify-tag.outputs.publication_scope }}"
+    )
+    assert release["secrets"] == {
+        "PYPI_API_TOKEN": (
+            "${{ needs.classify-tag.outputs.publication_scope == 'official' "
+            "&& secrets.PYPI_API_TOKEN || '' }}"
+        ),
+        "TEST_PYPI_API_TOKEN": (
+            "${{ needs.classify-tag.outputs.publication_scope == 'fork' "
+            "&& secrets.TEST_PYPI_API_TOKEN || '' }}"
+        ),
         "DOCKERHUB_USERNAME": "${{ secrets.DOCKERHUB_USERNAME }}",
         "DOCKERHUB_TOKEN": "${{ secrets.DOCKERHUB_TOKEN }}",
     }

--- a/.github/release/tests/test_compact_workflows.py
+++ b/.github/release/tests/test_compact_workflows.py
@@ -833,6 +833,8 @@ def test_shared_channel_writers_use_only_effective_enabled_decisions() -> None:
         for step in jobs["publish-pypi"]["steps"]
         if step.get("name") == "Publish backend Wheels, then the meta Wheel"
     )
+    assert 'if .publish.pypi.target == "testpypi" then 36 else 12 end' in pypi
+    assert '--attempts "${readback_attempts}" --interval 5' in pypi
     dockerhub_index = next(
         step["run"]
         for step in jobs["publish-image-indexes"]["steps"]

--- a/.github/release/tests/test_compact_workflows.py
+++ b/.github/release/tests/test_compact_workflows.py
@@ -833,8 +833,7 @@ def test_shared_channel_writers_use_only_effective_enabled_decisions() -> None:
         for step in jobs["publish-pypi"]["steps"]
         if step.get("name") == "Publish backend Wheels, then the meta Wheel"
     )
-    assert 'if .publish.pypi.target == "testpypi" then 36 else 12 end' in pypi
-    assert '--attempts "${readback_attempts}" --interval 5' in pypi
+    assert "--attempts 36 --interval 5" in pypi
     dockerhub_index = next(
         step["run"]
         for step in jobs["publish-image-indexes"]["steps"]

--- a/.github/release/tests/test_compact_workflows.py
+++ b/.github/release/tests/test_compact_workflows.py
@@ -128,10 +128,20 @@ def test_release_core_is_input_driven_and_uses_crane_before_plan() -> None:
     assert "if version >" not in profile_run
     assert '--tag "${RELEASE_TAG}" --classify' in profile_run
     assert "--version-config version.ini" in profile_run
-    assert (
-        "Fork Docker Hub username and token must be configured together" in profile_run
-    )
+    assert "Docker Hub namespace must be configured" in profile_run
+    assert "Docker Hub username and token must be configured together" in profile_run
+    assert 'if [ "${dockerhub_requested}" = true ]; then' in profile_run
+    assert '[ -z "${DOCKERHUB_NAMESPACE}" ]' in profile_run
+    assert '[ -z "${DOCKERHUB_USERNAME}" ]' in profile_run
+    assert '[ -z "${DOCKERHUB_TOKEN}" ]' in profile_run
+    assert "dockerhub_namespace=sys.argv[3] or None" in profile_run
     assert "fork_test_pypi" in profile_run
+    assert jobs["release-preflight"]["env"]["DOCKERHUB_NAMESPACE"] == (
+        "${{ vars.DOCKERHUB_NAMESPACE }}"
+    )
+    assert jobs["release-preflight"]["outputs"]["dockerhub_namespace"] == (
+        "${{ steps.profile.outputs.dockerhub_namespace }}"
+    )
     assert "refs/tags/${RELEASE_TAG}^{commit}" in profile_run
     assert 'test "${head_sha}" = "${SOURCE_SHA}"' in profile_run
     assert 'test "${tag_sha}" = "${SOURCE_SHA}"' in profile_run
@@ -149,6 +159,10 @@ def test_release_core_is_input_driven_and_uses_crane_before_plan() -> None:
     assert "'{include:[.families[]" in plan_text
     assert "--publication-context" in plan_run
     assert "needs.release-preflight.outputs.fork_test_pypi" in plan_text
+    assert "needs.release-preflight.outputs.dockerhub_namespace" in plan_text
+    assert "dockerhub_namespace" in plan_run
+    assert "FORK_DOCKERHUB_NAMESPACE" not in text
+    assert "docker.io/${DOCKERHUB_USERNAME,,}" not in text
 
 
 def test_pr_gate_keeps_ucm_artifact_builds_in_the_robot_lane() -> None:
@@ -569,6 +583,8 @@ def test_tag_entry_only_classifies_four_release_types_and_calls_core() -> None:
     assert workflow["jobs"]["release-official"]["secrets"] == "inherit"
     assert workflow["jobs"]["release-fork"]["secrets"] == {
         "TEST_PYPI_API_TOKEN": "${{ secrets.TEST_PYPI_API_TOKEN }}",
+        "DOCKERHUB_USERNAME": "${{ secrets.DOCKERHUB_USERNAME }}",
+        "DOCKERHUB_TOKEN": "${{ secrets.DOCKERHUB_TOKEN }}",
     }
 
 
@@ -898,7 +914,13 @@ def test_builder_sync_consumes_selection_and_uses_digest_pinned_mirror_only() ->
     assert "docker image inspect" not in text
     assert "ucm-builder-verification-${{ matrix.id }}" in text
     assert "candidate-${GITHUB_RUN_ID}" in text
-    assert 'imagetools create --tag "${target}" "${candidate}"' in text
+    promotion = 'docker buildx imagetools create --tag "${target}" "${candidate}"'
+    promotion_index = build.index(promotion)
+    retry_index = build.rfind("retry-registry-command.sh", 0, promotion_index)
+    assert 0 < promotion_index - retry_index < 240
+    retry_prefix = build[retry_index:promotion_index]
+    assert "${RUNNER_TEMP}/ucm-builder-promotion.log" in retry_prefix
+    assert "--retry-transport" in retry_prefix
     assert workflow["jobs"]["build-missing"]["timeout-minutes"] == 180
     assert set(workflow["jobs"]["finalize"]["needs"]) == {
         "prepare",

--- a/.github/release/tests/test_config.py
+++ b/.github/release/tests/test_config.py
@@ -141,81 +141,28 @@ def _platform_policy() -> dict[str, object]:
 
 
 def test_release_policy_matches_the_schema_v6_registry_surface() -> None:
-    release = _release_policy()
+    policy = importlib.import_module("ucm_release.policy")
 
-    assert release == {
-        "kind": "ucm-release-policy",
-        "schema_version": 6,
-        "runners": {"amd64": "ubuntu-24.04", "arm64": "ubuntu-24.04-arm"},
-        "products": [
-            {
-                "id": "vllm",
-                "runtime_repository": "docker.io/vllm/vllm-openai",
-                "target_repository": "ghcr.io/{owner}/vllm-openai",
-            },
-            {
-                "id": "vllm-ascend",
-                "runtime_repository": "quay.io/ascend/vllm-ascend",
-                "target_repository": "ghcr.io/{owner}/vllm-ascend",
-            },
-        ],
-        "publish": {
-            "pypi": {"index": "https://upload.pypi.org/legacy/"},
-            "ghcr": {"namespace": "ghcr.io/{owner}"},
-            "dockerhub": {"namespace": "docker.io/{owner}"},
-            "chart_oci": {"namespace": "ghcr.io/{owner}/charts"},
-            "github_release": {},
-        },
-        "release_profiles": {
-            "stable": {
-                "max_count": -1,
-                "publish": {
-                    "pypi": True,
-                    "ghcr": True,
-                    "dockerhub": True,
-                    "chart_oci": True,
-                    "github_release": True,
-                },
-            },
-            "prerelease": {
-                "max_count": -1,
-                "publish": {
-                    "pypi": True,
-                    "ghcr": True,
-                    "dockerhub": True,
-                    "chart_oci": True,
-                    "github_release": True,
-                },
-            },
-            "draft": {
-                "max_count": 7,
-                "publish": {
-                    "pypi": True,
-                    "ghcr": True,
-                    "dockerhub": True,
-                    "chart_oci": True,
-                    "github_release": True,
-                },
-            },
-            "nightly": {
-                "max_count": 7,
-                "publish": {
-                    "pypi": False,
-                    "ghcr": True,
-                    "dockerhub": False,
-                    "chart_oci": True,
-                    "github_release": True,
-                },
-            },
-        },
-        "chart": {
-            "source": "charts/unified-cache-chart",
-            "smoke_values": {
-                "vllm": "charts/unified-cache-chart/models/cuda/values-qwen3-0p6b-1e1.yaml",
-                "vllm-ascend": "charts/unified-cache-chart/models/ascend/values-qwen3-0p6b-1e1.yaml",
-            },
-        },
+    release = policy.load()["release"]
+
+    assert release["kind"] == "ucm-release-policy"
+    assert release["schema_version"] == 6
+    assert set(release) == {
+        "kind",
+        "schema_version",
+        "runners",
+        "products",
+        "publish",
+        "release_profiles",
+        "chart",
     }
+    assert set(release["publish"]) == set(policy.PUBLISH_CHANNELS)
+    assert release["publish"]["dockerhub"] == {}
+    assert set(release["release_profiles"]) == set(policy.RELEASE_TYPES)
+    for profile in release["release_profiles"].values():
+        assert set(profile) == {"max_count", "publish"}
+        assert set(profile["publish"]) == set(policy.PUBLISH_CHANNELS)
+        assert all(isinstance(value, bool) for value in profile["publish"].values())
 
 
 def test_release_yaml_has_expanded_commented_profiles_without_aliases() -> None:
@@ -232,26 +179,31 @@ def test_release_yaml_has_expanded_commented_profiles_without_aliases() -> None:
     )
 
 
-def test_readme_documents_fork_preview_publication_setup() -> None:
+def test_readme_documents_official_and_fork_publication_setup() -> None:
     text = (RELEASE_ROOT / "README.md").read_text(encoding="utf-8")
 
     for value in (
+        "## Official release setup",
+        "release-production",
+        "PYPI_API_TOKEN",
+        "gh secret set PYPI_API_TOKEN --repo",
         "## Fork preview setup",
         "fork-preview",
         "TEST_PYPI_API_TOKEN",
         "DOCKERHUB_USERNAME",
         "DOCKERHUB_TOKEN",
-        "FORK_DOCKERHUB_NAMESPACE",
-        "gh secret set TEST_PYPI_API_TOKEN --env fork-preview",
+        "DOCKERHUB_NAMESPACE",
+        "gh secret set TEST_PYPI_API_TOKEN --repo",
+        "gh variable set DOCKERHUB_NAMESPACE --repo",
         "Read and write permissions",
         "https://test.pypi.org/simple/",
-        'publish.pypi.target == "testpypi"',
         "scope-skipped",
-        "Disabled by Profile",
+        "selected Release Profile",
         "git push origin",
     ):
         assert value in text
-    assert "Do not copy it into `fork-preview`" in text
+    assert "FORK_DOCKERHUB_NAMESPACE" not in text
+    assert "copy it into the Fork or `fork-preview`" in text
     assert "not the empty meta Wheel" in text
 
 
@@ -312,21 +264,20 @@ def test_release_profile_limits_accept_minus_one_and_positive_int(
     assert loaded["release"]["release_profiles"]["nightly"]["max_count"] == value
 
 
-def test_draft_profile_publication_is_policy_driven(tmp_path: Path) -> None:
+@pytest.mark.parametrize("enabled", [False, True])
+def test_release_profile_publication_switches_are_policy_driven(
+    tmp_path: Path, enabled: bool
+) -> None:
     policy = importlib.import_module("ucm_release.policy")
     release = _release_policy()
+    switches = {channel: enabled for channel in policy.PUBLISH_CHANNELS}
+    release["release_profiles"]["draft"]["publish"] = switches
     path = tmp_path / "release.yaml"
     path.write_text(yaml.safe_dump(release, sort_keys=False), encoding="utf-8")
 
     loaded = policy.load(path)
 
-    assert loaded["release"]["release_profiles"]["draft"]["publish"] == {
-        "pypi": True,
-        "ghcr": True,
-        "dockerhub": True,
-        "chart_oci": True,
-        "github_release": True,
-    }
+    assert loaded["release"]["release_profiles"]["draft"]["publish"] == switches
 
 
 def test_version_ini_is_the_runtime_selector_authority() -> None:
@@ -450,69 +401,43 @@ def test_formal_policy_loads_exact_requirements_without_legacy_authorities() -> 
         assert legacy_key not in serialized
 
 
-@pytest.mark.parametrize(
-    ("release_type", "max_count"),
-    [
-        ("stable", -1),
-        ("prerelease", -1),
-        ("draft", 7),
-        ("nightly", 7),
-    ],
-)
+@pytest.mark.parametrize("release_type", ("stable", "prerelease", "draft", "nightly"))
 def test_policy_resolve_selects_one_profile_and_normalizes_publication(
-    release_type: str, max_count: int
+    release_type: str,
 ) -> None:
     policy = importlib.import_module("ucm_release.policy")
+    source = _release_policy()
+    selected_profile = source["release_profiles"][release_type]
 
     resolved = policy.resolve(repository="release-org/ucm", release_type=release_type)
 
     assert resolved["release_type"] == release_type
     assert resolved["publication_scope"] == "fork"
     assert resolved["runtime_image_tag_prefix"] == "release-org-"
-    shared_requested = release_type != "nightly"
-    assert resolved["release_profile"] == {
-        "max_count": max_count,
-        "publish": {
-            "pypi": shared_requested,
-            "ghcr": True,
-            "dockerhub": shared_requested,
-            "chart_oci": True,
-            "github_release": True,
-        },
-    }
-    assert resolved["publish"] == {
-        "pypi": {
-            "target": "testpypi",
-            **policy.PYPI_TARGETS["testpypi"],
-            "distribution_prefix": "release-org-",
-            "requested": shared_requested,
-            "enabled": False,
-            "disposition": "scope-skipped" if shared_requested else "disabled",
-        },
-        "ghcr": {
-            "namespace": "ghcr.io/release-org",
-            "requested": True,
-            "enabled": True,
-            "disposition": "publish",
-        },
-        "dockerhub": {
-            "namespace": "docker.io/release-org",
-            "requested": shared_requested,
-            "enabled": False,
-            "disposition": "scope-skipped" if shared_requested else "disabled",
-        },
-        "chart_oci": {
-            "namespace": "ghcr.io/release-org/charts",
-            "requested": True,
-            "enabled": True,
-            "disposition": "publish",
-        },
-        "github_release": {
-            "requested": True,
-            "enabled": True,
-            "disposition": "publish",
-        },
-    }
+    assert resolved["release_profile"] == selected_profile
+    for channel, requested in selected_profile["publish"].items():
+        publication = resolved["publish"][channel]
+        assert publication["requested"] is requested
+        if channel in {"pypi", "dockerhub"}:
+            assert publication["enabled"] is False
+            assert publication["disposition"] == (
+                "scope-skipped" if requested else "disabled"
+            )
+        else:
+            assert publication["enabled"] is requested
+            assert publication["disposition"] == (
+                "publish" if requested else "disabled"
+            )
+    assert resolved["publish"]["pypi"]["target"] == "testpypi"
+    assert resolved["publish"]["pypi"]["distribution_prefix"] == "release-org-"
+    for channel in ("ghcr", "chart_oci"):
+        expected_namespace = (
+            source["publish"][channel]["namespace"]
+            .replace("{owner}", "release-org")
+            .replace("{repo}", "ucm")
+        )
+        assert resolved["publish"][channel]["namespace"] == expected_namespace
+    assert "namespace" not in resolved["publish"]["dockerhub"]
 
 
 def test_policy_resolve_uses_only_the_selected_profile_switches(
@@ -520,9 +445,23 @@ def test_policy_resolve_uses_only_the_selected_profile_switches(
 ) -> None:
     policy = importlib.import_module("ucm_release.policy")
     release = _release_policy()
-    release["release_profiles"]["stable"]["publish"]["ghcr"] = False
-    release["release_profiles"]["stable"]["publish"]["dockerhub"] = False
-    release["release_profiles"]["draft"]["publish"]["chart_oci"] = False
+    # Synthetic inputs exercise profile isolation; they are not repository defaults.
+    stable_switches = {
+        "pypi": True,
+        "ghcr": False,
+        "dockerhub": False,
+        "chart_oci": False,
+        "github_release": True,
+    }
+    draft_switches = {
+        "pypi": False,
+        "ghcr": True,
+        "dockerhub": True,
+        "chart_oci": True,
+        "github_release": True,
+    }
+    release["release_profiles"]["stable"]["publish"] = stable_switches
+    release["release_profiles"]["draft"]["publish"] = draft_switches
     path = tmp_path / "release.yaml"
     path.write_text(yaml.safe_dump(release, sort_keys=False), encoding="utf-8")
 
@@ -530,96 +469,243 @@ def test_policy_resolve_uses_only_the_selected_profile_switches(
         path, repository=policy.OFFICIAL_REPOSITORY, release_type="stable"
     )
     draft = policy.resolve(
-        path, repository=policy.OFFICIAL_REPOSITORY, release_type="draft"
+        path,
+        repository=policy.OFFICIAL_REPOSITORY,
+        release_type="draft",
+        dockerhub_namespace="docker.io/ucm-debug",
     )
 
-    assert stable["publish"]["ghcr"]["enabled"] is False
-    assert stable["publish"]["pypi"]["enabled"] is True
-    assert draft["publish"]["ghcr"]["enabled"] is True
-    assert draft["publish"]["pypi"]["enabled"] is True
-    assert draft["publish"]["chart_oci"]["enabled"] is False
+    assert stable["release_profile"]["publish"] == stable_switches
+    assert draft["release_profile"]["publish"] == draft_switches
+    assert {
+        channel: publication["requested"]
+        for channel, publication in stable["publish"].items()
+    } == stable_switches
+    assert {
+        channel: publication["requested"]
+        for channel, publication in draft["publish"].items()
+    } == draft_switches
+    assert {
+        channel: publication["enabled"]
+        for channel, publication in stable["publish"].items()
+    } == stable_switches
+    assert {
+        channel: publication["enabled"]
+        for channel, publication in draft["publish"].items()
+    } == draft_switches
     assert draft["publication_scope"] == "official"
     assert draft["runtime_image_tag_prefix"] == ""
 
 
-def test_fork_scope_disables_shared_external_channels_only(tmp_path: Path) -> None:
+def test_fork_scope_only_skips_requested_pypi(tmp_path: Path) -> None:
     policy = importlib.import_module("ucm_release.policy")
     release = _release_policy()
+    # Give both external channels an explicit request before testing Fork scope.
+    switches = {channel: True for channel in policy.PUBLISH_CHANNELS}
+    release["release_profiles"]["draft"]["publish"] = switches
     path = tmp_path / "release.yaml"
     path.write_text(yaml.safe_dump(release, sort_keys=False), encoding="utf-8")
 
     official = policy.resolve(
-        path, repository=policy.OFFICIAL_REPOSITORY, release_type="draft"
+        path,
+        repository=policy.OFFICIAL_REPOSITORY,
+        release_type="draft",
+        dockerhub_namespace="docker.io/ucm-debug",
     )
     fork = policy.resolve(
         path,
         repository="SuperMarioYL/unified-cache-management",
         release_type="draft",
+        dockerhub_namespace="docker.io/ucm-debug",
     )
 
-    assert official["publish"]["pypi"] == {
-        "target": "pypi",
-        **policy.PYPI_TARGETS["pypi"],
-        "distribution_prefix": "",
-        "requested": True,
-        "enabled": True,
-        "disposition": "publish",
-    }
-    assert official["publish"]["dockerhub"]["requested"] is True
-    assert official["publish"]["dockerhub"]["enabled"] is True
-    assert official["publish"]["dockerhub"]["disposition"] == "publish"
+    assert (
+        official["publish"]["pypi"]["requested"],
+        official["publish"]["pypi"]["enabled"],
+        official["publish"]["pypi"]["disposition"],
+    ) == (True, True, "publish")
+    assert (
+        fork["publish"]["pypi"]["requested"],
+        fork["publish"]["pypi"]["enabled"],
+        fork["publish"]["pypi"]["disposition"],
+    ) == (True, False, "scope-skipped")
+    assert (
+        official["publish"]["dockerhub"]
+        == fork["publish"]["dockerhub"]
+        == {
+            "namespace": "docker.io/ucm-debug",
+            "requested": True,
+            "enabled": True,
+            "disposition": "publish",
+        }
+    )
     assert fork["publication_scope"] == "fork"
     assert fork["runtime_image_tag_prefix"] == "supermarioyl-"
-    assert fork["release_profile"]["publish"]["pypi"] is True
-    assert fork["release_profile"]["publish"]["dockerhub"] is True
-    assert fork["publish"]["pypi"]["requested"] is True
+    assert fork["release_profile"]["publish"] == switches
     assert fork["publish"]["pypi"]["distribution_prefix"] == "supermarioyl-"
-    assert fork["publish"]["pypi"]["enabled"] is False
-    assert fork["publish"]["pypi"]["disposition"] == "scope-skipped"
-    assert fork["publish"]["dockerhub"]["requested"] is True
-    assert fork["publish"]["dockerhub"]["enabled"] is False
-    assert fork["publish"]["dockerhub"]["disposition"] == "scope-skipped"
-    assert fork["publish"]["ghcr"]["enabled"] is True
-    assert fork["publish"]["ghcr"]["disposition"] == "publish"
-    assert fork["publish"]["chart_oci"]["enabled"] is True
-    assert fork["publish"]["github_release"]["enabled"] is True
+    for channel in ("ghcr", "chart_oci", "github_release"):
+        assert (
+            fork["publish"][channel]["requested"],
+            fork["publish"][channel]["enabled"],
+            fork["publish"][channel]["disposition"],
+        ) == (True, True, "publish")
 
 
-def test_fork_credentials_enable_only_requested_test_targets() -> None:
+def test_external_configuration_enables_only_profile_requested_channels(
+    tmp_path: Path,
+) -> None:
     policy = importlib.import_module("ucm_release.policy")
+    release = _release_policy()
+    # Opposite requests prove that credentials cannot override either channel.
+    release["release_profiles"]["prerelease"]["publish"] = {
+        "pypi": True,
+        "ghcr": True,
+        "dockerhub": False,
+        "chart_oci": False,
+        "github_release": True,
+    }
+    release["release_profiles"]["draft"]["publish"] = {
+        "pypi": False,
+        "ghcr": True,
+        "dockerhub": True,
+        "chart_oci": False,
+        "github_release": True,
+    }
+    path = tmp_path / "release.yaml"
+    path.write_text(yaml.safe_dump(release, sort_keys=False), encoding="utf-8")
 
+    prerelease = policy.resolve(
+        path,
+        repository="SuperMarioYL/unified-cache-management",
+        release_type="prerelease",
+        fork_test_pypi=True,
+        dockerhub_namespace="docker.io/ucm-debug",
+    )
     draft = policy.resolve(
+        path,
         repository="SuperMarioYL/unified-cache-management",
         release_type="draft",
         fork_test_pypi=True,
-        fork_dockerhub_namespace="docker.io/ucm-debug",
-    )
-    nightly = policy.resolve(
-        repository="SuperMarioYL/unified-cache-management",
-        release_type="nightly",
-        fork_test_pypi=True,
-        fork_dockerhub_namespace="docker.io/ucm-debug",
+        dockerhub_namespace="docker.io/ucm-debug",
     )
 
-    assert draft["publish"]["pypi"]["target"] == "testpypi"
-    assert draft["publish"]["pypi"]["distribution_prefix"] == "supermarioyl-"
-    assert draft["publish"]["pypi"]["enabled"] is True
+    assert prerelease["publish"]["pypi"]["target"] == "testpypi"
+    assert prerelease["publish"]["pypi"]["distribution_prefix"] == "supermarioyl-"
+    assert (
+        prerelease["publish"]["pypi"]["enabled"],
+        prerelease["publish"]["pypi"]["disposition"],
+    ) == (True, "publish")
+    assert (
+        prerelease["publish"]["dockerhub"]["enabled"],
+        prerelease["publish"]["dockerhub"]["disposition"],
+    ) == (False, "disabled")
+    assert (
+        draft["publish"]["pypi"]["enabled"],
+        draft["publish"]["pypi"]["disposition"],
+    ) == (False, "disabled")
     assert draft["publish"]["dockerhub"] == {
         "namespace": "docker.io/ucm-debug",
         "requested": True,
         "enabled": True,
         "disposition": "publish",
     }
-    assert nightly["publish"]["pypi"]["enabled"] is False
-    assert nightly["publish"]["pypi"]["disposition"] == "disabled"
-    assert nightly["publish"]["dockerhub"]["enabled"] is False
+
+
+@pytest.mark.parametrize(
+    "repository",
+    (
+        "ModelEngine-Group/unified-cache-management",
+        "SuperMarioYL/unified-cache-management",
+    ),
+)
+def test_requested_dockerhub_namespace_is_scope_independent(
+    tmp_path: Path, repository: str
+) -> None:
+    policy = importlib.import_module("ucm_release.policy")
+    release = _release_policy()
+    release["release_profiles"]["draft"]["publish"] = {
+        "pypi": False,
+        "ghcr": True,
+        "dockerhub": True,
+        "chart_oci": False,
+        "github_release": True,
+    }
+    path = tmp_path / "release.yaml"
+    path.write_text(yaml.safe_dump(release, sort_keys=False), encoding="utf-8")
+
+    missing = policy.resolve(path, repository=repository, release_type="draft")
+    configured = policy.resolve(
+        path,
+        repository=repository,
+        release_type="draft",
+        dockerhub_namespace="docker.io/ucm-debug",
+    )
+
+    assert missing["publish"]["dockerhub"] == {
+        "requested": True,
+        "enabled": False,
+        "disposition": "scope-skipped",
+    }
+    assert configured["publish"]["dockerhub"] == {
+        "namespace": "docker.io/ucm-debug",
+        "requested": True,
+        "enabled": True,
+        "disposition": "publish",
+    }
 
     with pytest.raises(ValueError, match="Docker Hub namespace"):
         policy.resolve(
-            repository="SuperMarioYL/unified-cache-management",
+            path,
+            repository=repository,
             release_type="draft",
-            fork_dockerhub_namespace="ghcr.io/not-dockerhub",
+            dockerhub_namespace="ghcr.io/not-dockerhub",
         )
+
+
+@pytest.mark.parametrize(
+    "repository",
+    (
+        "ModelEngine-Group/unified-cache-management",
+        "SuperMarioYL/unified-cache-management",
+    ),
+)
+def test_disabled_dockerhub_ignores_runtime_configuration(
+    tmp_path: Path, repository: str
+) -> None:
+    policy = importlib.import_module("ucm_release.policy")
+    release = _release_policy()
+    release["release_profiles"]["draft"]["publish"] = {
+        channel: False for channel in policy.PUBLISH_CHANNELS
+    }
+    path = tmp_path / "release.yaml"
+    path.write_text(yaml.safe_dump(release, sort_keys=False), encoding="utf-8")
+
+    resolved = policy.resolve(
+        path,
+        repository=repository,
+        release_type="draft",
+        dockerhub_namespace="not-a-docker-namespace",
+    )
+
+    assert resolved["publish"]["dockerhub"] == {
+        "requested": False,
+        "enabled": False,
+        "disposition": "disabled",
+    }
+
+
+def test_publication_context_uses_shared_dockerhub_namespace(tmp_path: Path) -> None:
+    cli = importlib.import_module("ucm_release.cli")
+    path = tmp_path / "publication-context.json"
+    path.write_text(
+        '{"fork_test_pypi":false,' '"dockerhub_namespace":"docker.io/ucm-debug"}',
+        encoding="utf-8",
+    )
+
+    assert cli._publication_context(path) == {  # noqa: SLF001
+        "fork_test_pypi": False,
+        "dockerhub_namespace": "docker.io/ucm-debug",
+    }
 
 
 def test_official_repository_identity_is_case_insensitive() -> None:
@@ -777,108 +863,40 @@ def test_core_projects_v6_for_release_consumers() -> None:
     )
 
 
-def test_release_yaml_is_the_exact_publication_authority() -> None:
-    release = _release_policy()
-
-    assert release["publish"] == {
-        "pypi": {"index": "https://upload.pypi.org/legacy/"},
-        "ghcr": {"namespace": "ghcr.io/{owner}"},
-        "dockerhub": {"namespace": "docker.io/{owner}"},
-        "chart_oci": {"namespace": "ghcr.io/{owner}/charts"},
-        "github_release": {},
-    }
-    assert release["release_profiles"] == {
-        "stable": {
-            "max_count": -1,
-            "publish": {
-                "pypi": True,
-                "ghcr": True,
-                "dockerhub": True,
-                "chart_oci": True,
-                "github_release": True,
-            },
-        },
-        "prerelease": {
-            "max_count": -1,
-            "publish": {
-                "pypi": True,
-                "ghcr": True,
-                "dockerhub": True,
-                "chart_oci": True,
-                "github_release": True,
-            },
-        },
-        "draft": {
-            "max_count": 7,
-            "publish": {
-                "pypi": True,
-                "ghcr": True,
-                "dockerhub": True,
-                "chart_oci": True,
-                "github_release": True,
-            },
-        },
-        "nightly": {
-            "max_count": 7,
-            "publish": {
-                "pypi": False,
-                "ghcr": True,
-                "dockerhub": False,
-                "chart_oci": True,
-                "github_release": True,
-            },
-        },
-    }
-    assert set(release) == {
-        "kind",
-        "schema_version",
-        "runners",
-        "products",
-        "publish",
-        "release_profiles",
-        "chart",
-    }
-    assert set(release["chart"]) == {"source", "smoke_values"}
-
-
 def test_publish_plan_is_the_normalized_config_without_runtime_layers() -> None:
     core = importlib.import_module("ucm_release.core")
-    policy = importlib.import_module("ucm_release.policy")
-
-    plan = core.compute_publish_plan(core.load_catalog())
-
-    assert plan == {
-        "pypi": {
-            "requested": True,
-            "enabled": False,
-            "disposition": "scope-skipped",
-            "target": "testpypi",
-            **policy.PYPI_TARGETS["testpypi"],
-        },
-        "ghcr": {
-            "requested": True,
-            "enabled": True,
-            "disposition": "publish",
-            "namespace": "ghcr.io/release-org",
-        },
-        "dockerhub": {
-            "requested": True,
-            "enabled": False,
-            "disposition": "scope-skipped",
-            "namespace": "docker.io/release-org",
-        },
-        "chart_oci": {
-            "requested": True,
-            "enabled": True,
-            "disposition": "publish",
-            "namespace": "ghcr.io/release-org/charts",
-        },
-        "github_release": {
-            "requested": True,
-            "enabled": True,
-            "disposition": "publish",
-        },
+    catalog = core.load_catalog()
+    expected = {
+        channel: dict(publication)
+        for channel, publication in catalog["publish"].items()
     }
+
+    plan = core.compute_publish_plan(catalog)
+
+    assert plan == expected
+    assert plan is not catalog["publish"]
+    assert all(plan[channel] is not catalog["publish"][channel] for channel in plan)
+
+
+def test_publish_plan_requires_namespace_only_for_enabled_dockerhub() -> None:
+    core = importlib.import_module("ucm_release.core")
+    catalog = core.load_catalog()
+
+    assert "namespace" not in catalog["publish"]["dockerhub"]
+    catalog["publish"]["dockerhub"] = {
+        "requested": True,
+        "enabled": True,
+        "disposition": "publish",
+    }
+
+    with pytest.raises(ValueError, match="Docker Hub namespace"):
+        core.compute_publish_plan(catalog)
+
+    catalog["publish"]["dockerhub"]["namespace"] = "docker.io/ucm-debug"
+
+    assert core.compute_publish_plan(catalog)["dockerhub"]["namespace"] == (
+        "docker.io/ucm-debug"
+    )
 
 
 @pytest.mark.parametrize(
@@ -890,6 +908,11 @@ def test_publish_plan_rejects_inconsistent_channel_decisions(
 ) -> None:
     core = importlib.import_module("ucm_release.core")
     catalog = core.load_catalog()
+    catalog["publish"]["pypi"].update(
+        requested=True,
+        enabled=False,
+        disposition="scope-skipped",
+    )
     catalog["publish"]["pypi"][field] = value
 
     with pytest.raises(ValueError, match="invalid publication decision"):
@@ -902,15 +925,20 @@ def test_ghcr_publication_accepts_both_boolean_modes(
 ) -> None:
     core = importlib.import_module("ucm_release.core")
     release = _release_policy()
-    release["release_profiles"]["stable"]["publish"]["ghcr"] = enabled
-    if not enabled:
-        release["release_profiles"]["stable"]["publish"]["dockerhub"] = False
+    release["release_profiles"]["stable"]["publish"] = {
+        "pypi": False,
+        "ghcr": enabled,
+        "dockerhub": False,
+        "chart_oci": False,
+        "github_release": enabled,
+    }
     path = tmp_path / "release.yaml"
     path.write_text(yaml.safe_dump(release, sort_keys=False), encoding="utf-8")
 
     catalog = core.load_catalog(path, repository="release-org/ucm")
     plan = core.compute_publish_plan(catalog)
 
+    assert plan["ghcr"]["requested"] is enabled
     assert plan["ghcr"]["enabled"] is enabled
 
 
@@ -922,7 +950,13 @@ def test_each_profile_requires_github_release_draft_barrier(
     release = yaml.safe_load(
         (REPO_ROOT / ".github" / "release" / "release.yaml").read_text(encoding="utf-8")
     )
-    release["release_profiles"][release_type]["publish"]["github_release"] = False
+    release["release_profiles"][release_type]["publish"] = {
+        "pypi": True,
+        "ghcr": False,
+        "dockerhub": False,
+        "chart_oci": False,
+        "github_release": False,
+    }
     path = tmp_path / "release.yaml"
     path.write_text(yaml.safe_dump(release, sort_keys=False), encoding="utf-8")
 
@@ -938,8 +972,13 @@ def test_each_profile_dockerhub_requires_ghcr_source_channel(
     release = yaml.safe_load(
         (REPO_ROOT / ".github" / "release" / "release.yaml").read_text(encoding="utf-8")
     )
-    release["release_profiles"][release_type]["publish"]["dockerhub"] = True
-    release["release_profiles"][release_type]["publish"]["ghcr"] = False
+    release["release_profiles"][release_type]["publish"] = {
+        "pypi": False,
+        "ghcr": False,
+        "dockerhub": True,
+        "chart_oci": False,
+        "github_release": True,
+    }
     path = tmp_path / "release.yaml"
     path.write_text(yaml.safe_dump(release, sort_keys=False), encoding="utf-8")
 

--- a/.github/release/tests/test_registry_retry.py
+++ b/.github/release/tests/test_registry_retry.py
@@ -4,6 +4,8 @@ import os
 import subprocess
 from pathlib import Path
 
+import pytest
+
 RELEASE_ROOT = Path(__file__).resolve().parents[1]
 RETRY = RELEASE_ROOT / "retry-registry-command.sh"
 FAKE_COMMAND = r"""
@@ -31,6 +33,7 @@ def _run_retry(
     failures: int,
     message: str,
     failure_status: int = 75,
+    retry_transport: bool = False,
     rate_limit_marker: Path | None = None,
     rate_limit_scope: str | None = None,
 ) -> tuple[subprocess.CompletedProcess[str], int]:
@@ -38,6 +41,8 @@ def _run_retry(
     environment = os.environ.copy()
     environment["UCM_REGISTRY_RETRY_DELAYS"] = "0 0 0 0"
     command = ["bash", str(RETRY), str(tmp_path / "command.log")]
+    if retry_transport:
+        command.append("--retry-transport")
     if rate_limit_marker is not None:
         command.extend(["--rate-limit-marker", str(rate_limit_marker)])
     if rate_limit_scope is not None:
@@ -79,6 +84,89 @@ def test_registry_rate_limit_retries_until_the_command_succeeds(
     assert attempts == 3
     assert completed.stderr.count("rate-limited; retrying") == 2
     assert not marker.exists()
+
+
+def test_registry_connection_reset_retries_until_the_command_succeeds(
+    tmp_path: Path,
+) -> None:
+    completed, attempts = _run_retry(
+        tmp_path,
+        failures=2,
+        message=(
+            "read tcp 10.1.1.185:45928->185.199.108.154:443: "
+            "read: connection reset by peer"
+        ),
+        retry_transport=True,
+    )
+
+    assert completed.returncode == 0
+    assert attempts == 3
+    assert completed.stderr.count("transient transport error; retrying") == 2
+
+
+@pytest.mark.parametrize("message", ["EOF", "unexpected EOF", "retrying EOF"])
+def test_registry_eof_retries_until_the_command_succeeds(
+    tmp_path: Path,
+    message: str,
+) -> None:
+    completed, attempts = _run_retry(
+        tmp_path,
+        failures=1,
+        message=message,
+        retry_transport=True,
+    )
+
+    assert completed.returncode == 0
+    assert attempts == 2
+    assert "transient transport error; retrying" in completed.stderr
+
+
+def test_registry_transport_failure_stops_at_the_bounded_attempt_count(
+    tmp_path: Path,
+) -> None:
+    marker = tmp_path / "rate-limit.marker"
+    completed, attempts = _run_retry(
+        tmp_path,
+        failures=10,
+        message="unexpected EOF",
+        failure_status=71,
+        retry_transport=True,
+        rate_limit_marker=marker,
+    )
+
+    assert completed.returncode == 71
+    assert attempts == 5
+    assert "failed after 5 attempts" in completed.stderr
+    assert not marker.exists()
+
+
+def test_registry_eof_requires_explicit_transport_retry(tmp_path: Path) -> None:
+    completed, attempts = _run_retry(
+        tmp_path,
+        failures=10,
+        message="Dockerfile parse error: unexpected EOF",
+        failure_status=42,
+    )
+
+    assert completed.returncode == 42
+    assert attempts == 1
+    assert "non-retryable error" in completed.stderr
+
+
+def test_transport_retry_does_not_retry_permanent_registry_error(
+    tmp_path: Path,
+) -> None:
+    completed, attempts = _run_retry(
+        tmp_path,
+        failures=10,
+        message="manifest unknown",
+        failure_status=42,
+        retry_transport=True,
+    )
+
+    assert completed.returncode == 42
+    assert attempts == 1
+    assert "non-retryable error" in completed.stderr
 
 
 def test_non_rate_limit_failure_is_not_retried(tmp_path: Path) -> None:

--- a/.github/release/ucm_release/cli.py
+++ b/.github/release/ucm_release/cli.py
@@ -50,12 +50,12 @@ def _publication_context(path: Path | None) -> dict[str, object]:
     value = core.load_json(path)
     if not isinstance(value, dict) or set(value) != {
         "fork_test_pypi",
-        "fork_dockerhub_namespace",
+        "dockerhub_namespace",
     }:
         raise ValueError("publication context fields must be exact")
     if not isinstance(value["fork_test_pypi"], bool):
         raise ValueError("publication context TestPyPI flag must be boolean")
-    namespace = value["fork_dockerhub_namespace"]
+    namespace = value["dockerhub_namespace"]
     if namespace is not None and (not isinstance(namespace, str) or not namespace):
         raise ValueError("publication context Docker Hub namespace is invalid")
     return value

--- a/.github/release/ucm_release/compact.py
+++ b/.github/release/ucm_release/compact.py
@@ -373,7 +373,8 @@ def resolve_plan(
             if not requested
             else (
                 {(True, "publish"), (False, "scope-skipped")}
-                if expected_scope == "fork" and channel in {"pypi", "dockerhub"}
+                if (expected_scope == "fork" and channel == "pypi")
+                or (channel == "dockerhub" and route != "release")
                 else {(True, "publish")}
             )
         )
@@ -381,6 +382,14 @@ def resolve_plan(
             raise ValueError(
                 f"formal {channel} publication decision does not match repository scope"
             )
+        if channel == "dockerhub":
+            namespace = channel_policy.get("namespace")
+            if channel_policy.get("enabled") != (
+                isinstance(namespace, str) and bool(namespace)
+            ):
+                raise ValueError(
+                    "formal Docker Hub namespace does not match publication decision"
+                )
     pypi_policy = _mapping(publication_policy["pypi"], "formal PyPI policy")
     expected_pypi_target = "pypi" if expected_scope == "official" else "testpypi"
     if pypi_policy.get("target") != expected_pypi_target:

--- a/.github/release/ucm_release/core.py
+++ b/.github/release/ucm_release/core.py
@@ -1254,10 +1254,11 @@ PUBLISH_CHANNEL_KEYS = {
     "pypi": _PUBLISH_DECISION_KEYS
     | {"target", "index", "simple_index", "json_api", "dependency_index"},
     "ghcr": _PUBLISH_DECISION_KEYS | {"namespace"},
-    "dockerhub": _PUBLISH_DECISION_KEYS | {"namespace"},
+    "dockerhub": _PUBLISH_DECISION_KEYS,
     "chart_oci": _PUBLISH_DECISION_KEYS | {"namespace"},
     "github_release": _PUBLISH_DECISION_KEYS,
 }
+PUBLISH_CHANNEL_OPTIONAL_KEYS = {"dockerhub": {"namespace"}}
 
 
 def compute_publish_plan(catalog: dict[str, Any]) -> dict[str, dict[str, Any]]:
@@ -1266,7 +1267,13 @@ def compute_publish_plan(catalog: dict[str, Any]) -> dict[str, dict[str, Any]]:
         raise ValueError("publish configuration requires the exact five channels")
     for channel in PUBLISH_CHANNELS:
         config = publish[channel]
-        if not isinstance(config, dict) or set(config) != PUBLISH_CHANNEL_KEYS[channel]:
+        required = PUBLISH_CHANNEL_KEYS[channel]
+        allowed = required | PUBLISH_CHANNEL_OPTIONAL_KEYS.get(channel, set())
+        if (
+            not isinstance(config, dict)
+            or not required.issubset(config)
+            or not set(config).issubset(allowed)
+        ):
             raise ValueError(f"publish channel {channel} configuration is malformed")
         if not isinstance(config["requested"], bool) or not isinstance(
             config["enabled"], bool
@@ -1284,7 +1291,11 @@ def compute_publish_plan(catalog: dict[str, Any]) -> dict[str, dict[str, Any]]:
             raise ValueError(
                 f"publish channel {channel} has an invalid publication decision"
             )
-        for field in PUBLISH_CHANNEL_KEYS[channel] - _PUBLISH_DECISION_KEYS:
+        if channel == "dockerhub" and config["enabled"] != ("namespace" in config):
+            raise ValueError(
+                "Docker Hub namespace is required exactly when publication is enabled"
+            )
+        for field in set(config) - _PUBLISH_DECISION_KEYS:
             if not isinstance(config[field], str) or not config[field]:
                 raise ValueError(f"publish channel {channel} {field} must be non-empty")
     return {channel: copy.deepcopy(publish[channel]) for channel in PUBLISH_CHANNELS}

--- a/.github/release/ucm_release/policy.py
+++ b/.github/release/ucm_release/policy.py
@@ -186,7 +186,7 @@ def _dockerhub_namespace(value: str) -> str:
         not isinstance(value, str)
         or re.fullmatch(r"docker\.io/[a-z0-9][a-z0-9._-]{0,127}", value) is None
     ):
-        raise ValueError("Fork Docker Hub namespace must be docker.io/<account-or-org>")
+        raise ValueError("Docker Hub namespace must be docker.io/<account-or-org>")
     return value
 
 
@@ -196,31 +196,34 @@ def _resolve_release_profile(
     publication_scope: str,
     *,
     fork_test_pypi: bool = False,
-    fork_dockerhub_namespace: str | None = None,
+    dockerhub_namespace: str | None = None,
 ) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
     profile, publish = _select_release_profile(release, release_type)
     publish["pypi"] = _pypi_target(
         publish["pypi"], "testpypi" if publication_scope == "fork" else "pypi"
     )
+    dockerhub = publish["dockerhub"]
+    dockerhub_requested = dockerhub["requested"]
+    if dockerhub_requested and dockerhub_namespace is not None:
+        dockerhub["namespace"] = _dockerhub_namespace(dockerhub_namespace)
+        dockerhub["enabled"] = True
+        dockerhub["disposition"] = "publish"
+    elif dockerhub_requested:
+        dockerhub["enabled"] = False
+        dockerhub["disposition"] = "scope-skipped"
+    else:
+        dockerhub["enabled"] = False
+        dockerhub["disposition"] = "disabled"
     if publication_scope == "fork":
         if not isinstance(fork_test_pypi, bool):
             raise ValueError("Fork TestPyPI availability must be boolean")
-        if fork_dockerhub_namespace is not None:
-            publish["dockerhub"]["namespace"] = _dockerhub_namespace(
-                fork_dockerhub_namespace
-            )
-        availability = {
-            "pypi": fork_test_pypi,
-            "dockerhub": fork_dockerhub_namespace is not None,
-        }
-        for channel, available in availability.items():
-            requested = publish[channel]["requested"]
-            publish[channel]["enabled"] = requested and available
-            publish[channel]["disposition"] = (
-                "publish"
-                if requested and available
-                else "scope-skipped" if requested else "disabled"
-            )
+        requested = publish["pypi"]["requested"]
+        publish["pypi"]["enabled"] = requested and fork_test_pypi
+        publish["pypi"]["disposition"] = (
+            "publish"
+            if requested and fork_test_pypi
+            else "scope-skipped" if requested else "disabled"
+        )
     return profile, publish
 
 
@@ -349,7 +352,7 @@ def resolve(
     version_override: str | None = None,
     release_type: str = "stable",
     fork_test_pypi: bool = False,
-    fork_dockerhub_namespace: str | None = None,
+    dockerhub_namespace: str | None = None,
 ) -> dict[str, Any]:
     """Resolve the two human policies into the formal runtime authority."""
     bundle = load(release_path, platforms_path=platforms_path)
@@ -389,7 +392,7 @@ def resolve(
         release_type,
         publication_scope,
         fork_test_pypi=fork_test_pypi,
-        fork_dockerhub_namespace=fork_dockerhub_namespace,
+        dockerhub_namespace=dockerhub_namespace,
     )
     normalized_publish["pypi"]["distribution_prefix"] = pypi_distribution_prefix(
         resolved_repository
@@ -465,6 +468,7 @@ def compatibility_projection(
     chart_name: str,
     release_type: str = "stable",
     repository: str = OFFICIAL_REPOSITORY,
+    dockerhub_namespace: str | None = None,
 ) -> dict[str, Any]:
     """Project v5 policy into the transitional schema-v3 catalog interface."""
     release = policy["release"]
@@ -484,7 +488,12 @@ def compatibility_projection(
         }
         upstream_products.append(projected)
     publication_scope, _ = publication_identity(repository)
-    _, publish = _resolve_release_profile(release, release_type, publication_scope)
+    _, publish = _resolve_release_profile(
+        release,
+        release_type,
+        publication_scope,
+        dockerhub_namespace=dockerhub_namespace,
+    )
     builder_families = platforms["builder_families"]
     return {
         "kind": "release-config",

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -58,10 +58,9 @@ jobs:
             echo "publication_scope=${publication_scope}"
           } >>"${GITHUB_OUTPUT}"
 
-  release-official:
-    name: Run official Release core
+  release:
+    name: Run Release core
     needs: classify-tag
-    if: ${{ needs.classify-tag.outputs.publication_scope == 'official' }}
     permissions:
       actions: write
       contents: write
@@ -76,29 +75,9 @@ jobs:
       release_kind: ${{ needs.classify-tag.outputs.release_kind }}
       is_prerelease: ${{ needs.classify-tag.outputs.is_prerelease == 'true' }}
       source_sha: ${{ github.sha }}
-      publication_scope: official
-    secrets: inherit
-
-  release-fork:
-    name: Run fork Release core
-    needs: classify-tag
-    if: ${{ needs.classify-tag.outputs.publication_scope == 'fork' }}
-    permissions:
-      actions: write
-      contents: write
-      packages: write
-    uses: ./.github/workflows/release-ucm.yml
-    with:
-      git_tag: ${{ needs.classify-tag.outputs.git_tag }}
-      release_type: ${{ needs.classify-tag.outputs.release_type }}
-      version: ${{ needs.classify-tag.outputs.version }}
-      chart_version: ${{ needs.classify-tag.outputs.chart_version }}
-      image_version: ${{ needs.classify-tag.outputs.image_version }}
-      release_kind: ${{ needs.classify-tag.outputs.release_kind }}
-      is_prerelease: ${{ needs.classify-tag.outputs.is_prerelease == 'true' }}
-      source_sha: ${{ github.sha }}
-      publication_scope: fork
+      publication_scope: ${{ needs.classify-tag.outputs.publication_scope }}
     secrets:
-      TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      PYPI_API_TOKEN: ${{ needs.classify-tag.outputs.publication_scope == 'official' && secrets.PYPI_API_TOKEN || '' }}
+      TEST_PYPI_API_TOKEN: ${{ needs.classify-tag.outputs.publication_scope == 'fork' && secrets.TEST_PYPI_API_TOKEN || '' }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -100,3 +100,5 @@ jobs:
       publication_scope: fork
     secrets:
       TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/release-ucm.yml
+++ b/.github/workflows/release-ucm.yml
@@ -65,7 +65,6 @@ jobs:
     outputs:
       enabled: ${{ steps.profile.outputs.enabled }}
       fork_test_pypi: ${{ steps.profile.outputs.fork_test_pypi }}
-      dockerhub_namespace: ${{ steps.profile.outputs.dockerhub_namespace }}
     permissions:
       contents: read
     env:
@@ -164,7 +163,6 @@ jobs:
           {
             echo "enabled=${enabled}"
             echo "fork_test_pypi=${fork_test_pypi}"
-            echo "dockerhub_namespace=${dockerhub_namespace}"
           } >>"${GITHUB_OUTPUT}"
   select-runtime-candidates:
     name: Select Runtime Registry Tags
@@ -543,7 +541,9 @@ jobs:
           PUBLICATION_SCOPE: ${{ inputs.publication_scope }}
           REPOSITORY: ${{ github.repository }}
           FORK_TEST_PYPI: ${{ needs.release-preflight.outputs.fork_test_pypi }}
-          DOCKERHUB_NAMESPACE: ${{ needs.release-preflight.outputs.dockerhub_namespace }}
+          # Do not relay this through a job output: GitHub suppresses outputs
+          # containing the Docker Hub username when it matches a Secret.
+          DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE }}
         run: |
           set -euo pipefail
           test "${IMAGE_VERSION}" = "${RELEASE_VERSION}"

--- a/.github/workflows/release-ucm.yml
+++ b/.github/workflows/release-ucm.yml
@@ -65,7 +65,7 @@ jobs:
     outputs:
       enabled: ${{ steps.profile.outputs.enabled }}
       fork_test_pypi: ${{ steps.profile.outputs.fork_test_pypi }}
-      fork_dockerhub_namespace: ${{ steps.profile.outputs.fork_dockerhub_namespace }}
+      dockerhub_namespace: ${{ steps.profile.outputs.dockerhub_namespace }}
     permissions:
       contents: read
     env:
@@ -83,7 +83,7 @@ jobs:
       TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-      FORK_DOCKERHUB_NAMESPACE: ${{ vars.FORK_DOCKERHUB_NAMESPACE }}
+      DOCKERHUB_NAMESPACE: ${{ vars.DOCKERHUB_NAMESPACE }}
     steps:
       - uses: actions/checkout@v4.2.2
         with:
@@ -132,36 +132,39 @@ jobs:
               raise SystemExit("the public package model requires a canonical non-local version")
           PY
           fork_test_pypi=false
-          fork_dockerhub_namespace=""
           if [ "${PUBLICATION_SCOPE}" = fork ]; then
             if [ -n "${TEST_PYPI_API_TOKEN}" ]; then
               fork_test_pypi=true
             fi
-            if { [ -n "${DOCKERHUB_USERNAME}" ] && [ -z "${DOCKERHUB_TOKEN}" ]; } || \
-               { [ -z "${DOCKERHUB_USERNAME}" ] && [ -n "${DOCKERHUB_TOKEN}" ]; }; then
-              echo "Fork Docker Hub username and token must be configured together" >&2
-              exit 2
-            fi
-            if [ -n "${DOCKERHUB_USERNAME}" ]; then
-              fork_dockerhub_namespace="${FORK_DOCKERHUB_NAMESPACE:-docker.io/${DOCKERHUB_USERNAME,,}}"
-            elif [ -n "${FORK_DOCKERHUB_NAMESPACE}" ]; then
-              echo "Fork Docker Hub namespace requires credentials" >&2
-              exit 2
-            fi
           fi
           resolved="$(PYTHONPATH=.github/release python -c \
-            'import json, sys; from ucm_release import policy; print(json.dumps(policy.resolve(release_type=sys.argv[1], fork_test_pypi=sys.argv[2] == "true", fork_dockerhub_namespace=sys.argv[3] or None)))' \
-            "${RELEASE_TYPE}" "${fork_test_pypi}" "${fork_dockerhub_namespace}")"
+            'import json, sys; from ucm_release import policy; print(json.dumps(policy.resolve(release_type=sys.argv[1], fork_test_pypi=sys.argv[2] == "true", dockerhub_namespace=sys.argv[3] or None)))' \
+            "${RELEASE_TYPE}" "${fork_test_pypi}" "${DOCKERHUB_NAMESPACE}")"
           jq -e --arg scope "${PUBLICATION_SCOPE}" \
             --arg repository "${GITHUB_REPOSITORY}" \
             '.publication_scope == $scope and
              (.repository | ascii_downcase) == ($repository | ascii_downcase)' \
             <<<"${resolved}" >/dev/null
+          dockerhub_requested="$(jq -r '.publish.dockerhub.requested' \
+            <<<"${resolved}")"
+          dockerhub_namespace="$(jq -r '.publish.dockerhub.namespace // empty' \
+            <<<"${resolved}")"
+          if [ "${dockerhub_requested}" = true ]; then
+            if [ -z "${DOCKERHUB_NAMESPACE}" ]; then
+              echo "Docker Hub namespace must be configured through DOCKERHUB_NAMESPACE" >&2
+              exit 2
+            fi
+            if [ -z "${DOCKERHUB_USERNAME}" ] || [ -z "${DOCKERHUB_TOKEN}" ]; then
+              echo "Docker Hub username and token must be configured together" >&2
+              exit 2
+            fi
+            test "${dockerhub_namespace}" = "${DOCKERHUB_NAMESPACE}"
+          fi
           enabled="$(jq -r '.publish.github_release.enabled' <<<"${resolved}")"
           {
             echo "enabled=${enabled}"
             echo "fork_test_pypi=${fork_test_pypi}"
-            echo "fork_dockerhub_namespace=${fork_dockerhub_namespace}"
+            echo "dockerhub_namespace=${dockerhub_namespace}"
           } >>"${GITHUB_OUTPUT}"
   select-runtime-candidates:
     name: Select Runtime Registry Tags
@@ -540,7 +543,7 @@ jobs:
           PUBLICATION_SCOPE: ${{ inputs.publication_scope }}
           REPOSITORY: ${{ github.repository }}
           FORK_TEST_PYPI: ${{ needs.release-preflight.outputs.fork_test_pypi }}
-          FORK_DOCKERHUB_NAMESPACE: ${{ needs.release-preflight.outputs.fork_dockerhub_namespace }}
+          DOCKERHUB_NAMESPACE: ${{ needs.release-preflight.outputs.dockerhub_namespace }}
         run: |
           set -euo pipefail
           test "${IMAGE_VERSION}" = "${RELEASE_VERSION}"
@@ -548,9 +551,9 @@ jobs:
             --version "${RELEASE_VERSION}" >/dev/null
           mkdir -p out/plan
           jq -n --argjson fork_test_pypi "${FORK_TEST_PYPI}" \
-            --arg namespace "${FORK_DOCKERHUB_NAMESPACE}" \
+            --arg namespace "${DOCKERHUB_NAMESPACE}" \
             '{fork_test_pypi:$fork_test_pypi,
-              fork_dockerhub_namespace:(if $namespace == "" then null else $namespace end)}' \
+              dockerhub_namespace:(if $namespace == "" then null else $namespace end)}' \
             >out/plan/publication-context.json
           PYTHONPATH=.github/release python -m ucm_release compact plan \
             --runtime-selection input/upstreams/runtime-selection.json \

--- a/.github/workflows/release-ucm.yml
+++ b/.github/workflows/release-ucm.yml
@@ -1283,16 +1283,13 @@ jobs:
             export PYPI_API_TOKEN
           fi
           test -n "${PYPI_API_TOKEN}"
-          readback_attempts="$(jq -r \
-            'if .publish.pypi.target == "testpypi" then 36 else 12 end' \
-            "${plan}")"
           mkdir -p out/pypi
           PYTHONPATH=.github/release python -m ucm_release pypi publish \
             --release-plan "${plan}" --wheel-results-dir input/wheels \
             --meta-result input/meta/meta-result.json \
             --wheel-root input/wheels --meta-root input/meta \
             --repository-url "$(jq -r '.publish.pypi.index' "${plan}")" \
-            --attempts "${readback_attempts}" --interval 5 \
+            --attempts 36 --interval 5 \
             --output out/pypi/pypi-receipt.json >/dev/null
       - uses: actions/upload-artifact@v4.6.2
         with:

--- a/.github/workflows/release-ucm.yml
+++ b/.github/workflows/release-ucm.yml
@@ -1283,13 +1283,16 @@ jobs:
             export PYPI_API_TOKEN
           fi
           test -n "${PYPI_API_TOKEN}"
+          readback_attempts="$(jq -r \
+            'if .publish.pypi.target == "testpypi" then 36 else 12 end' \
+            "${plan}")"
           mkdir -p out/pypi
           PYTHONPATH=.github/release python -m ucm_release pypi publish \
             --release-plan "${plan}" --wheel-results-dir input/wheels \
             --meta-result input/meta/meta-result.json \
             --wheel-root input/wheels --meta-root input/meta \
             --repository-url "$(jq -r '.publish.pypi.index' "${plan}")" \
-            --attempts 12 --interval 5 \
+            --attempts "${readback_attempts}" --interval 5 \
             --output out/pypi/pypi-receipt.json >/dev/null
       - uses: actions/upload-artifact@v4.6.2
         with:

--- a/.github/workflows/sync-builders.yml
+++ b/.github/workflows/sync-builders.yml
@@ -178,7 +178,10 @@ jobs:
           fi
           docker buildx imagetools inspect "${candidate}" >/dev/null
           if [ "${candidate}" != "${target}" ]; then
-            docker buildx imagetools create --tag "${target}" "${candidate}"
+            bash .github/release/retry-registry-command.sh \
+              "${RUNNER_TEMP}/ucm-builder-promotion.log" \
+              --retry-transport \
+              docker buildx imagetools create --tag "${target}" "${candidate}"
           fi
           target_digest="$(docker buildx imagetools inspect "${target}" \
             --format '{{json .Manifest}}' | jq -er '.digest // .Digest')"


### PR DESCRIPTION
Related: #1206

## Purpose

This PR follows up on #1289 and hardens the release publication boundaries.

It makes the selected Release Profile the sole authority for publication channels, replaces implicit Docker Hub destination inference with explicit configuration, and adds bounded retries for known transient Registry transport failures during Builder promotion.

## Modifications

### Publication policy

- Keep Stable and Prerelease configured to request all publication channels.
- Disable PyPI/TestPyPI and Docker Hub publication for Draft releases.
- Keep the existing Nightly publication policy unchanged.
- Ensure credentials or runtime configuration cannot enable a channel disabled by the selected Release Profile.

### Docker Hub configuration

- Use the repository variable `DOCKERHUB_NAMESPACE` as the explicit Docker Hub destination.
- Stop deriving the namespace from the GitHub repository owner or Docker Hub username.
- Apply the same namespace contract to official repositories and Forks.
- Require `DOCKERHUB_NAMESPACE`, `DOCKERHUB_USERNAME`, and `DOCKERHUB_TOKEN` together only when the selected Profile requests Docker Hub publication.
- Fail real Release preflight when Docker Hub is requested but its configuration is incomplete.
- Keep PR planning independent from production Docker Hub credentials.
- Forward Docker Hub credentials from the Fork Tag workflow to the reusable Release Core.
- Preserve the existing Fork-specific TestPyPI target and package-name prefix behavior.

### Registry retry

- Add opt-in retries for transient `connection reset` and `EOF` failures during Builder `imagetools create` promotion.
- Preserve the existing bounded five-attempt retry schedule.
- Continue to fail immediately for permanent Registry errors.
- Keep rate-limit fallback markers exclusive to exhausted `429` failures.

### Contracts and documentation

- Update the release schema and publication-context contract for the explicit Docker Hub namespace.
- Add coverage for Profile isolation, missing or invalid Docker Hub configuration, Official/Fork behavior, and PR-vs-Release boundaries.
- Add Registry retry coverage for connection resets, EOF failures, retry exhaustion, and permanent errors.
- Update the administrator setup documentation for official and Fork releases.

## Test

- `python -m pytest -q .github/release/tests`
  - `555 passed, 4 skipped`
- [Push Commit Checks](https://github.com/SuperMarioYL/unified-cache-management/actions/runs/33614239023)
  - Python lint and pre-commit checks passed
  - C++ lint passed
  - C++ unit tests passed