### PR TITLE
[Feat] Move KV cache preregistration into Store setup

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -321,6 +321,7 @@ class UCMDirectConnector(KVConnectorBase_V1):
         self,
         kv_cache_layout: Optional[KVCacheLayout],
         cpu_affinity_cores: Optional[list[int]] = None,
+        registrations: Optional[np.ndarray] = None,
     ) -> UcmKVStoreBaseV1:
         if len(self.connector_configs) != 1:
             raise RuntimeError(
@@ -332,6 +333,8 @@ class UCMDirectConnector(KVConnectorBase_V1):
         name = self.connector_configs[0]["ucm_connector_name"]
         module_path = self.connector_configs[0].get("ucm_connector_module_path", None)
         config = copy.deepcopy(self.connector_configs[0]["ucm_connector_config"])
+        config.pop("gpu_kv_buffer_addrs", None)
+        config.pop("gpu_kv_buffer_sizes", None)
         config.setdefault("share_buffer_enable", self.is_mla)
         if "storage_backends" in config:
             backends = [path for path in config["storage_backends"].split(":")]
@@ -349,6 +352,13 @@ class UCMDirectConnector(KVConnectorBase_V1):
             config["shard_size"] = kv_cache_layout.shard_size * self.blocks_per_chunk
             config["block_size"] = kv_cache_layout.block_size * self.blocks_per_chunk
             config["local_rank_size"] = self.tp_size if self.is_mla else 1
+            if registrations is not None and len(registrations):
+                config["gpu_kv_buffer_addrs"] = [
+                    int(item["addr"]) for item in registrations
+                ]
+                config["gpu_kv_buffer_sizes"] = [
+                    int(item["size"]) for item in registrations
+                ]
             if cpu_affinity_cores:
                 config["cpu_affinity_cores"] = list(cpu_affinity_cores)
         else:
@@ -400,10 +410,10 @@ class UCMDirectConnector(KVConnectorBase_V1):
             else (None, None)
         )
 
-        self.store = self._create_store(self.kv_cache_layout, store_cores)
-        if self.store.need_register_kv_caches():
-            registrations = self._collect_kv_cache_registrations()
-            self.store.register_kv_caches(registrations)
+        registrations = self._collect_kv_cache_registrations()
+        self.store = self._create_store(
+            self.kv_cache_layout, store_cores, registrations
+        )
 
         if worker_cores:
             try:

--- a/ucm/store/asu/cc/asu_store.cc
+++ b/ucm/store/asu/cc/asu_store.cc
@@ -266,6 +266,21 @@ public:
             return ConvertStatus(asuStatus);
         }
 
+        if (config_.role == "worker" && !config_.gpuKvBufferAddrs.empty()) {
+            std::vector<KVCacheRegistration> registrations;
+            registrations.reserve(config_.gpuKvBufferAddrs.size());
+            for (std::size_t index = 0; index < config_.gpuKvBufferAddrs.size(); ++index) {
+                registrations.push_back(
+                    {config_.gpuKvBufferAddrs[index], config_.gpuKvBufferSizes[index]});
+            }
+            status = RegisterKVCaches(registrations.data(), registrations.size());
+            if (status.Failure()) {
+                LogAsuStatus("shutdown after registration failure", client_->Shutdown());
+                client_.reset();
+                return status;
+            }
+        }
+
         ShowConfig(config_);
         return Status::OK();
     }
@@ -303,10 +318,8 @@ public:
         (void)num;
     }
 
-    bool NeedRegisterKVCaches() const override { return true; }
-
-    Status RegisterKVCaches(const UC::KVCacheRegistration* registrations,
-                            std::size_t count) override
+private:
+    Status RegisterKVCaches(const UC::KVCacheRegistration* registrations, std::size_t count)
     {
         if (!client_) { return Status::Error("ASU client is not initialized"); }
 
@@ -329,6 +342,9 @@ public:
             LogAsuStatus("register persistent regions", status);
             return ConvertStatus(status);
         }
+        if (registeredRegions.size() != regions.size()) {
+            return Status::Error("ASU registered region count mismatch");
+        }
         std::vector<RegisteredPersistentRegion> registered;
         registered.reserve(regions.size());
         for (std::size_t index = 0; index < regions.size(); ++index) {
@@ -344,6 +360,7 @@ public:
         return Status::OK();
     }
 
+public:
     Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override
     {
         return Submit(std::move(task), &UC::ASU::AsuClient::BatchLoadAsync);
@@ -403,6 +420,8 @@ private:
         inConfig.GetNumber("asu_transport_max_inflight_tasks", config.transportMaxInflightTasks);
         inConfig.GetNumber("asu_completion_poll_spin_limit", config.completionPollSpinLimit);
         inConfig.GetNumber("asu_max_inflight_bytes", config.maxInflightBytes);
+        inConfig.GetNumbers("gpu_kv_buffer_addrs", config.gpuKvBufferAddrs);
+        inConfig.GetNumbers("gpu_kv_buffer_sizes", config.gpuKvBufferSizes);
         inConfig.GetNumber("shard_size", config.shardSize);
         inConfig.GetNumber("block_size", config.blockSize);
         inConfig.GetNumber("device_id", config.deviceId);
@@ -463,6 +482,18 @@ private:
 
     Status CheckConfig(const Config& config)
     {
+        if (config.gpuKvBufferAddrs.size() != config.gpuKvBufferSizes.size()) {
+            return Status::InvalidParam("GPU KV cache address/size list lengths differ");
+        }
+        for (std::size_t index = 0; index < config.gpuKvBufferAddrs.size(); ++index) {
+            if (config.gpuKvBufferAddrs[index] == 0 || config.gpuKvBufferSizes[index] == 0 ||
+                config.gpuKvBufferAddrs[index] >
+                    static_cast<std::uintptr_t>(std::numeric_limits<ssize_t>::max()) ||
+                config.gpuKvBufferSizes[index] >
+                    static_cast<std::size_t>(std::numeric_limits<ssize_t>::max())) {
+                return Status::InvalidParam("invalid GPU KV cache range at index({})", index);
+            }
+        }
         if (config.sharedProviderMode != 0 && config.sharedProviderMode != 1) {
             return Status::InvalidParam("asu_shared_provider must be 0 or 1");
         }

--- a/ucm/store/asu/cc/asu_store.h
+++ b/ucm/store/asu/cc/asu_store.h
@@ -30,6 +30,8 @@ struct Config {
     std::uint64_t completionPollSpinLimit{16};
     std::uint64_t maxInflightBytes{1ULL << 30};
     std::vector<std::size_t> tensorSizes;
+    std::vector<std::uintptr_t> gpuKvBufferAddrs;
+    std::vector<std::size_t> gpuKvBufferSizes;
     std::size_t shardSize{0};
     std::size_t blockSize{0};
     std::int32_t deviceId{-1};

--- a/ucm/store/cache/cc/cache_store.cc
+++ b/ucm/store/cache/cc/cache_store.cc
@@ -99,11 +99,6 @@ public:
         if (s.Failure()) [[unlikely]] { UC_ERROR("Failed({}) to wait task({}).", s, taskId); }
         return s;
     }
-    bool NeedRegisterKVCaches() const override { return false; }
-    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
-    {
-        return Status::OK();
-    }
 
 private:
     Config ParseConfig(const Detail::Dictionary& config)

--- a/ucm/store/compress/cc/compressor.h
+++ b/ucm/store/compress/cc/compressor.h
@@ -20,11 +20,6 @@ public:
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override;
     Expected<bool> Check(Detail::TaskHandle taskId) override;
     Status Wait(Detail::TaskHandle taskId) override;
-    bool NeedRegisterKVCaches() const override { return false; }
-    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
-    {
-        return Status::OK();
-    }
 
 private:
     std::shared_ptr<CompressorImpl> impl_;

--- a/ucm/store/delegator/cc/delegator_executor.cc
+++ b/ucm/store/delegator/cc/delegator_executor.cc
@@ -81,7 +81,8 @@ Status BindDevice(std::int32_t deviceId)
 Expected<std::unique_ptr<Executor>> Executor::Create(std::shared_ptr<StoreV1> backend,
                                                      std::vector<std::size_t> tensorSizes,
                                                      std::int32_t deviceId, std::size_t slotNum,
-                                                     std::size_t streamNumber)
+                                                     std::size_t streamNumber,
+                                                     const Detail::Dictionary& backendConfig)
 {
     if (backend == nullptr || deviceId < 0 || slotNum == 0 || streamNumber == 0 ||
         tensorSizes.empty()) {
@@ -104,7 +105,7 @@ Expected<std::unique_ptr<Executor>> Executor::Create(std::shared_ptr<StoreV1> ba
     if (!executor) { return Status::OutOfMemory(); }
 
     try {
-        status = executor->Start(payloadSize, slotNum);
+        status = executor->Start(payloadSize, slotNum, backendConfig);
     } catch (const std::bad_alloc&) {
         return Status::OutOfMemory();
     } catch (const std::system_error& error) {
@@ -124,19 +125,24 @@ Executor::Executor(std::shared_ptr<StoreV1> backend, std::vector<std::size_t> te
 {
 }
 
-Status Executor::Start(std::size_t payloadSize, std::size_t slotNum)
+Status Executor::Start(std::size_t payloadSize, std::size_t slotNum,
+                       const Detail::Dictionary& backendConfig)
 {
     auto status = bufferPool_.Init("delegator_buffer_pool", BufferPool::MemoryType::Device,
                                    payloadSize, slotNum, false, kBufferAlignment);
     if (status.Failure()) { return status; }
     slotNum_ = slotNum;
-    if (backend_->NeedRegisterKVCaches()) {
-        const KVCacheRegistration registration{
-            reinterpret_cast<std::uintptr_t>(bufferPool_.GetDeviceAddr()),
-            bufferPool_.GetTotalSize()};
-        status = backend_->RegisterKVCaches(&registration, 1);
-        if (status.Failure()) { return status; }
+    const auto address = reinterpret_cast<std::uintptr_t>(bufferPool_.GetDeviceAddr());
+    const auto size = bufferPool_.GetTotalSize();
+    if (address > static_cast<std::uintptr_t>(std::numeric_limits<ssize_t>::max()) ||
+        size > static_cast<std::size_t>(std::numeric_limits<ssize_t>::max())) {
+        return Status::InvalidParam("delegator buffer range cannot be represented in config");
     }
+    auto config = backendConfig;
+    config.Set("gpu_kv_buffer_addrs", std::vector<ssize_t>{static_cast<ssize_t>(address)});
+    config.Set("gpu_kv_buffer_sizes", std::vector<ssize_t>{static_cast<ssize_t>(size)});
+    status = backend_->Setup(config);
+    if (status.Failure()) { return status; }
     availableSlots_ = slotNum;
 
     std::promise<Status> dumpStarted;

--- a/ucm/store/delegator/cc/delegator_executor.h
+++ b/ucm/store/delegator/cc/delegator_executor.h
@@ -56,8 +56,8 @@ public:
 
     static Expected<std::unique_ptr<Executor>> Create(
         std::shared_ptr<StoreV1> backend, std::vector<std::size_t> tensorSizes,
-        std::int32_t deviceId, std::size_t slotNum,
-        std::size_t streamNumber = kDefaultStreamNumber);
+        std::int32_t deviceId, std::size_t slotNum, std::size_t streamNumber = kDefaultStreamNumber,
+        const Detail::Dictionary& backendConfig = {});
     ~Executor();
 
     Executor(const Executor&) = delete;
@@ -122,7 +122,8 @@ private:
     };
 
     Status ValidateTask(const Detail::TaskDesc& task, Operation operation) const;
-    Status Start(std::size_t payloadSize, std::size_t slotNum);
+    Status Start(std::size_t payloadSize, std::size_t slotNum,
+                 const Detail::Dictionary& backendConfig);
     Expected<Detail::TaskDesc> MakeBackendTask(const TransferGroup& group) const;
 
     Status GatherAsync(const TransferGroup& group, CopyStream& streams);

--- a/ucm/store/delegator/cc/delegator_store.cc
+++ b/ucm/store/delegator/cc/delegator_store.cc
@@ -49,11 +49,6 @@ public:
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override;
     Expected<bool> Check(Detail::TaskHandle task) override;
     Status Wait(Detail::TaskHandle task) override;
-    bool NeedRegisterKVCaches() const override { return false; }
-    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
-    {
-        return Status::OK();
-    }
 
 private:
     std::shared_ptr<StoreV1> backend_;
@@ -146,20 +141,19 @@ Status DelegatorStore::Setup(const Detail::Dictionary& input)
         }
     }
 
-    auto status = backend_->Setup(input);
-    if (status.Failure()) {
-        backend_.reset();
-        return status;
-    }
-
     if (config.role == "scheduler") {
+        auto status = backend_->Setup(input);
+        if (status.Failure()) {
+            backend_.reset();
+            return status;
+        }
         setup_ = true;
         UC_INFO("DelegatorStore setup in scheduler query-only mode with {}.", backend_->Readme());
         return Status::OK();
     }
 
     auto created = Executor::Create(backend_, std::move(config.tensorSizes), config.deviceId,
-                                    config.bufferNumber, config.streamNumber);
+                                    config.bufferNumber, config.streamNumber, input);
     if (!created) {
         backend_.reset();
         return created.Error();

--- a/ucm/store/dram/cc/config.cc
+++ b/ucm/store/dram/cc/config.cc
@@ -289,6 +289,17 @@ Expected<DramConfig> DramConfig::Parse(const Detail::Dictionary& dictionary)
         }
         result.tensorSizes.assign(tensorSizes.begin(), tensorSizes.end());
 
+        std::vector<std::size_t> gpuKvBufferAddrs;
+        if (dictionary.Contains("gpu_kv_buffer_addrs")) {
+            status = NumberList(dictionary, "gpu_kv_buffer_addrs", &gpuKvBufferAddrs);
+            if (status.Failure()) { return status; }
+        }
+        result.gpuKvBufferAddrs.assign(gpuKvBufferAddrs.begin(), gpuKvBufferAddrs.end());
+        if (dictionary.Contains("gpu_kv_buffer_sizes")) {
+            status = NumberList(dictionary, "gpu_kv_buffer_sizes", &result.gpuKvBufferSizes);
+            if (status.Failure()) { return status; }
+        }
+
         status = result.Validate();
         if (status.Failure()) { return status; }
         return result;
@@ -299,6 +310,14 @@ Expected<DramConfig> DramConfig::Parse(const Detail::Dictionary& dictionary)
 
 Status DramConfig::Validate() const
 {
+    if (gpuKvBufferAddrs.size() != gpuKvBufferSizes.size()) {
+        return Status::InvalidParam("GPU KV cache address/size list lengths differ");
+    }
+    for (std::size_t index = 0; index < gpuKvBufferAddrs.size(); ++index) {
+        if (gpuKvBufferAddrs[index] == 0 || gpuKvBufferSizes[index] == 0) {
+            return Status::InvalidParam("invalid GPU KV cache range at index({})", index);
+        }
+    }
     if (localControlHost.empty() || localControlPort == 0 || localHost.empty() ||
         localTransportManagerId.empty()) {
         return Status::InvalidParam("local DramStore transport configuration is invalid");

--- a/ucm/store/dram/cc/config.h
+++ b/ucm/store/dram/cc/config.h
@@ -57,6 +57,8 @@ struct DramConfig {
     std::size_t replySlotCount{0};
     std::uint32_t replySlotSize{0};
     std::vector<std::uint64_t> tensorSizes;
+    std::vector<std::uintptr_t> gpuKvBufferAddrs;
+    std::vector<std::size_t> gpuKvBufferSizes;
 
     static Expected<DramConfig> Parse(const Detail::Dictionary& dictionary);
     Status Validate() const;

--- a/ucm/store/dram/cc/dram_store.cc
+++ b/ucm/store/dram/cc/dram_store.cc
@@ -70,10 +70,9 @@ public:
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override;
     Expected<bool> Check(Detail::TaskHandle taskId) override;
     Status Wait(Detail::TaskHandle taskId) override;
-    bool NeedRegisterKVCaches() const override;
-    Status RegisterKVCaches(const KVCacheRegistration* registrations, std::size_t count) override;
 
 private:
+    Status RegisterKVCaches(const KVCacheRegistration* registrations, std::size_t count);
     Expected<Detail::TaskHandle> SubmitTransfer(OpType op, Detail::TaskDesc task);
     Status Start();
 
@@ -81,6 +80,17 @@ private:
     {
         config_ = std::make_unique<DramConfig>(std::move(parsed));
         auto status = Compose();
+
+        if (status.Success() && config_->role == Role::WORKER) {
+            std::vector<KVCacheRegistration> registrations;
+            registrations.reserve(config_->gpuKvBufferAddrs.size());
+            for (std::size_t index = 0; index < config_->gpuKvBufferAddrs.size(); ++index) {
+                registrations.push_back(
+                    {config_->gpuKvBufferAddrs[index], config_->gpuKvBufferSizes[index]});
+            }
+            status = RegisterKVCaches(registrations.data(), registrations.size());
+        }
+        if (status.Success()) { status = Start(); }
 
         if (status.Failure()) {
             StopGraph();
@@ -178,7 +188,7 @@ private:
                                                    ? nodeScheduler_->Post(request)
                                                    : Status::Error("NodeScheduler is unavailable");
                                     }});
-        return config_->role == Role::SCHEDULER ? Start() : Status::OK();
+        return Status::OK();
 #else
         return Status::Unsupported();
 #endif
@@ -326,11 +336,6 @@ Expected<bool> DramStore::Check(Detail::TaskHandle taskId) { return taskManager_
 
 Status DramStore::Wait(Detail::TaskHandle taskId) { return taskManager_->WaitTransfer(taskId); }
 
-bool DramStore::NeedRegisterKVCaches() const
-{
-    return !config_ || config_->role != Role::SCHEDULER;
-}
-
 Status DramStore::RegisterKVCaches(const KVCacheRegistration* registrations, std::size_t count)
 {
     if (count != 0 && registrations == nullptr) {
@@ -376,8 +381,7 @@ Status DramStore::RegisterKVCaches(const KVCacheRegistration* registrations, std
     }
 
     UC_INFO("DramStore KV caches registered, count={}", count);
-    // RegisterKVCaches is the final initialization hook for the worker role.
-    return Start();
+    return Status::OK();
 }
 
 }  // namespace UC::Dram

--- a/ucm/store/ds3fs/cc/ds3fs_store.h
+++ b/ucm/store/ds3fs/cc/ds3fs_store.h
@@ -41,11 +41,6 @@ public:
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) override;
     Expected<bool> Check(Detail::TaskHandle taskId) override;
     Status Wait(Detail::TaskHandle taskId) override;
-    bool NeedRegisterKVCaches() const override { return false; }
-    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
-    {
-        return Status::OK();
-    }
 
 private:
     std::shared_ptr<Ds3fsStoreImpl> impl_;

--- a/ucm/store/empty/cc/empty_store.cc
+++ b/ucm/store/empty/cc/empty_store.cc
@@ -42,11 +42,6 @@ public:
     Expected<Detail::TaskHandle> Dump(Detail::TaskDesc task) { return NextId(); }
     Expected<bool> Check(Detail::TaskHandle taskId) { return true; }
     Status Wait(Detail::TaskHandle taskId) { return Status::OK(); }
-    bool NeedRegisterKVCaches() const override { return false; }
-    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
-    {
-        return Status::OK();
-    }
 
 private:
     static Detail::TaskHandle NextId() noexcept

--- a/ucm/store/fake/cc/fake_store.cc
+++ b/ucm/store/fake/cc/fake_store.cc
@@ -82,11 +82,6 @@ public:
     }
     Expected<bool> Check(Detail::TaskHandle taskId) override { return true; }
     Status Wait(Detail::TaskHandle taskId) override { return Status::OK(); }
-    bool NeedRegisterKVCaches() const override { return false; }
-    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
-    {
-        return Status::OK();
-    }
 
 private:
     static Detail::TaskHandle NextId() noexcept

--- a/ucm/store/pcstore/pcstore_connector_v1.py
+++ b/ucm/store/pcstore/pcstore_connector_v1.py
@@ -255,9 +255,3 @@ class UcmPcStoreV1(UcmKVStoreBaseV1):
             ``True`` if the task has finished, ``False`` if still in-flight.
         """
         return self.store.Check(task.task_id)
-
-    def need_register_kv_caches(self) -> bool:
-        return False
-
-    def register_kv_caches(self, registrations: np.ndarray) -> None:
-        return

--- a/ucm/store/pipeline/connector.py
+++ b/ucm/store/pipeline/connector.py
@@ -157,12 +157,6 @@ class UcmPipelineStore(UcmKVStoreBaseV1):
     def check(self, task: Task) -> bool:
         return self.store_.Check(task.task_id)
 
-    def need_register_kv_caches(self) -> bool:
-        return self.store_.NeedRegisterKVCaches()
-
-    def register_kv_caches(self, registrations: np.ndarray) -> None:
-        self.store_.RegisterKVCaches(registrations)
-
 
 def _cache_ds3fs_pipeline_builder(
     config: Dict[str, object], pipeline: ucmpipelinestore.PipelineStore

--- a/ucm/store/pipeline/cpy/pipeline_store.py.cc
+++ b/ucm/store/pipeline/cpy/pipeline_store.py.cc
@@ -168,12 +168,6 @@ public:
         }
         ThrowIfFailed(status);
     }
-    bool NeedRegisterKVCaches() const { return StoreBack()->NeedRegisterKVCaches(); }
-    void RegisterKVCaches(const pybind11::buffer& registrations)
-    {
-        BufferArrayView<KVCacheRegistration> registrationArr{registrations};
-        ThrowIfFailed(StoreBack()->RegisterKVCaches(registrationArr.data, registrationArr.num));
-    }
 };
 
 }  // namespace UC::PipelineStore
@@ -198,7 +192,4 @@ PYBIND11_MODULE(ucmpipelinestore, m)
           py::arg("addrs").noconvert(), py::arg("prerequisite_handle") = 0);
     s.def("Check", &PipelineStore::Check);
     s.def("Wait", &PipelineStore::Wait);
-    s.def("NeedRegisterKVCaches", &PipelineStore::NeedRegisterKVCaches);
-    s.def("RegisterKVCaches", &PipelineStore::RegisterKVCaches,
-          py::arg("registrations").noconvert());
 }

--- a/ucm/store/posix/cc/posix_store.cc
+++ b/ucm/store/posix/cc/posix_store.cc
@@ -97,11 +97,6 @@ public:
         if (s.Failure()) [[unlikely]] { UC_ERROR("Failed({}) to wait task({}).", s, taskId); }
         return s;
     }
-    bool NeedRegisterKVCaches() const override { return false; }
-    Status RegisterKVCaches(const KVCacheRegistration*, std::size_t) override
-    {
-        return Status::OK();
-    }
 
 private:
     Config ParseConfig(const Detail::Dictionary& inConfig)

--- a/ucm/store/test/case/asu/asu_store_test.cc
+++ b/ucm/store/test/case/asu/asu_store_test.cc
@@ -56,6 +56,10 @@ struct FakeAsuClientState {
     std::vector<UC::ASU::KVBuffer> lastLoadEntries;
     std::vector<UC::ASU::KVBuffer> lastStoreEntries;
     std::vector<UC::ASU::MemoryRegion> registeredRegions;
+    std::size_t registrationCalls{0};
+    std::size_t shutdownCalls{0};
+    bool failRegistration{false};
+    bool omitRegisteredHandle{false};
 };
 
 class FakeAsuClient final : public UC::ASU::AsuClient {
@@ -78,6 +82,7 @@ public:
 
     UC::ASU::Status Shutdown() override
     {
+        ++state_->shutdownCalls;
         initialized_ = false;
         return UC::ASU::Status::OK();
     }
@@ -168,6 +173,12 @@ public:
         const std::vector<UC::ASU::MemoryRegion>& regions,
         std::vector<UC::ASU::RegisteredMemory>& registeredRegions) override
     {
+        if (!initialized_) { return NotInitialized(); }
+        ++state_->registrationCalls;
+        if (state_->failRegistration) {
+            return UC::ASU::Status::Error(UC::ASU::StatusCode::NOT_INITIALIZED,
+                                          "injected registration failure");
+        }
         registeredRegions.clear();
         registeredRegions.reserve(regions.size());
         state_->registeredRegions.insert(state_->registeredRegions.end(), regions.begin(),
@@ -176,6 +187,7 @@ public:
             registeredRegions.emplace_back(
                 UC::ASU::RegisteredMemory{regions[index], MakeTestMrHandle(nextMrHandle_++)});
         }
+        if (state_->omitRegisteredHandle) { registeredRegions.clear(); }
         return UC::ASU::Status::OK();
     }
 
@@ -253,17 +265,19 @@ UC::Detail::TaskDesc MakeTask(const UC::Detail::BlockId& block, void* addr)
     return task;
 }
 
-void RegisterPersistentRanges(UC::StoreV1& store,
+void RegisterPersistentRanges(UC::Detail::Dictionary& config,
                               const std::vector<std::pair<void*, std::size_t>>& ranges)
 {
     ASSERT_FALSE(ranges.empty());
-    std::vector<UC::KVCacheRegistration> registrations;
-    registrations.reserve(ranges.size());
+    std::vector<ssize_t> addrs;
+    std::vector<ssize_t> sizes;
     for (const auto& [addr, size] : ranges) {
-        registrations.emplace_back(
-            UC::KVCacheRegistration{reinterpret_cast<std::uintptr_t>(addr), size});
+        addrs.push_back(static_cast<ssize_t>(reinterpret_cast<std::uintptr_t>(addr)));
+        sizes.push_back(static_cast<ssize_t>(size));
     }
-    ASSERT_TRUE(store.RegisterKVCaches(registrations.data(), registrations.size()).Success());
+    config.Set("role", std::string{"worker"});
+    config.Set("gpu_kv_buffer_addrs", addrs);
+    config.Set("gpu_kv_buffer_sizes", sizes);
 }
 
 void ExpectLookupMiss(UC::StoreV1& store, const UC::Detail::BlockId& block)
@@ -278,17 +292,13 @@ void ExpectLookupMiss(UC::StoreV1& store, const UC::Detail::BlockId& block)
     ASSERT_EQ(prefix.Value(), -1);
 }
 
-void ExpectLoadDumpSmoke(UC::StoreV1& store, const UC::Detail::BlockId& block)
+void ExpectLoadDumpSmoke(UC::StoreV1& store, const UC::Detail::BlockId& block, void* buffer)
 {
-    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
-    RegisterPersistentRanges(store, {
-                                        {buffer.data(), buffer.size()}
-    });
-    auto dump = store.Dump(MakeTask(block, buffer.data()));
+    auto dump = store.Dump(MakeTask(block, buffer));
     ASSERT_TRUE(dump.HasValue()) << dump.Error().ToString();
     ASSERT_TRUE(store.Wait(dump.Value()).Success());
 
-    auto load = store.Load(MakeTask(block, buffer.data()));
+    auto load = store.Load(MakeTask(block, buffer));
     ASSERT_TRUE(load.HasValue()) << load.Error().ToString();
     ASSERT_TRUE(store.Wait(load.Value()).Success());
 }
@@ -669,6 +679,7 @@ TEST(UCAsuStoreTest, WorkerUsesLocalRankDeviceId)
     ASSERT_TRUE(store.Setup(config).Success());
     ASSERT_FALSE(state->initConfigs.empty());
     EXPECT_EQ(state->initConfigs.back().deviceId, 2);
+    EXPECT_EQ(state->registrationCalls, std::size_t{0});
 }
 
 TEST(UCAsuStoreTest, TransportModeSmoke)
@@ -679,11 +690,15 @@ TEST(UCAsuStoreTest, TransportModeSmoke)
     config.Set("asu_mode", std::string{"transport"});
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
     config.Set("asu_ids", std::vector<ssize_t>{1001});
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
+    RegisterPersistentRanges(config, {
+                                         {buffer.data(), buffer.size()}
+    });
     ASSERT_TRUE(store.Setup(config).Success());
 
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("a1b2c3d4e5f6789012345678901234ab");
     ExpectLookupMiss(store, block);
-    ExpectLoadDumpSmoke(store, block);
+    ExpectLoadDumpSmoke(store, block, buffer.data());
 }
 
 TEST(UCAsuStoreTest, ClientModeSmoke)
@@ -694,11 +709,15 @@ TEST(UCAsuStoreTest, ClientModeSmoke)
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1", "127.0.0.2"});
     config.Set("asu_ports", std::vector<ssize_t>{12345, 12346});
     config.Set("asu_ids", std::vector<ssize_t>{1001, 1002});
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
+    RegisterPersistentRanges(config, {
+                                         {buffer.data(), buffer.size()}
+    });
     ASSERT_TRUE(store.Setup(config).Success());
 
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("b1b2c3d4e5f6789012345678901234ab");
     ExpectLookupMiss(store, block);
-    ExpectLoadDumpSmoke(store, block);
+    ExpectLoadDumpSmoke(store, block, buffer.data());
 }
 
 TEST(UCAsuStoreTest, AllowsQueryOnlyConfigWithoutTensorSizes)
@@ -754,11 +773,11 @@ TEST(UCAsuStoreTest, UsesPersistentRegionHandleBeforeSubmitAndKeepsItAfterWait)
     auto config = MakeBaseConfig();
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1"});
     config.Set("asu_ids", std::vector<ssize_t>{1001});
-    ASSERT_TRUE(store.Setup(config).Success());
     std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
-    RegisterPersistentRanges(store, {
-                                        {buffer.data(), buffer.size()}
+    RegisterPersistentRanges(config, {
+                                         {buffer.data(), buffer.size()}
     });
+    ASSERT_TRUE(store.Setup(config).Success());
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("a2b2c3d4e5f6789012345678901234ab");
     auto dump = store.Dump(MakeTask(block, buffer.data()));
     ASSERT_TRUE(dump.HasValue()) << dump.Error().ToString();
@@ -780,13 +799,11 @@ TEST(UCAsuStoreTest, PersistentRegionHandleIsSharedByEntriesAndNotReleasedPerTas
     config.Set("tensor_size_list", std::vector<ssize_t>{64, 64});
     config.SetNumber("shard_size", std::size_t{128});
     config.SetNumber("block_size", std::size_t{128});
-    ASSERT_TRUE(store.Setup(config).Success());
-
     std::array<std::byte, UC::ASU::kAsuAlignmentBytes * 2> buffer{};
-    const std::array<UC::KVCacheRegistration, 1> registrations{
-        UC::KVCacheRegistration{reinterpret_cast<std::uintptr_t>(buffer.data()), buffer.size()}
-    };
-    ASSERT_TRUE(store.RegisterKVCaches(registrations.data(), registrations.size()).Success());
+    RegisterPersistentRanges(config, {
+                                         {buffer.data(), buffer.size()}
+    });
+    ASSERT_TRUE(store.Setup(config).Success());
     ASSERT_EQ(state->registeredRegions.size(), std::size_t{1});
 
     UC::Detail::TaskDesc task;
@@ -817,17 +834,13 @@ TEST(UCAsuStoreTest, ResolvesEachEntryToItsContainingPersistentRegion)
     config.Set("tensor_size_list", std::vector<ssize_t>{64, 64});
     config.SetNumber("shard_size", std::size_t{128});
     config.SetNumber("block_size", std::size_t{128});
-    ASSERT_TRUE(store.Setup(config).Success());
-
     std::array<std::byte, UC::ASU::kAsuAlignmentBytes> firstBuffer{};
     std::array<std::byte, UC::ASU::kAsuAlignmentBytes> secondBuffer{};
-    const auto firstAddr = reinterpret_cast<std::uintptr_t>(firstBuffer.data());
-    const auto secondAddr = reinterpret_cast<std::uintptr_t>(secondBuffer.data());
-    const std::array<UC::KVCacheRegistration, 2> registrations{
-        UC::KVCacheRegistration{firstAddr,  UC::ASU::kAsuAlignmentBytes},
-        UC::KVCacheRegistration{secondAddr, UC::ASU::kAsuAlignmentBytes}
-    };
-    ASSERT_TRUE(store.RegisterKVCaches(registrations.data(), registrations.size()).Success());
+    RegisterPersistentRanges(config, {
+                                         {firstBuffer.data(),  firstBuffer.size() },
+                                         {secondBuffer.data(), secondBuffer.size()}
+    });
+    ASSERT_TRUE(store.Setup(config).Success());
 
     UC::Detail::TaskDesc task;
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("d2b2c3d4e5f6789012345678901234ab");
@@ -850,11 +863,11 @@ TEST(UCAsuStoreTest, LookupOnPrefixReturnsLastContiguousHit)
     config.Set("asu_ips", std::vector<std::string>{"127.0.0.1", "127.0.0.2"});
     config.Set("asu_ports", std::vector<ssize_t>{12345, 12346});
     config.Set("asu_ids", std::vector<ssize_t>{1001, 1002});
-    ASSERT_TRUE(store.Setup(config).Success());
     std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
-    RegisterPersistentRanges(store, {
-                                        {buffer.data(), buffer.size()}
+    RegisterPersistentRanges(config, {
+                                         {buffer.data(), buffer.size()}
     });
+    ASSERT_TRUE(store.Setup(config).Success());
     std::vector<UC::Detail::BlockId> blocks{
         UC::Test::Detail::TypesHelper::MakeBlockId("e1b2c3d4e5f6789012345678901234ab"),
         UC::Test::Detail::TypesHelper::MakeBlockId("f1b2c3d4e5f6789012345678901234ab"),
@@ -883,13 +896,17 @@ TEST(UCAsuStoreTest, ClientModeConfigPathSmoke)
     UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_config_path", std::string{kConfigPath});
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
+    RegisterPersistentRanges(config, {
+                                         {buffer.data(), buffer.size()}
+    });
     auto setupStatus = store.Setup(config);
     std::remove(kConfigPath);
     ASSERT_TRUE(setupStatus.Success()) << setupStatus.ToString();
 
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("c1b2c3d4e5f6789012345678901234ab");
     ExpectLookupMiss(store, block);
-    ExpectLoadDumpSmoke(store, block);
+    ExpectLoadDumpSmoke(store, block, buffer.data());
 }
 
 TEST(UCAsuStoreTest, TransportModeConfigPathSmoke)
@@ -909,13 +926,17 @@ TEST(UCAsuStoreTest, TransportModeConfigPathSmoke)
     auto config = MakeBaseConfig();
     config.Set("asu_mode", std::string{"transport"});
     config.Set("asu_config_path", std::string{kConfigPath});
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
+    RegisterPersistentRanges(config, {
+                                         {buffer.data(), buffer.size()}
+    });
     auto setupStatus = store.Setup(config);
     std::remove(kConfigPath);
     ASSERT_TRUE(setupStatus.Success()) << setupStatus.ToString();
 
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("d1b2c3d4e5f6789012345678901234ab");
     ExpectLookupMiss(store, block);
-    ExpectLoadDumpSmoke(store, block);
+    ExpectLoadDumpSmoke(store, block, buffer.data());
 }
 
 TEST(UCAsuStoreTest, RejectsOddMultiTensorLayout)
@@ -949,6 +970,14 @@ TEST(UCAsuStoreTest, UsesNonLayerwiseMlaTensorOffsets)
     config.SetNumber("shard_size", std::size_t{360});
     config.SetNumber("block_size", std::size_t{360});
 
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> first{};
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> second{};
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> third{};
+    RegisterPersistentRanges(config, {
+                                         {first.data(),  first.size() },
+                                         {second.data(), second.size()},
+                                         {third.data(),  third.size() }
+    });
     auto status = store.Setup(config);
     ASSERT_TRUE(status.Success()) << status.ToString();
     ASSERT_FALSE(state->initConfigs.empty());
@@ -957,14 +986,6 @@ TEST(UCAsuStoreTest, UsesNonLayerwiseMlaTensorOffsets)
     EXPECT_EQ(state->initConfigs.back().tensorSizes[1], std::size_t{512});
     EXPECT_EQ(state->initConfigs.back().tensorSizes[2], std::size_t{512});
 
-    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> first{};
-    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> second{};
-    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> third{};
-    RegisterPersistentRanges(store, {
-                                        {first.data(),  first.size() },
-                                        {second.data(), second.size()},
-                                        {third.data(),  third.size() }
-    });
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("d1b2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
@@ -997,15 +1018,15 @@ TEST(UCAsuStoreTest, UsesHmaTensorOffsetsInConnectorOrder)
     config.SetNumber("shard_size", std::size_t{600});
     config.SetNumber("block_size", std::size_t{600});
 
+    std::array<std::array<std::byte, 512>, 3> buffers{};
+    RegisterPersistentRanges(config, {
+                                         {buffers[0].data(), buffers[0].size()},
+                                         {buffers[1].data(), buffers[1].size()},
+                                         {buffers[2].data(), buffers[2].size()}
+    });
     auto status = store.Setup(config);
     ASSERT_TRUE(status.Success()) << status.ToString();
 
-    std::array<std::array<std::byte, 512>, 3> buffers{};
-    RegisterPersistentRanges(store, {
-                                        {buffers[0].data(), buffers[0].size()},
-                                        {buffers[1].data(), buffers[1].size()},
-                                        {buffers[2].data(), buffers[2].size()}
-    });
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("f1b2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
@@ -1039,13 +1060,13 @@ TEST(UCAsuStoreTest, UsesLayerwiseMlaTensorOffsets)
     config.SetNumber("shard_size", std::size_t{128});
     config.SetNumber("block_size", std::size_t{384});
 
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
+    RegisterPersistentRanges(config, {
+                                         {buffer.data(), buffer.size()}
+    });
     auto status = store.Setup(config);
     ASSERT_TRUE(status.Success()) << status.ToString();
 
-    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
-    RegisterPersistentRanges(store, {
-                                        {buffer.data(), buffer.size()}
-    });
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("e1b2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
@@ -1078,17 +1099,17 @@ TEST(UCAsuStoreTest, UsesMultiSegmentLayerwiseMlaTensorOffsets)
     config.SetNumber("shard_size", std::size_t{192});
     config.SetNumber("block_size", std::size_t{576});
 
-    auto status = store.Setup(config);
-    ASSERT_TRUE(status.Success()) << status.ToString();
-
     std::array<std::byte, alignment> mainCache{};
     std::array<std::byte, alignment> ropeCache{};
     const std::array<void*, 2> buffers{mainCache.data(), ropeCache.data()};
     RegisterPersistentRanges(
-        store, {
-                   {mainCache.data(), mainCache.size()},
-                   {ropeCache.data(), ropeCache.size()}
+        config, {
+                    {mainCache.data(), mainCache.size()},
+                    {ropeCache.data(), ropeCache.size()}
     });
+    auto status = store.Setup(config);
+    ASSERT_TRUE(status.Success()) << status.ToString();
+
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("e1b2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
@@ -1124,6 +1145,10 @@ TEST(UCAsuStoreTest, AlignsTensorSizeAndDerivesShardBlockSize)
     config.SetNumber("shard_size", std::size_t{100});
     config.SetNumber("block_size", std::size_t{300});
 
+    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
+    RegisterPersistentRanges(config, {
+                                         {buffer.data(), buffer.size()}
+    });
     auto status = store.Setup(config);
     ASSERT_TRUE(status.Success()) << status.ToString();
     ASSERT_FALSE(state->initConfigs.empty());
@@ -1135,10 +1160,6 @@ TEST(UCAsuStoreTest, AlignsTensorSizeAndDerivesShardBlockSize)
     EXPECT_EQ(state->initConfigs.back().blockSize,
               static_cast<std::size_t>(UC::ASU::kAsuAlignmentBytes) * 3);
 
-    std::array<std::byte, UC::ASU::kAsuAlignmentBytes> buffer{};
-    RegisterPersistentRanges(store, {
-                                        {buffer.data(), buffer.size()}
-    });
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("abb2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
@@ -1180,14 +1201,14 @@ TEST(UCAsuStoreTest, UsesLayerwiseGqaKeyValueOffsets)
     config.SetNumber("shard_size", std::size_t{300});
     config.SetNumber("block_size", std::size_t{900});
 
-    auto status = store.Setup(config);
-    ASSERT_TRUE(status.Success()) << status.ToString();
     std::array<std::byte, UC::ASU::kAsuAlignmentBytes> key{};
     std::array<std::byte, UC::ASU::kAsuAlignmentBytes> value{};
-    RegisterPersistentRanges(store, {
-                                        {key.data(),   key.size()  },
-                                        {value.data(), value.size()}
+    RegisterPersistentRanges(config, {
+                                         {key.data(),   key.size()  },
+                                         {value.data(), value.size()}
     });
+    auto status = store.Setup(config);
+    ASSERT_TRUE(status.Success()) << status.ToString();
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("b1b2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
@@ -1222,12 +1243,12 @@ TEST(UCAsuStoreTest, UsesNonLayerwiseGqaKeyValueOffsets)
     config.SetNumber("shard_size", std::size_t{900});
     config.SetNumber("block_size", std::size_t{900});
 
-    auto status = store.Setup(config);
-    ASSERT_TRUE(status.Success()) << status.ToString();
     std::array<std::array<std::byte, UC::ASU::kAsuAlignmentBytes>, 6> buffers{};
     std::vector<std::pair<void*, std::size_t>> ranges;
     for (auto& buffer : buffers) { ranges.emplace_back(buffer.data(), buffer.size()); }
-    RegisterPersistentRanges(store, ranges);
+    RegisterPersistentRanges(config, ranges);
+    auto status = store.Setup(config);
+    ASSERT_TRUE(status.Success()) << status.ToString();
     auto block = UC::Test::Detail::TypesHelper::MakeBlockId("c1b2c3d4e5f6789012345678901234ab");
     UC::Detail::TaskDesc task;
     task.brief = "asu-store-test";
@@ -1256,14 +1277,71 @@ TEST(UCAsuStoreTest, RegistersKvCacheRegions)
     auto state = UseFakeClient(store);
     auto config = MakeBaseConfig();
     config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("role", std::string{"worker"});
+    config.Set("gpu_kv_buffer_addrs", std::vector<ssize_t>{0x1000});
+    config.Set("gpu_kv_buffer_sizes", std::vector<ssize_t>{1024});
     ASSERT_TRUE(store.Setup(config).Success());
-    const UC::KVCacheRegistration registrations[]{
-        {0x1000, 1024}
-    };
-
-    EXPECT_TRUE(store.NeedRegisterKVCaches());
-    EXPECT_TRUE(store.RegisterKVCaches(registrations, std::size(registrations)).Success());
+    EXPECT_EQ(state->registrationCalls, std::size_t{1});
     ASSERT_EQ(state->registeredRegions.size(), std::size_t{1});
     EXPECT_EQ(state->registeredRegions[0].addr, std::uint64_t{0x1000});
     EXPECT_EQ(state->registeredRegions[0].size, std::uint64_t{1024});
+}
+
+TEST(UCAsuStoreTest, SchedulerSkipsKvCacheRegistration)
+{
+    UC::AsuStore::AsuStore store;
+    auto state = UseFakeClient(store);
+    auto config = MakeBaseConfig();
+    config.Set("asu_ids", std::vector<ssize_t>{1001});
+    config.Set("role", std::string{"scheduler"});
+    config.Set("gpu_kv_buffer_addrs", std::vector<ssize_t>{0x1000});
+    config.Set("gpu_kv_buffer_sizes", std::vector<ssize_t>{1024});
+    ASSERT_TRUE(store.Setup(config).Success());
+    EXPECT_EQ(state->registrationCalls, std::size_t{0});
+}
+
+TEST(UCAsuStoreTest, RejectsInvalidKvCacheConfigBeforeClientInit)
+{
+    const std::vector<std::pair<std::vector<ssize_t>, std::vector<ssize_t>>> invalid{
+        {{0x1000}, {}    },
+        {{},       {1024}},
+        {{0},      {1024}},
+        {{0x1000}, {0}   },
+        {{-1},     {1024}},
+        {{0x1000}, {-1}  }
+    };
+    for (const auto& [addrs, sizes] : invalid) {
+        UC::AsuStore::AsuStore store;
+        auto state = UseFakeClient(store);
+        auto config = MakeBaseConfig();
+        config.Set("asu_ids", std::vector<ssize_t>{1001});
+        config.Set("role", std::string{"worker"});
+        config.Set("gpu_kv_buffer_addrs", addrs);
+        config.Set("gpu_kv_buffer_sizes", sizes);
+        EXPECT_TRUE(store.Setup(config).Failure());
+        EXPECT_TRUE(state->initConfigs.empty());
+        EXPECT_EQ(state->registrationCalls, std::size_t{0});
+    }
+}
+
+TEST(UCAsuStoreTest, RegistrationFailureShutsDownClient)
+{
+    for (const bool missingHandle : {false, true}) {
+        auto state = std::make_shared<FakeAsuClientState>();
+        {
+            UC::AsuStore::AsuStore store;
+            state = UseFakeClient(store);
+            state->failRegistration = !missingHandle;
+            state->omitRegisteredHandle = missingHandle;
+            auto config = MakeBaseConfig();
+            config.Set("asu_ids", std::vector<ssize_t>{1001});
+            config.Set("role", std::string{"worker"});
+            config.Set("gpu_kv_buffer_addrs", std::vector<ssize_t>{0x1000});
+            config.Set("gpu_kv_buffer_sizes", std::vector<ssize_t>{1024});
+            EXPECT_TRUE(store.Setup(config).Failure());
+            EXPECT_EQ(state->registrationCalls, std::size_t{1});
+            EXPECT_EQ(state->shutdownCalls, std::size_t{1});
+        }
+        EXPECT_EQ(state->shutdownCalls, std::size_t{1});
+    }
 }

--- a/ucm/store/test/case/delegator/delegator_executor_test.cc
+++ b/ucm/store/test/case/delegator/delegator_executor_test.cc
@@ -77,7 +77,16 @@ public:
 
     explicit FakeStore(std::size_t payload_size) : payload_size_{payload_size} {}
 
-    Status Setup(const Detail::Dictionary&) override { return Status::OK(); }
+    Status Setup(const Detail::Dictionary& config) override
+    {
+        std::vector<uintptr_t> addrs;
+        std::vector<size_t> sizes;
+        config.GetNumbers("gpu_kv_buffer_addrs", addrs);
+        config.GetNumbers("gpu_kv_buffer_sizes", sizes);
+        if (addrs.size() != 1 || sizes.size() != 1) { return Status::InvalidParam(); }
+        const KVCacheRegistration registration{addrs[0], sizes[0]};
+        return RegisterKVCaches(&registration, 1);
+    }
 
     std::string Readme() const override { return "FakeStore"; }
 
@@ -90,9 +99,8 @@ public:
 
     void Prefetch(const Detail::BlockId*, size_t) override {}
 
-    bool NeedRegisterKVCaches() const override { return true; }
-
-    Status RegisterKVCaches(const KVCacheRegistration* registrations, std::size_t count) override
+private:
+    Status RegisterKVCaches(const KVCacheRegistration* registrations, std::size_t count)
     {
         if (registrations == nullptr || count != 1 || registrations[0].addr == 0 ||
             registrations[0].size == 0) {
@@ -103,6 +111,7 @@ public:
         return Status::OK();
     }
 
+public:
     Expected<Detail::TaskHandle> Load(Detail::TaskDesc task) override
     {
         if (task.empty()) { return Status::InvalidParam(); }

--- a/ucm/store/test/case/delegator/delegator_store_test.cc
+++ b/ucm/store/test/case/delegator/delegator_store_test.cc
@@ -38,8 +38,6 @@ TEST(UCDelegatorStoreTest, FactoryReturnsStoreV1)
     auto store = CreateStore();
     ASSERT_NE(store, nullptr);
     EXPECT_EQ(store->Readme(), "DelegatorStore");
-    EXPECT_FALSE(store->NeedRegisterKVCaches());
-    EXPECT_TRUE(store->RegisterKVCaches(nullptr, 0).Success());
 
     Detail::BlockId block{};
     EXPECT_FALSE(store->Lookup(&block, 1));

--- a/ucm/store/test/case/detail/mock_store.h
+++ b/ucm/store/test/case/detail/mock_store.h
@@ -44,11 +44,6 @@ public:
                 (override));
     MOCK_METHOD((UC::Expected<bool>), Check, (UC::Detail::TaskHandle taskId), (override));
     MOCK_METHOD((UC::Status), Wait, (UC::Detail::TaskHandle taskId), (override));
-    bool NeedRegisterKVCaches() const override { return false; }
-    Status RegisterKVCaches(const UC::KVCacheRegistration*, std::size_t) override
-    {
-        return Status::OK();
-    }
 };
 
 }  // namespace UC::Test::Detail

--- a/ucm/store/test/case/dram/dram_config_test.cc
+++ b/ucm/store/test/case/dram/dram_config_test.cc
@@ -212,5 +212,35 @@ TEST(DramConfigTest, RejectsInvalidRoleAndWorkerPortOverflow)
     EXPECT_FALSE(DramConfig::Parse(hixlOverflow));
 }
 
+TEST(DramConfigTest, ParsesKvCacheRegistrationConfig)
+{
+    auto input = BaseConfig();
+    input.Set("gpu_kv_buffer_addrs", std::vector<ssize_t>{0x1000, 0x2000});
+    input.Set("gpu_kv_buffer_sizes", std::vector<ssize_t>{1024, 2048});
+    auto parsed = DramConfig::Parse(input);
+    ASSERT_TRUE(parsed);
+    EXPECT_EQ(parsed.Value().gpuKvBufferAddrs, (std::vector<uintptr_t>{0x1000, 0x2000}));
+    EXPECT_EQ(parsed.Value().gpuKvBufferSizes, (std::vector<std::size_t>{1024, 2048}));
+}
+
+TEST(DramConfigTest, RejectsInvalidKvCacheRegistrationConfig)
+{
+    for (const auto value : {ssize_t{0}, ssize_t{-1}}) {
+        auto input = BaseConfig();
+        input.Set("gpu_kv_buffer_addrs", std::vector<ssize_t>{value});
+        input.Set("gpu_kv_buffer_sizes", std::vector<ssize_t>{1024});
+        EXPECT_FALSE(DramConfig::Parse(input));
+        input.Set("gpu_kv_buffer_addrs", std::vector<ssize_t>{0x1000});
+        input.Set("gpu_kv_buffer_sizes", std::vector<ssize_t>{value});
+        EXPECT_FALSE(DramConfig::Parse(input));
+    }
+    auto input = BaseConfig();
+    input.Set("gpu_kv_buffer_addrs", std::vector<ssize_t>{0x1000});
+    EXPECT_FALSE(DramConfig::Parse(input));
+    input = BaseConfig();
+    input.Set("gpu_kv_buffer_sizes", std::vector<ssize_t>{1024});
+    EXPECT_FALSE(DramConfig::Parse(input));
+}
+
 }  // namespace
 }  // namespace UC::Dram

--- a/ucm/store/test/case/dram/dram_construction_dependencies_test.cc
+++ b/ucm/store/test/case/dram/dram_construction_dependencies_test.cc
@@ -35,7 +35,6 @@ TEST(DramStoreConstructionTest, FactorySurvivesInvalidSetup)
     std::unique_ptr<StoreV1> store(MakeDramStore());
     ASSERT_NE(store, nullptr);
     EXPECT_FALSE(store->Readme().empty());
-    EXPECT_TRUE(store->NeedRegisterKVCaches());
 
     Detail::Dictionary invalid;
     EXPECT_TRUE(store->Setup(invalid).Failure());

--- a/ucm/store/test/e2e/dramstore_bench_test.py
+++ b/ucm/store/test/e2e/dramstore_bench_test.py
@@ -50,7 +50,6 @@ import importlib.util
 import os
 import secrets
 import statistics
-import struct
 import sys
 import time
 
@@ -159,15 +158,6 @@ class BareDramStore:
 
     def wait(self, task_id):
         self._ds.Wait(task_id)
-
-    def need_register_kv_caches(self):
-        return bool(self._ds.NeedRegisterKVCaches())
-
-    def register_kv_caches(self, addr_size_pairs):
-        buf = bytearray()
-        for addr, size in addr_size_pairs:
-            buf += struct.pack("<QQ", int(addr), int(size))
-        self._ds.RegisterKVCaches(bytes(buf))
 
     def dump(self, block_ids, shard_index, addrs):
         return self._ds.Dump(
@@ -354,9 +344,6 @@ def main():
     os.environ.setdefault("UC_LOGGER_LEVEL", "info")
 
     ucmdramstore = load_ucmdramstore(args.so_dir)
-    worker = BareDramStore(make_dram_config(args, "worker"), ucmdramstore)
-    scheduler = worker  # single-peer: worker does lookup+dump+load, one hixl engine
-
     shards = args.layer_size * args.chunk_size
     count = args.request_size * shards
     # NPU device memory: aclrtMalloc'd buffers; ptr == addr == device pointer.
@@ -366,10 +353,11 @@ def main():
     dst_regs, dst_total = build_device_regions(
         args.tensor_size, shards, args.request_size
     )
-    if worker.need_register_kv_caches():
-        worker.register_kv_caches(
-            [(src_regs[0].addr, src_total), (dst_regs[0].addr, dst_total)]
-        )
+    config = make_dram_config(args, "worker")
+    config["gpu_kv_buffer_addrs"] = [int(src_regs[0].addr), int(dst_regs[0].addr)]
+    config["gpu_kv_buffer_sizes"] = [int(src_total), int(dst_total)]
+    worker = BareDramStore(config, ucmdramstore)
+    scheduler = worker  # single-peer: worker does lookup+dump+load, one hixl engine
     print(
         f"[debug] registered {len(src_regs) + len(dst_regs)} regions", file=sys.stderr
     )

--- a/ucm/store/ucmstore_v1.h
+++ b/ucm/store/ucmstore_v1.h
@@ -156,11 +156,6 @@ public:
      */
     virtual Status Wait(Detail::TaskHandle taskId) = 0;
 
-    virtual bool NeedRegisterKVCaches() const = 0;
-
-    virtual Status RegisterKVCaches(const KVCacheRegistration* registrations,
-                                    std::size_t count) = 0;
-
 protected:
     /**
      * @brief Protected default constructor.

--- a/ucm/store/ucmstore_v1.py
+++ b/ucm/store/ucmstore_v1.py
@@ -202,13 +202,3 @@ class UcmKVStoreBaseV1(ABC):
             ``True`` if the task has finished, ``False`` if still in-flight.
         """
         pass
-
-    @abstractmethod
-    def need_register_kv_caches(self) -> bool:
-        """Return whether this store requires KV-cache registration."""
-        pass
-
-    @abstractmethod
-    def register_kv_caches(self, registrations: np.ndarray) -> None:
-        """Register pre-collected KV-cache memory regions for this store."""
-        pass


### PR DESCRIPTION
## Purpose

Move KV cache preregistration into Store setup through configuration, eliminating the separate public registration step.

## Modifications

- Collect KV cache memory ranges before Store creation and pass them through `gpu_kv_buffer_addrs` and `gpu_kv_buffer_sizes`.
- Perform registration during ASU and DRAM Store setup, preserving the existing private `RegisterKVCaches` method names.
- Initialize the Delegator backend after allocating its internal buffer and pass registration ranges through configuration.
- Remove obsolete public registration interfaces, bindings, and no-op overrides; update related configuration validation and tests.

## Test

- ASU unit tests: 376 passed; targeted Store tests: 63 passed.
- UCM offline and online inference test passed.
- KV-test passed.
- Changed files passed `clang-format 20.1.3 --dry-run --Werror`, Black, isort, codespell, and `git diff --check`.

## Compatibility

Public Store registration APIs are removed. External callers must provide registration ranges through configuration, and affected C++ plugins must be rebuilt.