### PR TITLE
[Bugfix] Override requires_kv_delivery to return False in UCMConnector

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -2862,6 +2862,18 @@ class UCMConnector(KVConnectorBase_V1, SupportsHMA):
         else:
             self.connector = UCMDirectConnector(vllm_config, role, kv_cache_config)
 
+    @property
+    def requires_kv_delivery(self) -> bool:
+        """UCM is a best-effort cache, not a P/D disaggregation producer.
+
+        Returning False keeps drop_stale_output=False so preempted requests
+        are protected by the stale-output guard in the scheduler, which
+        prevents the deadlock under async_scheduling + defer_block_free
+        where all running requests get preempted into deferred_frees and
+        no non-empty batch is ever produced to drain them.
+        """
+        return False
+
     @_record_connector_interface_duration
     def get_block_size(self) -> int:
         return self.connector.get_block_size()


### PR DESCRIPTION
## Purpose
UCM is a best-effort cache, not a P/D disaggregation producer. With kv_role='kv_both', the base class KVConnectorBase_V1 returns requires_kv_delivery=True (because is_kv_producer=True), which sets drop_stale_output=True on preemption.

Under async_scheduling + defer_block_free (enabled when is_kv_consumer is True and max_concurrent_batches > 1), this causes a deadlock:
- Preempted requests bypass the stale-output guard and immediately re-schedule, cascading preemptions of all running requests.
- All blocks land in deferred_frees and no non-empty batch is produced.
- update_from_output skips _drain_deferred_frees when total_num_scheduled_tokens == 0, so processed_step_seq never advances and deferred blocks are never returned to the free pool.

Returning False restores the stale-output guard, preventing the preemption cascade and keeping non-empty batches flowing so that deferred frees drain normally.
