### PR TITLE
chore: add UCM environment diagnostics

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -2763,6 +2763,15 @@ class UCMConnector(KVConnectorBase_V1, SupportsHMA):
             role=role,
             kv_cache_config=kv_cache_config,
         )
+        enable_ucm_patch = os.getenv("ENABLE_UCM_PATCH")
+        vllm_cpu_affinity = os.getenv("VLLM_CPU_AFFINITY")
+        if enable_ucm_patch is None or vllm_cpu_affinity is None:
+            logger.warning(
+                f"[UCM ENV CHECK] ENABLE_UCM_PATCH={enable_ucm_patch!r}, "
+                f"VLLM_CPU_AFFINITY={vllm_cpu_affinity!r}, "
+                f"device_type={getattr(current_platform, 'device_type', None)!r}, "
+                f"role={role}, pid={os.getpid()}"
+            )
         self.connector: KVConnectorBase_V1
         ucm_config = Config(vllm_config.kv_transfer_config)
         self.engine_id = vllm_config.kv_transfer_config.engine_id.rsplit("_dp", 1)[0]


### PR DESCRIPTION
## What this PR does

- Log the raw `ENABLE_UCM_PATCH` value when the patch module is imported and when patch application is skipped.
- Log `VLLM_CPU_AFFINITY`, the detected device type, and the resulting connector-side affinity decision.
- Log when worker CPU binding is skipped and report both environment variables when `UCMConnector` is initialized.

## Why

These diagnostics distinguish environment propagation failures from the intentional NPU behavior that disables connector-side CPU affinity. The existing `device_type != "npu"` condition and all patch/affinity control flow remain unchanged.

## Validation

- `py -3 -m py_compile ucm/integration/vllm/patch/apply_patch.py ucm/integration/vllm/ucm_connector.py`
- `git diff --check`