### PR TITLE
fix(posix): add actionable diagnostics for AIO setup failures

### DIFF
--- a/ucm/store/posix/cc/aio_impl.cc
+++ b/ucm/store/posix/cc/aio_impl.cc
@@ -95,10 +95,8 @@ static inline int32_t AioSetup(int32_t nEvents, aio_context_t* pCtx)
 
 static std::string AioSetupErrorMessage(int32_t eno, size_t requestedEvents)
 {
-    auto message = fmt::format(
-        "Failed to initialize UCM Posix AIO: io_setup(requested_events={}) failed "
-        "with errno={} ({}).",
-        requestedEvents, eno, strerror(eno));
+    auto message = fmt::format("UCM Posix AIO: io_setup({}) failed with errno={} ({}).",
+                               requestedEvents, eno, strerror(eno));
     if (eno == EAGAIN) {
         auto readLimit = [](const char* path) -> std::string {
             std::ifstream input(path);
@@ -109,17 +107,12 @@ static std::string AioSetupErrorMessage(int32_t eno, size_t requestedEvents)
         const auto aioNr = readLimit("/proc/sys/fs/aio-nr");
         const auto aioMaxNr = readLimit("/proc/sys/fs/aio-max-nr");
         message += fmt::format(
-            " System-wide AIO quota may be exhausted or concurrently requested by other "
-            "instances. Post-failure snapshot: fs.aio-nr={}, fs.aio-max-nr={} "
-            "(values may change during concurrent startup or shutdown). "
-            "Check with 'sysctl fs.aio-nr fs.aio-max-nr'. Ask the host administrator to "
-            "increase fs.aio-max-nr, or reduce the number of concurrent Posix AIO instances; "
-            "each instance requests {} events.",
-            aioNr, aioMaxNr, requestedEvents);
+            " Possible AIO quota exhaustion: fs.aio-nr={}, fs.aio-max-nr={} (snapshot). "
+            "Increase the host limit, e.g. 'sudo sysctl -w fs.aio-max-nr=1048576' "
+            "(choose a value above the current limit), or run fewer AIO instances.",
+            aioNr, aioMaxNr);
     } else if (eno == ENOMEM) {
-        message += " Insufficient kernel resources to create the AIO context. Check available "
-                   "memory and system/container resource limits; increasing fs.aio-max-nr "
-                   "alone does not resolve this allocation failure.";
+        message += " Insufficient kernel resources; check available memory and resource limits.";
     }
     return message;
 }

--- a/ucm/store/posix/cc/aio_impl.cc
+++ b/ucm/store/posix/cc/aio_impl.cc
@@ -26,6 +26,7 @@
 #include <cerrno>
 #include <chrono>
 #include <cstring>
+#include <fstream>
 #include <memory>
 #include <sys/epoll.h>
 #include <sys/eventfd.h>
@@ -91,6 +92,38 @@ static inline int32_t AioSetup(int32_t nEvents, aio_context_t* pCtx)
 {
     return syscall(SYS_io_setup, nEvents, pCtx);
 }
+
+static std::string AioSetupErrorMessage(int32_t eno, size_t requestedEvents)
+{
+    auto message = fmt::format(
+        "Failed to initialize UCM Posix AIO: io_setup(requested_events={}) failed "
+        "with errno={} ({}).",
+        requestedEvents, eno, strerror(eno));
+    if (eno == EAGAIN) {
+        auto readLimit = [](const char* path) -> std::string {
+            std::ifstream input(path);
+            uint64_t value;
+            if (input >> value) { return std::to_string(value); }
+            return "unavailable";
+        };
+        const auto aioNr = readLimit("/proc/sys/fs/aio-nr");
+        const auto aioMaxNr = readLimit("/proc/sys/fs/aio-max-nr");
+        message += fmt::format(
+            " System-wide AIO quota may be exhausted or concurrently requested by other "
+            "instances. Post-failure snapshot: fs.aio-nr={}, fs.aio-max-nr={} "
+            "(values may change during concurrent startup or shutdown). "
+            "Check with 'sysctl fs.aio-nr fs.aio-max-nr'. Ask the host administrator to "
+            "increase fs.aio-max-nr, or reduce the number of concurrent Posix AIO instances; "
+            "each instance requests {} events.",
+            aioNr, aioMaxNr, requestedEvents);
+    } else if (eno == ENOMEM) {
+        message += " Insufficient kernel resources to create the AIO context. Check available "
+                   "memory and system/container resource limits; increasing fs.aio-max-nr "
+                   "alone does not resolve this allocation failure.";
+    }
+    return message;
+}
+
 static inline int32_t AioGetEvents(aio_context_t ctx, int64_t minNr, int64_t maxNr,
                                    io_event* events, timespec* timeout)
 {
@@ -180,8 +213,9 @@ Status AioImpl::Setup(size_t timeoutMs)
     auto ret = AioSetup(queueDepth_, &ctx_);
     auto eno = errno;
     if (ret != 0) {
-        UC_ERROR("Failed(ret={}, errno={}, message={}) to call AioSetup.", ret, eno, strerror(eno));
-        return Status{eno, std::string(strerror(eno))};
+        auto message = AioSetupErrorMessage(eno, queueDepth_);
+        UC_ERROR("Failed(ret={}) to call AioSetup: {}", ret, message);
+        return Status{eno, std::move(message)};
     }
     eventFd_ = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
     eno = errno;


### PR DESCRIPTION
## Purpose

When system-wide AIO quota is insufficient, Posix store initialization only reports `RuntimeError: 11, Resource temporarily unavailable`, leaving users without a clear next step.

## Modifications

Include the requested event count and original errno in both the C++ log and propagated Python exception. For `EAGAIN`, add a best-effort `aio-nr`/`aio-max-nr` snapshot and a `sysctl` example; unreadable counters are shown as `unavailable`. For `ENOMEM`, point users to memory and resource limits. Error codes and AIO allocation behavior are unchanged.

Example expected exception when another worker requests 4096 events while both counters are 65536 (wrapped for readability):

```text
RuntimeError: 11, UCM Posix AIO: io_setup(4096) failed with errno=11 (Resource temporarily unavailable).
Possible AIO quota exhaustion: fs.aio-nr=65536, fs.aio-max-nr=65536 (snapshot).
Increase the host limit, e.g. 'sudo sysctl -w fs.aio-max-nr=1048576'
(choose a value above the current limit), or run fewer AIO instances.
```

## Test

- Passed `git diff --check`.
- Passed standalone C++17 syntax checking of the new diagnostic helper with MinGW g++ (`-Wall -Wextra -Werror -fsyntax-only`) and the repository's fmt headers.
- Full Linux build and runtime failure-path validation are pending; the example above is derived from the code, not a captured runtime log.
