### PR TITLE
[Feat] Refresh UCM connector metrics while vLLM engines are idle

### DIFF
--- a/docs/source/user-guide/metrics/health_metrics.md
+++ b/docs/source/user-guide/metrics/health_metrics.md
@@ -42,7 +42,7 @@ Metric names distinguish Store types, while labels distinguish vLLM instances an
 
 ### 2.1 Synchronization Delay in Connector Mode
 
-The health threads continue to run inside UCM at their configured interval, but connector metrics are synchronized to `/metrics` only when vLLM calls `get_kv_connector_stats()`. With no inference requests, the health metrics in Prometheus do not update even if the background probe result has changed.
+The health threads continue to run inside UCM at their configured interval. During inference, vLLM synchronizes their metrics through `get_kv_connector_stats()`. On vLLM 0.18 or later, `ENABLE_UCM_PATCH=1` also enables periodic idle collection for vLLM and vllm-ascend, so background probe changes can reach `/metrics` without an inference request. Set `ENABLE_UCM_IDLE_METRICS=0` in every API Server environment before startup to disable only idle collection; health probes and inference-triggered metric updates continue. Updates depend on both the probe interval and the idle collection cadence. See [Idle collection](metrics.md#idle-collection) for prerequisites and timing. Without idle collection, health metrics remain unchanged in the vLLM connector registry until inference triggers synchronization.
 
 ## 3. Recommended Aggregation
 

--- a/docs/source/user-guide/metrics/metrics.md
+++ b/docs/source/user-guide/metrics/metrics.md
@@ -6,7 +6,7 @@ We recommend using Prometheus to scrape vLLM metrics and Grafana to visualize th
 
 Use a scrape and dashboard refresh interval of **at least 5 seconds** for UCM metrics. The Prometheus and Metrics-view examples in this guide both use 5 seconds. A shorter interval usually does not make UCM metrics update faster.
 
-The effective refresh frequency also depends on vLLM. UCM first accumulates metrics internally. New data is synchronized to the Prometheus metrics exposed by vLLM only after vLLM processes a request and calls the connector's `get_kv_connector_stats()` method. **When there are no inference requests, vLLM does not call this method and UCM metrics do not update.**
+The effective refresh frequency also depends on vLLM. UCM first accumulates metrics internally. During inference, vLLM synchronizes them through the connector's `get_kv_connector_stats()` method. With `ENABLE_UCM_PATCH=1` on vLLM 0.18 or later, UCM also collects these metrics periodically while the engine is idle, including when using vllm-ascend.
 
 ## Metrics workflow
 
@@ -49,7 +49,29 @@ sequenceDiagram
 
 UCM accumulates Counters, Gauges, and Histograms in the process that performs each Lookup, Load, Save, or health probe. While processing requests, vLLM obtains the accumulated UCM metrics from the worker and scheduler connectors. These metrics return with each DP's engine stats, and vLLM Prometheus metrics write them to the corresponding series with the `model_name`, `engine`, and `worker_rank` labels.
 
-The vLLM `/metrics` endpoint and Prometheus registry reside in the API Server process. Prometheus scrapes that endpoint directly; the API Server's HTTP route only returns data that has already been synchronized to the registry and does not call `get_kv_connector_stats()`. With no inference requests, UCM may still produce new data internally, but that data appears in `/metrics` only after the next vLLM request triggers synchronization.
+The vLLM `/metrics` endpoint and Prometheus registry reside in the API Server process. Prometheus scrapes that endpoint directly; the API Server's HTTP route only returns data that has already been synchronized to the registry and does not call `get_kv_connector_stats()`.
+
+### Idle collection
+
+The UCM patch extends the API Server's existing `AsyncLLM.do_log_stats()` task. Each tick sends a utility request to each DP engine. An engine collects only when its existing `has_work()` check is false: no scheduled requests, no queued batches, and no running DP wave. Busy engines skip collection and continue reporting metrics through the normal inference path.
+
+An idle engine calls the workers through the executor's existing collective RPC, collects its scheduler connector stats, and returns the combined data with its engine index. The API Server updates the existing connector Prometheus metrics, preserving the `engine` and `worker_rank` labels. This also supports UCM inside a MultiConnector and uses the worker RPC transport across nodes; it does not require sharing Prometheus files between worker nodes. Standard multiple API Server processes still require vLLM's shared Prometheus registry setup.
+
+Idle collection uses the connector stats' `to_dict()` interface when available and falls back to `data` on older vLLM versions, preserving each version's MultiConnector payload format.
+
+Enable `ENABLE_UCM_PATCH=1` in the API Server, engine, and worker environments. Idle collection requires enabled UCM metrics, the `vllm_connector` consumer, and vLLM's periodic stats logging task. `--disable-log-stats` disables that task. Offline `LLM` usage does not start this timer.
+
+Idle collection is enabled by default. To disable only idle collection, set this environment variable before starting the API Server:
+
+```bash
+export ENABLE_UCM_IDLE_METRICS=0
+```
+
+With this switch disabled, UCM leaves `AsyncLLM.do_log_stats()` unchanged and sends no periodic idle metrics RPCs. Health probes, normal inference-triggered connector metrics, the optional `multiproc` exporter, and other UCM patches remain enabled according to their existing settings. Set the same value in every API Server process in a multiple-API deployment; an API Server with idle collection enabled can still collect from all of its DP engines. Restart the API Servers after changing the setting. Unset the variable or set it to `1` to enable idle collection again; `true`, `yes`, and `on` are also accepted, case-insensitively.
+
+The metrics configuration's positive, finite `log_interval` sets the minimum interval between idle collections per engine in seconds (default: `5`). This existing setting also controls the optional `multiproc` exporter. The actual cadence is also limited by vLLM's `VLLM_LOG_STATS_INTERVAL` and how long the engine remains busy. Multiple API clients share the same per-engine throttle. The existing metrics dispatcher drains each delta once and retains an independent copy for any enabled `multiproc` consumer, so returning to inference does not count an idle snapshot again.
+
+The patch adds utility and worker methods and wraps `do_log_stats()`; it does not replace EngineCore's constructor, scheduling loop, or model execution methods. Collection is synchronous inside an idle engine. A request arriving after the idle check can wait for the metrics RPC to finish; this approach does not guarantee zero impact on request latency. Without the patch or its timer, metrics still synchronize on inference as before.
 
 ## 1. Enable or Disable Metrics
 

--- a/test/test_ucm_connector_metrics.py
+++ b/test/test_ucm_connector_metrics.py
@@ -1,4 +1,5 @@
 import ast
+import asyncio
 import importlib
 import json
 import math
@@ -350,6 +351,7 @@ def _install_stubs():
         KVCacheConfig=type("KVCacheConfig", (), {}),
         KVCacheSpec=type("KVCacheSpec", (), {}),
         MambaSpec=type("MambaSpec", (), {}),
+        MLAAttentionSpec=type("MLAAttentionSpec", (), {}),
         SlidingWindowSpec=type("SlidingWindowSpec", (), {}),
         UniformTypeKVCacheSpecs=type("UniformTypeKVCacheSpecs", (), {}),
     )
@@ -360,6 +362,7 @@ def _install_stubs():
     _install_module(
         "ucm.integration.vllm.device",
         create_device=lambda *args, **kwargs: None,
+        get_current_device_id=lambda: 0,
     )
     _install_module("ucm.logger", init_logger=lambda name: _Logger())
     _install_module("ucm.shared.metrics", ucmmetrics=fake_ucmmetrics)
@@ -564,6 +567,402 @@ def _reset_fakes():
     import ucm.metrics_dispatcher as dispatcher_module
 
     dispatcher_module._DISPATCHER = None
+
+
+@pytest.fixture
+def idle_metrics(monkeypatch, request):
+    from ucm.integration.vllm.patch import idle_metrics_patch as patch
+
+    enabled = getattr(request, "param", None)
+    if enabled is None:
+        monkeypatch.delenv("ENABLE_UCM_IDLE_METRICS", raising=False)
+    else:
+        monkeypatch.setenv("ENABLE_UCM_IDLE_METRICS", enabled)
+
+    class Core:
+        def __init__(self, index, scheduler_connector=None, workers=()):
+            self.engine_index = index
+            self.scheduler = SimpleNamespace(
+                get_kv_connector=lambda: scheduler_connector,
+                has_requests=lambda: self.requests,
+            )
+            self.requests = False
+            self.engines_running = False
+            self.batch_queue = []
+            self.workers = workers
+            self.rpc_calls = 0
+
+        def has_work(self):
+            return (
+                self.engines_running
+                or self.scheduler.has_requests()
+                or bool(self.batch_queue)
+            )
+
+        def collective_rpc(self, method):
+            assert method == "ucm_get_kv_connector_stats"
+            self.rpc_calls += 1
+            return [patch._read_connector_stats(worker) for worker in self.workers]
+
+    class Client:
+        def __init__(self, cores):
+            self.cores = cores
+            self.core_engines = list(cores)
+            self.calls = []
+
+        async def _call_utility_async(self, method, *args, engine):
+            self.calls.append(engine)
+            await asyncio.sleep(0)
+            core = self.cores[engine]
+            if isinstance(core, Exception):
+                raise core
+            return getattr(core, method)(*args)
+
+    class LLM:
+        def __init__(self, client, prom):
+            self.engine_core = client
+            self.log_calls = 0
+            self.logger_manager = SimpleNamespace(stat_loggers=[PromLogger(prom)])
+
+        async def do_log_stats(self):
+            self.log_calls += 1
+
+    class PromLogger:
+        def __init__(self, prom):
+            self.kv_connector_prom = SimpleNamespace(
+                prom_metrics=prom,
+                observe=prom.observe if prom is not None else None,
+            )
+
+    class MultiProm:
+        def __init__(self, children):
+            self._prom_metrics = children
+
+        def observe(self, data, engine_idx):
+            for name, stats in data.items():
+                self._prom_metrics[name].observe(stats["data"], engine_idx)
+
+    for name, attributes in (
+        (
+            "vllm.distributed.kv_transfer.kv_connector.v1.multi_connector",
+            {"MultiKVConnectorPromMetrics": MultiProm},
+        ),
+        ("vllm.v1.metrics.loggers", {"PrometheusStatLogger": PromLogger}),
+    ):
+        module = ModuleType(name)
+        module.__dict__.update(attributes)
+        monkeypatch.setitem(sys.modules, name, module)
+    patch._patch_engine_core(SimpleNamespace(EngineCoreProc=Core))
+    patch._patch_engine_client(SimpleNamespace(AsyncMPClient=Client))
+    patch._patch_async_llm(SimpleNamespace(AsyncLLM=LLM))
+    return SimpleNamespace(
+        patch=patch, Core=Core, Client=Client, LLM=LLM, MultiProm=MultiProm
+    )
+
+
+@pytest.mark.parametrize("busy_state", ["requests", "engines_running", "batch_queue"])
+def test_idle_metrics_skips_busy_engine_without_draining(idle_metrics, busy_state):
+    def unexpected_drain():
+        pytest.fail("Busy engine must not drain scheduler or worker stats")
+
+    connector = SimpleNamespace(get_kv_connector_stats=unexpected_drain)
+    core = idle_metrics.Core(0, connector, [connector])
+    setattr(core, busy_state, [object()] if busy_state == "batch_queue" else True)
+    assert core.ucm_collect_idle_metrics(5) is None
+    assert core.rpc_calls == 0
+
+
+def test_idle_metrics_hooks_apply_after_other_ucm_patches(monkeypatch):
+    import runpy
+
+    from ucm.integration.vllm.patch import utils
+
+    core_module = ModuleType("vllm.v1.engine.core")
+    core_module._ucm_patched = True
+    core_module.EngineCoreProc = type("EngineCoreProc", (), {})
+    monkeypatch.setitem(sys.modules, core_module.__name__, core_module)
+    deferred = []
+
+    def defer(name):
+        def register(callback):
+            deferred.append(name)
+            return callback
+
+        return register
+
+    monkeypatch.setattr(utils, "when_imported", defer)
+    runpy.run_path(str(REPO_ROOT / "ucm/integration/vllm/patch/idle_metrics_patch.py"))
+    assert callable(core_module.EngineCoreProc.ucm_collect_idle_metrics)
+    assert set(deferred) == {
+        "vllm.v1.worker.worker_base",
+        "vllm.v1.engine.core_client",
+        "vllm.v1.engine.async_llm",
+    }
+
+
+def test_idle_metrics_throttle_and_resume_do_not_duplicate(idle_metrics, monkeypatch):
+    _reset_fakes()
+    config = _metrics_config()
+    connector = UCMConnector.__new__(UCMConnector)
+    connector._vllm_metrics_enabled = True
+    connector._metrics_dispatcher = get_metrics_dispatcher(config)
+    connector._vllm_metric_definitions = get_vllm_connector_metric_definitions(config)
+    connector._worker_rank = 2
+    core = idle_metrics.Core(
+        3, SimpleNamespace(get_kv_connector_stats=lambda: None), [connector]
+    )
+    monkeypatch.setattr(idle_metrics.patch.time, "monotonic", lambda: 100)
+    fake_ucmmetrics.snapshot = (
+        {"load_bytes_total": 20},
+        {"test_health": 1},
+        {"load_duration": ([1, 0, 0], 30)},
+    )
+    index, data = core.ucm_collect_idle_metrics(5)
+    assert index == 3
+    assert data["counters_by_rank"]["2"] == {"load_bytes_total": 20}
+    assert data["histograms_by_rank"]["2"]["load_duration"]["bucket_counts"] == [
+        1,
+        0,
+        0,
+    ]
+    assert connector.get_kv_connector_stats() is None
+    assert connector._metrics_dispatcher.get_stats_and_clear("multiproc")[0] == {
+        "load_bytes_total": 20
+    }
+
+    fake_ucmmetrics.snapshot = ({"load_bytes_total": 7}, {"test_health": 0}, {})
+    drain_count = len(fake_ucmmetrics.drained)
+    assert core.ucm_collect_idle_metrics(5) is None
+    assert len(fake_ucmmetrics.drained) == drain_count
+    monkeypatch.setattr(idle_metrics.patch.time, "monotonic", lambda: 105)
+    _, data = core.ucm_collect_idle_metrics(5)
+    assert data["gauges_by_rank"]["2"] == {"test_health": 0}
+    assert data["counters_by_rank"]["2"] == {"load_bytes_total": 7}
+    assert core.rpc_calls == 2
+    fake_ucmmetrics.snapshot = ({"load_bytes_total": 4}, {}, {})
+    resumed = connector.get_kv_connector_stats()
+    assert resumed.data["counters_by_rank"]["2"] == {"load_bytes_total": 4}
+
+
+@pytest.mark.parametrize(
+    "idle_metrics", [None, "1", "TRUE", "yes", " on "], indirect=True
+)
+def test_idle_metrics_publish_all_dp_workers_and_scheduler(idle_metrics):
+    _reset_fakes()
+    cores = {}
+    for index in (0, 1):
+        connectors = []
+        for rank in ("scheduler", str(index * 2), str(index * 2 + 1)):
+            stats = UCMConnectorStats(worker_rank=rank)
+            stats.record({"test_health": index}, {"test_health": "gauge"})
+            stats.record({"load_bytes_total": 10}, {"load_bytes_total": "counter"})
+            connectors.append(
+                SimpleNamespace(get_kv_connector_stats=stats.clone_and_reset)
+            )
+        cores[bytes([index])] = idle_metrics.Core(index, connectors[0], connectors[1:])
+    client = idle_metrics.Client(cores)
+    prom = UCMPromMetrics(
+        _vllm_config(_metrics_config()),
+        _metric_types(),
+        ["model_name", "engine"],
+        {0: ["model-a", "0"], 1: ["model-a", "1"]},
+    )
+    llm = idle_metrics.LLM(client, prom)
+    # Repeated registration must not wrap logging or collect twice.
+    idle_metrics.patch._patch_async_llm(SimpleNamespace(AsyncLLM=type(llm)))
+    asyncio.run(llm.do_log_stats())
+    assert llm.log_calls == 1
+    assert client.calls == [b"\x00", b"\x01"]
+    for index in (0, 1):
+        for rank in ("scheduler", str(index * 2), str(index * 2 + 1)):
+            labels = ("model-a", str(index), rank)
+            assert FakeGauge.created["ucm:test_health"].children[labels].set_values == [
+                index
+            ]
+            assert FakeCounter.created["ucm:load_bytes_total"].children[
+                labels
+            ].increments == [10]
+
+
+@pytest.mark.parametrize("mode", ["no_logger", "no_ucm", "disabled"])
+def test_idle_metrics_disabled_does_not_rpc(idle_metrics, mode):
+    _reset_fakes()
+    config = _metrics_config()
+    if mode == "disabled":
+        config["consumers"]["vllm_connector"] = False
+    prom = UCMConnector.build_prom_metrics(
+        _vllm_config(config), _metric_types(), ["engine"], {0: ["0"]}
+    )
+    if mode == "no_ucm":
+        prom = SimpleNamespace(observe=lambda *args: pytest.fail("Unexpected observe"))
+    client = idle_metrics.Client({})
+    llm = idle_metrics.LLM(client, prom)
+    if mode == "no_logger":
+        llm.logger_manager = None
+    asyncio.run(llm.do_log_stats())
+    assert client.calls == []
+    assert llm.log_calls == 1
+
+
+@pytest.mark.parametrize("idle_metrics", ["0", "false", "OFF", "no"], indirect=True)
+@pytest.mark.parametrize("nested", [False, True])
+def test_idle_collection_switch_preserves_inference_metrics(idle_metrics, nested):
+    _reset_fakes()
+    config = _metrics_config()
+    connector = UCMConnector.__new__(UCMConnector)
+    connector._vllm_metrics_enabled = True
+    connector._metrics_dispatcher = get_metrics_dispatcher(config)
+    connector._vllm_metric_definitions = get_vllm_connector_metric_definitions(config)
+    connector._worker_rank = 0
+    core = idle_metrics.Core(0, connector, [connector])
+    client = idle_metrics.Client({b"0": core})
+    prom = UCMConnector.build_prom_metrics(
+        _vllm_config(config), _metric_types(), ["engine"], {0: ["0"]}
+    )
+    sink = idle_metrics.MultiProm({"UCM": prom}) if nested else prom
+    llm = idle_metrics.LLM(client, sink)
+    fake_ucmmetrics.snapshot = ({"load_bytes_total": 20}, {"test_health": 1}, {})
+
+    asyncio.run(llm.do_log_stats())
+    assert llm.log_calls == 1
+    assert client.calls == []
+    assert core.rpc_calls == 0
+    assert fake_ucmmetrics.drained == []
+
+    stats = connector.get_kv_connector_stats()
+    prom.observe(stats.data, 0)
+    assert FakeCounter.created["ucm:load_bytes_total"].children[
+        ("0", "0")
+    ].increments == [20]
+    assert FakeGauge.created["ucm:test_health"].children[("0", "0")].set_values == [1]
+
+
+@pytest.mark.parametrize("interval", [0, -1, math.inf, math.nan])
+def test_idle_metrics_rejects_invalid_interval(interval):
+    config = _metrics_config()
+    config["log_interval"] = interval
+    with pytest.raises(ValueError, match="log_interval must be finite and > 0"):
+        UCMPromMetrics(_vllm_config(config), _metric_types(), ["engine"], {0: ["0"]})
+
+
+@pytest.mark.parametrize("use_to_dict", [False, True])
+@pytest.mark.parametrize("nested", [False, True])
+def test_idle_metrics_serialization_and_dp_failure(
+    idle_metrics, monkeypatch, use_to_dict, nested
+):
+    import msgspec
+
+    _reset_fakes()
+    prom = UCMPromMetrics(
+        _vllm_config(_metrics_config()), _metric_types(), ["engine"], {1: ["1"]}
+    )
+
+    class MultiStats(KVConnectorStats):
+        def to_dict(self):
+            return {name: child.to_dict() for name, child in self.data.items()}
+
+    if use_to_dict:
+        monkeypatch.setattr(
+            KVConnectorStats, "to_dict", lambda self: self.data, raising=False
+        )
+
+        def observe(self, data, engine_idx):
+            for name, child in data.items():
+                self._prom_metrics[name].observe(child, engine_idx)
+
+        monkeypatch.setattr(idle_metrics.MultiProm, "observe", observe)
+
+    stats = UCMConnectorStats(worker_rank=3)
+    stats.record({"test_health": 0}, {"test_health": "gauge"})
+    stats.record({"load_bytes_total": 10}, {"load_bytes_total": "counter"})
+    stats.record({"load_duration": 25}, {"load_duration": "histogram"})
+    payload = stats
+    sink = prom
+    if nested:
+        stats_class = MultiStats if use_to_dict else KVConnectorStats
+        payload = stats_class(data={"outer": stats_class(data={"UCM": stats})})
+        sink = idle_metrics.MultiProm({"outer": idle_metrics.MultiProm({"UCM": prom})})
+    core = idle_metrics.Core(1, SimpleNamespace(get_kv_connector_stats=lambda: payload))
+
+    collect = core.ucm_collect_idle_metrics
+
+    def collect_over_wire(interval):
+        return msgspec.msgpack.decode(msgspec.msgpack.encode(collect(interval)))
+
+    core.ucm_collect_idle_metrics = collect_over_wire
+    client = idle_metrics.Client({b"0": RuntimeError("unavailable"), b"1": core})
+    llm = idle_metrics.LLM(client, sink)
+    asyncio.run(llm.do_log_stats())
+    assert FakeGauge.created["ucm:test_health"].children[("1", "3")].set_values == [0]
+    assert FakeCounter.created["ucm:load_bytes_total"].children[
+        ("1", "3")
+    ].increments == [10]
+    assert FakeHistogram.created["ucm:load_duration"].children[
+        ("1", "3")
+    ].observations == [25]
+    assert not llm._ucm_idle_metrics_running
+
+
+def test_idle_metrics_single_inflight_and_cancellation(idle_metrics):
+    _reset_fakes()
+    prom = UCMPromMetrics(
+        _vllm_config(_metrics_config()), _metric_types(), ["engine"], {0: ["0"]}
+    )
+
+    async def run():
+        started = asyncio.Event()
+        calls = []
+
+        async def collect(interval):
+            calls.append(interval)
+            started.set()
+            await asyncio.Event().wait()
+
+        llm = idle_metrics.LLM(
+            SimpleNamespace(ucm_collect_idle_metrics_async=collect), prom
+        )
+        task = asyncio.create_task(llm.do_log_stats())
+        await started.wait()
+        await llm.do_log_stats()
+        assert calls == [5]
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert not llm._ucm_idle_metrics_running
+        assert llm.log_calls == 2
+
+    asyncio.run(run())
+
+
+def test_idle_metrics_worker_extension_supports_gpu_and_npu(idle_metrics, monkeypatch):
+    class WorkerBase:
+        pass
+
+    class GPUWorker(WorkerBase):
+        pass
+
+    class NPUWorker(WorkerBase):
+        pass
+
+    def failed_stats():
+        raise RuntimeError("metrics backend unavailable")
+
+    module = ModuleType("vllm.distributed.kv_transfer")
+    module.has_kv_transfer_group = lambda: True
+    stats = UCMConnectorStats(worker_rank=0)
+    module.get_kv_transfer_group = lambda: SimpleNamespace(
+        get_kv_connector_stats=lambda: stats
+    )
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    idle_metrics.patch._patch_worker(SimpleNamespace(WorkerBase=WorkerBase))
+    for worker in (GPUWorker(), NPUWorker()):
+        assert worker.ucm_get_kv_connector_stats() is stats
+    module.get_kv_transfer_group = lambda: SimpleNamespace(
+        get_kv_connector_stats=failed_stats
+    )
+    assert GPUWorker().ucm_get_kv_connector_stats() is None
+    module.has_kv_transfer_group = lambda: False
+    assert NPUWorker().ucm_get_kv_connector_stats() is None
 
 
 def test_config_definitions_register_enable_list_and_metric_names():

--- a/ucm/integration/vllm/metrics.py
+++ b/ucm/integration/vllm/metrics.py
@@ -199,6 +199,12 @@ if UCM_HAS_PROM_METRICS:
                 vllm_config, metric_types, labelnames, per_engine_labelvalues
             )
             config = _metrics_config_from_vllm_config(vllm_config)
+            self.idle_collection_interval = float(config.get("log_interval", 5))
+            if (
+                not math.isfinite(self.idle_collection_interval)
+                or self.idle_collection_interval <= 0
+            ):
+                raise ValueError("UCM metrics log_interval must be finite and > 0")
             definitions = get_vllm_connector_metric_definitions(config)
             self._definitions = {
                 definition.name: definition for definition in definitions

--- a/ucm/integration/vllm/patch/apply_patch.py
+++ b/ucm/integration/vllm/patch/apply_patch.py
@@ -213,6 +213,8 @@ def apply_all_patches() -> None:
 
         major, minor, *_ = version.split(".")
         if (int(major), int(minor)) >= (0, 18):
+            import ucm.integration.vllm.patch.idle_metrics_patch
+
             logger.info("UCM patching vllm for load-failure recovery...")
             import ucm.integration.vllm.patch.load_failure_patch
 

--- a/ucm/integration/vllm/patch/idle_metrics_patch.py
+++ b/ucm/integration/vllm/patch/idle_metrics_patch.py
@@ -1,0 +1,195 @@
+"""Collect connector metrics through utility RPCs while an engine is idle."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+import sys
+import time
+from collections.abc import Iterator
+from functools import wraps
+from types import ModuleType
+from typing import TYPE_CHECKING, Any
+
+from ucm.integration.vllm.patch.utils import when_imported
+from ucm.logger import init_logger
+
+if TYPE_CHECKING:
+    from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorBase_V1
+    from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+        KVConnectorProm,
+        KVConnectorPromMetrics,
+        KVConnectorStats,
+    )
+    from vllm.v1.engine.async_llm import AsyncLLM
+    from vllm.v1.engine.core import EngineCoreProc
+    from vllm.v1.engine.core_client import AsyncMPClient
+    from vllm.v1.worker.worker_base import WorkerBase
+
+logger = init_logger(__name__)
+IdleMetrics = tuple[int, dict[str, Any]]
+
+
+def _read_connector_stats(
+    connector: KVConnectorBase_V1 | None,
+) -> KVConnectorStats | None:
+    if connector is None:
+        return None
+    try:
+        return connector.get_kv_connector_stats()
+    except Exception:
+        logger.warning("Failed to collect idle KV connector metrics", exc_info=True)
+        return None
+
+
+def _patch_worker(module: ModuleType) -> None:
+    def ucm_get_kv_connector_stats(self: WorkerBase) -> KVConnectorStats | None:
+        from vllm.distributed.kv_transfer import (
+            get_kv_transfer_group,
+            has_kv_transfer_group,
+        )
+
+        if not has_kv_transfer_group():
+            return None
+        return _read_connector_stats(get_kv_transfer_group())
+
+    # Both the vLLM GPU Worker and vllm-ascend NPUWorker inherit WorkerBase.
+    module.WorkerBase.ucm_get_kv_connector_stats = ucm_get_kv_connector_stats
+
+
+def _patch_engine_core(module: ModuleType) -> None:
+    def ucm_collect_idle_metrics(
+        self: EngineCoreProc, interval_seconds: float
+    ) -> IdleMetrics | None:
+        import msgspec
+
+        if not math.isfinite(interval_seconds) or interval_seconds <= 0:
+            return None
+        if self.has_work():
+            return None
+        now = time.monotonic()
+        if now - self._ucm_last_idle_metrics < interval_seconds:
+            return None
+        connector = self.scheduler.get_kv_connector()
+        if connector is None:
+            return None
+        self._ucm_last_idle_metrics = now
+        # Stay on the engine's serialized RPC path; a timeout can leave worker
+        # replies queued for the next executor operation.
+        snapshots = self.collective_rpc("ucm_get_kv_connector_stats")
+        snapshots.append(_read_connector_stats(connector))
+        combined = None
+        for stats in snapshots:
+            if stats is None or stats.is_empty():
+                continue
+            combined = stats if combined is None else combined.aggregate(stats)
+        if combined is None:
+            return None
+        # Newer MultiConnector stats flatten child payloads through to_dict().
+        to_dict = getattr(combined, "to_dict", None)
+        data = to_dict() if callable(to_dict) else combined.data
+        return self.engine_index, msgspec.to_builtins(data)
+
+    if "ucm_collect_idle_metrics" not in module.EngineCoreProc.__dict__:
+        module.EngineCoreProc._ucm_last_idle_metrics = float("-inf")
+        module.EngineCoreProc.ucm_collect_idle_metrics = ucm_collect_idle_metrics
+
+
+def _patch_engine_client(module: ModuleType) -> None:
+    async def ucm_collect_idle_metrics_async(
+        self: AsyncMPClient, interval_seconds: float
+    ) -> list[IdleMetrics | None | BaseException]:
+        # DP's public utility wrapper returns only the first engine's result.
+        return await asyncio.gather(
+            *(
+                self._call_utility_async(
+                    "ucm_collect_idle_metrics", interval_seconds, engine=engine
+                )
+                for engine in self.core_engines
+            ),
+            return_exceptions=True,
+        )
+
+    module.AsyncMPClient.ucm_collect_idle_metrics_async = ucm_collect_idle_metrics_async
+
+
+def _patch_async_llm(module: ModuleType) -> None:
+    if os.getenv("ENABLE_UCM_IDLE_METRICS", "1").strip().lower() not in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    ):
+        return
+    if getattr(module.AsyncLLM.do_log_stats, "_ucm_idle_metrics_patched", False):
+        return
+    original = module.AsyncLLM.do_log_stats
+
+    @wraps(original)
+    async def do_log_stats(self: AsyncLLM) -> None:
+        await original(self)
+        if self.logger_manager is None or self._ucm_idle_metrics_running:
+            return
+
+        from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
+            MultiKVConnectorPromMetrics,
+        )
+        from vllm.v1.metrics.loggers import PrometheusStatLogger
+
+        from ucm.integration.vllm.metrics import UCMPromMetrics
+
+        def collection_intervals(
+            prom_metrics: KVConnectorPromMetrics | None,
+        ) -> Iterator[float]:
+            if isinstance(prom_metrics, UCMPromMetrics):
+                yield prom_metrics.idle_collection_interval
+            elif isinstance(prom_metrics, MultiKVConnectorPromMetrics):
+                for child in prom_metrics._prom_metrics.values():
+                    yield from collection_intervals(child)
+
+        sinks: list[KVConnectorProm] = []
+        intervals: list[float] = []
+        for stat_logger in self.logger_manager.stat_loggers:
+            if isinstance(stat_logger, PrometheusStatLogger):
+                sink = stat_logger.kv_connector_prom
+                sink_intervals = list(collection_intervals(sink.prom_metrics))
+                if sink_intervals:
+                    sinks.append(sink)
+                    intervals.extend(sink_intervals)
+        if not sinks:
+            return
+        self._ucm_idle_metrics_running = True
+        try:
+            results = await self.engine_core.ucm_collect_idle_metrics_async(
+                min(intervals)
+            )
+            for result in results:
+                if isinstance(result, BaseException):
+                    logger.warning("Idle UCM metrics utility failed: %s", result)
+                    continue
+                if result is not None:
+                    engine_index, data = result
+                    for sink in sinks:
+                        sink.observe(data, engine_index)
+        except Exception:
+            logger.warning("Failed to publish idle UCM metrics", exc_info=True)
+        finally:
+            self._ucm_idle_metrics_running = False
+
+    do_log_stats._ucm_idle_metrics_patched = True
+    module.AsyncLLM._ucm_idle_metrics_running = False
+    module.AsyncLLM.do_log_stats = do_log_stats
+
+
+for _module_name, _patch in (
+    ("vllm.v1.worker.worker_base", _patch_worker),
+    ("vllm.v1.engine.core", _patch_engine_core),
+    ("vllm.v1.engine.core_client", _patch_engine_client),
+    ("vllm.v1.engine.async_llm", _patch_async_llm),
+):
+    # Other UCM hooks may already have marked an imported module as patched.
+    if _module_name in sys.modules:
+        _patch(sys.modules[_module_name])
+    else:
+        when_imported(_module_name)(_patch)


### PR DESCRIPTION
## Purpose

UCM health and background metrics remain stale in vLLM's `/metrics` while no inference requests are running, even when background probes have new results.

## Modifications

- Extend the existing stats timer to collect worker and scheduler metrics from every idle DP engine through utility and collective RPCs, then update the existing Prometheus series. Skip busy engines and throttle collection per engine across API servers.
- Add `ENABLE_UCM_IDLE_METRICS=0` to disable idle collection independently, and use `to_dict()` when available with a `data` fallback for older MultiConnector formats.

## Test

- `python -m pytest --noconftest test/test_ucm_connector_metrics.py -q -o addopts=` — 97 passed.
- Black, isort, codespell and `git diff --check` passed for changed files.
- Earlier A2 DP2/TP2 validation with two API servers verified both clients could collect all DP metrics without inference or duplicate deltas. The later switch and serialization changes were checked locally; A2 was not rerun for those changes.
