### PR TITLE
feat(ci): gate PRs on native wheel builds

### DIFF
--- a/.github/release/tests/test_builders.py
+++ b/.github/release/tests/test_builders.py
@@ -74,6 +74,45 @@ def _all_keys(value: object) -> set[str]:
     return set()
 
 
+def test_source_binding_pins_upstream_builders_without_mutating_desired_catalog() -> (
+    None
+):
+    desired = _catalog()
+
+    bound = builders.bind_source_catalog(desired)
+
+    assert desired["schema_version"] == 3
+    assert bound["schema_version"] == 4
+    assert len(bound["builders"]) == len(desired["builders"])
+    for original, selected in zip(desired["builders"], bound["builders"], strict=True):
+        source_repository, _source_tag = original["source_image"].rsplit(":", 1)
+        assert selected["target_repository"] == source_repository
+        assert selected["target_tag"] == original["target_tag"]
+        assert selected["target_digest"] == original["source_image_digest"]
+        assert original["target_repository"] == "ghcr.io/release-org/" + (
+            "ucm-builder-vllm"
+            if original["accelerator"] == "cuda"
+            else "ucm-builder-vllm-ascend"
+        )
+
+
+def test_source_binding_rejects_an_already_finalized_catalog() -> None:
+    desired = _catalog()
+    observations = {
+        item["id"]: {
+            "target_digest": f"sha256:{index + 1:064x}",
+            "config": {
+                "created": "2026-08-24T00:00:00Z",
+                "config": {"Labels": builders.builder_labels(item)},
+            },
+        }
+        for index, item in enumerate(desired["builders"])
+    }
+
+    with pytest.raises(ValueError, match="desired Catalog schema 3"):
+        builders.bind_source_catalog(builders.finalize_catalog(desired, observations))
+
+
 def test_registry_tag_selection_uses_version_ranges_and_all_winner_variants() -> None:
     product = {
         "id": "vllm-ascend",

--- a/.github/release/tests/test_compact_release.py
+++ b/.github/release/tests/test_compact_release.py
@@ -90,6 +90,30 @@ def _all_keys(value: object) -> set[str]:
     return set()
 
 
+def test_pr_plan_can_build_directly_from_pinned_upstream_builders() -> None:
+    formal, selection, _finalized_catalog = _inputs()
+    desired = builders.catalog_from_selection(
+        selection,
+        owner="release-org",
+        formal_policy=formal,
+    )
+
+    plan = compact.resolve_plan(
+        formal,
+        runtime_selection=selection,
+        builder_catalog=builders.bind_source_catalog(desired),
+        route="pr",
+    )
+
+    builds = {item["id"]: item for item in selection["wheel_builds"]}
+    assert len(plan["wheels"]) == len(builds)
+    for wheel in plan["wheels"]:
+        build = builds[wheel["id"]]
+        source_repository, _source_tag = build["source_image"].rsplit(":", 1)
+        assert wheel["builder"]["repository"] == source_repository
+        assert wheel["builder"]["digest"] == build["source_image_digest"]
+
+
 def _write_wheel_fixture(
     path: Path,
     metadata_tag: str,

--- a/.github/release/tests/test_compact_workflows.py
+++ b/.github/release/tests/test_compact_workflows.py
@@ -25,6 +25,7 @@ def test_user_facing_release_workflow_names_explain_the_build_lanes() -> None:
         "UCM Nightly Release · Shanghai 02:00"
     )
     assert _load("release-ucm.yml")["name"] == "UCM Reusable Release Core"
+    assert _load("_native-wheel-gate.yml")["name"] == "UCM Native Wheel Gate"
     assert _load("ucm-build-bot.yml")["name"] == (
         "UCM PR Build Robot · Wheel, Image, and Chart"
     )
@@ -165,10 +166,87 @@ def test_release_core_is_input_driven_and_uses_crane_before_plan() -> None:
     assert "docker.io/${DOCKERHUB_USERNAME,,}" not in text
 
 
-def test_pr_gate_keeps_ucm_artifact_builds_in_the_robot_lane() -> None:
+def test_pr_gate_runs_the_native_wheel_matrix_behind_one_stable_check() -> None:
+    workflow = _load("pull-request.yml")
+    assert "feature/**" in workflow["on"]["pull_request"]["branches"]
+    jobs = workflow["jobs"]
+    pre_check = jobs["pre-check"]
+    build = jobs["native-wheel-build"]
+    gate = jobs["native-wheel-compile"]
+
+    assert pre_check["outputs"]["native_wheel_required"] == (
+        "${{ steps.build-impact.outputs.required }}"
+    )
+    impact = next(
+        step for step in pre_check["steps"] if step.get("id") == "build-impact"
+    )
+    for build_input in (
+        "CMakeLists.txt",
+        "ucm/*",
+        "setup.py",
+        "pyproject.toml",
+        "version.ini",
+        ".github/release/ucm_release/*",
+        ".github/release/docker/*",
+        ".github/release/requirements/*",
+        ".github/workflows/_build-wheel.yml",
+        ".github/workflows/_native-wheel-gate.yml",
+    ):
+        assert build_input in impact["run"]
+    assert build["needs"] == "pre-check"
+    assert "native_wheel_required == 'true'" in build["if"]
+    assert build["permissions"] == {"contents": "read", "packages": "read"}
+    assert build["uses"] == "./.github/workflows/_native-wheel-gate.yml"
+    assert build["with"]["source_ref"] == "${{ github.sha }}"
+    assert set(gate["needs"]) == {"pre-check", "native-wheel-build"}
+    assert gate["if"] == "${{ always() }}"
+    assert gate["name"] == "native-wheel-compile"
+    gate_text = yaml.safe_dump(gate)
+    assert "PRE_CHECK_RESULT" in gate_text
+    assert "BUILD_REQUIRED" in gate_text
+    assert "BUILD_RESULT" in gate_text
+    assert jobs["test-e2e-pc-a2"]["if"] == (
+        "github.repository == 'ModelEngine-Group/unified-cache-management'"
+    )
+
     text = (WORKFLOWS / "pull-request.yml").read_text(encoding="utf-8")
-    assert "release-catalog-smoke" not in text
     assert "./.github/workflows/release-ucm.yml" not in text
+
+
+def test_native_wheel_gate_uses_source_builders_without_publication() -> None:
+    workflow = _load("_native-wheel-gate.yml")
+    assert set(workflow["on"]) == {"workflow_call"}
+    assert set(workflow["on"]["workflow_call"]["inputs"]) == {
+        "source_ref",
+        "retention_days",
+    }
+    assert workflow["permissions"] == {"contents": "read", "packages": "read"}
+    jobs = workflow["jobs"]
+    assert set(jobs) == {
+        "inspect-runtimes",
+        "probe-runtimes",
+        "resolve-upstreams",
+        "plan-wheels",
+        "build-wheels",
+    }
+    assert jobs["probe-runtimes"]["uses"] == ("./.github/workflows/_probe-runtime.yml")
+    assert jobs["build-wheels"]["strategy"]["fail-fast"] is False
+    assert jobs["build-wheels"]["strategy"]["matrix"] == (
+        "${{ fromJSON(needs.plan-wheels.outputs.wheel_matrix) }}"
+    )
+    assert jobs["build-wheels"]["uses"] == "./.github/workflows/_build-wheel.yml"
+    assert jobs["build-wheels"]["permissions"] == {
+        "contents": "read",
+        "packages": "read",
+    }
+    text = (WORKFLOWS / "_native-wheel-gate.yml").read_text(encoding="utf-8")
+    assert "builders bind-source" in text
+    assert "compact plan" in text and "--route pr" in text
+    assert "sync-builders.yml" not in text
+    assert "packages: write" not in text
+    assert "docker push" not in text
+    assert "open-release" not in text
+    assert "publish" not in text.lower()
 
 
 def test_release_workflow_has_staged_publication_jobs() -> None:
@@ -1199,6 +1277,7 @@ def test_compact_wheel_passes_dynamic_python_and_platform_to_build() -> None:
     assert 'source_builder="${source_repository}@$(jq -er' in workflow
     assert 'build_wheel "${builder}"' in workflow
     assert 'build_wheel "${source_builder}"' in workflow
+    assert 'if [ "${builder}" = "${source_builder}" ]; then' in workflow
     assert '--rate-limit-marker "${rate_limit_marker}"' in workflow
     assert '--rate-limit-scope "${rate_limit_scope}"' in workflow
     assert 'builder_rate_limit_scope="${builder_repository#ghcr.io/}"' in workflow
@@ -1561,6 +1640,7 @@ def test_cross_job_artifact_names_survive_failed_job_reruns() -> None:
         "_build-image.yml",
         "_build-release-image.yml",
         "_build-chart.yml",
+        "_native-wheel-gate.yml",
         "ucm-build-bot.yml",
     )
     text = "\n".join((WORKFLOWS / name).read_text(encoding="utf-8") for name in names)

--- a/.github/release/ucm_release/builders.py
+++ b/.github/release/ucm_release/builders.py
@@ -380,6 +380,37 @@ def finalize_catalog(catalog: object, observations: object) -> dict[str, object]
     )
 
 
+def bind_source_catalog(catalog: object) -> dict[str, object]:
+    """Pin Wheel builds directly to their immutable upstream Builder images."""
+
+    desired = validate_catalog(catalog)
+    if desired.get("schema_version") != 3:
+        raise ValueError("Source Builder binding requires desired Catalog schema 3")
+
+    bound: list[dict[str, object]] = []
+    for raw_item in desired["builders"]:  # type: ignore[index]
+        item = _require_mapping(raw_item, "Builder source binding")
+        source_image = _require_string(item, "source_image", "Builder source binding")
+        separator = source_image.rfind(":")
+        if separator <= source_image.rfind("/"):
+            raise ValueError("Builder source image must include a tag")
+        bound.append(
+            {
+                **copy.deepcopy(item),
+                "target_repository": source_image[:separator],
+                "target_digest": item["source_image_digest"],
+            }
+        )
+
+    return validate_catalog(
+        {
+            "kind": "ucm-builder-catalog",
+            "schema_version": 4,
+            "builders": bound,
+        }
+    )
+
+
 def compute_sync_plan(catalog: object, existing_tags: object) -> dict[str, object]:
     """Return only catalog entries whose exact target tag is absent."""
     validated = validate_catalog(catalog)

--- a/.github/release/ucm_release/cli.py
+++ b/.github/release/ucm_release/cli.py
@@ -170,6 +170,18 @@ def build_parser() -> argparse.ArgumentParser:
 
     builders_finalize.set_defaults(func=_cmd_builders_finalize)
 
+    builders_bind_source = builders_actions.add_parser("bind-source")
+    builders_bind_source.add_argument("--catalog", type=Path, required=True)
+    builders_bind_source.add_argument("--output", type=Path, required=True)
+
+    def _cmd_builders_bind_source(a):
+        result = builders.bind_source_catalog(core.load_json(a.catalog))
+        a.output.parent.mkdir(parents=True, exist_ok=True)
+        _write(a.output, result)
+        return result
+
+    builders_bind_source.set_defaults(func=_cmd_builders_bind_source)
+
     builders_scan = builders_actions.add_parser("scan-registry")
     builders_scan.add_argument("--output", type=Path, required=True)
 

--- a/.github/workflows/_build-wheel.yml
+++ b/.github/workflows/_build-wheel.yml
@@ -143,7 +143,11 @@ jobs:
           }
           target_rate_limit_marker="${RUNNER_TEMP}/ucm-wheel-target-rate-limited"
           selected_builder="${builder}"
-          if build_wheel "${builder}" "${RUNNER_TEMP}/ucm-wheel-target-build.log" \
+          if [ "${builder}" = "${source_builder}" ]; then
+            build_wheel "${source_builder}" \
+              "${RUNNER_TEMP}/ucm-wheel-source-build.log"
+          elif build_wheel "${builder}" \
+            "${RUNNER_TEMP}/ucm-wheel-target-build.log" \
             "${target_rate_limit_marker}" "${builder_rate_limit_scope}"; then
             :
           else

--- a/.github/workflows/_native-wheel-gate.yml
+++ b/.github/workflows/_native-wheel-gate.yml
@@ -1,0 +1,228 @@
+name: UCM Native Wheel Gate
+
+on:
+  workflow_call:
+    inputs:
+      source_ref:
+        description: Exact PR merge commit to compile
+        type: string
+        required: true
+      retention_days:
+        description: Retention for diagnostic Gate artifacts
+        type: number
+        required: false
+        default: 7
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  inspect-runtimes:
+    name: Inspect configured Runtime range
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      inputs_artifact: ${{ steps.inspect.outputs.inputs_artifact }}
+      probe_matrix: ${{ steps.inspect.outputs.probe_matrix }}
+      has_probe_fallback: ${{ steps.inspect.outputs.has_probe_fallback }}
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: actions/setup-python@v5.6.0
+        with:
+          python-version: "3.12"
+      - run: >-
+          python -m pip install --disable-pip-version-check --no-cache-dir
+          --only-binary=:all: PyYAML==6.0.2 packaging==24.2
+      - name: Install crane
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/crane"
+          curl -fsSL --retry 3 \
+            https://github.com/google/go-containerregistry/releases/download/v0.20.3/go-containerregistry_Linux_x86_64.tar.gz \
+            | tar -xz -C "${RUNNER_TEMP}/crane" crane
+          echo "${RUNNER_TEMP}/crane" >>"${GITHUB_PATH}"
+      - id: inspect
+        name: Select and inspect Runtime manifests
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p out/inputs
+          PYTHONPATH=.github/release python -m ucm_release upstreams candidates \
+            --output out/inputs/runtime-candidates.json >/dev/null
+          jq -er '.references[]' out/inputs/runtime-candidates.json \
+            >out/inputs/runtime-refs.txt
+          PYTHONPATH=.github/release python -m ucm_release runtime inspect \
+            --references-file out/inputs/runtime-refs.txt \
+            --output out/inputs/runtime-inspection.json >/dev/null
+          artifact="ucm-native-wheel-inputs-run-${GITHUB_RUN_ID}"
+          {
+            echo "inputs_artifact=${artifact}"
+            echo "probe_matrix=$(jq -c 'if (.probe_matrix.include | length) > 0 then .probe_matrix else {include:[.members[0]]} end' out/inputs/runtime-inspection.json)"
+            echo "has_probe_fallback=$(jq -r '.probe_matrix.include | length > 0' out/inputs/runtime-inspection.json)"
+          } >>"${GITHUB_OUTPUT}"
+      - uses: actions/upload-artifact@v4.6.2
+        with:
+          name: ${{ steps.inspect.outputs.inputs_artifact }}
+          path: out/inputs/
+          if-no-files-found: error
+          overwrite: true
+          retention-days: ${{ inputs.retention_days }}
+
+  probe-runtimes:
+    name: Capability check · ${{ matrix.runtime_ref }} · ${{ matrix.cpu_arch }}
+    needs: inspect-runtimes
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.inspect-runtimes.outputs.probe_matrix) }}
+    uses: ./.github/workflows/_probe-runtime.yml
+    with:
+      probe_id: ${{ matrix.probe_id }}
+      runtime_ref: ${{ matrix.runtime_ref }}
+      image_reference: ${{ matrix.image_reference }}
+      platform: ${{ matrix.platform }}
+      accelerator: ${{ matrix.accelerator }}
+      runner: ${{ matrix.runner }}
+      enabled: ${{ matrix.fallback_required }}
+      retention_days: ${{ inputs.retention_days }}
+
+  resolve-upstreams:
+    name: Resolve Runtime capabilities and upstream Builders
+    needs: [inspect-runtimes, probe-runtimes]
+    if: >-
+      ${{
+        always() &&
+        needs.inspect-runtimes.result == 'success' &&
+        (needs.probe-runtimes.result == 'success' ||
+         needs.probe-runtimes.result == 'skipped')
+      }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    outputs:
+      selection_artifact: ${{ steps.resolve.outputs.selection_artifact }}
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: actions/setup-python@v5.6.0
+        with:
+          python-version: "3.12"
+      - run: >-
+          python -m pip install --disable-pip-version-check --no-cache-dir
+          --only-binary=:all: PyYAML==6.0.2 packaging==24.2
+      - name: Install crane
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/crane"
+          curl -fsSL --retry 3 \
+            https://github.com/google/go-containerregistry/releases/download/v0.20.3/go-containerregistry_Linux_x86_64.tar.gz \
+            | tar -xz -C "${RUNNER_TEMP}/crane" crane
+          echo "${RUNNER_TEMP}/crane" >>"${GITHUB_PATH}"
+      - uses: actions/download-artifact@v4.3.0
+        with:
+          name: ${{ needs.inspect-runtimes.outputs.inputs_artifact }}
+          path: input/runtimes
+      - uses: actions/download-artifact@v4.3.0
+        if: needs.inspect-runtimes.outputs.has_probe_fallback == 'true'
+        with:
+          pattern: ucm-runtime-probe-*-run-${{ github.run_id }}
+          path: input/probes
+      - id: resolve
+        run: |
+          set -euo pipefail
+          mkdir -p out/selection input/probes
+          PYTHONPATH=.github/release python -m ucm_release runtime aggregate \
+            --inspection input/runtimes/runtime-inspection.json \
+            --probe-dir input/probes \
+            --output out/selection/runtime-probe.json >/dev/null
+          PYTHONPATH=.github/release python -m ucm_release upstreams resolve \
+            --candidates input/runtimes/runtime-candidates.json \
+            --runtime-probe out/selection/runtime-probe.json \
+            --output out/selection/runtime-selection.json >/dev/null
+          artifact="ucm-native-wheel-selection-run-${GITHUB_RUN_ID}"
+          echo "selection_artifact=${artifact}" >>"${GITHUB_OUTPUT}"
+      - uses: actions/upload-artifact@v4.6.2
+        with:
+          name: ${{ steps.resolve.outputs.selection_artifact }}
+          path: out/selection/
+          if-no-files-found: error
+          overwrite: true
+          retention-days: ${{ inputs.retention_days }}
+
+  plan-wheels:
+    name: Plan complete native Wheel matrix
+    needs: resolve-upstreams
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    outputs:
+      plan_artifact: ${{ steps.plan.outputs.plan_artifact }}
+      wheel_matrix: ${{ steps.plan.outputs.wheel_matrix }}
+    steps:
+      - uses: actions/checkout@v4.2.2
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: actions/setup-python@v5.6.0
+        with:
+          python-version: "3.12"
+      - run: >-
+          python -m pip install --disable-pip-version-check --no-cache-dir
+          --only-binary=:all: PyYAML==6.0.2 packaging==24.2
+      - uses: actions/download-artifact@v4.3.0
+        with:
+          name: ${{ needs.resolve-upstreams.outputs.selection_artifact }}
+          path: input/selection
+      - id: plan
+        name: Bind source Builders and generate Wheel tasks
+        run: |
+          set -euo pipefail
+          mkdir -p out/plan
+          PYTHONPATH=.github/release python -m ucm_release builders discover \
+            --selection input/selection/runtime-selection.json \
+            --output out/plan/builder-catalog.desired.json >/dev/null
+          PYTHONPATH=.github/release python -m ucm_release builders bind-source \
+            --catalog out/plan/builder-catalog.desired.json \
+            --output out/plan/builder-catalog.json >/dev/null
+          PYTHONPATH=.github/release python -m ucm_release compact plan \
+            --runtime-selection input/selection/runtime-selection.json \
+            --builder-catalog out/plan/builder-catalog.json --route pr \
+            --output out/plan/release-plan.json >/dev/null
+          wheel_matrix="$(jq -ce '.wheel_matrix' out/plan/release-plan.json)"
+          test "$(jq '.include | length' <<<"${wheel_matrix}")" -gt 0
+          artifact="ucm-native-wheel-plan-run-${GITHUB_RUN_ID}"
+          {
+            echo "plan_artifact=${artifact}"
+            echo "wheel_matrix=${wheel_matrix}"
+          } >>"${GITHUB_OUTPUT}"
+      - uses: actions/upload-artifact@v4.6.2
+        with:
+          name: ${{ steps.plan.outputs.plan_artifact }}
+          path: out/plan/release-plan.json
+          if-no-files-found: error
+          overwrite: true
+          retention-days: ${{ inputs.retention_days }}
+
+  build-wheels:
+    name: Wheel · ${{ matrix.label }}
+    needs: plan-wheels
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.plan-wheels.outputs.wheel_matrix) }}
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/_build-wheel.yml
+    with:
+      wheel_id: ${{ matrix.id }}
+      runner: ${{ matrix.runner }}
+      plan_artifact: ${{ needs.plan-wheels.outputs.plan_artifact }}
+      source_ref: ${{ inputs.source_ref }}
+      retention_days: ${{ inputs.retention_days }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,7 +2,7 @@ name: 'Pull Request Gate'
 
 on:
   pull_request:
-    branches: [ "dev*", "main", "*release", "feature*" ]
+    branches: [ "dev*", "main", "*release", "feature/**" ]
 
 permissions:
   contents: read
@@ -11,6 +11,8 @@ permissions:
 jobs:
   pre-check:
     runs-on: ubuntu-latest
+    outputs:
+      native_wheel_required: ${{ steps.build-impact.outputs.required }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -18,20 +20,24 @@ jobs:
 
       - id: fetch_base_and_pr_branches
         env:
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          git fetch origin ${{ github.base_ref }}
+          git fetch origin "${BASE_REF}"
 
-          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
+          if [ "${HEAD_REPOSITORY}" != "${REPOSITORY}" ]; then
             echo "PR is from a fork, adding remote."
-            git remote add fork ${{ github.event.pull_request.head.repo.clone_url }}
-            git fetch fork $HEAD_REF
-            HEAD_BRANCH_NAME=fork/$HEAD_REF
-            echo "HEAD_BRANCH_NAME=$HEAD_BRANCH_NAME" >> $GITHUB_OUTPUT
+            git remote add fork "${HEAD_CLONE_URL}"
+            git fetch fork "${HEAD_REF}"
+            HEAD_BRANCH_NAME="fork/${HEAD_REF}"
+            echo "HEAD_BRANCH_NAME=${HEAD_BRANCH_NAME}" >>"${GITHUB_OUTPUT}"
           else
-            git fetch origin $HEAD_REF
-            HEAD_BRANCH_NAME=origin/$HEAD_REF
-            echo "HEAD_BRANCH_NAME=$HEAD_BRANCH_NAME" >> $GITHUB_OUTPUT
+            git fetch origin "${HEAD_REF}"
+            HEAD_BRANCH_NAME="origin/${HEAD_REF}"
+            echo "HEAD_BRANCH_NAME=${HEAD_BRANCH_NAME}" >>"${GITHUB_OUTPUT}"
           fi
 
       # protect the workflows dir, only allow specific users to modify
@@ -73,9 +79,67 @@ jobs:
             exit 1
           fi
 
+      - id: build-impact
+        name: Detect native Wheel build inputs
+        run: |
+          set -euo pipefail
+          required=false
+          while IFS= read -r path; do
+            case "${path}" in
+              CMakeLists.txt|cmake/*|ucm/*|setup.py|pyproject.toml|MANIFEST.in|version.ini|ucm_patch.pth|README.md|LICENSE|scripts/materialize_version.py|.github/release/ucm_release/*|.github/release/docker/*|.github/release/requirements/*|.github/release/release.yaml|.github/release/platforms.yaml|.github/actions/download-artifact-retry/*|.github/workflows/_build-wheel.yml|.github/workflows/_probe-runtime.yml|.github/workflows/_native-wheel-gate.yml|.github/workflows/release-ucm.yml|.github/workflows/pull-request.yml)
+                required=true
+                break
+                ;;
+            esac
+          done < <(git diff --name-only \
+            "origin/${{ github.base_ref }}...${{ steps.fetch_base_and_pr_branches.outputs.HEAD_BRANCH_NAME }}")
+          echo "required=${required}" >>"${GITHUB_OUTPUT}"
+
   lint-and-unit-tests:
     needs: pre-check
     uses: ./.github/workflows/lint-and-test.yml
+
+  native-wheel-build:
+    name: Native Wheel Matrix
+    needs: pre-check
+    if: needs.pre-check.outputs.native_wheel_required == 'true'
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/_native-wheel-gate.yml
+    with:
+      source_ref: ${{ github.sha }}
+      retention_days: 7
+
+  native-wheel-compile:
+    name: native-wheel-compile
+    needs: [pre-check, native-wheel-build]
+    if: ${{ always() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Require the applicable native Wheel build
+        env:
+          PRE_CHECK_RESULT: ${{ needs.pre-check.result }}
+          BUILD_REQUIRED: ${{ needs.pre-check.outputs.native_wheel_required }}
+          BUILD_RESULT: ${{ needs.native-wheel-build.result }}
+        run: |
+          set -euo pipefail
+          if [ "${PRE_CHECK_RESULT}" != success ]; then
+            echo "Native Wheel Gate cannot pass because pre-check did not succeed" >&2
+            exit 1
+          fi
+          if [ "${BUILD_REQUIRED}" != true ]; then
+            echo "Native Wheel Gate is not required for this PR"
+            exit 0
+          fi
+          if [ "${BUILD_RESULT}" != success ]; then
+            echo "Native Wheel Gate failed: ${BUILD_RESULT}" >&2
+            exit 1
+          fi
+          echo "All planned native Wheels compiled successfully"
 
   test-build-vllm-ascend:
     timeout-minutes: 25
@@ -177,6 +241,7 @@ jobs:
     timeout-minutes: 20
     runs-on: [self-hosted, npu, a2]
     needs: lint-and-unit-tests
+    if: github.repository == 'ModelEngine-Group/unified-cache-management'
     permissions:
       checks: write
       pull-requests: write
@@ -225,7 +290,7 @@ jobs:
           SHORT_SHA=$(echo '${{ github.sha }}' | cut -c1-7)
           REF_NAME=$(echo '${{ github.ref_name }}' | tr '/' '-')
           VERSION="${REF_NAME}-${DATE}-${{ github.run_number }}-${SHORT_SHA}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >>"${GITHUB_OUTPUT}"
           echo "Docker image version: ${VERSION}"
 
       - name: Build


### PR DESCRIPTION
## Summary

- add a path-aware PR gate for the complete native Wheel matrix
- resolve Runtime/Builder inputs dynamically from `version.ini` and Registry metadata
- reuse the release Wheel build path with read-only upstream Builder digests
- expose one stable `native-wheel-compile` result while keeping existing Runtime image checks
- skip the official A2 hardware E2E in Fork repositories without changing upstream behavior

## Verification

- `.github/release/tests`: 574 passed, 4 skipped
- codespell, Black, isort, actionlint, and ShellCheck passed
- patch rebased directly onto current `develop` (`ac84a680`)

## Expected first Gate signal

The Gate intentionally keeps `-Wall -Werror`. With the current source tree it surfaces the existing GCC 14 CANN Wheel warning in `MaglevRouter::Build`; this PR does not modify UCM runtime sources.