### PR TITLE
[Fix] Ignore PP-disaggregated handshake metadata in UCMConnector for MultiConnector PD deployment

### DIFF
--- a/ucm/integration/vllm/ucm_connector.py
+++ b/ucm/integration/vllm/ucm_connector.py
@@ -3212,3 +3212,11 @@ class UCMConnector(KVConnectorBase_V1, SupportsHMA):
             Empty set if no load errors occurred.
         """
         return self.connector.get_block_ids_with_load_errors()
+
+    @_record_connector_interface_duration
+    def set_xfer_handshake_metadata_pp_aware(self, metadata) -> None:
+        logger.info(
+            "UCMConnector ignores PP-disaggregated handshake metadata: %s",
+            list(metadata.keys()),
+        )
+        return


### PR DESCRIPTION
Description

This PR fixes an EngineCore startup failure when using UCM + Mooncake through MultiConnector with PD disaggregation and Pipeline Parallelism (PP > 1).

In this deployment, Mooncake is responsible for Prefill-to-Decode KV transfer, while UCM is used for prefix/external KV cache management.

MultiConnector forwards PP-aware handshake metadata to all child connectors. Since UCMConnector did not override set_xfer_handshake_metadata_pp_aware(), it fell back to KVConnectorBase_V1, which raises an error when the metadata contains pp_rank > 0:

ValueError: UCMConnector received pp_rank > 0 handshake metadata
but does not support PP-disaggregated KV transfer.

This PR adds an override in UCMConnector:

Verified with the UCM Distributed PD deployment on Ascend in a single-node PD-separated PP2 configuration.

Reference:
https://ucm.readthedocs.io/en/latest/user-guide/pd-disaggregation/distributed_pd.html