### PR TITLE
[Toolkit][SGLang] Add offline model compatibility checker for UCM integration

### DIFF
--- a/toolkit/README.md
+++ b/toolkit/README.md
@@ -11,6 +11,7 @@
 | `nic-monitor` | `nic_monitor` | 可运行 | 监控物理网卡实时流量、后台采样落盘，并生成阶段统计。 | [nic-monitor README](ucm_toolkit/tools/nic_monitor/README.md) |
 | `metrics-view` | `metrics_view`, `terminal-metrics`, `terminal_metrics` | 可运行 | 采集 Prometheus/OpenMetrics 样本到 SQLite，并在终端查询聚合指标。 | [metrics-view README](ucm_toolkit/tools/metrics_view/README.md) |
 | `precheck` | `pre_check` | 可运行 | 在 UCM 部署前于宿主机本地运行环境预检，校验 serving-stack/uc-manager 版本、加速卡驱动（CUDA 算力或昇腾 HDK）、内核版本、`/dev/shm` 及 posix store 带宽，输出 `PASS`/`WARN`/`FAIL` 并对失败项给出修复建议（RFC #1208）。 | [precheck README](ucm_toolkit/tools/precheck/README.md) |
+| `sglang-model-check` | `sglang_model_check` | 可运行 | 不启动 SGLang 服务、不加载 checkpoint 权重，检查模型缓存需求与 UCM integration 能力，并可执行 Host KV Cache dump/load 回环。 | [sglang-model-check README](ucm_toolkit/tools/sglang_model_check/README.md) |
 
 各子工具的依赖、参数、示例与常见问题都在各自 README 中说明。
 
@@ -48,6 +49,7 @@ python -m pip install -e toolkit
 | `nic-monitor` | Linux、`bash`、`ethtool`，并且需要 root 或 sudo 权限读取网卡统计。 |
 | `metrics-view` | 仅依赖 Python 标准库（`sqlite3` 内置）；采集需要可访问的 Prometheus/OpenMetrics `/metrics` HTTP 接口。 |
 | `precheck` | 核心检查仅依赖 Python 标准库；带宽基准需要已安装 UCM 主软件包（native 扩展）与 `numpy`，且仅 Linux 可运行。 |
+| `sglang-model-check` | `torch`、`sglang` 和 UCM 主软件包；`roundtrip` 模式还需要可写的 UCM storage backend。 |
 
 `dev-sandbox` 的后端探测优先级与切换方式见 [dev-sandbox README](ucm_toolkit/tools/dev_sandbox/README.md#依赖)。
 
@@ -70,6 +72,7 @@ ucm-toolkit doctor dev-sandbox
 ucm-toolkit doctor posix-aio
 ucm-toolkit doctor nic-monitor
 ucm-toolkit doctor precheck
+ucm-toolkit doctor sglang-model-check
 ```
 
 构建工具：

--- a/toolkit/tests/test_sglang_model_check_toolkit.py
+++ b/toolkit/tests/test_sglang_model_check_toolkit.py
@@ -27,6 +27,10 @@ from ucm_toolkit.tools.sglang_model_check.runner import (  # noqa: E402
     _result_for_pool,
     _roundtrip,
 )
+from ucm_toolkit.tools.sglang_model_check.sglang_compat.inspector import (  # noqa: E402
+    _linear_attention,
+    supported_platforms_for_quantization,
+)
 
 
 class SglangModelCheckToolkitTest(unittest.TestCase):
@@ -229,6 +233,34 @@ class SglangModelCheckToolkitTest(unittest.TestCase):
         self.assertEqual(
             raised.exception.code, "CHECKER_RUNTIME_POOL_PROBE_REQUIRED"
         )
+
+    def test_linear_detection_does_not_require_uses_kda_attention(self):
+        config = type(
+            "Config",
+            (),
+            {"linear_attn_registry_result": None, "hf_text_config": object()},
+        )()
+
+        def optional(module, name):
+            if name == "mambaish_config":
+                return lambda _: object()
+            return None
+
+        with patch(
+            "ucm_toolkit.tools.sglang_model_check.sglang_compat.inspector._optional_callable",
+            side_effect=optional,
+        ):
+            value, source, error = _linear_attention(config)
+        self.assertTrue(value)
+        self.assertEqual(source, "mambaish_config")
+        self.assertIsNone(error)
+
+    def test_nvfp4_is_reported_as_cuda_specific(self):
+        self.assertEqual(
+            supported_platforms_for_quantization("modelopt_fp4"), ["cuda"]
+        )
+        self.assertEqual(supported_platforms_for_quantization("NVFP4"), ["cuda"])
+        self.assertIsNone(supported_platforms_for_quantization("awq"))
 
 
 if __name__ == "__main__":

--- a/toolkit/tests/test_sglang_model_check_toolkit.py
+++ b/toolkit/tests/test_sglang_model_check_toolkit.py
@@ -1,0 +1,235 @@
+"""Tests for the SGLang model compatibility checker."""
+
+from __future__ import annotations
+
+import io
+import os
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from ucm_toolkit import registry  # noqa: E402
+from ucm_toolkit.cli import main  # noqa: E402
+from ucm_toolkit.tools.sglang_model_check.compatibility import (  # noqa: E402
+    find_missing_capabilities,
+    infer_capabilities,
+    requirements_from_facts,
+)
+from ucm_toolkit.tools.sglang_model_check.config import CONFIG_ENV  # noqa: E402
+from ucm_toolkit.tools.sglang_model_check.runner import (  # noqa: E402
+    CheckFailure,
+    _require_page_results,
+    _result_for_pool,
+    _roundtrip,
+)
+
+
+class SglangModelCheckToolkitTest(unittest.TestCase):
+    def setUp(self):
+        registry._TOOLS.clear()
+        registry._ALIASES.clear()
+
+    def test_registered(self):
+        registry.init_builtin_tools()
+        tool = registry.get("sglang-model-check")
+        self.assertEqual(tool.name, "sglang-model-check")
+        self.assertEqual(registry.get("sglang_model_check"), tool)
+        self.assertFalse(tool.buildable)
+
+    def test_help_is_lazy(self):
+        registry.init_builtin_tools()
+        output = io.StringIO()
+        with patch(
+            "ucm_toolkit.tools.sglang_model_check.adapter.importlib.util.find_spec"
+        ) as find_spec, redirect_stdout(output):
+            result = main(["run", "sglang-model-check", "--help"])
+        self.assertEqual(result, 0)
+        self.assertIn("without starting a service", output.getvalue())
+        find_spec.assert_not_called()
+
+    @patch("ucm_toolkit.tools.sglang_model_check.adapter.run_command")
+    @patch("ucm_toolkit.tools.sglang_model_check.adapter.importlib.util.find_spec")
+    def test_dispatches_isolated_child(self, find_spec, run_command):
+        find_spec.return_value = object()
+        run_command.return_value = 0
+        registry.init_builtin_tools()
+        result = main(
+            [
+                "run",
+                "sglang-model-check",
+                "--model",
+                "/models/qwen",
+                "--skip-meta-model",
+            ]
+        )
+        self.assertEqual(result, 0)
+        command = run_command.call_args.args[0]
+        env = run_command.call_args.kwargs["env"]
+        self.assertEqual(command[:2], [sys.executable, "-m"])
+        self.assertTrue(command[2].endswith("sglang_model_check.runner"))
+        self.assertIn('"model": "/models/qwen"', env[CONFIG_ENV])
+        self.assertNotIn(CONFIG_ENV, os.environ)
+
+    def test_single_pool_mla_requires_v1(self):
+        requirements = requirements_from_facts({"attention_arch": "MLA"})
+        self.assertEqual(requirements.pool_names, ("kv",))
+        self.assertEqual(requirements.storage_api, "v1")
+        self.assertTrue(requirements.is_mla)
+
+    def test_linear_model_requires_v2_mamba_pool(self):
+        requirements = requirements_from_facts(
+            {"attention_arch": "MHA", "has_linear_attention": True}
+        )
+        self.assertEqual(requirements.pool_names, ("kv", "mamba"))
+        self.assertEqual(requirements.storage_api, "v2")
+
+    def test_combined_mamba_swa_model_keeps_both_side_pools(self):
+        requirements = requirements_from_facts(
+            {
+                "attention_arch": "MHA",
+                "has_linear_attention": True,
+                "is_hybrid_swa": True,
+            }
+        )
+        self.assertEqual(requirements.pool_names, ("kv", "mamba", "swa"))
+
+    def test_inherited_v2_stubs_are_not_capabilities(self):
+        class Base:
+            def batch_get_v1(self):
+                raise NotImplementedError
+
+            def batch_set_v1(self):
+                raise NotImplementedError
+
+            def batch_exists_v2(self):
+                raise NotImplementedError
+
+            def batch_get_v2(self):
+                raise NotImplementedError
+
+            def batch_set_v2(self):
+                raise NotImplementedError
+
+        class Storage(Base):
+            def batch_get_v1(self):
+                return []
+
+            def batch_set_v1(self):
+                return []
+
+        capabilities = infer_capabilities(Storage, Base)
+        self.assertEqual(capabilities["api_versions"], ["v1"])
+        self.assertEqual(capabilities["detection"], "method_override")
+
+    def test_does_not_depend_on_business_capability_declaration(self):
+        class Base:
+            def batch_get_v1(self):
+                raise NotImplementedError
+
+            def batch_set_v1(self):
+                raise NotImplementedError
+
+        class Storage(Base):
+            @classmethod
+            def get_capabilities(cls):
+                raise AssertionError("checker must not call business declarations")
+
+            def batch_get_v1(self):
+                return []
+
+            def batch_set_v1(self):
+                return []
+
+        capabilities = infer_capabilities(Storage, Base)
+        self.assertEqual(capabilities["api_versions"], ["v1"])
+
+    def test_missing_capabilities_are_actionable(self):
+        requirements = requirements_from_facts(
+            {"attention_arch": "MLA", "is_dsa": True}
+        )
+        capabilities = {
+            "api_versions": ["v1"],
+            "layouts": ["page_first"],
+            "pool_names": ["kv"],
+            "attention_archs": ["MLA"],
+            "supports_multi_pool": False,
+        }
+        missing = find_missing_capabilities(requirements, capabilities)
+        self.assertIn("storage API v2", missing)
+
+    def test_hybrid_contract_requires_v1_anchor_and_v2_side_pools(self):
+        requirements = requirements_from_facts(
+            {"attention_arch": "MHA", "has_linear_attention": True}
+        )
+        missing = find_missing_capabilities(
+            requirements, {"api_versions": ["v2"]}
+        )
+        self.assertEqual(missing, ["storage API v1"])
+
+    def test_v2_results_accept_enum_like_and_string_pool_keys(self):
+        class Pool(str):
+            value = "mamba"
+
+            def __str__(self):
+                return self.value
+
+        pool = Pool("mamba")
+        self.assertEqual(_result_for_pool({"mamba": [True]}, pool), [True])
+        _require_page_results(
+            {"mamba": [True, True]}, [pool], 2, "LOAD_FAILED", "load"
+        )
+
+    def test_v2_page_failure_reports_pool_name(self):
+        with self.assertRaises(CheckFailure) as raised:
+            _require_page_results(
+                {"swa": [True, False]},
+                ["swa"],
+                2,
+                "LOAD_FAILED",
+                "roundtrip_load_v2",
+            )
+        self.assertEqual(raised.exception.code, "LOAD_FAILED")
+        self.assertIn("swa", raised.exception.reason)
+
+    def test_requested_layout_is_preserved_for_runtime_probe(self):
+        requirements = requirements_from_facts(
+            {"attention_arch": "MHA"}, host_layout="layer_first"
+        )
+        self.assertEqual(requirements.host_layout, "layer_first")
+
+    def test_deepseek_v4_pool_names_follow_installed_sglang(self):
+        requirements = requirements_from_facts(
+            {
+                "attention_arch": "MLA",
+                "is_deepseek_v4": True,
+                "sglang_pool_names": [
+                    "kv",
+                    "deepseek_v4_c4",
+                    "deepseek_v4_c4_indexer_scale",
+                ],
+            }
+        )
+        self.assertEqual(
+            requirements.pool_names,
+            ("deepseek_v4_c4", "deepseek_v4_c4_indexer_scale"),
+        )
+        self.assertEqual(requirements.probe_fidelity, "runtime_pool_required")
+
+    def test_hybrid_roundtrip_never_uses_synthetic_kv_pools(self):
+        requirements = requirements_from_facts(
+            {"attention_arch": "MLA", "is_dsa": True}
+        )
+        with self.assertRaises(CheckFailure) as raised:
+            _roundtrip(object(), object(), requirements)
+        self.assertEqual(
+            raised.exception.code, "CHECKER_RUNTIME_POOL_PROBE_REQUIRED"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/toolkit/tests/test_sglang_model_check_toolkit.py
+++ b/toolkit/tests/test_sglang_model_check_toolkit.py
@@ -22,6 +22,7 @@ from ucm_toolkit.tools.sglang_model_check.compatibility import (  # noqa: E402
     requirements_from_facts,
 )
 from ucm_toolkit.tools.sglang_model_check.config import CONFIG_ENV  # noqa: E402
+from ucm_toolkit.tools.sglang_model_check.result import CheckResult  # noqa: E402
 from ucm_toolkit.tools.sglang_model_check.runner import (  # noqa: E402
     CheckFailure,
     _require_page_results,
@@ -272,6 +273,26 @@ class SglangModelCheckToolkitTest(unittest.TestCase):
         ):
             with server_args_guard():
                 pass
+
+    def test_result_defaults_to_summary_and_verbose_preserves_details(self):
+        result = CheckResult(model="/models/test", mode="inspect")
+        result.reason = "ImportError: missing helper\nTraceback: details"
+        result.model_info = {
+            "architectures": ["TestForCausalLM"],
+            "model_type": "test",
+            "detection_sources": {"linear_attention": "mambaish_config"},
+        }
+        result.roundtrip = {}
+        summary = result.to_dict()
+        self.assertEqual(summary["detail_level"], "summary")
+        self.assertEqual(summary["reason"], "ImportError: missing helper")
+        self.assertNotIn("detection_sources", summary["model_info"])
+        self.assertNotIn("roundtrip", summary)
+
+        verbose = result.to_dict(verbose=True)
+        self.assertEqual(verbose["detail_level"], "verbose")
+        self.assertIn("Traceback", verbose["reason"])
+        self.assertIn("detection_sources", verbose["model_info"])
 
 
 if __name__ == "__main__":

--- a/toolkit/tests/test_sglang_model_check_toolkit.py
+++ b/toolkit/tests/test_sglang_model_check_toolkit.py
@@ -294,6 +294,23 @@ class SglangModelCheckToolkitTest(unittest.TestCase):
         self.assertIn("Traceback", verbose["reason"])
         self.assertIn("detection_sources", verbose["model_info"])
 
+    def test_result_exposes_compatible_and_inconclusive_status(self):
+        result = CheckResult(model="model", mode="inspect")
+        result.succeed("inspect", "passed")
+        self.assertTrue(result.supported)
+        self.assertEqual(result.status, "compatible")
+
+        result.fail(
+            "CHECKER_RUNTIME_POOL_PROBE_REQUIRED",
+            "roundtrip_prepare",
+            "runtime pool required",
+        )
+        self.assertFalse(result.supported)
+        self.assertEqual(result.status, "inconclusive")
+
+        result.fail("UCM_STORAGE_API_UNSUPPORTED", "capability_check", "v2")
+        self.assertEqual(result.status, "incompatible")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/toolkit/tests/test_sglang_model_check_toolkit.py
+++ b/toolkit/tests/test_sglang_model_check_toolkit.py
@@ -8,6 +8,7 @@ import sys
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -29,6 +30,7 @@ from ucm_toolkit.tools.sglang_model_check.runner import (  # noqa: E402
 )
 from ucm_toolkit.tools.sglang_model_check.sglang_compat.inspector import (  # noqa: E402
     _linear_attention,
+    server_args_guard,
     supported_platforms_for_quantization,
 )
 
@@ -261,6 +263,15 @@ class SglangModelCheckToolkitTest(unittest.TestCase):
         )
         self.assertEqual(supported_platforms_for_quantization("NVFP4"), ["cuda"])
         self.assertIsNone(supported_platforms_for_quantization("awq"))
+
+    def test_server_args_guard_reuses_published_context(self):
+        runtime = SimpleNamespace(get_server_args=lambda: object())
+        with patch(
+            "ucm_toolkit.tools.sglang_model_check.sglang_compat.inspector.importlib.import_module",
+            return_value=runtime,
+        ):
+            with server_args_guard():
+                pass
 
 
 if __name__ == "__main__":

--- a/toolkit/ucm_toolkit/registry.py
+++ b/toolkit/ucm_toolkit/registry.py
@@ -143,9 +143,11 @@ def init_builtin_tools() -> None:
     from .tools.nic_monitor import NicMonitorTool
     from .tools.posix_aio import PosixAioTool
     from .tools.precheck import PrecheckTool
+    from .tools.sglang_model_check import SglangModelCheckTool
 
     register(DevSandboxTool())
     register(MetricsViewTool())
     register(PosixAioTool())
     register(NicMonitorTool())
     register(PrecheckTool())
+    register(SglangModelCheckTool())

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/README.md
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/README.md
@@ -41,13 +41,14 @@ of Mamba, SWA, DSA indexer, or DeepSeek-V4 compatibility.
 Use `--skip-meta-model` only for a weaker configuration-only scan. A successful
 result in that mode does not prove that the SGLang model class can be built.
 
-Use `--platform auto|cuda|rocm|ascend|xpu|cpu` to select platform-specific
-visibility and reporting. Auto prefers an existing Ascend environment or
-`torch_npu`; otherwise it selects CUDA. The JSON `environment` field records
-the detected SGLang version and platform. Accelerator-specific formats such as
-NVFP4 are rejected on incompatible platforms.
+Output is a compact JSON summary by default. Add `--verbose` when debugging to
+include detection sources, detection errors, full tracebacks, and roundtrip
+details. `--output` writes the same summary or verbose representation shown on
+standard output.
 
 Use `--platform auto|cuda|rocm|ascend|xpu|cpu` to select the accelerator family.
-The child process sets only the matching visibility variable. Accelerator-specific
-quantization such as NVFP4 is rejected on a non-CUDA platform before meta-model
-construction.
+Auto prefers an existing Ascend environment or `torch_npu`; otherwise it selects
+CUDA. The child process sets only the matching visibility variable, and the JSON
+`environment` field records the detected SGLang version and platform.
+Accelerator-specific quantization such as NVFP4 is rejected on a non-CUDA
+platform before meta-model construction.

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/README.md
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/README.md
@@ -46,6 +46,11 @@ include detection sources, detection errors, full tracebacks, and roundtrip
 details. `--output` writes the same summary or verbose representation shown on
 standard output.
 
+Use the `status` field for automation: `compatible`, `inconclusive`, or
+`incompatible`. In particular, `CHECKER_RUNTIME_POOL_PROBE_REQUIRED` is
+`inconclusive`, not evidence that the model is incompatible. The legacy
+`supported` boolean remains available for backward compatibility.
+
 Use `--platform auto|cuda|rocm|ascend|xpu|cpu` to select the accelerator family.
 Auto prefers an existing Ascend environment or `torch_npu`; otherwise it selects
 CUDA. The child process sets only the matching visibility variable, and the JSON

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/README.md
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/README.md
@@ -40,3 +40,14 @@ of Mamba, SWA, DSA indexer, or DeepSeek-V4 compatibility.
 
 Use `--skip-meta-model` only for a weaker configuration-only scan. A successful
 result in that mode does not prove that the SGLang model class can be built.
+
+Use `--platform auto|cuda|rocm|ascend|xpu|cpu` to select platform-specific
+visibility and reporting. Auto prefers an existing Ascend environment or
+`torch_npu`; otherwise it selects CUDA. The JSON `environment` field records
+the detected SGLang version and platform. Accelerator-specific formats such as
+NVFP4 are rejected on incompatible platforms.
+
+Use `--platform auto|cuda|rocm|ascend|xpu|cpu` to select the accelerator family.
+The child process sets only the matching visibility variable. Accelerator-specific
+quantization such as NVFP4 is rejected on a non-CUDA platform before meta-model
+construction.

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/README.md
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/README.md
@@ -1,0 +1,42 @@
+# SGLang model compatibility checker
+
+`sglang-model-check` checks whether the installed UCM SGLang integration can
+serve a model without starting an inference service or loading checkpoint
+weights.
+
+Inspect the model structure and the storage methods actually overridden by the
+installed integration:
+
+```bash
+ucm-toolkit run sglang-model-check --model /models/Qwen2.5-14B-Instruct
+```
+
+Run an actual UCM dump/load roundtrip through a selected SGLang host-pool layout:
+
+```bash
+ucm-toolkit run sglang-model-check \
+  --model /models/Qwen2.5-14B-Instruct \
+  --mode roundtrip \
+  --layout page_first \
+  --storage-backends /mnt/test \
+  --output result.json
+```
+
+The checker intentionally does not instantiate `Engine`, `Scheduler` or an HTTP
+server. Model modules are constructed on Torch's `meta` device. Roundtrip mode
+allocates only a bounded CPU host-cache buffer using SGLang's production
+`MHATokenToKVPoolHost` or `MLATokenToKVPoolHost`, then calls the production
+`UnifiedCacheStore` production API. Single-pool models exercise a real SGLang
+host pool through v1.
+
+Hybrid models that require Mamba, SWA, indexer or DeepSeek-V4 sidecar pools are
+reported as `UCM_STORAGE_API_UNSUPPORTED` until `UnifiedCacheStore` actually
+overrides SGLang's v2 multi-pool methods. The checker requires no capability
+declaration and does not modify the production integration. Once those methods
+are implemented, inspect mode verifies the v2 API surface. Hybrid roundtrip
+returns `CHECKER_RUNTIME_POOL_PROBE_REQUIRED` until specialized SGLang runtime
+pools can be constructed; synthetic MHA/MLA pools are not accepted as evidence
+of Mamba, SWA, DSA indexer, or DeepSeek-V4 compatibility.
+
+Use `--skip-meta-model` only for a weaker configuration-only scan. A successful
+result in that mode does not prove that the SGLang model class can be built.

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/__init__.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/__init__.py
@@ -1,0 +1,5 @@
+"""Offline SGLang/UCM model compatibility checker."""
+
+from .adapter import SglangModelCheckTool
+
+__all__ = ["SglangModelCheckTool"]

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/adapter.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/adapter.py
@@ -1,0 +1,108 @@
+"""Toolkit adapter for the offline SGLang compatibility checker."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import sys
+
+from ...errors import ToolkitError
+from ...registry import ToolAdapter
+from ...runner import run_command
+from .config import CONFIG_ENV, CheckConfig
+
+
+class SglangModelCheckTool(ToolAdapter):
+    name = "sglang-model-check"
+    aliases = ("sglang_model_check",)
+    description = (
+        "Check SGLang model/UCM cache compatibility without starting a service "
+        "or loading checkpoint weights."
+    )
+    buildable = False
+
+    def add_run_args(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument("--model", required=True, help="model path or HF model id")
+        parser.add_argument(
+            "--mode",
+            choices=("inspect", "roundtrip"),
+            default="inspect",
+            help="inspect requirements, or additionally perform UCM host-cache IO",
+        )
+        parser.add_argument("--device-id", default="0")
+        parser.add_argument("--page-size", type=int, default=64)
+        parser.add_argument("--pages", type=int, default=2)
+        parser.add_argument(
+            "--layout",
+            default="page_first",
+            help="SGLang Host KV Cache layout to probe",
+        )
+        parser.add_argument("--dtype", default="auto")
+        parser.add_argument(
+            "--trust-remote-code",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+        )
+        parser.add_argument(
+            "--skip-meta-model",
+            action="store_true",
+            help="skip meta-device model construction (weaker config-only result)",
+        )
+        parser.add_argument(
+            "--storage-backends",
+            help="colon-separated paths passed to UcmPipelineStore; required for roundtrip",
+        )
+        parser.add_argument("--connector-name", default="UcmPipelineStore")
+        parser.add_argument("--connector-module-path")
+        parser.add_argument("--output", help="also write the JSON result to this path")
+
+    def _parser(self) -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser(
+            prog="ucm-toolkit run sglang-model-check",
+            description=self.description,
+        )
+        self.add_run_args(parser)
+        return parser
+
+    def run(self, tool_args: list[str]) -> int:
+        try:
+            args = self._parser().parse_args(tool_args)
+        except SystemExit as exc:
+            return exc.code if isinstance(exc.code, int) else 1
+
+        if args.page_size <= 0 or args.pages <= 0:
+            raise ToolkitError("--page-size and --pages must be positive")
+        if args.mode == "roundtrip" and not args.storage_backends:
+            raise ToolkitError("--storage-backends is required in roundtrip mode")
+        if importlib.util.find_spec("sglang") is None:
+            raise ToolkitError("sglang-model-check cannot find the sglang package")
+
+        config = CheckConfig(
+            model=args.model,
+            mode=args.mode,
+            device_id=args.device_id,
+            page_size=args.page_size,
+            pages=args.pages,
+            layout=args.layout,
+            dtype=args.dtype,
+            trust_remote_code=args.trust_remote_code,
+            skip_meta_model=args.skip_meta_model,
+            storage_backends=args.storage_backends,
+            connector_name=args.connector_name,
+            connector_module_path=args.connector_module_path,
+            output=args.output,
+        )
+        env = os.environ.copy()
+        env[CONFIG_ENV] = config.to_json()
+        env["CUDA_VISIBLE_DEVICES"] = args.device_id
+        env["ASCEND_RT_VISIBLE_DEVICES"] = args.device_id
+        module = f"{__package__}.runner"
+        return run_command([sys.executable, "-m", module], env=env)
+
+    def doctor(self, args: argparse.Namespace | None = None) -> int:
+        packages = ("torch", "sglang", "ucm")
+        missing = [name for name in packages if importlib.util.find_spec(name) is None]
+        status = "OK" if not missing else f"MISSING ({', '.join(missing)})"
+        print(f"{self.name}: {status}")
+        return 0 if not missing else 1

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/adapter.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/adapter.py
@@ -108,6 +108,10 @@ class SglangModelCheckTool(ToolAdapter):
         )
         env = os.environ.copy()
         env[CONFIG_ENV] = config.to_json()
+        # Keep stdout/stderr suitable for machine-readable checker output. Model
+        # generation settings such as top_p are irrelevant to this offline check.
+        env["TRANSFORMERS_VERBOSITY"] = "error"
+        env["TRANSFORMERS_NO_ADVISORY_WARNINGS"] = "1"
         platform = args.platform
         if platform == "auto":
             ascend_env = env.get("ASCEND_RT_VISIBLE_DEVICES") or env.get(

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/adapter.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/adapter.py
@@ -31,6 +31,12 @@ class SglangModelCheckTool(ToolAdapter):
             help="inspect requirements, or additionally perform UCM host-cache IO",
         )
         parser.add_argument("--device-id", default="0")
+        parser.add_argument(
+            "--platform",
+            choices=("auto", "cuda", "rocm", "ascend", "xpu", "cpu"),
+            default="auto",
+            help="accelerator platform used for compatibility reporting and visibility",
+        )
         parser.add_argument("--page-size", type=int, default=64)
         parser.add_argument("--pages", type=int, default=2)
         parser.add_argument(
@@ -82,6 +88,7 @@ class SglangModelCheckTool(ToolAdapter):
             model=args.model,
             mode=args.mode,
             device_id=args.device_id,
+            platform=args.platform,
             page_size=args.page_size,
             pages=args.pages,
             layout=args.layout,
@@ -95,8 +102,24 @@ class SglangModelCheckTool(ToolAdapter):
         )
         env = os.environ.copy()
         env[CONFIG_ENV] = config.to_json()
-        env["CUDA_VISIBLE_DEVICES"] = args.device_id
-        env["ASCEND_RT_VISIBLE_DEVICES"] = args.device_id
+        platform = args.platform
+        if platform == "auto":
+            ascend_env = env.get("ASCEND_RT_VISIBLE_DEVICES") or env.get(
+                "ASCEND_VISIBLE_DEVICES"
+            )
+            platform = (
+                "ascend"
+                if ascend_env or importlib.util.find_spec("torch_npu") is not None
+                else "cuda"
+            )
+        if platform in {"cuda", "rocm"}:
+            env["CUDA_VISIBLE_DEVICES"] = args.device_id
+            env.pop("ASCEND_RT_VISIBLE_DEVICES", None)
+        elif platform == "ascend":
+            env["ASCEND_RT_VISIBLE_DEVICES"] = args.device_id
+            env.pop("CUDA_VISIBLE_DEVICES", None)
+        elif platform == "xpu":
+            env["ZE_AFFINITY_MASK"] = args.device_id
         module = f"{__package__}.runner"
         return run_command([sys.executable, "-m", module], env=env)
 

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/adapter.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/adapter.py
@@ -62,6 +62,11 @@ class SglangModelCheckTool(ToolAdapter):
         parser.add_argument("--connector-name", default="UcmPipelineStore")
         parser.add_argument("--connector-module-path")
         parser.add_argument("--output", help="also write the JSON result to this path")
+        parser.add_argument(
+            "--verbose",
+            action="store_true",
+            help="include detection sources, full environment details and traceback",
+        )
 
     def _parser(self) -> argparse.ArgumentParser:
         parser = argparse.ArgumentParser(
@@ -99,6 +104,7 @@ class SglangModelCheckTool(ToolAdapter):
             connector_name=args.connector_name,
             connector_module_path=args.connector_module_path,
             output=args.output,
+            verbose=args.verbose,
         )
         env = os.environ.copy()
         env[CONFIG_ENV] = config.to_json()

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/compatibility.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/compatibility.py
@@ -1,0 +1,121 @@
+"""Pure compatibility rules, intentionally importable without SGLang/Torch."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class ModelRequirements:
+    attention_arch: str
+    pool_names: tuple[str, ...]
+    storage_api: str
+    host_layout: str
+    is_mla: bool
+    is_hybrid: bool
+    probe_fidelity: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "attention_arch": self.attention_arch,
+            "pool_names": list(self.pool_names),
+            "storage_api": self.storage_api,
+            "host_layout": self.host_layout,
+            "is_mla": self.is_mla,
+            "is_hybrid": self.is_hybrid,
+            "probe_fidelity": self.probe_fidelity,
+        }
+
+
+def requirements_from_facts(
+    facts: dict[str, Any], host_layout: str = "page_first"
+) -> ModelRequirements:
+    """Convert facts produced by SGLang ModelConfig into storage requirements."""
+    attention_arch = str(facts.get("attention_arch", "UNKNOWN")).upper()
+    pools: list[str] = ["kv"]
+
+    if facts.get("is_deepseek_v4"):
+        # Reuse names exported by the installed SGLang instead of maintaining
+        # a second DeepSeek-V4 list in this tool. This picks up additions such
+        # as the FP4 indexer scale pool.
+        pools = sorted(
+            name
+            for name in _strings(facts.get("sglang_pool_names"))
+            if name.startswith("deepseek_v4_")
+        )
+        if not pools:
+            pools = ["deepseek_v4_runtime_pools_unknown"]
+    else:
+        if facts.get("is_minimax_sparse") or facts.get("is_dsa"):
+            pools.append("indexer")
+        if facts.get("has_linear_attention"):
+            pools.append("mamba")
+        if facts.get("is_hybrid_swa"):
+            pools.append("swa")
+
+    pools = list(dict.fromkeys(pools))
+    is_hybrid = len(pools) > 1 or pools[0] != "kv"
+    return ModelRequirements(
+        attention_arch=attention_arch,
+        pool_names=tuple(pools),
+        storage_api="v2" if is_hybrid else "v1",
+        host_layout=host_layout,
+        is_mla=attention_arch == "MLA",
+        is_hybrid=is_hybrid,
+        probe_fidelity="runtime_pool_required" if is_hybrid else "real_host_pool",
+    )
+
+
+def normalize_capabilities(raw: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": int(raw.get("schema_version", 1)),
+        "api_versions": sorted(_strings(raw.get("api_versions"))),
+        "detection": str(raw.get("detection", "method_override")),
+    }
+
+
+def _strings(value: Any) -> set[str]:
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        return {value}
+    if isinstance(value, Iterable):
+        return {str(item) for item in value}
+    return {str(value)}
+
+
+def find_missing_capabilities(
+    requirements: ModelRequirements, capabilities: dict[str, Any]
+) -> list[str]:
+    caps = normalize_capabilities(capabilities)
+    missing: list[str] = []
+    # SGLang's hybrid path stores the anchor pool through v1 and side pools
+    # through v2, so a v2 model requires both contracts.
+    required_apis = ("v1", "v2") if requirements.storage_api == "v2" else ("v1",)
+    for api in required_apis:
+        if api not in caps["api_versions"]:
+            missing.append(f"storage API {api}")
+    return missing
+
+
+def infer_capabilities(storage_cls: type[Any], base_cls: type[Any]) -> dict[str, Any]:
+    """Inspect the production class without requiring a capability declaration."""
+
+    def overridden(name: str) -> bool:
+        return getattr(storage_cls, name, None) is not getattr(base_cls, name, None)
+
+    versions = []
+    if overridden("batch_get_v1") and overridden("batch_set_v1"):
+        versions.append("v1")
+    if all(
+        overridden(name)
+        for name in ("batch_exists_v2", "batch_get_v2", "batch_set_v2")
+    ):
+        versions.append("v2")
+    return normalize_capabilities(
+        {
+            "api_versions": versions,
+            "detection": "method_override",
+        }
+    )

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/config.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/config.py
@@ -1,0 +1,45 @@
+"""Configuration shared with the isolated checker process."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any
+
+CONFIG_ENV = "UCM_SGLANG_MODEL_CHECK_CONFIG"
+
+
+@dataclass(frozen=True)
+class CheckConfig:
+    model: str
+    mode: str = "inspect"
+    device_id: str = "0"
+    page_size: int = 64
+    pages: int = 2
+    layout: str = "page_first"
+    dtype: str = "auto"
+    trust_remote_code: bool = True
+    skip_meta_model: bool = False
+    storage_backends: str | None = None
+    connector_name: str = "UcmPipelineStore"
+    connector_module_path: str | None = None
+    output: str | None = None
+
+    @classmethod
+    def from_mapping(cls, data: dict[str, Any]) -> "CheckConfig":
+        known = cls.__dataclass_fields__
+        return cls(**{key: value for key, value in data.items() if key in known})
+
+    @classmethod
+    def from_env(cls) -> "CheckConfig":
+        raw = os.environ.get(CONFIG_ENV)
+        if not raw:
+            raise ValueError(f"{CONFIG_ENV} is not set")
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise ValueError(f"{CONFIG_ENV} must contain a JSON object")
+        return cls.from_mapping(data)
+
+    def to_json(self) -> str:
+        return json.dumps(self.__dict__, ensure_ascii=False)

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/config.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/config.py
@@ -15,6 +15,7 @@ class CheckConfig:
     model: str
     mode: str = "inspect"
     device_id: str = "0"
+    platform: str = "auto"
     page_size: int = 64
     pages: int = 2
     layout: str = "page_first"

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/config.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/config.py
@@ -26,6 +26,7 @@ class CheckConfig:
     connector_name: str = "UcmPipelineStore"
     connector_module_path: str | None = None
     output: str | None = None
+    verbose: bool = False
 
     @classmethod
     def from_mapping(cls, data: dict[str, Any]) -> "CheckConfig":

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/result.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/result.py
@@ -1,0 +1,46 @@
+"""Machine-readable result types for SGLang model checks."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass
+class CheckResult:
+    model: str
+    mode: str
+    supported: bool = False
+    code: str = "INTERNAL_ERROR"
+    stage: str = "startup"
+    reason: str = ""
+    model_info: dict[str, Any] = field(default_factory=dict)
+    cache_requirements: dict[str, Any] = field(default_factory=dict)
+    ucm_capabilities: dict[str, Any] = field(default_factory=dict)
+    roundtrip: dict[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+    framework: str = "sglang"
+
+    def succeed(self, stage: str, reason: str = "") -> None:
+        self.supported = True
+        self.code = "PASS"
+        self.stage = stage
+        self.reason = reason
+
+    def fail(self, code: str, stage: str, reason: str) -> None:
+        self.supported = False
+        self.code = code
+        self.stage = stage
+        self.reason = reason
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def emit_result(result: CheckResult, output: str | None = None) -> None:
+    text = json.dumps(result.to_dict(), ensure_ascii=False, indent=2, sort_keys=True)
+    print(text)
+    if output:
+        Path(output).write_text(text + "\n", encoding="utf-8")

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/result.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/result.py
@@ -20,7 +20,8 @@ class CheckResult:
     cache_requirements: dict[str, Any] = field(default_factory=dict)
     ucm_capabilities: dict[str, Any] = field(default_factory=dict)
     roundtrip: dict[str, Any] = field(default_factory=dict)
-    schema_version: int = 1
+    environment: dict[str, Any] = field(default_factory=dict)
+    schema_version: int = 2
     framework: str = "sglang"
 
     def succeed(self, stage: str, reason: str = "") -> None:

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/result.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/result.py
@@ -36,12 +36,64 @@ class CheckResult:
         self.stage = stage
         self.reason = reason
 
-    def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+    def to_dict(self, verbose: bool = False) -> dict[str, Any]:
+        data = asdict(self)
+        if verbose:
+            data["detail_level"] = "verbose"
+            return data
+
+        model_keys = (
+            "architectures",
+            "model_type",
+            "attention_arch",
+            "dtype",
+            "quantization",
+            "supported_platforms",
+        )
+        requirement_keys = (
+            "pool_names",
+            "storage_api",
+            "host_layout",
+            "probe_fidelity",
+        )
+        capability_keys = ("api_versions", "detection")
+        environment_keys = ("sglang_version", "platform", "requested_platform")
+
+        data["model_info"] = {
+            key: self.model_info[key]
+            for key in model_keys
+            if key in self.model_info and self.model_info[key] is not None
+        }
+        data["cache_requirements"] = {
+            key: self.cache_requirements[key]
+            for key in requirement_keys
+            if key in self.cache_requirements
+        }
+        data["ucm_capabilities"] = {
+            key: self.ucm_capabilities[key]
+            for key in capability_keys
+            if key in self.ucm_capabilities
+        }
+        data["environment"] = {
+            key: self.environment[key]
+            for key in environment_keys
+            if key in self.environment and self.environment[key] is not None
+        }
+        if "\n" in data["reason"]:
+            data["reason"] = data["reason"].splitlines()[0]
+        data["detail_level"] = "summary"
+        for key in ("model_info", "cache_requirements", "ucm_capabilities", "environment", "roundtrip"):
+            if not data[key]:
+                data.pop(key)
+        return data
 
 
-def emit_result(result: CheckResult, output: str | None = None) -> None:
-    text = json.dumps(result.to_dict(), ensure_ascii=False, indent=2, sort_keys=True)
+def emit_result(
+    result: CheckResult, output: str | None = None, verbose: bool = False
+) -> None:
+    text = json.dumps(
+        result.to_dict(verbose=verbose), ensure_ascii=False, indent=2, sort_keys=True
+    )
     print(text)
     if output:
         Path(output).write_text(text + "\n", encoding="utf-8")

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/result.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/result.py
@@ -13,6 +13,7 @@ class CheckResult:
     model: str
     mode: str
     supported: bool = False
+    status: str = "inconclusive"
     code: str = "INTERNAL_ERROR"
     stage: str = "startup"
     reason: str = ""
@@ -26,12 +27,18 @@ class CheckResult:
 
     def succeed(self, stage: str, reason: str = "") -> None:
         self.supported = True
+        self.status = "compatible"
         self.code = "PASS"
         self.stage = stage
         self.reason = reason
 
     def fail(self, code: str, stage: str, reason: str) -> None:
         self.supported = False
+        self.status = (
+            "inconclusive"
+            if code == "CHECKER_RUNTIME_POOL_PROBE_REQUIRED"
+            else "incompatible"
+        )
         self.code = code
         self.stage = stage
         self.reason = reason

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/runner.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/runner.py
@@ -137,13 +137,14 @@ def _check_meta_model(model_config: Any) -> Any:
         resolve_layer_indices,
     )
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+    from .sglang_compat import server_args_guard
 
     load_config = LoadConfig()
     old_dtype = torch.get_default_dtype()
     try:
         torch.set_default_dtype(model_config.dtype)
         quant_config = _get_quantization_config(model_config, load_config)
-        with _single_rank_model_parallel():
+        with server_args_guard(), _single_rank_model_parallel():
             with torch.device("meta"), _meta_device_guard(torch):
                 model = _initialize_model(model_config, load_config, quant_config)
             resolve_layer_indices(

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/runner.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/runner.py
@@ -594,11 +594,15 @@ def run(config: CheckConfig) -> CheckResult:
         else:
             qualifier = "config-only" if config.skip_meta_model else "meta-model"
             if requirements.is_hybrid:
-                qualifier += "; specialized runtime pools were not constructed"
-            result.succeed(
-                "inspect",
-                f"{qualifier} structural checks passed; storage IO was not probed",
-            )
+                reason = (
+                    f"{qualifier} structural checks passed; UCM v2 API is available; "
+                    "specialized runtime pools and storage IO were not probed"
+                )
+            else:
+                reason = (
+                    f"{qualifier} structural checks passed; storage IO was not probed"
+                )
+            result.succeed("inspect", reason)
         return result
     except CheckFailure as exc:
         result.fail(exc.code, exc.stage, exc.reason)

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/runner.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/runner.py
@@ -615,7 +615,7 @@ def run(config: CheckConfig) -> CheckResult:
 def main() -> int:
     config = CheckConfig.from_env()
     result = run(config)
-    emit_result(result, config.output)
+    emit_result(result, config.output, verbose=config.verbose)
     return 0 if result.supported else 1
 
 

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/runner.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/runner.py
@@ -27,52 +27,9 @@ class CheckFailure(RuntimeError):
 
 
 def _model_facts(model_config: Any) -> dict[str, Any]:
-    from sglang.srt.configs.hybrid_arch import mambaish_config
-    from sglang.srt.configs.model_config import (
-        is_deepseek_dsa,
-        is_deepseek_v4,
-        is_minimax_sparse,
-        uses_kda_attention,
-    )
+    from .sglang_compat import collect_model_facts
 
-    hf_config = model_config.hf_config
-    text_config = model_config.hf_text_config
-    architectures = list(getattr(hf_config, "architectures", None) or [])
-    try:
-        has_linear_attention = bool(mambaish_config(model_config))
-    except Exception:
-        has_linear_attention = uses_kda_attention(text_config)
-
-    attention_arch = getattr(model_config.attention_arch, "name", None)
-    if attention_arch is None:
-        attention_arch = str(model_config.attention_arch).split(".")[-1]
-
-    try:
-        from sglang.srt.mem_cache.hicache_storage import PoolName
-
-        sglang_pool_names = [str(item.value) for item in PoolName]
-    except Exception:
-        sglang_pool_names = []
-
-    return {
-        "architectures": architectures,
-        "model_type": getattr(hf_config, "model_type", None),
-        "attention_arch": attention_arch,
-        "is_hybrid_swa": bool(getattr(model_config, "is_hybrid_swa", False)),
-        "has_linear_attention": has_linear_attention,
-        "is_dsa": is_deepseek_dsa(text_config),
-        "is_deepseek_v4": is_deepseek_v4(hf_config),
-        "is_minimax_sparse": is_minimax_sparse(hf_config),
-        "num_layers": int(
-            max(
-                getattr(model_config, "num_hidden_layers", 0),
-                getattr(model_config, "num_attention_layers", 0),
-            )
-        ),
-        "dtype": str(model_config.dtype),
-        "quantization": getattr(model_config, "quantization", None),
-        "sglang_pool_names": sglang_pool_names,
-    }
+    return collect_model_facts(model_config)
 
 
 def _redirect_device(value: Any) -> Any:
@@ -569,6 +526,7 @@ def _roundtrip(
 def run(config: CheckConfig) -> CheckResult:
     result = CheckResult(model=config.model, mode=config.mode)
     try:
+        from .sglang_compat import environment_info, refine_facts_from_model
         from sglang.srt.configs.model_config import ModelConfig
         from sglang.srt.mem_cache.hicache_storage import HiCacheStorage
         from ucm.integration.sglang.unifiedcache_store import UnifiedCacheStore
@@ -578,7 +536,37 @@ def run(config: CheckConfig) -> CheckResult:
             trust_remote_code=config.trust_remote_code,
             dtype=config.dtype,
         )
+        result.environment = environment_info()
+        result.environment["requested_platform"] = config.platform
         facts = _model_facts(model_config)
+
+        supported_platforms = facts.get("supported_platforms")
+        detected_platform = result.environment.get("platform")
+        if supported_platforms and detected_platform not in supported_platforms:
+            result.model_info = facts
+            result.fail(
+                "PLATFORM_UNSUPPORTED",
+                "platform_check",
+                f"quantization {facts.get('quantization')!r} requires one of "
+                f"{supported_platforms}, detected {detected_platform!r}",
+            )
+            return result
+
+        model = None
+        if not config.skip_meta_model:
+            model = _check_meta_model(model_config)
+            facts = refine_facts_from_model(facts, model)
+
+        linear_model = facts.get("has_linear_attention")
+        if linear_model is None:
+            result.model_info = facts
+            result.fail(
+                "CACHE_REQUIREMENTS_UNDETERMINED",
+                "model_inspection",
+                "SGLang compatibility layer could not determine whether the "
+                "model uses linear-attention state; refusing to assume a v1 KV-only model",
+            )
+            return result
         requirements = requirements_from_facts(facts, host_layout=config.layout)
         capabilities = infer_capabilities(UnifiedCacheStore, HiCacheStorage)
         result.model_info = facts
@@ -594,8 +582,7 @@ def run(config: CheckConfig) -> CheckResult:
             )
             return result
 
-        if not config.skip_meta_model:
-            model = _check_meta_model(model_config)
+        if model is not None:
             del model
 
         if config.mode == "roundtrip":

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/runner.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/runner.py
@@ -1,0 +1,634 @@
+"""Isolated implementation of the SGLang/UCM compatibility check."""
+
+from __future__ import annotations
+
+import contextlib
+import socket
+import traceback
+import uuid
+from types import SimpleNamespace
+from typing import Any, Iterator
+
+from .compatibility import (
+    find_missing_capabilities,
+    infer_capabilities,
+    requirements_from_facts,
+)
+from .config import CheckConfig
+from .result import CheckResult, emit_result
+
+
+class CheckFailure(RuntimeError):
+    def __init__(self, code: str, stage: str, reason: str):
+        super().__init__(reason)
+        self.code = code
+        self.stage = stage
+        self.reason = reason
+
+
+def _model_facts(model_config: Any) -> dict[str, Any]:
+    from sglang.srt.configs.hybrid_arch import mambaish_config
+    from sglang.srt.configs.model_config import (
+        is_deepseek_dsa,
+        is_deepseek_v4,
+        is_minimax_sparse,
+        uses_kda_attention,
+    )
+
+    hf_config = model_config.hf_config
+    text_config = model_config.hf_text_config
+    architectures = list(getattr(hf_config, "architectures", None) or [])
+    try:
+        has_linear_attention = bool(mambaish_config(model_config))
+    except Exception:
+        has_linear_attention = uses_kda_attention(text_config)
+
+    attention_arch = getattr(model_config.attention_arch, "name", None)
+    if attention_arch is None:
+        attention_arch = str(model_config.attention_arch).split(".")[-1]
+
+    try:
+        from sglang.srt.mem_cache.hicache_storage import PoolName
+
+        sglang_pool_names = [str(item.value) for item in PoolName]
+    except Exception:
+        sglang_pool_names = []
+
+    return {
+        "architectures": architectures,
+        "model_type": getattr(hf_config, "model_type", None),
+        "attention_arch": attention_arch,
+        "is_hybrid_swa": bool(getattr(model_config, "is_hybrid_swa", False)),
+        "has_linear_attention": has_linear_attention,
+        "is_dsa": is_deepseek_dsa(text_config),
+        "is_deepseek_v4": is_deepseek_v4(hf_config),
+        "is_minimax_sparse": is_minimax_sparse(hf_config),
+        "num_layers": int(
+            max(
+                getattr(model_config, "num_hidden_layers", 0),
+                getattr(model_config, "num_attention_layers", 0),
+            )
+        ),
+        "dtype": str(model_config.dtype),
+        "quantization": getattr(model_config, "quantization", None),
+        "sglang_pool_names": sglang_pool_names,
+    }
+
+
+def _redirect_device(value: Any) -> Any:
+    if isinstance(value, str) and value.split(":", 1)[0] in {
+        "cuda",
+        "npu",
+        "xpu",
+        "musa",
+    }:
+        return "meta"
+    try:
+        if getattr(value, "type", None) in {"cuda", "npu", "xpu", "musa"}:
+            return "meta"
+    except Exception:
+        pass
+    return value
+
+
+def _free_local_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@contextlib.contextmanager
+def _single_rank_model_parallel() -> Iterator[None]:
+    """Initialize the one-rank groups required by SGLang model constructors."""
+    import torch
+    from sglang.srt.distributed.parallel_state import (
+        cleanup_dist_env_and_memory,
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+
+    owns_environment = not torch.distributed.is_initialized()
+    try:
+        if owns_environment:
+            init_distributed_environment(
+                world_size=1,
+                rank=0,
+                local_rank=0,
+                distributed_init_method=f"tcp://127.0.0.1:{_free_local_port()}",
+                backend="gloo",
+            )
+            initialize_model_parallel(backend="gloo")
+        yield
+    finally:
+        if owns_environment and torch.distributed.is_initialized():
+            cleanup_dist_env_and_memory()
+
+
+@contextlib.contextmanager
+def _meta_device_guard(torch: Any) -> Iterator[None]:
+    """Redirect explicit accelerator allocations made during model construction."""
+    factories = ("empty", "zeros", "ones", "full", "rand", "randn", "arange")
+    originals: dict[str, Any] = {}
+
+    for name in factories:
+        original = getattr(torch, name)
+        originals[name] = original
+
+        def wrapper(*args: Any, __original: Any = original, **kwargs: Any) -> Any:
+            if "device" in kwargs:
+                kwargs["device"] = _redirect_device(kwargs["device"])
+            return __original(*args, **kwargs)
+
+        setattr(torch, name, wrapper)
+
+    original_module_to = torch.nn.Module.to
+    original_tensor_to = torch.Tensor.to
+
+    def module_to(module: Any, *args: Any, **kwargs: Any) -> Any:
+        if args:
+            args = (_redirect_device(args[0]), *args[1:])
+        if "device" in kwargs:
+            kwargs["device"] = _redirect_device(kwargs["device"])
+        return original_module_to(module, *args, **kwargs)
+
+    def tensor_to(tensor: Any, *args: Any, **kwargs: Any) -> Any:
+        if args:
+            args = (_redirect_device(args[0]), *args[1:])
+        if "device" in kwargs:
+            kwargs["device"] = _redirect_device(kwargs["device"])
+        return original_tensor_to(tensor, *args, **kwargs)
+
+    torch.nn.Module.to = module_to
+    torch.Tensor.to = tensor_to
+    try:
+        yield
+    finally:
+        torch.nn.Module.to = original_module_to
+        torch.Tensor.to = original_tensor_to
+        for name, original in originals.items():
+            setattr(torch, name, original)
+
+
+def _check_meta_model(model_config: Any) -> Any:
+    import torch
+    from sglang.srt.configs.load_config import LoadConfig
+    from sglang.srt.model_loader.loader import (
+        _get_quantization_config,
+        _initialize_model,
+    )
+    from sglang.srt.model_executor.model_runner_components.layer_setup import (
+        resolve_layer_indices,
+    )
+    from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+    load_config = LoadConfig()
+    old_dtype = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(model_config.dtype)
+        quant_config = _get_quantization_config(model_config, load_config)
+        with _single_rank_model_parallel():
+            with torch.device("meta"), _meta_device_guard(torch):
+                model = _initialize_model(model_config, load_config, quant_config)
+            resolve_layer_indices(
+                model=model,
+                model_config=model_config,
+                is_draft_worker=False,
+                spec_algorithm=SpeculativeAlgorithm.NONE,
+            )
+            return model
+    except Exception as exc:
+        raise CheckFailure(
+            "META_MODEL_INIT_UNSUPPORTED",
+            "meta_model_init",
+            f"{type(exc).__name__}: {exc}",
+        ) from exc
+    finally:
+        torch.set_default_dtype(old_dtype)
+
+
+def _make_storage_config(config: CheckConfig, requirements: Any) -> Any:
+    from sglang.srt.mem_cache.hicache_storage import HiCacheStorageConfig
+
+    extra = {
+        "kv_connector_extra_config": {
+            "ucm_connector_name": config.connector_name,
+            "ucm_connector_module_path": config.connector_module_path,
+            "ucm_connector_config": {
+                "storage_backends": config.storage_backends,
+            },
+        }
+    }
+    return HiCacheStorageConfig(
+        tp_rank=0,
+        tp_size=1,
+        pp_rank=0,
+        pp_size=1,
+        attn_cp_rank=0,
+        attn_cp_size=1,
+        is_mla_model=requirements.is_mla,
+        enable_storage_metrics=False,
+        is_page_first_layout=config.layout.startswith("page_first"),
+        model_name=config.model,
+        extra_config=extra,
+    )
+
+
+def _make_host_pool(model_config: Any, requirements: Any, config: CheckConfig) -> Any:
+    import torch
+
+    layer_num = int(
+        max(
+            getattr(model_config, "num_hidden_layers", 0),
+            getattr(model_config, "num_attention_layers", 0),
+        )
+    )
+    if layer_num <= 0:
+        raise CheckFailure("KV_POOL_UNSUPPORTED", "host_pool", "invalid layer count")
+
+    device_pool = SimpleNamespace(
+        store_dtype=model_config.dtype,
+        size=config.page_size * (config.pages * 2 + 1),
+        start_layer=0,
+        end_layer=layer_num,
+        layer_num=layer_num,
+        device="cpu",
+        layer_shard_enabled=False,
+        layer_shard_size=layer_num,
+    )
+    if requirements.is_mla:
+        from sglang.srt.mem_cache.pool_host.mla import MLATokenToKVPoolHost
+
+        device_pool.kv_lora_rank = int(model_config.kv_lora_rank)
+        device_pool.qk_rope_head_dim = int(model_config.qk_rope_head_dim)
+        device_pool.index_head_dim = getattr(model_config, "index_head_dim", None)
+        pool_cls = MLATokenToKVPoolHost
+    else:
+        from sglang.srt.mem_cache.pool_host.mha import MHATokenToKVPoolHost
+
+        device_pool.head_num = int(
+            getattr(model_config, "num_key_value_heads", None)
+            or model_config.num_attention_heads
+        )
+        device_pool.head_dim = int(model_config.head_dim)
+        pool_cls = MHATokenToKVPoolHost
+
+    try:
+        return pool_cls(
+            device_pool=device_pool,
+            host_to_device_ratio=1.0,
+            host_size=0,
+            page_size=config.page_size,
+            layout=config.layout,
+            pin_memory=False,
+            device="cpu",
+            allocator_type="default",
+        )
+    except Exception as exc:
+        raise CheckFailure(
+            "HICACHE_HOST_POOL_UNSUPPORTED",
+            "host_pool",
+            f"{type(exc).__name__}: {exc}",
+        ) from exc
+
+
+def _page_view(host_pool: Any, start: int, stop: int, is_mla: bool) -> Any:
+    layout = host_pool.layout
+    if layout == "page_first":
+        return (
+            host_pool.kv_buffer[start:stop]
+            if is_mla
+            else host_pool.kv_buffer[:, start:stop]
+        )
+    if layout == "layer_first":
+        return (
+            host_pool.kv_buffer[:, start:stop]
+            if is_mla
+            else host_pool.kv_buffer[:, :, start:stop]
+        )
+    if layout == "page_first_direct":
+        first_page = start // host_pool.page_size
+        last_page = stop // host_pool.page_size
+        return (
+            host_pool.kv_buffer[first_page:last_page]
+            if is_mla
+            else host_pool.kv_buffer[:, first_page:last_page]
+        )
+    raise CheckFailure(
+        "CHECKER_LAYOUT_UNSUPPORTED",
+        "roundtrip_prepare",
+        f"checker has no data comparison strategy for layout {layout!r}",
+    )
+
+
+def _fill_pattern(tensor: Any) -> None:
+    import torch
+
+    generator = torch.Generator(device=tensor.device)
+    generator.manual_seed(20260909)
+    try:
+        tensor.uniform_(-1.0, 1.0, generator=generator)
+    except RuntimeError:
+        # Some low-precision cache dtypes do not implement uniform_.  A
+        # non-zero sentinel still detects missing or partial transfers.
+        tensor.fill_(0.5)
+
+
+def _pool_name(value: str) -> Any:
+    """Use SGLang's enum when known while tolerating future pool names."""
+    from sglang.srt.mem_cache.hicache_storage import PoolName
+
+    try:
+        return PoolName(value)
+    except ValueError:
+        return value
+
+
+def _result_for_pool(results: Any, pool_name: Any) -> Any:
+    if not isinstance(results, dict):
+        return None
+    for key in (pool_name, str(pool_name), getattr(pool_name, "value", None)):
+        if key is not None and key in results:
+            return results[key]
+    return None
+
+
+def _require_page_results(
+    results: Any, pool_names: list[Any], pages: int, code: str, stage: str
+) -> None:
+    for pool_name in pool_names:
+        pool_results = _result_for_pool(results, pool_name)
+        if (
+            not isinstance(pool_results, (list, tuple))
+            or len(pool_results) != pages
+            or not all(pool_results)
+        ):
+            raise CheckFailure(
+                code,
+                stage,
+                f"pool {pool_name}: expected {pages} successful pages, "
+                f"got {pool_results!r}",
+            )
+
+
+def _roundtrip_v1(
+    storage: Any,
+    host_pool: Any,
+    keys: list[str],
+    config: Any,
+    is_mla: bool,
+) -> dict[str, Any]:
+    import torch
+
+    tokens = config.pages * config.page_size
+    source = _page_view(host_pool, 0, tokens, is_mla)
+    target = _page_view(host_pool, tokens, tokens * 2, is_mla)
+    _fill_pattern(source)
+    expected = source.clone()
+    target.zero_()
+    source_indices = torch.arange(0, tokens, dtype=torch.int64)
+    target_indices = torch.arange(tokens, tokens * 2, dtype=torch.int64)
+
+    written = storage.batch_set_v1(keys, source_indices)
+    if len(written) != config.pages or not all(written):
+        raise CheckFailure("DUMP_FAILED", "roundtrip_dump", repr(written))
+    hits = storage.batch_exists(keys)
+    if hits != config.pages:
+        raise CheckFailure(
+            "LOAD_MISS",
+            "roundtrip_exists",
+            f"expected {config.pages} hit pages, got {hits}",
+        )
+    loaded = storage.batch_get_v1(keys, target_indices)
+    if len(loaded) != config.pages or not all(loaded):
+        raise CheckFailure("LOAD_FAILED", "roundtrip_load", repr(loaded))
+    if not torch.equal(expected, target):
+        mismatch = int(torch.count_nonzero(expected != target).item())
+        raise CheckFailure(
+            "ROUNDTRIP_MISMATCH",
+            "roundtrip_compare",
+            f"kv: {mismatch} tensor elements differ",
+        )
+    return {
+        "pages_written": config.pages,
+        "pages_loaded": config.pages,
+        "bytes_compared": expected.numel() * expected.element_size(),
+    }
+
+
+def _roundtrip_v2(
+    storage: Any,
+    pools: dict[str, Any],
+    keys: list[str],
+    config: Any,
+    is_mla: bool,
+) -> dict[str, Any]:
+    """Exercise the same anchor-v1 + side-pool-v2 contract used by SGLang."""
+    import torch
+    from sglang.srt.mem_cache.hicache_storage import PoolTransfer
+
+    names = list(pools)
+    anchor_name = names[0]
+    anchor = pools[anchor_name]
+    totals = _roundtrip_v1(storage, anchor, keys, config, is_mla)
+    side_names = names[1:]
+    if not side_names:
+        return totals
+
+    tokens = config.pages * config.page_size
+    source_transfers = []
+    target_transfers = []
+    expected_by_name = {}
+    enum_names = []
+    for name in side_names:
+        pool = pools[name]
+        source = _page_view(pool, 0, tokens, is_mla)
+        target = _page_view(pool, tokens, tokens * 2, is_mla)
+        _fill_pattern(source)
+        expected_by_name[name] = source.clone()
+        target.zero_()
+        enum_name = _pool_name(name)
+        enum_names.append(enum_name)
+        source_transfers.append(
+            PoolTransfer(
+                name=enum_name,
+                host_indices=torch.arange(0, tokens, dtype=torch.int64),
+                keys=list(keys),
+            )
+        )
+        target_transfers.append(
+            PoolTransfer(
+                name=enum_name,
+                host_indices=torch.arange(tokens, tokens * 2, dtype=torch.int64),
+                keys=list(keys),
+            )
+        )
+
+    written = storage.batch_set_v2(source_transfers)
+    _require_page_results(
+        written, enum_names, config.pages, "DUMP_FAILED", "roundtrip_dump_v2"
+    )
+    hit = storage.batch_exists_v2(keys, source_transfers)
+    if int(getattr(hit, "kv_hit_pages", -1)) != config.pages:
+        raise CheckFailure(
+            "LOAD_MISS",
+            "roundtrip_exists_v2",
+            f"expected {config.pages} restorable pages, got {hit!r}",
+        )
+    extra_hits = getattr(hit, "extra_pool_hit_pages", {})
+    for enum_name in enum_names:
+        count = _result_for_pool(extra_hits, enum_name)
+        if count is None or int(count) < config.pages:
+            raise CheckFailure(
+                "LOAD_MISS",
+                "roundtrip_exists_v2",
+                f"pool {enum_name}: expected {config.pages} hit pages, got {count!r}",
+            )
+
+    loaded = storage.batch_get_v2(target_transfers)
+    _require_page_results(
+        loaded, enum_names, config.pages, "LOAD_FAILED", "roundtrip_load_v2"
+    )
+    for name in side_names:
+        target = _page_view(pools[name], tokens, tokens * 2, is_mla)
+        expected = expected_by_name[name]
+        if not torch.equal(expected, target):
+            mismatch = int(torch.count_nonzero(expected != target).item())
+            raise CheckFailure(
+                "ROUNDTRIP_MISMATCH",
+                "roundtrip_compare_v2",
+                f"{name}: {mismatch} tensor elements differ",
+            )
+        totals["bytes_compared"] += expected.numel() * expected.element_size()
+    totals["pool_names"] = names
+    totals["storage_api"] = "v2"
+    return totals
+
+
+def _roundtrip(
+    config: CheckConfig, model_config: Any, requirements: Any
+) -> dict[str, Any]:
+    if requirements.is_hybrid:
+        raise CheckFailure(
+            "CHECKER_RUNTIME_POOL_PROBE_REQUIRED",
+            "roundtrip_prepare",
+            "the model uses specialized SGLang side pools; synthetic MHA/MLA "
+            "pools cannot prove v2 compatibility. Inspect validates the model "
+            "and UCM API surface only",
+        )
+
+    from sglang.srt.mem_cache.hicache_storage import HiCacheStorage
+    from ucm.integration.sglang.unifiedcache_store import UnifiedCacheStore
+
+    pools = {
+        name: _make_host_pool(model_config, requirements, config)
+        for name in requirements.pool_names
+    }
+    anchor_name = next(iter(pools))
+    host_pool = pools[anchor_name]
+    storage = None
+    try:
+        capabilities = infer_capabilities(UnifiedCacheStore, HiCacheStorage)
+        missing = find_missing_capabilities(requirements, capabilities)
+        if missing:
+            raise CheckFailure(
+                "UCM_STORAGE_API_UNSUPPORTED",
+                "capability_check",
+                "; ".join(missing),
+            )
+
+        storage = UnifiedCacheStore(_make_storage_config(config, requirements))
+        storage.register_mem_pool_host(host_pool)
+        salt = uuid.uuid4().hex
+        keys = [
+            f"sglang-model-check-{salt}-{index}" for index in range(config.pages)
+        ]
+        if requirements.storage_api == "v2":
+            for name, pool in pools.items():
+                storage.register_mem_host_pool_v2(pool, _pool_name(name))
+            totals = _roundtrip_v2(
+                storage, pools, keys, config, requirements.is_mla
+            )
+        else:
+            totals = _roundtrip_v1(
+                storage, host_pool, keys, config, requirements.is_mla
+            )
+            totals.update(pool_names=[anchor_name], storage_api="v1")
+        totals["host_pool_classes"] = {
+            name: type(pool).__name__ for name, pool in pools.items()
+        }
+        return totals
+    finally:
+        if storage is not None:
+            storage.close()
+        for pool in pools.values():
+            destroy = getattr(pool, "destroy", None)
+            if callable(destroy):
+                destroy()
+
+
+def run(config: CheckConfig) -> CheckResult:
+    result = CheckResult(model=config.model, mode=config.mode)
+    try:
+        from sglang.srt.configs.model_config import ModelConfig
+        from sglang.srt.mem_cache.hicache_storage import HiCacheStorage
+        from ucm.integration.sglang.unifiedcache_store import UnifiedCacheStore
+
+        model_config = ModelConfig(
+            model_path=config.model,
+            trust_remote_code=config.trust_remote_code,
+            dtype=config.dtype,
+        )
+        facts = _model_facts(model_config)
+        requirements = requirements_from_facts(facts, host_layout=config.layout)
+        capabilities = infer_capabilities(UnifiedCacheStore, HiCacheStorage)
+        result.model_info = facts
+        result.cache_requirements = requirements.to_dict()
+        result.ucm_capabilities = capabilities
+
+        missing = find_missing_capabilities(requirements, capabilities)
+        if missing:
+            result.fail(
+                "UCM_STORAGE_API_UNSUPPORTED",
+                "capability_check",
+                "; ".join(missing),
+            )
+            return result
+
+        if not config.skip_meta_model:
+            model = _check_meta_model(model_config)
+            del model
+
+        if config.mode == "roundtrip":
+            with _single_rank_model_parallel():
+                result.roundtrip = _roundtrip(config, model_config, requirements)
+            result.succeed("roundtrip", "UCM dump/load data matched")
+        else:
+            qualifier = "config-only" if config.skip_meta_model else "meta-model"
+            if requirements.is_hybrid:
+                qualifier += "; specialized runtime pools were not constructed"
+            result.succeed(
+                "inspect",
+                f"{qualifier} structural checks passed; storage IO was not probed",
+            )
+        return result
+    except CheckFailure as exc:
+        result.fail(exc.code, exc.stage, exc.reason)
+        return result
+    except Exception as exc:
+        result.fail(
+            "ENVIRONMENT_UNSUPPORTED",
+            "startup",
+            f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}",
+        )
+        return result
+
+
+def main() -> int:
+    config = CheckConfig.from_env()
+    result = run(config)
+    emit_result(result, config.output)
+    return 0 if result.supported else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/runner.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/runner.py
@@ -143,22 +143,23 @@ def _check_meta_model(model_config: Any) -> Any:
     old_dtype = torch.get_default_dtype()
     try:
         torch.set_default_dtype(model_config.dtype)
-        quant_config = _get_quantization_config(model_config, load_config)
-        with server_args_guard(), _single_rank_model_parallel():
-            with torch.device("meta"), _meta_device_guard(torch):
-                model = _initialize_model(model_config, load_config, quant_config)
-            resolve_layer_indices(
-                model=model,
-                model_config=model_config,
-                is_draft_worker=False,
-                spec_algorithm=SpeculativeAlgorithm.NONE,
-            )
-            return model
+        with server_args_guard():
+            quant_config = _get_quantization_config(model_config, load_config)
+            with _single_rank_model_parallel():
+                with torch.device("meta"), _meta_device_guard(torch):
+                    model = _initialize_model(model_config, load_config, quant_config)
+                resolve_layer_indices(
+                    model=model,
+                    model_config=model_config,
+                    is_draft_worker=False,
+                    spec_algorithm=SpeculativeAlgorithm.NONE,
+                )
+                return model
     except Exception as exc:
         raise CheckFailure(
             "META_MODEL_INIT_UNSUPPORTED",
             "meta_model_init",
-            f"{type(exc).__name__}: {exc}",
+            f"{type(exc).__name__}: {exc}\n{traceback.format_exc()}",
         ) from exc
     finally:
         torch.set_default_dtype(old_dtype)

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/sglang_compat/__init__.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/sglang_compat/__init__.py
@@ -1,5 +1,15 @@
 """Version-tolerant access to SGLang model inspection APIs."""
 
-from .inspector import collect_model_facts, environment_info, refine_facts_from_model
+from .inspector import (
+    collect_model_facts,
+    environment_info,
+    refine_facts_from_model,
+    server_args_guard,
+)
 
-__all__ = ["collect_model_facts", "environment_info", "refine_facts_from_model"]
+__all__ = [
+    "collect_model_facts",
+    "environment_info",
+    "refine_facts_from_model",
+    "server_args_guard",
+]

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/sglang_compat/__init__.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/sglang_compat/__init__.py
@@ -1,0 +1,5 @@
+"""Version-tolerant access to SGLang model inspection APIs."""
+
+from .inspector import collect_model_facts, environment_info, refine_facts_from_model
+
+__all__ = ["collect_model_facts", "environment_info", "refine_facts_from_model"]

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/sglang_compat/inspector.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/sglang_compat/inspector.py
@@ -26,11 +26,27 @@ def server_args_guard():
     framework-provided reversible boundary for tests and offline tools.
     """
     runtime = importlib.import_module("sglang.srt.runtime_context")
+
+    @contextmanager
+    def single_rank_parallel():
+        get_parallel = getattr(runtime, "get_parallel", None)
+        parallel = get_parallel() if callable(get_parallel) else None
+        override = getattr(parallel, "override", None)
+        if not callable(override):
+            yield
+            return
+        with override(
+            attn_dp_size=1,
+            attn_dp_rank=0,
+        ):
+            yield
+
     get_server_args = getattr(runtime, "get_server_args", None)
     if callable(get_server_args):
         try:
             get_server_args()
-            yield
+            with single_rank_parallel():
+                yield
             return
         except ValueError as exc:
             if "server args" not in str(exc).lower():
@@ -41,7 +57,8 @@ def server_args_guard():
     override = getattr(context, "override_server_args", None)
     if callable(override):
         with override():
-            yield
+            with single_rank_parallel():
+                yield
         return
 
     raise RuntimeError(

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/sglang_compat/inspector.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/sglang_compat/inspector.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import importlib.metadata
+from contextlib import contextmanager
 from typing import Any
 
 
@@ -14,6 +15,39 @@ def _optional_callable(module_name: str, name: str):
         return None
     value = getattr(module, name, None)
     return value if callable(value) else None
+
+
+@contextmanager
+def server_args_guard():
+    """Publish SGLang's minimal scoped test context when no Engine did so.
+
+    Newer SGLang model constructors read process-wide ServerArgs even during
+    weight-free initialization.  RuntimeContext.override_server_args() is the
+    framework-provided reversible boundary for tests and offline tools.
+    """
+    runtime = importlib.import_module("sglang.srt.runtime_context")
+    get_server_args = getattr(runtime, "get_server_args", None)
+    if callable(get_server_args):
+        try:
+            get_server_args()
+            yield
+            return
+        except ValueError as exc:
+            if "server args" not in str(exc).lower():
+                raise
+
+    get_context = getattr(runtime, "get_context", None)
+    context = get_context() if callable(get_context) else None
+    override = getattr(context, "override_server_args", None)
+    if callable(override):
+        with override():
+            yield
+        return
+
+    raise RuntimeError(
+        "this SGLang version requires global ServerArgs during model init but "
+        "does not expose RuntimeContext.override_server_args()"
+    )
 
 
 def _call_bool(module_name: str, name: str, argument: Any):

--- a/toolkit/ucm_toolkit/tools/sglang_model_check/sglang_compat/inspector.py
+++ b/toolkit/ucm_toolkit/tools/sglang_model_check/sglang_compat/inspector.py
@@ -1,0 +1,190 @@
+"""Keep unstable SGLang imports out of the checker core."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+from typing import Any
+
+
+def _optional_callable(module_name: str, name: str):
+    try:
+        module = importlib.import_module(module_name)
+    except Exception:
+        return None
+    value = getattr(module, name, None)
+    return value if callable(value) else None
+
+
+def _call_bool(module_name: str, name: str, argument: Any):
+    function = _optional_callable(module_name, name)
+    if function is None:
+        return None, None, f"{module_name}.{name} is unavailable"
+    try:
+        return bool(function(argument)), name, None
+    except Exception as exc:
+        return None, name, f"{name}: {type(exc).__name__}: {exc}"
+
+
+def _linear_attention(model_config: Any):
+    if hasattr(model_config, "linear_attn_registry_result"):
+        value = getattr(model_config, "linear_attn_registry_result")
+        if value:
+            return True, "linear_attn_registry_result", None
+
+    function = _optional_callable(
+        "sglang.srt.configs.hybrid_arch", "mambaish_config"
+    )
+    if function is not None:
+        try:
+            value = function(model_config)
+            return value is not None and bool(value), "mambaish_config", None
+        except Exception as exc:
+            mamba_error = f"mambaish_config: {type(exc).__name__}: {exc}"
+    else:
+        mamba_error = "mambaish_config is unavailable"
+
+    function = _optional_callable(
+        "sglang.srt.configs.model_config", "uses_kda_attention"
+    )
+    if function is not None:
+        try:
+            return (
+                bool(function(model_config.hf_text_config)),
+                "uses_kda_attention",
+                mamba_error,
+            )
+        except Exception as exc:
+            return None, "uses_kda_attention", f"{mamba_error}; {type(exc).__name__}: {exc}"
+
+    text_config = model_config.hf_text_config
+    indicators = (
+        "linear_attention_config",
+        "mamba_config",
+        "mamba2_cache_params",
+        "hybrid_override_pattern",
+        "mtp_hybrid_override_pattern",
+        "kda_config",
+    )
+    if any(getattr(text_config, name, None) is not None for name in indicators):
+        return True, "config_structure", mamba_error
+    return None, "undetermined", mamba_error
+
+
+def environment_info() -> dict[str, Any]:
+    try:
+        version = importlib.metadata.version("sglang")
+    except importlib.metadata.PackageNotFoundError:
+        try:
+            version = str(importlib.import_module("sglang").__version__)
+        except Exception:
+            version = "unknown"
+
+    platform = "unknown"
+    device_name = None
+    try:
+        current = importlib.import_module("sglang.srt.platforms").current_platform
+        platform = str(getattr(current, "device_type", None) or "unknown")
+        device_name = getattr(current, "device_name", None)
+        if callable(device_name):
+            device_name = device_name()
+        if bool(getattr(current, "is_hip", lambda: False)()):
+            platform = "rocm"
+    except Exception:
+        pass
+    return {"sglang_version": version, "platform": platform, "device_name": device_name}
+
+
+def supported_platforms_for_quantization(quantization: Any) -> list[str] | None:
+    """Return a conservative platform constraint for accelerator-specific formats."""
+    value = str(quantization or "").lower().replace("-", "_")
+    if "nvfp4" in value or value == "modelopt_fp4":
+        return ["cuda"]
+    return None
+
+
+def collect_model_facts(model_config: Any) -> dict[str, Any]:
+    hf_config = model_config.hf_config
+    text_config = model_config.hf_text_config
+    architectures = list(getattr(hf_config, "architectures", None) or [])
+    attention_arch = getattr(model_config.attention_arch, "name", None)
+    if attention_arch is None:
+        attention_arch = str(model_config.attention_arch).split(".")[-1]
+
+    linear, linear_source, linear_error = _linear_attention(model_config)
+    dsa, dsa_source, dsa_error = _call_bool(
+        "sglang.srt.configs.model_config", "is_deepseek_dsa", text_config
+    )
+    dsv4, dsv4_source, dsv4_error = _call_bool(
+        "sglang.srt.configs.model_config", "is_deepseek_v4", hf_config
+    )
+    minimax, minimax_source, minimax_error = _call_bool(
+        "sglang.srt.configs.model_config", "is_minimax_sparse", hf_config
+    )
+    try:
+        PoolName = importlib.import_module(
+            "sglang.srt.mem_cache.hicache_storage"
+        ).PoolName
+        pool_names = [str(item.value) for item in PoolName]
+    except Exception:
+        pool_names = []
+
+    errors = [item for item in (linear_error, dsa_error, dsv4_error, minimax_error) if item]
+    quantization = getattr(model_config, "quantization", None)
+    return {
+        "architectures": architectures,
+        "model_type": getattr(hf_config, "model_type", None),
+        "attention_arch": attention_arch,
+        "is_hybrid_swa": bool(getattr(model_config, "is_hybrid_swa", False)),
+        "has_linear_attention": linear,
+        "is_dsa": dsa,
+        "is_deepseek_v4": dsv4,
+        "is_minimax_sparse": minimax,
+        "num_layers": int(max(getattr(model_config, "num_hidden_layers", 0), getattr(model_config, "num_attention_layers", 0))),
+        "dtype": str(model_config.dtype),
+        "quantization": quantization,
+        "supported_platforms": supported_platforms_for_quantization(quantization),
+        "sglang_pool_names": pool_names,
+        "detection_sources": {
+            "linear_attention": linear_source,
+            "dsa": dsa_source,
+            "deepseek_v4": dsv4_source,
+            "minimax_sparse": minimax_source,
+        },
+        "detection_errors": errors,
+    }
+
+
+def refine_facts_from_model(facts: dict[str, Any], model: Any) -> dict[str, Any]:
+    """Use the instantiated meta model only when config discovery was unknown."""
+    if facts.get("has_linear_attention") is not None:
+        return facts
+    markers = ("mamba", "linearattention", "kda", "gdn", "shortconv")
+    matches = []
+    for name, module in model.named_modules():
+        identity = f"{type(module).__module__}.{type(module).__name__}".lower()
+        if any(marker in identity for marker in markers):
+            matches.append(name or "<root>")
+    if matches:
+        facts["has_linear_attention"] = True
+        facts["detection_sources"]["linear_attention"] = "meta_model_modules"
+        facts["linear_attention_modules"] = matches[:32]
+    return facts
+
+
+def refine_facts_from_model(facts: dict[str, Any], model: Any) -> dict[str, Any]:
+    if facts.get("has_linear_attention") is not None:
+        return facts
+    markers = ("mamba", "linearattention", "kda", "gdn")
+    matches = []
+    for name, module in model.named_modules():
+        identity = f"{type(module).__module__}.{type(module).__name__}".lower()
+        if any(marker in identity for marker in markers):
+            matches.append(name or "<root>")
+    updated = dict(facts)
+    if matches:
+        updated["has_linear_attention"] = True
+        updated["detection_sources"] = dict(updated["detection_sources"])
+        updated["detection_sources"]["linear_attention"] = "meta_model_modules"
+        updated["linear_attention_modules"] = matches[:32]
+    return updated


### PR DESCRIPTION
## Description

  ## What does this PR do?

  This PR introduces `sglang-model-check`, an offline compatibility checker for
  validating whether a model can work with the installed UCM SGLang integration.

  The checker does not:

  - start an SGLang inference service;
  - create an Engine, Scheduler, or HTTP server;
  - load model checkpoint weights;
  - modify the production UCM SGLang integration.

  It inspects the installed SGLang and UCM implementations at runtime, allowing
  future UCM integration changes, including v2 multi-pool API support, to be
  detected without adding model-specific branches to the checker.

  ## Motivation

  SGLang models may use different cache architectures and storage interfaces,
  including:

  - standard MHA/MLA KV cache;
  - Mamba or linear-attention state;
  - sliding-window attention;
  - DSA indexer cache;
  - DeepSeek-V4 multi-pool cache layouts;
  - draft-model cache pools.

  Previously, checking model compatibility generally required starting an
  inference service and loading checkpoint weights. It was also difficult to
  distinguish between:

  1. an unsupported model or UCM API;
  2. a checker limitation;
  3. a missing runtime environment.

  This tool provides a lightweight and machine-readable preflight check.

  ## Usage

  Run the default inspection:

  ```bash
  ucm-toolkit run sglang-model-check \
    --model /path/to/model

  Run configuration-only inspection without constructing the model skeleton:

  ucm-toolkit run sglang-model-check \
    --model /path/to/model \
    --skip-meta-model

  Run a storage roundtrip for models whose real host cache pools can be
  constructed offline:

  ucm-toolkit run sglang-model-check \
    --model /path/to/model \
    --mode roundtrip \
    --storage-backends /path/to/storage

  Show complete detection details and tracebacks:

  ucm-toolkit run sglang-model-check \
    --model /path/to/model \
    --verbose

  ## Validation stages

  ### Configuration inspection

  The checker loads the model configuration through SGLang and determines:

  - model architecture and model type;
  - attention architecture;
  - quantization format;
  - accelerator requirements;
  - required cache pools;
  - required UCM storage API version.

  ### Meta-device model construction

  By default, the checker invokes the real SGLang model initialization path while
  creating model parameters on the PyTorch meta device.

  This validates the model class and module structure without allocating storage
  for checkpoint parameters and without loading checkpoint weights.

  --skip-meta-model disables this stage and produces a weaker,
  configuration-only result.

  ### UCM capability detection

  The checker determines capabilities from methods actually overridden by the
  installed UCM UnifiedCacheStore.

  It does not require the production integration to maintain a separate
  checker-specific capability list.

  As a result, future v2 integration implementations can be detected without
  modifying the checker for each newly supported model.

  ### Storage roundtrip

  For supported single-pool cache layouts, roundtrip mode constructs a bounded
  SGLang host cache pool and verifies UCM dump/load data consistency.

  Models requiring specialized runtime pools, such as DSA indexer, Mamba, SWA,
  or DeepSeek-V4 side pools, return:

  CHECKER_RUNTIME_POOL_PROBE_REQUIRED

  until those real runtime pools can be constructed by the checker. Synthetic
  MHA/MLA pools are intentionally not used as proof of multi-pool compatibility.

  ## Result semantics

  The JSON result contains a three-state status field:

   Status          Meaning
  ━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   compatible      All checks covered by the selected mode passed
  ──────────────  ──────────────────────────────────────────────────────────────────────────
   inconclusive    The checker lacks the runtime conditions required to complete validation
  ──────────────  ──────────────────────────────────────────────────────────────────────────
   incompatible    A concrete model, platform, or UCM API incompatibility was found

  The existing supported boolean is retained for backward compatibility.
  New consumers should use status to avoid treating an inconclusive runtime-pool
  probe as a confirmed incompatibility.

  Examples:

  - GLM DSA inspect with UCM v2 available: compatible
  - GLM DSA roundtrip without a real indexer runtime pool: inconclusive
  - Model requiring UCM v2 while only v1 is implemented: incompatible

  ## Output

  Compact JSON is emitted by default and includes:

  - compatibility status and result code;
  - model and attention architecture;
  - cache pool and storage API requirements;
  - detected UCM API capabilities;
  - SGLang version and accelerator platform.

  --verbose includes detection sources, detection errors, full tracebacks,
  environment details, and roundtrip diagnostics.

  Unrelated Transformers generation-configuration warnings are suppressed so the
  command output remains suitable for machine parsing.

  ## Compatibility considerations

  The checker includes a compatibility layer around version-sensitive SGLang
  inspection APIs.

  Optional SGLang helpers are not imported as hard dependencies. When a helper is
  unavailable, the checker falls back to model configuration and structural
  inspection where possible.

  The tool supports explicit platform selection:

  auto, cuda, rocm, ascend, xpu, cpu

  Platform-specific quantization requirements, such as NVFP4 requiring CUDA, are
  checked before model construction.

  ## Limitations

  A successful inspection means that the model structure, cache requirements, and
  installed UCM API surface are compatible within the scope of the offline check.

  It does not verify:

  - checkpoint tensor names or shapes;
  - accelerator kernels;
  - distributed communication;
  - inference correctness;
  - production memory capacity;
  - end-to-end SGLang serving;
  - specialized multi-pool data paths unless a real runtime pool is available.

  Therefore, this checker is a preflight validation tool and does not replace
  end-to-end integration testing.
