### PR TITLE
[Fix][CI] Improve release notes for published packages and images

### DIFF
--- a/.github/release/README.md
+++ b/.github/release/README.md
@@ -161,8 +161,13 @@ artifact. It is not attached to the public GitHub Release. Fresh-environment
 install validation downloads the exact receipt-bound meta/backend URLs,
 verifies their SHA256 digests, and uses production PyPI only for ordinary
 dependencies; index ordering never chooses the UCM distributions. GitHub
-Release notes omit Python-index installation commands for both official and
-Fork releases.
+Release notes show version-pinned installation commands only after a complete
+Python-index publication receipt is available. Official PyPI commands install
+one meta-package extra. TestPyPI examples download the meta Wheel and one
+backend Wheel, then install those local files with dependencies from PyPI.
+Package names, versions, and extras come from the receipt; index URLs come from
+the frozen publication configuration. Unpublished channels have no installation
+section.
 
 Python distribution names are repository-owned and deterministic. The official
 repository publishes canonical `uc-manager*` names. A Fork always prefixes the

--- a/.github/release/tests/test_release_manifest.py
+++ b/.github/release/tests/test_release_manifest.py
@@ -228,6 +228,49 @@ def _asset_urls(manifest: dict[str, object]) -> dict[str, str]:
     }
 
 
+def _single_family_release_notes_manifest(
+    *,
+    expected_targets: dict[str, str],
+    targets: list[dict[str, str]],
+    release_status: str = "complete",
+    family_status: str = "published",
+) -> dict[str, object]:
+    return {
+        "release": {"git_tag": "v1.0.0rc1", "status": release_status},
+        "chart": {"filename": "unified-cache-chart-1.0.0-rc.1.tgz"},
+        "wheels": [
+            {
+                "id": "cuda-amd64",
+                "filename": "uc_manager_cuda-amd64.whl",
+                "backend": "cuda",
+                "runtime_variant": "cu130",
+                "python_abi": "cp312",
+                "cpu_arch": "amd64",
+            }
+        ],
+        "images": [
+            {
+                "family_id": "openai-v1",
+                "wheel_id": "cuda-amd64",
+                "cpu_arch": "amd64",
+            }
+        ],
+        "families": [
+            {
+                "id": "openai-v1",
+                "runtime": {
+                    "repository": "docker.io/vllm/vllm-openai",
+                    "tag": "v1.0.0",
+                    "accelerator_runtime": "cuda-13.0",
+                },
+                "expected_targets": expected_targets,
+                "status": family_status,
+                "targets": targets,
+            }
+        ],
+    }
+
+
 def _write_meta_artifact(tmp_path: Path, plan: dict[str, object]) -> Path:
     meta_root = tmp_path / "meta"
     meta_root.mkdir()
@@ -460,7 +503,7 @@ def test_artifacts_and_image_receipts_form_one_mapping(tmp_path: Path) -> None:
         manifest, repository="example/ucm", asset_urls=asset_urls
     )
     assert "Upstream Runtime tags<br>docker.io/vllm/vllm-openai：" in notes
-    assert "Runtime tags<br>ghcr.io/example/vllm：" in notes
+    assert "Runtime tags<br>GHCR: ghcr.io/example/vllm" in notes
     assert "`v0.23.0`" in notes
     assert f"[x86_64]({asset_urls[filename]})" in notes
     assert "amd64=" not in notes
@@ -917,17 +960,6 @@ def test_release_notes_split_products_and_aggregate_wheel_capabilities() -> None
                 "targets": [{"channel": "ghcr"}],
             },
         ],
-        "pypi": {
-            "target": "testpypi",
-            "version": "1.0.0",
-            "extras": {"cu130": "supermarioyl-uc-manager-cuda-cu130==1.0.0"},
-            "projects": [
-                {
-                    "project": "supermarioyl-uc-manager",
-                    "role": "meta",
-                }
-            ],
-        },
     }
     asset_urls = _asset_urls(manifest)
 
@@ -945,9 +977,9 @@ def test_release_notes_split_products_and_aggregate_wheel_capabilities() -> None
     assert notes.count("[aarch64](") == 2
     assert notes.count("[x86_64](") == 2
     assert "Upstream Runtime tags<br>docker.io/vllm/vllm-openai：" in notes
-    assert "Runtime tags<br>ghcr.io/example/vllm-openai：" in notes
+    assert "Runtime tags<br>GHCR: ghcr.io/example/vllm-openai" in notes
     assert "Upstream Runtime tags<br>quay.io/ascend/vllm-ascend：" in notes
-    assert "Runtime tags<br>ghcr.io/example/vllm-ascend：" in notes
+    assert "Runtime tags<br>GHCR: ghcr.io/example/vllm-ascend" in notes
     assert "`v1.0.0`<br>`v1.1.0`" in notes
     assert "`v1.0.0-ucm`<br>`v1.1.0-ucm`" in notes
     cuda_row = next(line for line in notes.splitlines() if line.startswith("| CUDA"))
@@ -959,22 +991,6 @@ def test_release_notes_split_products_and_aggregate_wheel_capabilities() -> None
     assert "2 image families / 4 architecture members" in notes
     assert "2 image families / 3 architecture members" in notes
     assert " tags / " not in notes
-    assert "## TestPyPI" not in notes
-    assert "pip install" not in notes
-
-    official_manifest = json.loads(json.dumps(manifest))
-    official_manifest["pypi"] = {
-        "target": "pypi",
-        "version": "1.0.0",
-        "extras": {"cu130": "uc-manager-cuda-cu130==1.0.0"},
-        "projects": [{"project": "uc-manager", "role": "meta"}],
-    }
-    official_notes = release.render_notes(
-        official_manifest, repository="example/ucm", asset_urls=asset_urls
-    )
-    assert "## PyPI" not in official_notes
-    assert "pip install" not in official_notes
-
     draft_notes = release.render_notes(
         manifest,
         repository="example/ucm",
@@ -986,6 +1002,212 @@ def test_release_notes_split_products_and_aggregate_wheel_capabilities() -> None
     assert "[x86_64](" not in draft_notes
     assert draft_notes.count("`aarch64`") == 2
     assert draft_notes.count("`x86_64`") == 2
+
+
+@pytest.mark.parametrize("receipt_status", [None, "uploading"])
+def test_release_notes_hide_pypi_until_a_complete_receipt(
+    receipt_status: str | None,
+) -> None:
+    manifest = _single_family_release_notes_manifest(
+        expected_targets={}, targets=[], release_status="artifacts-ready"
+    )
+    manifest["publish"] = {
+        "pypi": {
+            "enabled": True,
+            "target": "testpypi",
+            "simple_index": "https://test.pypi.org/simple/",
+            "dependency_index": "https://pypi.org/simple/",
+        }
+    }
+    if receipt_status is not None:
+        manifest["pypi"] = {"status": receipt_status}
+
+    notes = release.render_notes(
+        manifest, repository="example/ucm", asset_urls=_asset_urls(manifest)
+    )
+
+    assert "## PyPI" not in notes
+    assert "## TestPyPI" not in notes
+    assert "pip install" not in notes
+    assert "pip download" not in notes
+
+
+@pytest.mark.parametrize(
+    ("version", "extra"),
+    [("1.0.0", "cu130"), ("2.4.0rc3", "cann920-a3")],
+)
+def test_release_notes_show_pypi_installation_from_published_receipt(
+    version: str, extra: str
+) -> None:
+    manifest = _single_family_release_notes_manifest(
+        expected_targets={},
+        targets=[],
+        release_status="images-failed",
+        family_status="failed",
+    )
+    simple_index = "https://pypi.org/simple/"
+    manifest["publish"] = {
+        "pypi": {
+            "enabled": True,
+            "simple_index": simple_index,
+            "dependency_index": simple_index,
+        }
+    }
+    meta_project = "uc-manager"
+    backend_project = f"uc-manager-{extra}"
+    manifest["pypi"] = {
+        "status": "complete",
+        "target": "pypi",
+        "version": version,
+        "extras": {extra: f"{backend_project}=={version}"},
+        "projects": [
+            {"project": backend_project, "role": "backend"},
+            {"project": meta_project, "role": "meta"},
+        ],
+    }
+
+    notes = release.render_notes(
+        manifest, repository="example/ucm", asset_urls=_asset_urls(manifest)
+    )
+
+    assert "Status: `images-failed`" in notes
+    assert "## PyPI" in notes
+    assert f"https://pypi.org/project/{meta_project}/{version}/" in notes
+    assert (
+        f"python -m pip install --index-url {simple_index} "
+        f'"{meta_project}[{extra}]=={version}"'
+    ) in notes
+    assert "## TestPyPI" not in notes
+    assert "pip download" not in notes
+
+
+def test_release_notes_testpypi_installs_one_published_backend_at_a_time() -> None:
+    manifest = _single_family_release_notes_manifest(expected_targets={}, targets=[])
+    simple_index = "https://test.pypi.org/simple/"
+    dependency_index = "https://pypi.org/simple/"
+    manifest["publish"] = {
+        "pypi": {
+            "enabled": True,
+            "simple_index": simple_index,
+            "dependency_index": dependency_index,
+        }
+    }
+    meta_project = "another-fork-uc-manager"
+    version = "2.4.0rc3"
+    extras = {
+        "cu140": f"{meta_project}-cuda-cu140=={version}",
+        "cann920-a3": f"{meta_project}-cann920-a3=={version}",
+    }
+    manifest["pypi"] = {
+        "status": "complete",
+        "target": "testpypi",
+        "version": version,
+        "extras": extras,
+        "projects": [{"project": meta_project, "role": "meta"}],
+    }
+
+    notes = release.render_notes(
+        manifest, repository="example/ucm", asset_urls=_asset_urls(manifest)
+    )
+
+    assert "## TestPyPI" in notes
+    assert f"https://test.pypi.org/project/{meta_project}/{version}/" in notes
+    commands = [part.split("```", 1)[0] for part in notes.split("```bash\n")[1:]]
+    assert len(commands) == len(extras)
+    for requirement in extras.values():
+        command = next(block for block in commands if f'"{requirement}"' in block)
+        assert 'ucm_wheel_dir="$(mktemp -d)"' in command
+        assert "python -m pip download --no-deps" in command
+        assert f"--index-url {simple_index}" in command
+        assert '--dest "$ucm_wheel_dir"' in command
+        assert f'"{meta_project}=={version}"' in command
+        assert f"python -m pip install --index-url {dependency_index}" in command
+        assert '"$ucm_wheel_dir"/*.whl' in command
+        assert sum(f'"{item}"' in command for item in extras.values()) == 1
+    assert "--extra-index-url" not in notes
+    assert "wrapt" not in notes
+    assert "supermarioyl" not in notes
+
+
+def test_release_notes_show_dockerhub_only_after_a_published_target() -> None:
+    ghcr_reference = "ghcr.io/example/vllm-openai:release-tag"
+    dockerhub_reference = "docker.io/example/vllm-openai:release-tag"
+    configured_manifest = _single_family_release_notes_manifest(
+        expected_targets={
+            "ghcr": ghcr_reference,
+            "dockerhub": dockerhub_reference,
+        },
+        targets=[],
+        release_status="artifacts-ready",
+        family_status="building",
+    )
+
+    before_dockerhub_push = release.render_notes(
+        configured_manifest,
+        repository="example/ucm",
+        asset_urls=_asset_urls(configured_manifest),
+    )
+
+    assert "ghcr.io/example/vllm-openai" in before_dockerhub_push
+    assert "https://github.com/example/ucm/pkgs/container/vllm-openai" in (
+        before_dockerhub_push
+    )
+    assert "docker.io/example/vllm-openai" not in before_dockerhub_push
+    assert "https://hub.docker.com/r/example/vllm-openai" not in before_dockerhub_push
+
+    published_manifest = _single_family_release_notes_manifest(
+        expected_targets={
+            "ghcr": ghcr_reference,
+            "dockerhub": dockerhub_reference,
+        },
+        targets=[
+            {"channel": "ghcr", "reference": ghcr_reference},
+            {"channel": "dockerhub", "reference": dockerhub_reference},
+        ],
+    )
+    after_dockerhub_push = release.render_notes(
+        published_manifest,
+        repository="example/ucm",
+        asset_urls=_asset_urls(published_manifest),
+    )
+    header = next(
+        line
+        for line in after_dockerhub_push.splitlines()
+        if line.startswith("| Runtime capability |")
+    )
+
+    assert (
+        "[`ghcr.io/example/vllm-openai`]"
+        "(https://github.com/example/ucm/pkgs/container/vllm-openai)"
+    ) in after_dockerhub_push
+    assert (
+        "[`docker.io/example/vllm-openai`]"
+        "(https://hub.docker.com/r/example/vllm-openai)"
+    ) in after_dockerhub_push
+    assert "ghcr.io/example/vllm-openai" in header
+    assert "docker.io/example/vllm-openai" in header
+
+
+def test_release_notes_use_dockerhub_target_tag_without_a_ghcr_target() -> None:
+    dockerhub_reference = "docker.io/example/vllm-openai:dockerhub-only-tag"
+    manifest = _single_family_release_notes_manifest(
+        expected_targets={"dockerhub": dockerhub_reference},
+        targets=[{"channel": "dockerhub", "reference": dockerhub_reference}],
+    )
+
+    notes = release.render_notes(
+        manifest,
+        repository="example/ucm",
+        asset_urls=_asset_urls(manifest),
+    )
+    header = next(
+        line for line in notes.splitlines() if line.startswith("| Runtime capability |")
+    )
+
+    assert "docker.io/example/vllm-openai" in header
+    assert "ghcr.io/example/vllm-openai" not in notes
+    assert "`dockerhub-only-tag`" in notes
+    assert "https://hub.docker.com/r/example/vllm-openai" in notes
 
 
 def test_github_asset_urls_require_backend_and_chart_but_not_meta() -> None:

--- a/.github/release/ucm_release/release.py
+++ b/.github/release/ucm_release/release.py
@@ -911,6 +911,20 @@ def _ghcr_package_link(repository: str, target_repository: str) -> str:
     return f"[`{target_repository}`]({url})"
 
 
+def _dockerhub_repository_link(target_repository: str) -> str:
+    prefix = "docker.io/"
+    target_parts = target_repository.removeprefix(prefix).split("/")
+    if (
+        not target_repository.startswith(prefix)
+        or len(target_parts) != 2
+        or any(re.fullmatch(r"[A-Za-z0-9_.-]+", part) is None for part in target_parts)
+    ):
+        raise ValueError("Docker Hub target is not a namespaced repository")
+    path = "/".join(target_parts)
+    url = f"https://hub.docker.com/r/{quote(path, safe='/')}"
+    return f"[`{target_repository}`]({url})"
+
+
 def _architecture_label(cpu_arch: str) -> str:
     return {"amd64": "x86_64", "arm64": "aarch64"}.get(cpu_arch, cpu_arch)
 
@@ -961,7 +975,10 @@ def _render_product_tables(
     for runtime_repository in product_order:
         product_families = families_by_product[runtime_repository]
         rows: dict[tuple[str, str, str], dict[str, Any]] = {}
-        ghcr_repositories: set[str] = set()
+        target_repositories: dict[str, set[str]] = {
+            "ghcr": set(),
+            "dockerhub": set(),
+        }
         member_count = 0
         published_count = 0
         for family in product_families:
@@ -1004,39 +1021,57 @@ def _render_product_tables(
             for wheel in family_wheels:
                 row["wheels"][str(wheel["cpu_arch"])] = wheel
 
-            actual_ghcr_references = [
-                str(target["reference"])
-                for target in family.get("targets", [])
-                if target.get("channel") == "ghcr"
-                and isinstance(target.get("reference"), str)
-            ]
-            if len(actual_ghcr_references) > 1:
-                raise ValueError(
-                    f"release family {family_id!r} has multiple GHCR targets"
-                )
-            ghcr_reference = (
-                actual_ghcr_references[0]
-                if actual_ghcr_references
-                else family["expected_targets"].get("ghcr")
-            )
-            if isinstance(ghcr_reference, str):
+            target_tag = None
+            for channel, label in (("ghcr", "GHCR"), ("dockerhub", "Docker Hub")):
+                actual_references = [
+                    str(target["reference"])
+                    for target in family.get("targets", [])
+                    if target.get("channel") == channel
+                    and isinstance(target.get("reference"), str)
+                ]
+                if len(actual_references) > 1:
+                    raise ValueError(
+                        f"release family {family_id!r} has multiple {label} targets"
+                    )
+                reference = actual_references[0] if actual_references else None
+                if reference is None and channel == "ghcr":
+                    reference = family["expected_targets"].get("ghcr")
+                if not isinstance(reference, str):
+                    continue
                 target_repository = _target_repository(
-                    ghcr_reference, "release family GHCR target"
+                    reference, f"release family {label} target"
                 )
-                ghcr_repositories.add(target_repository)
-                row["families"][-1]["target_tag"] = ghcr_reference.rpartition(":")[2]
-            if family.get("status") == "published" and any(
-                target.get("channel") == "ghcr" for target in family["targets"]
-            ):
+                target_repositories[channel].add(target_repository)
+                reference_tag = reference.rpartition(":")[2]
+                if target_tag is not None and reference_tag != target_tag:
+                    raise ValueError(
+                        f"release family {family_id!r} target tags do not match"
+                    )
+                target_tag = reference_tag
+            row["families"][-1]["target_tag"] = target_tag
+            if family.get("status") == "published" and family.get("targets"):
                 published_count += 1
 
         _, title = _product_title(runtime_repository)
         rendered.extend([f"## {title}", "", f"Runtime: `{runtime_repository}`", ""])
-        if len(ghcr_repositories) > 1:
-            raise ValueError(f"{title} maps to multiple GHCR packages")
-        if ghcr_repositories:
-            ghcr_repository = next(iter(ghcr_repositories))
-            package = _ghcr_package_link(repository, ghcr_repository)
+        repositories: dict[str, str] = {}
+        for channel, label in (("ghcr", "GHCR"), ("dockerhub", "Docker Hub")):
+            channel_repositories = target_repositories[channel]
+            if len(channel_repositories) > 1:
+                raise ValueError(f"{title} maps to multiple {label} repositories")
+            if channel_repositories:
+                repositories[channel] = next(iter(channel_repositories))
+        if repositories:
+            packages = []
+            if "ghcr" in repositories:
+                packages.append(
+                    f"GHCR {_ghcr_package_link(repository, repositories['ghcr'])}"
+                )
+            if "dockerhub" in repositories:
+                packages.append(
+                    "Docker Hub "
+                    + _dockerhub_repository_link(repositories["dockerhub"])
+                )
             family_count = len(product_families)
             release_status = manifest["release"]["status"]
             if release_status == "complete":
@@ -1053,14 +1088,24 @@ def _render_product_tables(
                     f"building {family_count} image families / "
                     f"{member_count} architecture members"
                 )
-            rendered.extend([f"Images: {package} — {image_status}", ""])
+            rendered.extend([f"Images: {' · '.join(packages)} — {image_status}", ""])
+
+        repository_headers = []
+        if "ghcr" in repositories:
+            repository_headers.append(f"GHCR: {repositories['ghcr']}")
+        if "dockerhub" in repositories:
+            repository_headers.append(f"Docker Hub: {repositories['dockerhub']}")
 
         rendered.extend(
             [
                 "| Runtime capability | "
                 f"Upstream Runtime tags<br>{runtime_repository}： | "
                 "Runtime tags"
-                + (f"<br>{ghcr_repository}：" if ghcr_repositories else "")
+                + (
+                    "<br>" + "<br>".join(repository_headers)
+                    if repository_headers
+                    else ""
+                )
                 + " | Python ABI | Wheel |",
                 "| --- | --- | --- | --- | --- |",
             ]
@@ -1119,6 +1164,79 @@ def _render_product_tables(
             )
         rendered.append("")
     return rendered
+
+
+def _render_pypi_installation(manifest: dict[str, Any]) -> list[str]:
+    receipt = manifest.get("pypi")
+    if not receipt or receipt.get("status") != "complete":
+        return []
+
+    target = receipt["target"]
+    title = {"pypi": "PyPI", "testpypi": "TestPyPI"}[target]
+    meta_projects = [
+        project["project"]
+        for project in receipt["projects"]
+        if project["role"] == "meta"
+    ]
+    if len(meta_projects) != 1:
+        raise ValueError(
+            "PyPI installation requires exactly one published meta project"
+        )
+    meta_project = meta_projects[0]
+    version = receipt["version"]
+    publication = manifest["publish"]["pypi"]
+    simple_index = publication["simple_index"]
+    index_url = urlparse(simple_index)
+    project_url = (
+        f"{index_url.scheme}://{index_url.netloc}/project/"
+        f"{quote(meta_project, safe='')}/{quote(version, safe='')}/"
+    )
+    lines = [
+        f"## {title}",
+        "",
+        f"Package: [`{meta_project}=={version}`]({project_url})",
+        "",
+        "Choose **one** extra matching the Runtime, Python ABI, and architecture "
+        "in the tables above. The meta package alone does not install a UCM backend.",
+        "",
+    ]
+    if target == "pypi":
+        lines.extend(["| Extra | Install |", "| --- | --- |"])
+        for extra in sorted(receipt["extras"]):
+            lines.append(
+                f"| `{extra}` | `python -m pip install --index-url {simple_index} "
+                f'"{meta_project}[{extra}]=={version}"` |'
+            )
+        return [*lines, ""]
+
+    lines.extend(
+        [
+            "Download the selected packages from TestPyPI, then install the local "
+            "Wheels with dependencies from PyPI. Run only one of the examples below.",
+            "",
+        ]
+    )
+    for extra, backend_requirement in sorted(receipt["extras"].items()):
+        lines.extend(
+            [
+                "<details>",
+                f"<summary>{extra}</summary>",
+                "",
+                "```bash",
+                'ucm_wheel_dir="$(mktemp -d)"',
+                f"python -m pip download --no-deps --index-url {simple_index} \\",
+                '  --dest "$ucm_wheel_dir" \\',
+                f'  "{meta_project}=={version}" "{backend_requirement}"',
+                "python -m pip install --index-url "
+                f'{publication["dependency_index"]} \\',
+                '  "$ucm_wheel_dir"/*.whl',
+                "```",
+                "",
+                "</details>",
+                "",
+            ]
+        )
+    return lines
 
 
 def render_notes(
@@ -1181,6 +1299,7 @@ def render_notes(
             link_assets=link_assets,
         )
     )
+    lines.extend(_render_pypi_installation(manifest))
     return "\n".join(lines) + "\n"
 
 


### PR DESCRIPTION
## Purpose

Improve GitHub Release notes with published image repositories and version-pinned Python package installation instructions.

This PR only changes Release-note rendering, its tests, and documentation. **Squash merge into `feature/cicd` is appropriate.** It does not synchronize `develop` or resolve the `feature/cicd` -> `develop` conflict; upstream maintainers should resolve that conflict in the subsequent PR.

## Modifications

- Display published Docker Hub links alongside GHCR links.
- Generate version-pinned PyPI/TestPyPI installation instructions from completed publication receipts.
- Keep unpublished Python-index channels out of the installation section.
- Update the Release documentation and focused regression tests.

## Test

- Local release tests: 562 passed, 4 skipped.
- Ruff, Black, isort, and actionlint with the repository CI configuration passed.
- `git diff --check` passed.
- Fork Push Commit Checks for `5d3a1be7`: C++ build/unit tests, C++ formatting, and Python checks all passed.

GitHub Actions: [Push Commit Checks](https://github.com/SuperMarioYL/unified-cache-management/actions/runs/33732831949)
