### PR TITLE
feat: reject kv_load_failure_policy=recompute for hybrid UCM connectors

### DIFF
--- a/ucm/integration/vllm/hla_connector.py
+++ b/ucm/integration/vllm/hla_connector.py
@@ -37,6 +37,7 @@ from ucm.integration.vllm.ucm_connector import (
     _scheduler_read_block_size,
     _short_list,
     _use_ucm_connector_cpu_affinity,
+    validate_hybrid_kv_load_failure_policy,
 )
 from ucm.logger import init_logger
 from ucm.shared.metrics import ucmmetrics
@@ -795,6 +796,7 @@ class UCMHybridLinearAttentionConnector(UCMDirectConnector, SupportsHMA):
         role: KVConnectorRole,
         kv_cache_config: "KVCacheConfig",
     ):
+        validate_hybrid_kv_load_failure_policy(vllm_config)
         super().__init__(
             vllm_config=vllm_config, role=role, kv_cache_config=kv_cache_config
         )

--- a/ucm/integration/vllm/hma_connector.py
+++ b/ucm/integration/vllm/hma_connector.py
@@ -19,6 +19,7 @@ from ucm.integration.vllm.ucm_connector import (
     UCMDirectConnector,
     _check_shm_capacity,
     _use_ucm_connector_cpu_affinity,
+    validate_hybrid_kv_load_failure_policy,
 )
 from ucm.logger import init_logger
 from ucm.shared.metrics import ucmmetrics
@@ -328,6 +329,7 @@ class UCMFAWAConnector(UCMDirectConnector, SupportsHMA):
         role: KVConnectorRole,
         kv_cache_config: "KVCacheConfig",
     ):
+        validate_hybrid_kv_load_failure_policy(vllm_config)
         self._defer_scheduler_store = True
         super().__init__(vllm_config, role, kv_cache_config)
         self.hash_block_size = self.DEFAULT_HASH_BLOCK_SIZE

--- a/ucm/integration/vllm/patch/apply_patch.py
+++ b/ucm/integration/vllm/patch/apply_patch.py
@@ -216,6 +216,9 @@ def apply_all_patches() -> None:
             logger.info("UCM patching vllm for load-failure recovery...")
             import ucm.integration.vllm.patch.load_failure_patch
 
+            logger.info("UCM patching vllm MultiConnector policy propagation...")
+            import ucm.integration.vllm.patch.multi_connector_policy_patch
+
         # vllm_ascend patches
         # Disable CpuAlloc.bind_memory BEFORE any cpu_binding_patch so that
         # bind_memory is a no-op before bind_threads replacement is installed.

--- a/ucm/integration/vllm/patch/multi_connector_policy_patch.py
+++ b/ucm/integration/vllm/patch/multi_connector_policy_patch.py
@@ -1,0 +1,91 @@
+"""Propagate the top-level kv_load_failure_policy into each MultiConnector child.
+
+vLLM's ``MultiConnector._get_connector_classes_and_configs`` rebuilds each
+child ``VllmConfig`` from only the child config dict::
+
+    temp_config = copy.copy(vllm_config)
+    temp_config.kv_transfer_config = KVTransferConfig(**ktc, engine_id=engine_id)
+
+So fields set only on the outer (top-level) KV transfer config are never
+inherited by UCM child connectors. In particular ``kv_load_failure_policy``
+falls back to its upstream default "fail" even when the user requested
+"recompute" on the top-level config.
+
+UCM's hybrid/multi-group connectors (``UCMFAWAConnector`` /
+``UCMHybridLinearAttentionConnector``) do not implement the recompute path, so
+the mismatch would silently go unnoticed. This patch forwards the top-level
+policy into each child config (using ``setdefault`` so an explicit per-child
+setting still wins), letting the HMA/HLA validation reject the unsupported
+combination up front.
+"""
+
+from copy import copy
+from typing import Any
+
+from ucm.integration.vllm.patch.utils import when_imported
+from ucm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def _propagate_load_failure_policy_to_children(
+    vllm_config: "Any", ktcs: list[dict]
+) -> list[dict]:
+    """Return the child configs with the top-level policy forwarded to each."""
+    top_policy = getattr(
+        vllm_config.kv_transfer_config, "kv_load_failure_policy", "fail"
+    )
+    forwarded: list[dict] = []
+    for ktc in ktcs:
+        child_ktc = dict(ktc)
+        child_ktc.setdefault("kv_load_failure_policy", top_policy)
+        forwarded.append(child_ktc)
+    return forwarded
+
+
+def patch_multi_connector_policy(mod: Any) -> None:
+    if getattr(mod, "_ucm_multi_connector_policy_patch", False):
+        return
+
+    original = getattr(mod.MultiConnector, "_get_connector_classes_and_configs", None)
+    if original is None:
+        # Module layout mismatch between vLLM versions; leave untouched.
+        return
+
+    @classmethod
+    def wrapped(cls, vllm_config):
+        ktcs = vllm_config.kv_transfer_config.kv_connector_extra_config.get(
+            "connectors"
+        )
+        assert ktcs is not None
+        from vllm.config.kv_transfer import KVTransferConfig
+        from vllm.distributed.kv_transfer.kv_connector.factory import KVConnectorFactory
+
+        ret = []
+        for ktc in _propagate_load_failure_policy_to_children(vllm_config, ktcs):
+            temp_config = copy(vllm_config)
+            engine_id = ktc.get("engine_id", vllm_config.kv_transfer_config.engine_id)
+            temp_config.kv_transfer_config = KVTransferConfig(
+                **ktc, engine_id=engine_id
+            )
+            ret.append(
+                (
+                    KVConnectorFactory.get_connector_class(
+                        temp_config.kv_transfer_config
+                    ),
+                    temp_config,
+                )
+            )
+        return ret
+
+    mod.MultiConnector._get_connector_classes_and_configs = wrapped
+    mod._ucm_multi_connector_policy_patch = True
+    logger.debug(
+        "Patched MultiConnector to propagate the top-level "
+        "kv_load_failure_policy to each child connector"
+    )
+
+
+when_imported("vllm.distributed.kv_transfer.kv_connector.v1.multi_connector")(
+    patch_multi_connector_policy
+)

--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -1,4 +1,4 @@
-﻿import copy
+import copy
 import glob
 import hashlib
 import math
@@ -172,6 +172,36 @@ def _check_shm_capacity(cache_buffer_capacity_gb: int) -> None:
             f"Either increase the size of {_SHM_DIR} (e.g. remount tmpfs with a "
             f"larger size= option) or decrease cache_buffer_capacity_gb."
         )
+
+
+def validate_hybrid_kv_load_failure_policy(vllm_config: "VllmConfig") -> None:
+    """Guard hybrid (HMA/HLA) connectors against unsupported load-failure policy.
+
+    vLLM's ``KVTransferConfig`` defaults ``kv_load_failure_policy`` to "fail";
+    when it is set to "recompute", load failures trigger scheduler recompute
+    paths that UCM's hybrid/multi-group connectors (UCMFAWAConnector /
+    UCMHybridLinearAttentionConnector) do not currently implement. Reject the
+    combination up front so the user gets an actionable message instead of a
+    runtime failure later.
+
+    For MultiConnector, vLLM rebuilds each child ``VllmConfig`` from only the
+    child dict (``KVTransferConfig(**ktc)``), so outer fields are not inherited.
+    ``multi_connector_policy_patch`` propagates the top-level policy into each
+    child so this check also fires in that case.
+    """
+    # Older vLLM versions (<= 0.23) may not define the field at all; treat
+    # them as "fail", which is the upstream default and is safe for UCM.
+    ktc = getattr(vllm_config, "kv_transfer_config", None)
+    if ktc is None:
+        return
+    if getattr(ktc, "kv_load_failure_policy", "fail") != "recompute":
+        return
+    raise RuntimeError(
+        "UCM hybrid/multi-group KV cache connectors (HMA/HLA) do not "
+        "currently support kv_load_failure_policy='recompute'. "
+        "Please set kv_load_failure_policy='fail' in --kv-transfer-config. "
+        "For MultiConnector, set it on the top-level kv-transfer-config."
+    )
 
 
 def _drop_null_vllm_blocks(


### PR DESCRIPTION
## Summary
Reject \kv_load_failure_policy=recompute\ for UCM hybrid/multi-group connectors.

## Background
vLLM's \KVTransferConfig\ defaults \kv_load_failure_policy\ to \"fail"\. When set to \"recompute"\, load failures trigger recompute paths that UCM's hybrid connectors (\UCMFAWAConnector\ / \UCMHybridLinearAttentionConnector\) do not implement. Previously the unsafe combination was only caught at runtime, deep inside the scheduler.

vLLM's \MultiConnector._get_connector_classes_and_configs\ rebuilds each child config from only the child dict (\KVTransferConfig(**ktc)\), so top-level fields are not inherited. A plain connector-level check would silently miss the MultiConnector case.

## Changes
1. **Validation helper** (\ucm_connector.py\): \alidate_hybrid_kv_load_failure_policy()\ raises an actionable error when \kv_load_failure_policy=recompute\. Uses \getattr\ fallback for older vLLM versions (\<= 0.23) that lack the field.
2. **HMA**: called at the very start of \UCMFAWAConnector.__init__\ (before store creation side effects).
3. **HLA**: called in \UCMHybridLinearAttentionConnector.__init__\ before \super().__init__()\ (subclass \UCMHybridLinearAttentionLayerWiseConnector\ inherits the check).
4. **MultiConnector patch** (\multi_connector_policy_patch.py\): wraps \_get_connector_classes_and_configs\ to propagate the top-level policy into each child config via \setdefault\ (explicit per-child setting still wins), so the validation also fires in MultiConnector deployments. Registered in \pply_patch.py\ for vLLM >= 0.18.

## Behavior unchanged
- \kv_load_failure_policy=fail\ (default): same as before.
- Non-hybrid models using \ecompute\: unaffected (validation lives only in the two hybrid connector classes).
- Old vLLM without the field: \getattr\ defaults keep them working.

## Validation
- black / isort / py_compile all pass.
- Logic tests pass for: top-level recompute propagation, explicit per-child override, missing-field fallback, patch registration, and both hybrid connector call sites.